### PR TITLE
Script Panel: Better error reporting.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/script/BeanshellEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/BeanshellEngine.java
@@ -13,7 +13,7 @@ public class BeanshellEngine implements ScriptingEngine {
    boolean error_ = false;
    EvalThread evalThd_;
    boolean stop_ = false;
-   private ScriptPanel panel_;
+   private final ScriptPanel panel_;
    private Interpreter interp_old_;
 
    public class EvalThread extends Thread {
@@ -136,11 +136,13 @@ public class BeanshellEngine implements ScriptingEngine {
          Throwable t = ((TargetError)e).getTarget();
          return "Line " + line + ": run-time error : " + (t != null ? t.getMessage() : e.getErrorText());       
       } else if (e instanceof ParseException) {
-         return "Line " + line + ": syntax error : " + e.getErrorText();         
+         return "Line " + line + ": syntax error : " + e.getErrorText();  
+      } else if (e instanceof EvalError) {
+         return "Line " + line + ": evaluation error : " + e.getMessage();
       } else {
          Throwable t = e.getCause();
          return "Line " + line + ": general error : " + (t != null ? t.getMessage() : e.getErrorText());
       }
-      
    }
+   
 }


### PR DESCRIPTION
An EvalError was previously degraded to a - general - error, and
the getErrorText() function was used to show feedback to the user.
For whatever reasons, an EvalError has much more useful information
in the getMessage() function.  Therefore the formatBeanshellError
function now uses the getMessage() function to provide feedback to
the user for errors of type EvalError.  This greatly helps scripts writers.