### PR TITLE
Fix user profile not saved on linux machine

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/utils/DefaultUserProfile.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/DefaultUserProfile.java
@@ -601,9 +601,14 @@ public class DefaultUserProfile implements UserProfile {
             }
             destination.renameTo(backup);
          }
-         if (!tempFile.renameTo(destination)) {
-            ReportingUtils.logError("Unable to move exported property map to " + path + "; temporary backup file is available at " + tempFile.getAbsolutePath());
-         }
+         
+          try {
+              Files.move(tempFile, destination);
+          } catch (IOException e) {
+              ReportingUtils.logError(e);
+              ReportingUtils.logError("Unable to move exported property map to " + path + "; temporary backup file is available at " + tempFile.getAbsolutePath());
+          }
+         
       }
       catch (FileNotFoundException e) {
          ReportingUtils.logError(e, "Unable to open writer to save user profile mapping file");


### PR DESCRIPTION
I have a constant log error : `unable to move user profile to ~/.config/Micro-manager`. The directory can be written and the user profile file in `/tmp` exists.

The bug appears on java 1.6 and java 1.8.

Replacing `renameTo` by `Files.move` makes it work.

What do you think ?