### PR TITLE
Remove error window message in Flat Field plugin 

### DIFF
--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
@@ -335,7 +335,7 @@ public class MultiChannelShadingMigForm extends MMDialog implements ProcessorCon
                  DARKFIELDFILENAME, backgroundFileName_);
          studio_.data().notifyPipelineChanged();
       } catch (MMException ex) {
-         studio_.logs().showError(ex, "Failed to set background image");
+         studio_.logs().logError(ex, "Failed to set background image");
          return "";
       }
       return fileName;


### PR DESCRIPTION
I am not sure if you will accept this PR but I found very annoying to have an additional window with an error message opening when the dark image has been removed from the hard drive in the Flat field plugin ...

MM should be silent about it in my opinion.

Did you consider adding a "Log Window" ? The same way Fiji did recently ? So users without a dev environment would be able to see the log in real time instead of having to open `CoreLogs/*.txt` files.