### PR TITLE
Shading plugin bug fixes

### DIFF
--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ImageCollection.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ImageCollection.java
@@ -221,8 +221,11 @@ public class ImageCollection {
       if (binning == 1 && (roi == null || roi.width == 0)) {
          return BASEIMAGE;
       }
-      String key = binning + "-" + roi.x + "-" + roi.y + "-" + roi.width + "-"
+      String key = "" + binning;
+      if (roi != null) {
+         key = binning + "-" + roi.x + "-" + roi.y + "-" + roi.width + "-"
               + roi.height;
+      }
       return key;
    }
 

--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ShadingProcessor.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ShadingProcessor.java
@@ -184,16 +184,15 @@ public class ShadingProcessor extends Processor {
          try {
             Configuration config = studio_.getCMMCore().getConfigData(
                     channelGroup_, preset);
-            boolean presetMatch = false;
+            boolean presetMatch = true;
             for (int i = 0; i < config.size(); i++) {
                PropertySetting ps = config.getSetting(i);
                String key = ps.getKey();
                String value = ps.getPropertyValue();
                if (scopeData.containsKey(key)
                        && scopeData.getPropertyType(key) == String.class) {
-                  String tagValue = scopeData.getString(key);
-                  if (value.equals(tagValue)) {
-                     presetMatch = true;
+                  if (!value.equals(scopeData.getString(key))) {
+                     presetMatch = false;
                      break;
                   }
                }


### PR DESCRIPTION
The multichannel shading plugin did not work when no ROI was set.  
Due to an error in the code matching the current state to the configuration preset, it could choose the wrong flatfield image.
Both of these bugs are fixed.