### PR TITLE
Add an option to disable the use of the ROI pixels 

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -182,6 +182,7 @@ public interface DisplaySettings {
       DisplaySettingsBuilder histogramUpdateRate(Double histogramUpdateRate);
       DisplaySettingsBuilder shouldSyncChannels(Boolean shouldSyncChannels);
       DisplaySettingsBuilder shouldAutostretch(Boolean shouldAutostretch);
+      DisplaySettingsBuilder shouldScaleWithROI(Boolean shouldScaleWithROI);
       DisplaySettingsBuilder extremaPercentage(Double extremaPercentage);
       DisplaySettingsBuilder bitDepthIndices(Integer[] bitDepthIndices);
       DisplaySettingsBuilder shouldUseLogScale(Boolean shouldUseLogScale);
@@ -359,6 +360,12 @@ public interface DisplaySettings {
     * @return True if new images should be auto-stretched
     */
    public Boolean getShouldAutostretch();
+   
+   /**
+    * Whether each newly-displayed image should use the pixels inside the ROI to scale the contrast.
+    * @return True if ROI should be used
+    */
+   public Boolean getShouldScaleWithROI();
 
    /**
     * The percentage of values off the top and bottom of the image's value

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -362,7 +362,7 @@ public interface DisplaySettings {
    public Boolean getShouldAutostretch();
    
    /**
-    * Whether each newly-displayed image should use the pixels inside the ROI to scale the contrast.
+    * Whether histogram calculations should use only the pixels in the current ROI.
     * @return True if ROI should be used
     */
    public Boolean getShouldScaleWithROI();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/ContrastCalculator.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/ContrastCalculator.java
@@ -63,6 +63,7 @@ public class ContrastCalculator {
       private final double extremaPercentage_;
       private final int depthPower_;
       private final boolean shouldCalcStdDev_;
+      private final boolean shouldScaleWithROI_;
 
       private int minVal_;
       private int maxVal_;
@@ -72,7 +73,7 @@ public class ContrastCalculator {
 
       public InternalCalculator(Image image, ImagePlus plus, int component,
             int binPower, int depthPower, double extremaPercentage,
-            boolean shouldCalcStdDev) {
+            boolean shouldCalcStdDev, boolean shouldScaleWithROI) {
          width_ = image.getWidth();
          height_ = image.getHeight();
          bytesPerPixel_ = image.getBytesPerPixel();
@@ -81,6 +82,7 @@ public class ContrastCalculator {
          depthPower_ = depthPower;
          extremaPercentage_ = extremaPercentage;
          shouldCalcStdDev_ = shouldCalcStdDev;
+         shouldScaleWithROI_ = shouldScaleWithROI;
 
          minVal_ = Integer.MAX_VALUE;
          maxVal_ = Integer.MIN_VALUE;
@@ -97,7 +99,7 @@ public class ContrastCalculator {
          // Get ROI information. This consists of a rectangle containing the
          // ROI, and then, for non-rectangular ROIs, a pixel mask (fortunately
          // not a *bit* mask though; each byte is one pixel).
-         if (plus != null) {
+         if (plus != null && shouldScaleWithROI_) {
             if (plus.getMask() != null) {
                maskPixels_ = (byte[]) (plus.getMask().getPixels());
             }
@@ -479,9 +481,9 @@ public class ContrastCalculator {
     */
    public static HistogramData calculateHistogram(Image image,
          ImagePlus plus, int component, int binPower, int depthPower,
-         double extremaPercentage, boolean shouldCalcStdDev) {
+         double extremaPercentage, boolean shouldCalcStdDev, boolean shouldScaleWithROI) {
       return new InternalCalculator(image, plus, component, binPower,
-            depthPower, extremaPercentage, shouldCalcStdDev).calculate();
+            depthPower, extremaPercentage, shouldCalcStdDev, shouldScaleWithROI).calculate();
    }
 
    /**
@@ -503,6 +505,6 @@ public class ContrastCalculator {
       // We use the bit depth as the bin power, so that each individual
       // intensity gets its own bin.
       return calculateHistogram(image, plus, component, bitDepth, bitDepth,
-            percentage, shouldStdDev);
+            percentage, shouldStdDev, settings.getShouldScaleWithROI());
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/ContrastCalculator.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/ContrastCalculator.java
@@ -502,9 +502,13 @@ public class ContrastCalculator {
       if (shouldStdDev == null) {
          shouldStdDev = false;
       }
+      Boolean shouldScaleWithROI = settings.getShouldScaleWithROI();
+      if (shouldScaleWithROI == null) {
+         shouldScaleWithROI = true;
+      }
       // We use the bit depth as the bin power, so that each individual
       // intensity gets its own bin.
       return calculateHistogram(image, plus, component, bitDepth, bitDepth,
-            percentage, shouldStdDev, settings.getShouldScaleWithROI());
+            percentage, shouldStdDev, shouldScaleWithROI);
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -193,7 +193,8 @@ public final class DefaultDisplayManager implements DisplayManager {
          int binPower, int bitDepth, double extremaPercentage,
          boolean shouldCalcStdDev) {
       return ContrastCalculator.calculateHistogram(image, null, component,
-            binPower, bitDepth, extremaPercentage, shouldCalcStdDev);
+            binPower, bitDepth, extremaPercentage, shouldCalcStdDev,
+            getStandardDisplaySettings().getShouldScaleWithROI());
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -192,9 +192,14 @@ public final class DefaultDisplayManager implements DisplayManager {
    public HistogramData calculateHistogram(Image image, int component,
          int binPower, int bitDepth, double extremaPercentage,
          boolean shouldCalcStdDev) {
+      
+      Boolean shouldScaleWithROI = getStandardDisplaySettings().getShouldScaleWithROI();
+      if (shouldScaleWithROI == null) {
+         shouldScaleWithROI = true;
+      }
+      
       return ContrastCalculator.calculateHistogram(image, null, component,
-            binPower, bitDepth, extremaPercentage, shouldCalcStdDev,
-            getStandardDisplaySettings().getShouldScaleWithROI());
+            binPower, bitDepth, extremaPercentage, shouldCalcStdDev, shouldScaleWithROI);
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -57,6 +57,7 @@ public class DefaultDisplaySettings implements DisplaySettings {
    private static final String MAGNIFICATION = "magnification";
    private static final String SHOULD_SYNC_CHANNELS = "shouldSyncChannels";
    private static final String SHOULD_AUTOSTRETCH = "shouldAutostretch";
+   private static final String SHOULD_SCALE_WITH_ROI = "shouldScaleWithROI";
    private static final String EXTREMA_PERCENTAGE = "extremaPercentage";
    private static final String BIT_DEPTH_INDICES = "bitDepthIndices";
    private static final String SHOULD_USE_LOG_SCALE = "shouldUseLogScale";
@@ -104,6 +105,9 @@ public class DefaultDisplaySettings implements DisplaySettings {
       builder.shouldAutostretch(profile.getBoolean(
             DefaultDisplaySettings.class,
                key + SHOULD_AUTOSTRETCH, true));
+      builder.shouldScaleWithROI(profile.getBoolean(
+            DefaultDisplaySettings.class,
+               key + SHOULD_SCALE_WITH_ROI, true));
       builder.extremaPercentage(profile.getDouble(
             DefaultDisplaySettings.class,
                key + EXTREMA_PERCENTAGE, 0.0));
@@ -146,6 +150,8 @@ public class DefaultDisplaySettings implements DisplaySettings {
             key + SHOULD_SYNC_CHANNELS, settings.getShouldSyncChannels());
       profile.setBoolean(DefaultDisplaySettings.class,
             key + SHOULD_AUTOSTRETCH, settings.getShouldAutostretch());
+      profile.setBoolean(DefaultDisplaySettings.class,
+            key + SHOULD_SCALE_WITH_ROI, settings.getShouldScaleWithROI());
       profile.setDouble(DefaultDisplaySettings.class,
             key + EXTREMA_PERCENTAGE, settings.getExtremaPercentage());
       profile.setIntArray(DefaultDisplaySettings.class,
@@ -343,6 +349,7 @@ public class DefaultDisplaySettings implements DisplaySettings {
       private Double histogramUpdateRate_ = null;
       private Boolean shouldSyncChannels_ = null;
       private Boolean shouldAutostretch_ = null;
+      private Boolean shouldScaleWithROI_ = null;
       private Double extremaPercentage_ = null;
       private Integer[] bitDepthIndices_ = null;
       private Boolean shouldUseLogScale_ = null;
@@ -444,6 +451,12 @@ public class DefaultDisplaySettings implements DisplaySettings {
          shouldAutostretch_ = shouldAutostretch;
          return this;
       }
+      
+      @Override
+      public DisplaySettingsBuilder shouldScaleWithROI(Boolean shouldScaleWithROI) {
+         shouldScaleWithROI_ = shouldScaleWithROI;
+         return this;
+      }
 
       @Override
       public DisplaySettingsBuilder extremaPercentage(Double extremaPercentage) {
@@ -484,6 +497,7 @@ public class DefaultDisplaySettings implements DisplaySettings {
    private Double histogramUpdateRate_ = null;
    private Boolean shouldSyncChannels_ = null;
    private Boolean shouldAutostretch_ = null;
+   private Boolean shouldScaleWithROI_ = null;
    private Double extremaPercentage_ = null;
    private Integer[] bitDepthIndices_ = null;
    private Boolean shouldUseLogScale_ = null;
@@ -499,6 +513,7 @@ public class DefaultDisplaySettings implements DisplaySettings {
       histogramUpdateRate_ = builder.histogramUpdateRate_;
       shouldSyncChannels_ = builder.shouldSyncChannels_;
       shouldAutostretch_ = builder.shouldAutostretch_;
+      shouldScaleWithROI_ = builder.shouldScaleWithROI_;
       extremaPercentage_ = builder.extremaPercentage_;
       bitDepthIndices_ = builder.bitDepthIndices_;
       shouldUseLogScale_ = builder.shouldUseLogScale_;
@@ -610,6 +625,11 @@ public class DefaultDisplaySettings implements DisplaySettings {
    public Boolean getShouldAutostretch() {
       return shouldAutostretch_;
    }
+   
+   @Override
+   public Boolean getShouldScaleWithROI() {
+      return shouldScaleWithROI_;
+   }
 
    @Override
    public Double getExtremaPercentage() {
@@ -658,6 +678,7 @@ public class DefaultDisplaySettings implements DisplaySettings {
             .histogramUpdateRate(histogramUpdateRate_)
             .shouldSyncChannels(shouldSyncChannels_)
             .shouldAutostretch(shouldAutostretch_)
+            .shouldScaleWithROI(shouldScaleWithROI_)
             .extremaPercentage(extremaPercentage_)
             .bitDepthIndices(bitDepthIndices_)
             .shouldUseLogScale(shouldUseLogScale_)
@@ -741,6 +762,9 @@ public class DefaultDisplaySettings implements DisplaySettings {
          }
          if (tags.has(SHOULD_AUTOSTRETCH)) {
             builder.shouldAutostretch(tags.getBoolean(SHOULD_AUTOSTRETCH));
+         }
+         if (tags.has(SHOULD_SCALE_WITH_ROI)) {
+            builder.shouldScaleWithROI(tags.getBoolean(SHOULD_SCALE_WITH_ROI));
          }
          if (tags.has(EXTREMA_PERCENTAGE)) {
             builder.extremaPercentage(tags.getDouble(EXTREMA_PERCENTAGE));
@@ -888,6 +912,7 @@ public class DefaultDisplaySettings implements DisplaySettings {
          result.put(HISTOGRAM_UPDATE_RATE, histogramUpdateRate_);
          result.put(SHOULD_SYNC_CHANNELS, shouldSyncChannels_);
          result.put(SHOULD_AUTOSTRETCH, shouldAutostretch_);
+         result.put(SHOULD_SCALE_WITH_ROI, shouldScaleWithROI_);
          result.put(EXTREMA_PERCENTAGE, extremaPercentage_);
          if (bitDepthIndices_ != null && bitDepthIndices_.length > 0) {
             JSONArray indices = new JSONArray();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/inspector/HistogramsPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/inspector/HistogramsPanel.java
@@ -95,7 +95,7 @@ public final class HistogramsPanel extends InspectorPanel {
    // histograms. Make this a static singleton, maybe?
    private final HashMap<DataViewer, ArrayList<ChannelControlPanel>> displayToPanels_;
    private JCheckBox shouldAutostretch_;
-   private JCheckBox shouldScaleWithROI;
+   private JCheckBoxMenuItem shouldScaleWithROI;
    private JLabel extremaLabel_;
    private JSpinner extrema_;
    private JLabel percentLabel_;
@@ -244,26 +244,6 @@ public final class HistogramsPanel extends InspectorPanel {
             boolean newVal = shouldAutostretch_.isSelected();
             DisplaySettings newSettings = viewer_.getDisplaySettings()
                   .copy().shouldAutostretch(newVal).build();
-            viewer_.setDisplaySettings(newSettings);
-         }
-      });
-      
-      boolean shouldScaleWithROISetting = true;
-      if (viewer_.getDisplaySettings().getShouldScaleWithROI() != null) {
-         shouldScaleWithROISetting = viewer_.getDisplaySettings().getShouldScaleWithROI();
-      }
-      
-      shouldScaleWithROI = new JCheckBox("Use ROI When Scaling");
-      shouldScaleWithROI.setSelected(shouldScaleWithROISetting);
-      shouldScaleWithROI.setToolTipText("Use the pixels inside the ROI to rescale the histograms.");
-      add(shouldScaleWithROI, "gapleft 10");
-      
-      shouldScaleWithROI.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            boolean newVal = shouldScaleWithROI.isSelected();
-            DisplaySettings newSettings = viewer_.getDisplaySettings()
-                  .copy().shouldScaleWithROI(newVal).build();
             viewer_.setDisplaySettings(newSettings);
          }
       });
@@ -572,6 +552,26 @@ public final class HistogramsPanel extends InspectorPanel {
       updateRate.add(oncePerSec);
       updateRate.add(never);
       result.add(updateRate);
+      
+      boolean shouldScaleWithROISetting = true;
+      if (viewer_.getDisplaySettings().getShouldScaleWithROI() != null) {
+         shouldScaleWithROISetting = viewer_.getDisplaySettings().getShouldScaleWithROI();
+      }
+      
+      shouldScaleWithROI = new JCheckBoxMenuItem("Use ROI When Scaling");
+      shouldScaleWithROI.setSelected(shouldScaleWithROISetting);
+      shouldScaleWithROI.setToolTipText("Use the pixels inside the ROI to rescale the histograms.");
+      result.add(shouldScaleWithROI);
+      
+      shouldScaleWithROI.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            boolean newVal = shouldScaleWithROI.isSelected();
+            DisplaySettings newSettings = viewer_.getDisplaySettings()
+                  .copy().shouldScaleWithROI(newVal).build();
+            viewer_.setDisplaySettings(newSettings);
+         }
+      });
 
       return result;
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/inspector/HistogramsPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/inspector/HistogramsPanel.java
@@ -95,6 +95,7 @@ public final class HistogramsPanel extends InspectorPanel {
    // histograms. Make this a static singleton, maybe?
    private final HashMap<DataViewer, ArrayList<ChannelControlPanel>> displayToPanels_;
    private JCheckBox shouldAutostretch_;
+   private JCheckBox shouldScaleWithROI;
    private JLabel extremaLabel_;
    private JSpinner extrema_;
    private JLabel percentLabel_;
@@ -200,7 +201,7 @@ public final class HistogramsPanel extends InspectorPanel {
       add(new JLabel("Color mode: "), "split 2, flowx, gapleft 15");
       ColorModeCombo colorModeCombo = new ColorModeCombo(viewer_);
       add(colorModeCombo, "align right");
-
+      
       boolean shouldAutostretchSetting = true;
       if (viewer_.getDisplaySettings().getShouldAutostretch() != null) {
          shouldAutostretchSetting = viewer_.getDisplaySettings().getShouldAutostretch();
@@ -246,6 +247,27 @@ public final class HistogramsPanel extends InspectorPanel {
             viewer_.setDisplaySettings(newSettings);
          }
       });
+      
+      boolean shouldScaleWithROISetting = true;
+      if (viewer_.getDisplaySettings().getShouldScaleWithROI() != null) {
+         shouldScaleWithROISetting = viewer_.getDisplaySettings().getShouldScaleWithROI();
+      }
+      
+      shouldScaleWithROI = new JCheckBox("Use ROI When Scaling");
+      shouldScaleWithROI.setSelected(shouldScaleWithROISetting);
+      shouldScaleWithROI.setToolTipText("Use the pixels inside the ROI to rescale the histograms.");
+      add(shouldScaleWithROI, "gapleft 10");
+      
+      shouldScaleWithROI.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            boolean newVal = shouldScaleWithROI.isSelected();
+            DisplaySettings newSettings = viewer_.getDisplaySettings()
+                  .copy().shouldScaleWithROI(newVal).build();
+            viewer_.setDisplaySettings(newSettings);
+         }
+      });
+      
    }
 
    private void setExtremaPercentage(JSpinner extrema) {


### PR DESCRIPTION
Add an option to disable the use of the ROI pixels for scaling the intensity of the image displayed. See #262 for discussion.

@ChrisWeisiger I added the option to the histogram panel (not in the gear menu) because I already did it when I saw your message. I like it here but if you want me to move it to the gear menu, I'll do it.