### PR TITLE
Reduced dependency of OughtaFocus on internal components and reduced use of math commons 2

### DIFF
--- a/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
@@ -55,12 +55,12 @@ import org.json.JSONException;
 
 import org.micromanager.AutofocusPlugin;
 import org.micromanager.Studio;
+
 import org.micromanager.internal.utils.AutofocusBase;
 import org.micromanager.internal.utils.ImageUtils;
 import org.micromanager.internal.utils.MDUtils;
 import org.micromanager.internal.utils.MMException;
 import org.micromanager.internal.utils.MMScriptException;
-import org.micromanager.internal.utils.MathFunctions;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.internal.utils.TextUtils;
@@ -164,13 +164,13 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
          searchRange = NumberUtils.displayStringToDouble(getPropertyValue(SEARCH_RANGE));
          absTolerance = NumberUtils.displayStringToDouble(getPropertyValue(TOLERANCE));
          cropFactor = NumberUtils.displayStringToDouble(getPropertyValue(CROP_FACTOR));
-         cropFactor = MathFunctions.clip(0.01, cropFactor, 1.0);
+         cropFactor = clip(0.01, cropFactor, 1.0);
          channel = getPropertyValue(CHANNEL);
          exposure = NumberUtils.displayStringToDouble(getPropertyValue(EXPOSURE));
          fftLowerCutoff = NumberUtils.displayStringToDouble(getPropertyValue(FFT_LOWER_CUTOFF));
-         fftLowerCutoff = MathFunctions.clip(0.0, fftLowerCutoff, 100.0);
+         fftLowerCutoff = clip(0.0, fftLowerCutoff, 100.0);
          fftUpperCutoff = NumberUtils.displayStringToDouble(getPropertyValue(FFT_UPPER_CUTOFF));
-         fftUpperCutoff = MathFunctions.clip(0.0, fftUpperCutoff, 100.0);
+         fftUpperCutoff = clip(0.0, fftUpperCutoff, 100.0);
          show = getPropertyValue(SHOW_IMAGES);
          scoringMethod = getPropertyValue(SCORING_METHOD);
 
@@ -972,6 +972,10 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
          super.loadSettings();
          settingsLoaded_ = true;
       }
+   }
+   
+   private static double clip(double min, double val, double max) {
+      return Math.min(Math.max(min, val), max);
    }
 
    @Override

--- a/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
@@ -62,7 +62,6 @@ import org.micromanager.internal.utils.MDUtils;
 import org.micromanager.internal.utils.MMException;
 import org.micromanager.internal.utils.MMScriptException;
 import org.micromanager.internal.utils.NumberUtils;
-import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.internal.utils.TextUtils;
 
 import org.scijava.plugin.Plugin;
@@ -175,9 +174,9 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
          scoringMethod = getPropertyValue(SCORING_METHOD);
 
       } catch (MMException ex) {
-         ReportingUtils.logError(ex);
+         app_.logs().logError(ex);
       } catch (ParseException ex) {
-         ReportingUtils.logError(ex);
+         app_.logs().logError(ex);
       }
    }
 
@@ -276,7 +275,7 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
               GoalType.MAXIMIZE,
               new MaxEval(100),
               new SearchInterval(z - searchRange / 2, z + searchRange / 2));
-      ReportingUtils.logMessage("OughtaFocus Iterations: " + brentOptimizer.getIterations()
+      app_.logs().logMessage("OughtaFocus Iterations: " + brentOptimizer.getIterations()
               + ", z=" + TextUtils.FMT2.format(result.getPoint())
               + ", dz=" + TextUtils.FMT2.format(result.getPoint() - startZUm_)
               + ", t=" + (System.currentTimeMillis() - startTimeMs_));
@@ -362,14 +361,14 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
          ImageProcessor proc = makeMonochromeProcessor(core, getMonochromePixels(img));
          double score = computeScore(proc);
          long tC = System.currentTimeMillis() - start - tZ - tI;
-         ReportingUtils.logMessage("OughtaFocus: image=" + imageCount_++
+         app_.logs().logMessage("OughtaFocus: image=" + imageCount_++
                  + ", t=" + (System.currentTimeMillis() - startTimeMs_)
                  + ", z=" + TextUtils.FMT2.format(z)
                  + ", score=" + TextUtils.FMT2.format(score)
                  + ", Tz=" + tZ + ", Ti=" + tI + ", Tc=" + tC);
          return score;
       } catch (Exception e) {
-         ReportingUtils.logError(e);
+         app_.logs().logError(e);
          throw e;
       }
    }
@@ -403,10 +402,10 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
          }
          ImageProcessor proc = ImageUtils.makeProcessor(core, img);
          score = computeScore(proc);
-         ReportingUtils.logMessage("OughtaFocus: z=" + TextUtils.FMT2.format(z)
+         app_.logs().logMessage("OughtaFocus: z=" + TextUtils.FMT2.format(z)
                  + ", score=" + TextUtils.FMT2.format(score));
       } catch (Exception e) {
-         ReportingUtils.logError(e);
+         app_.logs().logError(e);
       }
       return score;
    }
@@ -583,7 +582,7 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
          ps.setRoi(outerCutoff);
          return ps.getStatistics().mean;
       } catch (Exception e) {
-         ReportingUtils.logError(e);
+         app_.logs().logError(e);
          return 0;
       }
    }
@@ -965,7 +964,7 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
          createProperty(CHANNEL, curChan,
                  core.getAvailableConfigs(core.getChannelGroup()).toArray());
       } catch (Exception ex) {
-         ReportingUtils.logError(ex);
+         app_.logs().logError(ex);
       }
 
       if (!settingsLoaded_) {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/MathFunctions.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/MathFunctions.java
@@ -22,14 +22,16 @@
 package org.micromanager.internal.utils;
 
 import java.awt.geom.NoninvertibleTransformException;
-import org.apache.commons.math.linear.DecompositionSolver;
-import org.apache.commons.math.linear.RealMatrix;
+
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.math.linear.Array2DRowRealMatrix;
-import org.apache.commons.math.linear.QRDecompositionImpl;
+
+import org.apache.commons.math3.linear.DecompositionSolver;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.Array2DRowRealMatrix;
+import org.apache.commons.math3.linear.QRDecomposition;
 
 public class MathFunctions {
 
@@ -65,7 +67,7 @@ public class MathFunctions {
       }
       // Find the 3x3 linear least squares solution to u*m'=v
       // (the last row should be [0,0,1]):
-      DecompositionSolver solver = (new QRDecompositionImpl(u)).getSolver();
+      DecompositionSolver solver = (new QRDecomposition(u)).getSolver();
       double[][] m = solver.solve(v).transpose().getData();
 
       // Create an AffineTransform object from the elements of m

--- a/mmstudio/src/test/java/org/micromanager/internal/utils/MathFunctionsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/internal/utils/MathFunctionsTest.java
@@ -5,6 +5,7 @@ package org.micromanager.internal.utils;
 import java.util.Map;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
+import java.util.HashMap;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -24,7 +25,7 @@ public class MathFunctionsTest {
       pointPairs.put(new Point2D.Double(9, 1), new Point2D.Double(18, 18));
 
       // Run the computation to be tested:
-      AffineTransform affineTransform = generateAffineTransformFromPointPairs(pointPairs);
+      AffineTransform affineTransform = MathFunctions.generateAffineTransformFromPointPairs(pointPairs);
 
       // Print input and output:
       // System.out.println(pointPairs);

--- a/mmstudio/src/test/java/org/micromanager/internal/utils/MathFunctionsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/internal/utils/MathFunctionsTest.java
@@ -1,0 +1,42 @@
+
+
+package org.micromanager.internal.utils;
+
+import java.util.Map;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MathFunctionsTest {
+
+   @Test
+   public void runAffineTest() {
+
+      final double delta = 0.0000000001;
+      Map<Point2D.Double, Point2D.Double> pointPairs = 
+         new HashMap<Point2D.Double, Point2D.Double>();
+
+      // Create sample src and dest points:
+      pointPairs.put(new Point2D.Double(1, 1), new Point2D.Double(18, 2));
+      pointPairs.put(new Point2D.Double(1, 9), new Point2D.Double(2, 2));
+      pointPairs.put(new Point2D.Double(9, 9), new Point2D.Double(2, 18));
+      pointPairs.put(new Point2D.Double(9, 1), new Point2D.Double(18, 18));
+
+      // Run the computation to be tested:
+      AffineTransform affineTransform = generateAffineTransformFromPointPairs(pointPairs);
+
+      // Print input and output:
+      // System.out.println(pointPairs);
+      // System.out.println(affineTransform);
+
+      // Check that affineTransform works correctly:
+      for (Map.Entry pair : pointPairs.entrySet()) {
+         Point2D.Double uPt = (Point2D.Double) pair.getKey();
+         Point2D.Double vPt = (Point2D.Double) pair.getValue();
+         Point2D.Double result = new Point2D.Double();
+         affineTransform.transform(uPt, result);
+         assertEquals(0.0, vPt.distance(result), delta);
+      }
+   }
+}


### PR DESCRIPTION
Uncoupled OughtaFocus from internal.MathFunctions.  Also ported MathFunctions from math commons 2 to 3.  Tested with build-in test function.  This class is possibly only used in Projector plugin, in which case it would be moved there. Reason:  I need to use OughtaFocus with the diSPIM and MMClearVolume plugins and want to reduce the dependencies I need to bring into the MMClearVolume project to get it to run under Netbeans. Also, generally useful to get rid of math commons 2 and to reduce dependencies on internal classes.