### PR TITLE
Prevent repeated loading of plugins contained in MMJ_.jar

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
@@ -167,6 +167,7 @@ public class DefaultPluginManager implements PluginManager {
       // MMPlugin in loadPlugins(), below.
       loadPlugins(PluginFinder.findPluginsWithLoader(
             getClass().getClassLoader()));
+
       ReportingUtils.logMessage("Plugin loading took " +
             (System.currentTimeMillis() - startTime) + "ms");
    }


### PR DESCRIPTION
Fixes issue #110 and clarifies the behavior of the class loader used by
plugins (once plugin discovery is finished, it is just a URLClassLoader).