### PR TITLE
Add "export image sequence" functionality to the display API

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
@@ -307,6 +307,12 @@ public interface DisplayManager {
    public boolean promptToSave(Datastore store, DisplayWindow display);
 
    /**
+    * Provide an ImagceExporter for generating image sequences.
+    * @return an ImageExporter instance.
+    */
+   public ImageExporter createExporter();
+
+   /**
     * Given a Datastore, close any open DisplayWindows for that Datastore.
     * If the Datastore is managed, then the user may receive a prompt to
     * save their data, which they have the option to cancel.

--- a/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
@@ -20,6 +20,8 @@
 
 package org.micromanager.display;
 
+import java.io.IOException;
+
 import org.micromanager.data.Datastore;
 
 /**
@@ -48,13 +50,22 @@ public interface ImageExporter {
    public void setOutputFormat(OutputFormat format);
 
    /**
+    * Set the image quality. This is currently only relevant if the output
+    * format is OUTPUT_JPG.
+    * @param quality An integer quality ranging from 1 through 10. The default
+    *        value is 10.
+    */
+   public void setOutputQuality(int quality);
+
+   /**
     * Set the path to save images to, and the filename prefix to use when
     * saving images. These values are ignored if the output format is set to
     * OUTPUT_IMAGEJ.
     * @param path Directory in which images will be placed
     * @param prefix String to place at beginning of each output image's name.
+    * @throws IllegalArgumentException if the directory does not exist.
     */
-   public void setSaveInfo(String path, String prefix);
+   public void setSaveInfo(String path, String prefix) throws IOException;
 
    /**
     * Add a new "inner loop" to the export parameters. This determines what
@@ -75,4 +86,39 @@ public interface ImageExporter {
     * Reset the current export loop parameters to empty.
     */
    public void resetLoops();
+
+   /**
+    * Run the export process. This will generate the image sequence as
+    * configured previously by calling setOutputFormat, setSaveInfo, and loop.
+    * Only one export is allowed to run at a time; if a second export is
+    * started, it will block until the first has finished. Otherwise, this
+    * method will return immediately. If you want to wait for exporting to
+    * finish, call the waitForCompletion() method.
+    *
+    * NOTE: the exporter will silently ignore the following "configuration
+    * errors":
+    * - Setting a save path when using the OUTPUT_IMAGEJ format
+    * - Loops over axes that do not exist in the display's datastore
+    * - Loops that have invalid start/end boundary conditions (e.g. starting
+    *   or ending index is greater than largest index in the datastore).
+    * In the latter two cases, image coordinates that do not refer to a valid
+    * image will be ignored (for example, trying to access a Z coordinate of 1
+    * in a dataset that is two-dimensional). It is therefore possible that this
+    * method will not actually do anything, if none of the loops encompass
+    * valid image coordinates.
+    * @throws IOException if the export process would attempt to write to a
+    *         file that already exists
+    * @throws IllegalArgumentException if no output format has been set, or
+    *         OUTPUT_PNG or OUTPUT_JPG formats are used but no save information
+    *         has been set, or if no loops have been configured, or if no
+    *         display has been set.
+    */
+   public void export() throws IOException, IllegalArgumentException;
+
+   /**
+    * Block until a prior call to export() returns. Returns immediately if no
+    * export is currently running.
+    * @throws InterruptedException if the thread was interrupted while waiting.
+    */
+   public void waitForExport() throws InterruptedException;
 }

--- a/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
@@ -1,0 +1,78 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     Display implementation
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Chris Weisiger, 2016
+//
+// COPYRIGHT:    (c) 2016 Open Imaging, Inc.
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+package org.micromanager.display;
+
+import org.micromanager.data.Datastore;
+
+/**
+ * ImageExporters are used to generate linear sequences of images-as-rendered
+ * by a DisplayWindow. Thus they include the current image scaling, any
+ * overlays, et cetera.
+ */
+public interface ImageExporter {
+   /**
+    * Set the display to use for image exporting. The same ImageExporter may
+    * be re-used for exporting multiple images.
+    * @param display Display to use for exporting images.
+    */
+   public void setDisplay(DisplayWindow display);
+
+   public enum OutputFormat {
+      OUTPUT_PNG,
+      OUTPUT_JPG,
+      OUTPUT_IMAGEJ
+   }
+
+   /**
+    * Set the output format to use.
+    * @param format The format to output in.
+    */
+   public void setOutputFormat(OutputFormat format);
+
+   /**
+    * Set the path to save images to, and the filename prefix to use when
+    * saving images. These values are ignored if the output format is set to
+    * OUTPUT_IMAGEJ.
+    * @param path Directory in which images will be placed
+    * @param prefix String to place at beginning of each output image's name.
+    */
+   public void setSaveInfo(String path, String prefix);
+
+   /**
+    * Add a new "inner loop" to the export parameters. This determines what
+    * order the images will be output in. For example:
+    * exporter.loop(Coords.Z, 0, 10).loop(Coords.CHANNEL, 0, 2)
+    * This will cause the channel axis to be the "inner loop", changing most
+    * frequently, and the Z axis to be the "outer loop", changing least
+    * frequently.
+    * @param axis Axis name, like Coords.CHANNEL, Coords.Z, etc.
+    * @param start Axis index to start exporting from, inclusive.
+    * @param stop Axis index to stop exporting from, exclusive (i.e. one more
+    *        than the index of the last image you want to export).
+    * @return This instance, allowing calls to be chained together.
+    */
+   public ImageExporter loop(String axis, int start, int stop);
+
+   /**
+    * Reset the current export loop parameters to empty.
+    */
+   public void resetLoops();
+}

--- a/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
@@ -35,9 +35,22 @@ public interface ImageExporter {
     */
    public void setDisplay(DisplayWindow display);
 
+   /**
+    * Allowed export formats.
+    */
    public enum OutputFormat {
+      /**
+       * Output as a sequence of Portable Network Graphics (PNG) files.
+       */
       OUTPUT_PNG,
+      /**
+       * Output as a sequence of Joint Photographic Experts Group (JPEG) files.
+       */
       OUTPUT_JPG,
+      /**
+       * Output as an ImageJ stack, which will open in a new window; this
+       * "format" does not create any files on disk.
+       */
       OUTPUT_IMAGEJ
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 public interface ImageExporter {
    /**
     * Set the display to use for image exporting. The same ImageExporter may
-    * be re-used for exporting multiple images.
+    * be re-used for multiple displays, if desired.
     * @param display Display to use for exporting images.
     */
    public void setDisplay(DisplayWindow display);
@@ -91,14 +91,15 @@ public interface ImageExporter {
     * Only one export is allowed to run at a time; if a second export is
     * started, it will block until the first has finished. Otherwise, this
     * method will return immediately. If you want to wait for exporting to
-    * finish, call the waitForCompletion() method.
+    * finish, call the waitForExport() method.
     *
     * NOTE: the exporter will silently ignore the following "configuration
     * errors":
     * - Setting a save path when using the OUTPUT_IMAGEJ format
-    * - Loops over axes that do not exist in the display's datastore
-    * - Loops that have invalid start/end boundary conditions (e.g. starting
-    *   or ending index is greater than largest index in the datastore).
+    * - Loops over axes that are not used by any images in the display's
+    *   datastore
+    * - Loops that have invalid start/end boundary conditions (starting or
+    *   ending index is greater than largest index in the datastore).
     * In the latter two cases, image coordinates that do not refer to a valid
     * image will be ignored (for example, trying to access a Z coordinate of 1
     * in a dataset that is two-dimensional). It is therefore possible that this

--- a/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
@@ -22,8 +22,6 @@ package org.micromanager.display;
 
 import java.io.IOException;
 
-import org.micromanager.data.Datastore;
-
 /**
  * ImageExporters are used to generate linear sequences of images-as-rendered
  * by a DisplayWindow. Thus they include the current image scaling, any

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -44,6 +44,7 @@ import org.micromanager.display.DisplayManager;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.HistogramData;
+import org.micromanager.display.ImageExporter;
 import org.micromanager.display.NewHistogramsEvent;
 import org.micromanager.display.OverlayPanel;
 import org.micromanager.display.OverlayPanelFactory;
@@ -436,6 +437,11 @@ public final class DefaultDisplayManager implements DisplayManager {
          }
       }
       return true;
+   }
+
+   @Override
+   public ImageExporter createExporter() {
+      return new DefaultImageExporter();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultImageExporter.java
@@ -1,0 +1,463 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Chris Weisiger, 2016
+//
+// COPYRIGHT:    (c) 2016 Open Imaging, Inc.
+// COPYRIGHT:    University of California, San Francisco, 2006
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+package org.micromanager.display.internal;
+
+import com.google.common.eventbus.Subscribe;
+
+import ij.CompositeImage;
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.process.ColorProcessor;
+
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.awt.Rectangle;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.HashSet;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+
+import org.micromanager.data.Coords;
+import org.micromanager.data.Datastore;
+import org.micromanager.display.DisplayWindow;
+import org.micromanager.display.ImageExporter;
+import org.micromanager.display.ImageExporter.OutputFormat;
+import org.micromanager.display.internal.events.CanvasDrawCompleteEvent;
+
+import org.micromanager.internal.utils.ReportingUtils;
+
+
+public class DefaultImageExporter implements ImageExporter {
+
+   /**
+    * This recursive structure represents the "nested loop" approach to
+    * exporting.
+    */
+   public static class ExporterLoop {
+      private Datastore store_;
+      private String axis_;
+      private int startIndex_;
+      private int stopIndex_;
+      private ExporterLoop child_;
+
+      public ExporterLoop(String axis, int start, int stop) {
+         axis_ = axis;
+         startIndex_ = start;
+         stopIndex_ = stop;
+      }
+
+      /**
+       * Insert a new innermost ExporterLoop -- recursively propagates the
+       * provided child to the end of the list.
+       */
+      public void setInnermostLoop(ExporterLoop child) {
+         if (child_ == null) {
+            child_ = child;
+         }
+         else {
+            child_.setInnermostLoop(child);
+         }
+      }
+
+      /**
+       * Recursively propagate a display through the list.
+       */
+      public void setDisplay(DisplayWindow display) {
+         store_ = display.getDatastore();
+         if (child_ != null) {
+            child_.setDisplay(display);
+         }
+      }
+
+      /**
+       * Iterate over our specified axis, while running any inner loop(s),
+       * determining which images will be exported. Use the provided
+       * base coordinates to cover for any coords we aren't iterating over.
+       */
+      public void selectImageCoords(Coords baseCoords,
+            ArrayList<Coords> result) {
+         for (int i = startIndex_; i < stopIndex_; ++i) {
+            Coords newCoords = baseCoords.copy().index(axis_, i).build();
+            if (child_ == null) {
+               // Add the corresponding image, if any.
+               if (store_.hasImage(newCoords)) {
+                  result.add(newCoords);
+               }
+            }
+            else {
+               // Recurse.
+               child_.selectImageCoords(newCoords, result);
+            }
+         }
+      }
+   }
+
+   private DefaultDisplayWindow display_;
+   private OutputFormat format_;
+   private String directory_;
+   private String prefix_;
+   private ExporterLoop outerLoop_;
+
+   private int sequenceNum_ = 0;
+   private ImageStack stack_;
+   private String mode_;
+   private AtomicBoolean drawFlag_;
+   private AtomicBoolean doneFlag_;
+   private boolean isSingleShot_;
+   private int jpegQuality_ = 10;
+
+   private BufferedImage currentImage_ = null;
+   private Graphics currentGraphics_ = null;
+
+   public DefaultImageExporter() {
+      // Initialize to true so that waitForCompletion returns immediately.
+      doneFlag_ = new AtomicBoolean(true);
+      drawFlag_ = new AtomicBoolean(false);
+   }
+
+   @Override
+   public void setDisplay(DisplayWindow display) {
+      display_ = (DefaultDisplayWindow) display;
+      if (outerLoop_ != null) {
+         outerLoop_.setDisplay(display);
+      }
+   }
+
+   @Override
+   public void setOutputFormat(OutputFormat format) {
+      format_ = format;
+   }
+
+   @Override
+   public void setOutputQuality(int quality) {
+      jpegQuality_ = quality;
+   }
+
+   @Override
+   public void setSaveInfo(String directory, String prefix) throws IOException {
+      if (!(new File(directory).exists())) {
+         throw new IOException("Directory " + directory + " does not exist");
+      }
+      directory_ = directory;
+      prefix_ = prefix;
+   }
+
+   @Override
+   public ImageExporter loop(String axis, int startIndex, int stopIndex) {
+      ExporterLoop exporter = new ExporterLoop(axis, startIndex, stopIndex);
+      if (outerLoop_ == null) {
+         outerLoop_ = exporter;
+      }
+      else {
+         outerLoop_.setInnermostLoop(exporter);
+      }
+      // Ensure loops have displays set.
+      outerLoop_.setDisplay(display_);
+      return this;
+   }
+
+   @Override
+   public void resetLoops() {
+      outerLoop_ = null;
+   }
+
+   /**
+    * This method gets called twice for each image we export: once for the
+    * display responding to our request to set the image coordinates, and
+    * then once for the display painting to our provided Graphics object.
+    */
+   @Subscribe
+   public void onDrawComplete(CanvasDrawCompleteEvent event) {
+      try {
+         if (event.getGraphics() != currentGraphics_) {
+            // We now know that the correct image is visible on the canvas, so
+            // have it paint that image to our own Graphics object. This is
+            // inefficient (having to paint the same image twice), but
+            // unfortunately there's no way (so far as I'm aware) to get an
+            // Image from a component except by painting.
+            // HACK: the getCanvas() and paintImageWithGraphics methods aren't
+            // exposed in DisplayWindow; hence why we need display_ to be
+            // DefaultDisplayWindow.
+            Dimension canvasSize = display_.getCanvas().getSize();
+            currentImage_ = new BufferedImage(canvasSize.width,
+                  canvasSize.height, BufferedImage.TYPE_INT_RGB);
+            currentGraphics_ = currentImage_.getGraphics();
+            display_.paintImageWithGraphics(currentGraphics_);
+         }
+         else {
+            // Display just finished painting to currentGraphics_, so export
+            // now.
+            if (format_ == OutputFormat.OUTPUT_IMAGEJ) {
+               if (stack_ == null) {
+                  // Create the ImageJ stack object to add images to.
+                  stack_ = new ImageStack(currentImage_.getWidth(),
+                        currentImage_.getHeight());
+               }
+               addToStack(stack_, currentImage_);
+            }
+            else {
+               // Save the image to disk in appropriate format.
+               exportImage(currentImage_, sequenceNum_++);
+            }
+            currentGraphics_.dispose();
+            drawFlag_.set(false);
+            if (isSingleShot_) {
+               doneFlag_.set(true);
+            }
+         }
+      }
+      catch (Exception e) {
+         ReportingUtils.logError(e, "Error handling draw complete");
+      }
+   }
+
+   /**
+    * Save a single image to disk at the provided directory, with a filename
+    * based on the provided sequence number, in the specified mode.
+    */
+   private void exportImage(BufferedImage image, int sequenceNum) {
+      String filename = getOutputFilename(isSingleShot_ ? -1 : sequenceNum);
+      File file = new File(filename);
+      if (format_ == OutputFormat.OUTPUT_PNG) {
+         try {
+            ImageIO.write(image, "png", file);
+         }
+         catch (IOException e) {
+            ReportingUtils.logError(e, "Error writing exported PNG image");
+         }
+      }
+      else if (format_ == OutputFormat.OUTPUT_JPG) {
+         // Set the compression quality.
+         float quality = jpegQuality_ / ((float) 10.0);
+         ImageWriter writer = ImageIO.getImageWritersByFormatName(
+               "jpeg").next();
+         ImageWriteParam param = writer.getDefaultWriteParam();
+         param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+         param.setCompressionQuality(quality);
+         try {
+            ImageOutputStream stream = ImageIO.createImageOutputStream(file);
+            writer.setOutput(stream);
+            writer.write(image);
+            stream.close();
+         }
+         catch (IOException e) {
+            ReportingUtils.logError(e, "Error writing exported JPEG image");
+         }
+         writer.dispose();
+      }
+      else {
+         ReportingUtils.logError("Unrecognized save format " + format_);
+      }
+   }
+
+   /**
+    * Append the provided image onto the end of the given ImageJ ImageStack.
+    */
+   private void addToStack(ImageStack stack, BufferedImage image) {
+      ColorProcessor processor = new ColorProcessor(image);
+      stack.addSlice(processor);
+   }
+
+   /**
+    * Run sanity checks prior to exporting images. Determine how many images
+    * will be exported. Ensure that each image will not overwrite any existing
+    * file. Return the image list.
+    */
+   private ArrayList<Coords> prepAndSanityCheck()
+      throws IOException, IllegalArgumentException {
+      if (format_ == null) {
+         throw new IllegalArgumentException("No output format was selected");
+      }
+      if (outerLoop_ == null) {
+         throw new IllegalArgumentException("No loops have been configured");
+      }
+      if (display_ == null) {
+         throw new IllegalArgumentException("No display has been set");
+      }
+      ArrayList<Coords> coords = new ArrayList<Coords>();
+      outerLoop_.selectImageCoords(
+            display_.getDisplayedImages().get(0).getCoords(), coords);
+      if (coords.size() == 0) {
+         // Nothing to do.
+         return coords;
+      }
+      if (format_ != OutputFormat.OUTPUT_IMAGEJ) {
+         if (directory_ == null || prefix_ == null) {
+            // Can't save.
+            throw new IllegalArgumentException(String.format("Save parameters for exporter were not properly set (directory %s, prefix %s)", directory_, prefix_));
+         }
+         // Check for potential file overwrites.
+         if (coords.size() == 1) {
+            checkForOverwrite(-1);
+         }
+         else {
+            for (int i = 0; i < coords.size(); ++i) {
+               checkForOverwrite(i);
+            }
+         }
+      }
+      return coords;
+   }
+
+   /**
+    * Check to make certain that outputting the nth image will not overwrite
+    * an existing file.
+    */
+   private void checkForOverwrite(int n) throws IOException {
+      String path = getOutputFilename(n);
+      if (new File(path).exists()) {
+         throw new IOException("File at " + path + " would be overwritten during export");
+      }
+   }
+
+   /**
+    * Generate a filename to save the nth image.
+    * @param n image index, or -1 for a single-shot export (of only one image).
+    */
+   private String getOutputFilename(int n) {
+      if (format_ == OutputFormat.OUTPUT_IMAGEJ) {
+         throw new RuntimeException("Asked for output filename when exporting in ImageJ format.");
+      }
+      String suffix = (format_ == OutputFormat.OUTPUT_PNG) ? "png" : "jpg";
+      if (n == -1) {
+         return String.format("%s/%s.%s", directory_, prefix_, suffix);
+      }
+      return String.format("%s/%s_%010d.%s", directory_, prefix_, n, suffix);
+   }
+
+   /**
+    * Export images according to the user's setup. Iterate over each axis,
+    * setting the displayed image to the desired coordinates, drawing it,
+    * saving the drawn image to disk, and then moving on.
+    * This method is synchronized, which doesn't mean a whole lot because
+    * the actual export process happens on separate threads. However, it calls
+    * waitForExport() as its first action, which will block if another export
+    * is in progress.
+    */
+   @Override
+   public synchronized void export() throws IOException, IllegalArgumentException {
+      // Don't run two exports at the same time.
+      try {
+         waitForExport();
+      }
+      catch (InterruptedException e) {
+         // Give up.
+         ReportingUtils.logError(e, "Interrupted while waiting for other export to finish.");
+         return;
+      }
+      final ArrayList<Coords> coords = prepAndSanityCheck();
+      if (coords.size() == 0) {
+         // Nothing to do.
+         return;
+      }
+      display_.registerForEvents(this);
+      File outputDir = null;
+
+      // This thread will handle telling the display window to display new
+      // images.
+      Thread loopThread;
+      if (coords.size() == 1) {
+         isSingleShot_ = true;
+         // Only one image to draw.
+         loopThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+               display_.requestRedraw();
+            }
+         }, "Image export thread");
+      }
+      else {
+         isSingleShot_ = false;
+         loopThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+               for (Coords imageCoords : coords) {
+                  drawFlag_.set(true);
+                  // Setting the displayed image will result in our
+                  // CanvasDrawCompleteEvent handler being invoked, which
+                  // causes images to be exported.
+                  display_.setDisplayedImageTo(imageCoords);
+                  // Wait until drawing is done.
+                  while (drawFlag_.get()) {
+                     try {
+                        Thread.sleep(10);
+                     }
+                     catch (InterruptedException e) {
+                        ReportingUtils.logError("Interrupted while waiting for drawing to complete.");
+                        return;
+                     }
+                  }
+               }
+               doneFlag_.set(true);
+            }
+         }, "Image export thread");
+      }
+
+      // Create a thread to wait for the process to finish, and unsubscribe
+      // us at that time.
+      Thread unsubscriber = new Thread(new Runnable() {
+         @Override
+         public void run() {
+            while (!doneFlag_.get()) {
+               try {
+                  Thread.sleep(100);
+               }
+               catch (InterruptedException e) {
+                  ReportingUtils.logError("Interrupted while waiting for export to complete.");
+                  return;
+               }
+            }
+            display_.unregisterForEvents(DefaultImageExporter.this);
+            if (stack_ != null) {
+               // Show the ImageJ stack.
+               ImagePlus plus = new ImagePlus("MM export results", stack_);
+               plus.show();
+            }
+         }
+      });
+
+      doneFlag_.set(false);
+      unsubscriber.start();
+      loopThread.start();
+   }
+
+   @Override
+   public void waitForExport() throws InterruptedException {
+      while (!doneFlag_.get()) {
+         Thread.sleep(100);
+      }
+   }
+}
+

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultImageExporter.java
@@ -23,26 +23,17 @@ package org.micromanager.display.internal;
 
 import com.google.common.eventbus.Subscribe;
 
-import ij.CompositeImage;
 import ij.ImagePlus;
 import ij.ImageStack;
 import ij.process.ColorProcessor;
 
-import java.awt.Canvas;
-import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
-import java.awt.Rectangle;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.HashSet;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriteParam;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultImageExporter.java
@@ -237,8 +237,7 @@ public class DefaultImageExporter implements ImageExporter {
    }
 
    /**
-    * Save a single image to disk at the provided directory, with a filename
-    * based on the provided sequence number, in the specified mode.
+    * Save a single image to disk.
     */
    private void exportImage(BufferedImage image, int sequenceNum) {
       String filename = getOutputFilename(isSingleShot_ ? -1 : sequenceNum);
@@ -286,7 +285,7 @@ public class DefaultImageExporter implements ImageExporter {
    /**
     * Run sanity checks prior to exporting images. Determine how many images
     * will be exported. Ensure that each image will not overwrite any existing
-    * file. Return the image list.
+    * file. Return the list of image coordinates to be exported.
     */
    private ArrayList<Coords> prepAndSanityCheck()
       throws IOException, IllegalArgumentException {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultImageExporter.java
@@ -95,7 +95,9 @@ public class DefaultImageExporter implements ImageExporter {
        * Recursively propagate a display through the list.
        */
       public void setDisplay(DisplayWindow display) {
-         store_ = display.getDatastore();
+         if (display != null) {
+            store_ = display.getDatastore();
+         }
          if (child_ != null) {
             child_.setDisplay(display);
          }

--- a/scripts/ExportImageSequence.bsh
+++ b/scripts/ExportImageSequence.bsh
@@ -1,0 +1,42 @@
+// This script demonstrates how to use the ImageExporter API, for
+// generating sequences of "images as rendered" (including histogram
+// scaling, overlays, etc.).
+// Before running this script, open the file you want to export.
+
+import org.micromanager.data.Coords;
+import org.micromanager.display.ImageExporter;
+
+exporter = mm.displays().createExporter();
+
+// Select display to pull images from
+display = mm.displays().getCurrentWindow();
+exporter.setDisplay(display);
+
+// Options are OUTPUT_JPG, OUTPUT_PNG, OUTPUT_IMAGEJ.
+exporter.setOutputFormat(ImageExporter.OutputFormat.OUTPUT_PNG);
+
+// Directory and file prefix. Directory must already exist!
+// Not required if using OUTPUT_IMAGEJ mode.
+exporter.setSaveInfo("/Users/chriswei/Documents/image_export", "test");
+
+// Set quality of image. Only relevant for OUTPUT_JPG; values range from 1-10
+exporter.setOutputQuality(1);
+
+// Select images to output. Args are coordinate axis, first index inclusive,
+// last index non-inclusive. Valid axes include Coords.Z, Coords.CHANNEL,
+// Coords.TIME, and Coords.STAGE_POSITION. 
+// First loop() call is the outer loop, last is the innermost.
+
+// Export the entire range of an axis:
+exporter.loop(Coords.TIME, 0, display.getDatastore().getAxisLength(Coords.TIME));
+// Export a specific range (the first 5 Z positions)
+exporter.loop(Coords.Z, 0, 5);
+
+// Reset the loops so new ones can be set.
+// exporter.resetLoops();
+
+// Perform export.
+exporter.export();
+
+// Wait for exporting to complete.
+exporter.waitForExport();


### PR DESCRIPTION
This adds a new API interface `ImageExporter` and its implementation, which can be used to generate a sequence of images-as-rendered in PNG, JPG, and ImageJ stack formats. Effectively it is an API implementation of the logic from the "Export Images as Displayed" menu option in the image display's gear menu (said option now uses the new API).

It also adds a script, ExportImageSequence.bsh, that demonstrates how to use the API.