### PR TITLE
fix for warnings C4456 in VS2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ test-reports/
 /MMCorePy_wrap/MMCorePy_wrap.h
 /DeviceAdapters/DirectElectron/src/DEMessaging/DEServer.pb.cc
 /DeviceAdapters/DirectElectron/src/DEMessaging/DEServer.pb.h
+*.opendb
+micromanager.VC.db

--- a/MMDevice/ImageMetadata.h
+++ b/MMDevice/ImageMetadata.h
@@ -467,7 +467,7 @@ public:
             as.SetReadOnly(atoi(readLine(is).c_str()) == 1 ? true : false);
 
             long sizea = atol(readLine(is).c_str());
-            for (long i=0; i<sizea; i++)
+            for (long j=0; j<sizea; j++)
             {
                as.AddValue(readLine(is).c_str());
             }

--- a/MMDevice/ImgBuffer.cpp
+++ b/MMDevice/ImgBuffer.cpp
@@ -234,8 +234,8 @@ bool FrameBuffer::SetImage(unsigned channel, unsigned slice, const ImgBuffer& im
    else
    {
       // create a new buffer
-      ImgBuffer* img = InsertNewImage(channel, slice);
-      *img = imgBuf;
+      ImgBuffer* img2 = InsertNewImage(channel, slice);
+      *img2 = imgBuf;
    }
 
    return true;
@@ -267,8 +267,8 @@ bool FrameBuffer::SetPixels(unsigned channel, unsigned slice, const unsigned cha
    else
    {
       // create a new buffer
-      ImgBuffer* img = InsertNewImage(channel, slice);
-      img->SetPixels(pixels);
+      ImgBuffer* img2 = InsertNewImage(channel, slice);
+      img2->SetPixels(pixels);
    }
 
    return true;


### PR DESCRIPTION
Avoid using the name of an existing variable when creating a new
variable.  The behavior is not incorrect but it generates warning C4456
in VS2015 and can cause confusion when inspecting code.