### PR TITLE
mmstudio: cleanup of display-internal code.  

### DIFF
--- a/mmstudio/src/org/micromanager/display/internal/ButtonPanel.java
+++ b/mmstudio/src/org/micromanager/display/internal/ButtonPanel.java
@@ -30,7 +30,6 @@ import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 

--- a/mmstudio/src/org/micromanager/display/internal/CanvasUpdateThread.java
+++ b/mmstudio/src/org/micromanager/display/internal/CanvasUpdateThread.java
@@ -20,15 +20,12 @@
 
 package org.micromanager.display.internal;
 
-import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
 import ij.ImagePlus;
 
-import java.lang.Thread;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 import javax.swing.SwingUtilities;
 
@@ -48,14 +45,13 @@ import org.micromanager.internal.utils.ReportingUtils;
  */
 public class CanvasUpdateThread extends Thread {
 
-   private Datastore store_;
-   private MMVirtualStack stack_;
-   private ImagePlus plus_;
-   private DisplayWindow display_;
+   private final Datastore store_;
+   private final MMVirtualStack stack_;
+   private final ImagePlus plus_;
+   private final DisplayWindow display_;
    
-   private LinkedBlockingQueue<Coords> coordsQueue_;
-   private AtomicBoolean shouldStop_;
-   private Thread displayThread_;
+   private final LinkedBlockingQueue<Coords> coordsQueue_;
+   private final AtomicBoolean shouldStop_;
    private int imagesDisplayed_ = 0;
    private long lastImageIndex_ = 0;
    private long lastFPSUpdateTimestamp_ = -1;
@@ -213,6 +209,7 @@ public class CanvasUpdateThread extends Thread {
    /**
     * Add image coordinates for an image to display (i.e. request that the
     * display show the indicated image).
+    * @param coords ??? what kind of image coordinates are these?
     */
    public void addCoords(Coords coords) {
       try {

--- a/mmstudio/src/org/micromanager/display/internal/ChannelSettings.java
+++ b/mmstudio/src/org/micromanager/display/internal/ChannelSettings.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.micromanager.internal.utils.DefaultUserProfile;
-import org.micromanager.internal.utils.ReportingUtils;
 
 /**
  * This container class stores histogram and color settings for a specific
@@ -42,13 +41,13 @@ public class ChannelSettings {
 
    // Used to prevent simultaneous read/writes of the profile
    private static final Object profileLock_ = new Object();
-   private String channelName_;
-   private String channelGroup_;
+   private final String channelName_;
+   private final String channelGroup_;
 
-   private Color color_;
-   private Integer histogramMin_;
-   private Integer histogramMax_;
-   private boolean shouldAutoscale_;
+   private final Color color_;
+   private final Integer histogramMin_;
+   private final Integer histogramMax_;
+   private final boolean shouldAutoscale_;
 
    public ChannelSettings(String channelName, String channelGroup,
          Color color, Integer histogramMin, Integer histogramMax,

--- a/mmstudio/src/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -43,7 +43,6 @@ import org.micromanager.display.RequestToCloseEvent;
 import org.micromanager.display.RequestToDrawEvent;
 import org.micromanager.display.OverlayPanel;
 import org.micromanager.display.OverlayPanelFactory;
-import org.micromanager.display.internal.events.DefaultNewDisplayEvent;
 import org.micromanager.display.internal.events.DefaultRequestToDrawEvent;
 import org.micromanager.display.internal.events.NewOverlayEvent;
 
@@ -59,12 +58,12 @@ import org.micromanager.data.internal.DefaultPropertyMap;
 import org.micromanager.PropertyMap;
 
 
-public class DefaultDisplayManager implements DisplayManager {
+public final class DefaultDisplayManager implements DisplayManager {
    private static DefaultDisplayManager staticInstance_;
 
-   private MMStudio studio_;
-   private HashMap<Datastore, ArrayList<DisplayWindow>> storeToDisplays_;
-   private LinkedHashMap<String, OverlayPanelFactory> titleToOverlay_;
+   private final MMStudio studio_;
+   private final HashMap<Datastore, ArrayList<DisplayWindow>> storeToDisplays_;
+   private final LinkedHashMap<String, OverlayPanelFactory> titleToOverlay_;
 
    public DefaultDisplayManager(MMStudio studio) {
       studio_ = studio;
@@ -118,6 +117,7 @@ public class DefaultDisplayManager implements DisplayManager {
    /**
     * When a Datastore is closed, we need to remove all references to it so
     * it can be garbage-collected.
+    * @param event
     */
    @Subscribe
    public void onDatastoreClosed(DatastoreClosingEvent event) {

--- a/mmstudio/src/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -35,7 +35,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import org.micromanager.data.Coords;
 import org.micromanager.display.DisplaySettings;
 
 import org.micromanager.internal.utils.DefaultUserProfile;
@@ -50,6 +49,7 @@ public class DefaultDisplaySettings implements DisplaySettings {
     * Retrieve the display settings that have been saved in the preferences.
     * Note: we explicitly don't cache these settings, to ensure that
     * displays don't end up with copies of the same settings.
+    * @return 
     */
    public static DefaultDisplaySettings getStandardSettings() {
       DefaultUserProfile profile = DefaultUserProfile.getInstance();

--- a/mmstudio/src/org/micromanager/display/internal/DefaultDisplayWindow.java
+++ b/mmstudio/src/org/micromanager/display/internal/DefaultDisplayWindow.java
@@ -31,7 +31,6 @@ import ij.measure.Calibration;
 import ij.Menus;
 import ij.WindowManager;
 
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GraphicsConfiguration;
@@ -39,22 +38,17 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.Window;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
-import java.lang.Math;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.event.MouseInputAdapter;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -92,7 +86,6 @@ import org.micromanager.display.internal.events.StatusEvent;
 import org.micromanager.display.internal.inspector.InspectorFrame;
 import org.micromanager.display.internal.link.DisplayGroupManager;
 
-import org.micromanager.internal.LineProfile;
 
 import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.JavaUtils;
@@ -117,7 +110,7 @@ public class DefaultDisplayWindow extends MMFrame implements DisplayWindow {
       new InspectorFrame(null);
    }
 
-   private Datastore store_;
+   private final Datastore store_;
    private DisplaySettings displaySettings_;
    private MMVirtualStack stack_;
    private ImagePlus ijImage_;
@@ -130,7 +123,7 @@ public class DefaultDisplayWindow extends MMFrame implements DisplayWindow {
    private JFrame fullScreenFrame_;
 
    // Used to generate custom display controls.
-   private ControlsFactory controlsFactory_;
+   private final ControlsFactory controlsFactory_;
 
    // GUI components
    private JPanel contentsPanel_;
@@ -139,7 +132,7 @@ public class DefaultDisplayWindow extends MMFrame implements DisplayWindow {
    private JPanel controlsPanel_;
    private HyperstackControls hyperstackControls_;
 
-   private Object guiLock_ = new Object();
+   private final Object guiLock_ = new Object();
    private boolean haveCreatedGUI_ = false;
 
    // Used by the pack() method to track changes in our size.
@@ -170,7 +163,7 @@ public class DefaultDisplayWindow extends MMFrame implements DisplayWindow {
     * @param factory A ControlsFactory to create any extra controls for this
     *        display. May be null, in which case there will be no extra
     *        controls
-    * @param DisplaySettings The DisplaySettings to use for this display. May
+    * @param settings The DisplaySettings to use for this display. May
     *        be null, in which case default settings will be pulled from the
     *        user's profile.
     * @param title A custom title. May be null, in which case the title will

--- a/mmstudio/src/org/micromanager/display/internal/DisplayDestroyedEvent.java
+++ b/mmstudio/src/org/micromanager/display/internal/DisplayDestroyedEvent.java
@@ -27,12 +27,13 @@ import org.micromanager.display.DisplayWindow;
  * forceClosed() method.
  */
 public class DisplayDestroyedEvent implements org.micromanager.display.DisplayDestroyedEvent {
-   private DisplayWindow display_;
+   private final DisplayWindow display_;
 
    public DisplayDestroyedEvent(DisplayWindow display) {
       display_ = display;
    }
 
+   @Override
    public DisplayWindow getDisplay() {
       return display_;
    }

--- a/mmstudio/src/org/micromanager/display/internal/DummyImageWindow.java
+++ b/mmstudio/src/org/micromanager/display/internal/DummyImageWindow.java
@@ -20,7 +20,6 @@
 
 package org.micromanager.display.internal;
 
-import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
 import ij.gui.ImageCanvas;
@@ -49,7 +48,7 @@ import org.micromanager.internal.utils.ReportingUtils;
  */
 public class DummyImageWindow extends StackWindow {
    private static DefaultDisplayWindow staticMaster_;
-   private static ReentrantLock masterLock_ = new ReentrantLock();
+   private static final ReentrantLock masterLock_ = new ReentrantLock();
    /**
     * We have a problem. StackWindows automatically try to draw themselves,
     * and raise themselves to the front, as soon as they are created. We
@@ -88,6 +87,7 @@ public class DummyImageWindow extends StackWindow {
    /**
     * Instead of drawing to our canvas, draw to our master's.
     */
+   @Override
    public ImageCanvas getCanvas() {
       if (master_ == null) { // I.e. we're still in the StackWindow constructor
          return staticMaster_.getCanvas();

--- a/mmstudio/src/org/micromanager/display/internal/GearButton.java
+++ b/mmstudio/src/org/micromanager/display/internal/GearButton.java
@@ -25,14 +25,12 @@ import com.bulenkov.iconloader.IconLoader;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
-import java.awt.Window;
 
 import javax.swing.event.MouseInputAdapter;
 import javax.swing.JButton;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 
-import org.micromanager.data.Datastore;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.internal.inspector.InspectorFrame;
 import org.micromanager.internal.LineProfile;

--- a/mmstudio/src/org/micromanager/display/internal/MMCompositeImage.java
+++ b/mmstudio/src/org/micromanager/display/internal/MMCompositeImage.java
@@ -35,8 +35,8 @@ import org.micromanager.internal.utils.JavaUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 
 public class MMCompositeImage extends CompositeImage implements IMMImagePlus {
-   private ImagePlus hyperImage_;
-   private String title_;
+   private final ImagePlus hyperImage_;
+   private final String title_;
 
    public MMCompositeImage(ImagePlus imgp, int type, String title) {
       super(imgp, type);

--- a/mmstudio/src/org/micromanager/display/internal/MMImageCanvas.java
+++ b/mmstudio/src/org/micromanager/display/internal/MMImageCanvas.java
@@ -34,7 +34,6 @@ import java.awt.event.MouseEvent;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 
-import java.lang.Math;
 
 import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.DisplayWindow;

--- a/mmstudio/src/org/micromanager/display/internal/MMVirtualStack.java
+++ b/mmstudio/src/org/micromanager/display/internal/MMVirtualStack.java
@@ -52,11 +52,11 @@ import org.micromanager.internal.utils.ReportingUtils;
  * ever access an XYZTC volume.
  */
 public class MMVirtualStack extends ij.VirtualStack {
-   private Datastore store_;
-   private EventBus displayBus_;
+   private final Datastore store_;
+   private final EventBus displayBus_;
    private ImagePlus plus_;
    private Coords curCoords_;
-   private HashMap<Integer, Image> channelToLastValidImage_;
+   private final HashMap<Integer, Image> channelToLastValidImage_;
 
    public MMVirtualStack(Datastore store, EventBus displayBus,
          ImagePlus plus) {

--- a/mmstudio/src/org/micromanager/display/internal/ScaleBarOverlayFactory.java
+++ b/mmstudio/src/org/micromanager/display/internal/ScaleBarOverlayFactory.java
@@ -20,11 +20,11 @@
 
 package org.micromanager.display.internal;
 
-import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.OverlayPanel;
 import org.micromanager.display.OverlayPanelFactory;
 
 public class ScaleBarOverlayFactory implements OverlayPanelFactory {
+   @Override
    public OverlayPanel createOverlayPanel() {
       return new ScaleBarOverlayPanel();
    }

--- a/mmstudio/src/org/micromanager/display/internal/ScaleBarOverlayPanel.java
+++ b/mmstudio/src/org/micromanager/display/internal/ScaleBarOverlayPanel.java
@@ -38,13 +38,11 @@ import javax.swing.JTextField;
 import net.miginfocom.swing.MigLayout;
 
 import org.micromanager.data.Image;
-import org.micromanager.data.internal.DefaultPropertyMap;
 import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.OverlayPanel;
 import org.micromanager.PropertyMap;
 
-import org.micromanager.display.internal.events.DefaultRequestToDrawEvent;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.ReportingUtils;
 
@@ -65,18 +63,18 @@ public class ScaleBarOverlayPanel extends OverlayPanel {
          Color.red, Color.magenta, Color.blue, Color.cyan, Color.green};
    // Would you believe this isn't built-in to the Color module? Naturally
    // this list of names must match the list of colors, above.
-   private static String[] COLORNAMES = new String[] {
+   private static final String[] COLORNAMES = new String[] {
       "Black", "White", "Gray", "Yellow", "Orange", "Red", "Magenta",
          "Blue", "Cyan", "Green"
    };
 
-   private JCheckBox shouldDrawText_;
-   private JCheckBox isBarFilled_;
-   private JComboBox color_;
-   private JTextField xOffset_;
-   private JTextField yOffset_;
-   private JTextField scaleSize_;
-   private JComboBox position_;
+   private final JCheckBox shouldDrawText_;
+   private final JCheckBox isBarFilled_;
+   private final JComboBox color_;
+   private final JTextField xOffset_;
+   private final JTextField yOffset_;
+   private final JTextField scaleSize_;
+   private final JComboBox position_;
 
    private boolean haveLoggedError_ = false;
    

--- a/mmstudio/src/org/micromanager/display/internal/ScrollbarAnimateIcon.java
+++ b/mmstudio/src/org/micromanager/display/internal/ScrollbarAnimateIcon.java
@@ -35,18 +35,18 @@ import javax.swing.JButton;
  * and is used for handling animation of an AxisScroller.
  */
 public class ScrollbarAnimateIcon extends JButton {
-   private static final int WIDTH = 30;
-   private static final int HEIGHT = 18;
+   private static final int ICONWIDTH = 30;
+   private static final int ICONHEIGHT = 18;
    private static final Icon PLAY_ICON = IconLoader.getIcon(
          "/org/micromanager/internal/icons/play.png");
    private static final Icon PAUSE_ICON = IconLoader.getIcon(
          "/org/micromanager/internal/icons/pause.png");
-   private String label_;
+   private final String label_;
    private boolean isAnimated_;
 
    public ScrollbarAnimateIcon(final String axis, final ScrollerPanel parent) {
       super(PLAY_ICON);
-      setSize(WIDTH, HEIGHT);
+      setSize(ICONWIDTH, ICONHEIGHT);
       // Only use the first letter of the axis.
       label_ = axis.substring(0, 1);
       setText(label_);
@@ -73,11 +73,11 @@ public class ScrollbarAnimateIcon extends JButton {
    /** Don't require more space than is needed to show the icon. */
    @Override
    public Dimension getPreferredSize() {
-      return new Dimension(WIDTH, HEIGHT);
+      return new Dimension(ICONWIDTH, ICONHEIGHT);
    }
    @Override
    public Dimension getMinimumSize() {
-      return new Dimension(WIDTH, HEIGHT);
+      return new Dimension(ICONWIDTH, ICONHEIGHT);
    }
 }
 

--- a/mmstudio/src/org/micromanager/display/internal/ScrollbarLockIcon.java
+++ b/mmstudio/src/org/micromanager/display/internal/ScrollbarLockIcon.java
@@ -25,11 +25,7 @@ import com.bulenkov.iconloader.IconLoader;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
-import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
 import java.awt.event.MouseEvent;
 
 import java.util.HashMap;
@@ -72,8 +68,8 @@ public class ScrollbarLockIcon extends JButton {
     * This event informs listeners of when the lock button is toggled.
     */
    public static class LockEvent {
-      private String axis_;
-      private LockedState lockedState_;
+      private final String axis_;
+      private final LockedState lockedState_;
       public LockEvent(String axis, LockedState lockedState) {
          axis_ = axis;
          lockedState_ = lockedState;
@@ -90,7 +86,7 @@ public class ScrollbarLockIcon extends JButton {
     * This event causes other lock icons to be updated to match our state.
     */
    public static class ForceLockEvent {
-      private LockedState state_;
+      private final LockedState state_;
       public ForceLockEvent(LockedState state) {
          state_ = state;
       }
@@ -101,8 +97,8 @@ public class ScrollbarLockIcon extends JButton {
    }
 
    private LockedState lockedState_;
-   private String axis_;
-   private EventBus bus_;
+   private final String axis_;
+   private final EventBus bus_;
    
    public ScrollbarLockIcon(final String axis, final EventBus bus) {
       // Start out unlocked.

--- a/mmstudio/src/org/micromanager/display/internal/ScrollerPanel.java
+++ b/mmstudio/src/org/micromanager/display/internal/ScrollerPanel.java
@@ -33,7 +33,6 @@ import java.awt.event.MouseEvent;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Timer;
@@ -129,7 +128,7 @@ public class ScrollerPanel extends JPanel {
    private final DisplayWindow parent_;
    private final Thread updateThread_;
    private final LinkedBlockingQueue<Coords> updateQueue_;
-   private AtomicBoolean shouldStopUpdates_;
+   private final AtomicBoolean shouldStopUpdates_;
 
    private final HashMap<String, AxisState> axisToState_;
    private final HashMap<String, Integer> axisToSavedPosition_;

--- a/mmstudio/src/org/micromanager/display/internal/TimestampOverlayFactory.java
+++ b/mmstudio/src/org/micromanager/display/internal/TimestampOverlayFactory.java
@@ -20,11 +20,11 @@
 
 package org.micromanager.display.internal;
 
-import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.OverlayPanel;
 import org.micromanager.display.OverlayPanelFactory;
 
 public class TimestampOverlayFactory implements OverlayPanelFactory {
+   @Override
    public OverlayPanel createOverlayPanel() {
       return new TimestampOverlayPanel();
    }

--- a/mmstudio/src/org/micromanager/display/internal/TimestampOverlayPanel.java
+++ b/mmstudio/src/org/micromanager/display/internal/TimestampOverlayPanel.java
@@ -50,21 +50,20 @@ import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.OverlayPanel;
 
-import org.micromanager.display.internal.events.DefaultRequestToDrawEvent;
 
 /**
  * This overlay draws the timestamps of the currently-displayed images.
  */
 public class TimestampOverlayPanel extends OverlayPanel {
-   private static int LINE_HEIGHT = 13;
+   private static final int LINE_HEIGHT = 13;
 
-   private JCheckBox shouldDraw_;
-   private JCheckBox amMultiChannel_;
-   private JCheckBox shouldDrawBackground_;
-   private JTextField xOffset_;
-   private JTextField yOffset_;
-   private JComboBox position_;
-   private JComboBox color_;
+   private final JCheckBox shouldDraw_;
+   private final JCheckBox amMultiChannel_;
+   private final JCheckBox shouldDrawBackground_;
+   private final JTextField xOffset_;
+   private final JTextField yOffset_;
+   private final JComboBox position_;
+   private final JComboBox color_;
 
    public TimestampOverlayPanel() {
       setLayout(new MigLayout("flowx"));


### PR DESCRIPTION
Mainly removal of superfluous imports, making variables final whenever possible and avoiding hiding names used in superclass