### PR TITLE
Add "search" filter to Device Property Browser and Config Group Editor

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -789,11 +789,9 @@ public class MMStudio implements Studio, CompatibilityInterface, PositionListMan
          propertyBrowser_.dispose();
       }
 
-      propertyBrowser_ = new PropertyEditor();
-      propertyBrowser_.setGui(studio_);
+      propertyBrowser_ = new PropertyEditor(studio_);
       propertyBrowser_.setVisible(true);
       propertyBrowser_.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-      propertyBrowser_.setCore(core_);
    }
 
    public void createCalibrationListDlg() {

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -17,9 +17,6 @@
 //               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
-//
-// CVS:          $Id$
-//
 
 package org.micromanager.internal;
 
@@ -44,12 +41,13 @@ import javax.swing.JCheckBox;
 import javax.swing.JFrame;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import javax.swing.SpringLayout;
 import javax.swing.border.BevelBorder;
 import javax.swing.table.TableColumn;
 
 import mmcorej.CMMCore;
 import mmcorej.StrVector;
+
+import net.miginfocom.swing.MigLayout;
 
 import org.micromanager.events.PropertiesChangedEvent;
 import org.micromanager.events.PropertyChangedEvent;
@@ -62,6 +60,7 @@ import org.micromanager.internal.utils.PropertyValueCellRenderer;
 import org.micromanager.internal.utils.PropertyItem;
 import org.micromanager.internal.utils.PropertyTableData;
 import org.micromanager.internal.utils.ShowFlags;
+import org.micromanager.internal.utils.ShowFlagsPanel;
 import org.micromanager.internal.utils.PropertyNameCellRenderer;
 import org.micromanager.internal.utils.ReportingUtils;
 
@@ -73,13 +72,12 @@ import org.micromanager.internal.utils.ReportingUtils;
  * aka the "Device/Property Browser"
  */
 public class PropertyEditor extends MMFrame {
-   private final SpringLayout springLayout;
    private static final long serialVersionUID = 1507097881635431043L;
-   
+
    private JTable table_;
    private PropertyEditorTableData data_;
    private ShowFlags flags_;
-   
+
    private static final String PREF_SHOW_READONLY = "show_readonly";
    private JCheckBox showCamerasCheckBox_;
    private JCheckBox showShuttersCheckBox_;
@@ -87,46 +85,48 @@ public class PropertyEditor extends MMFrame {
    private JCheckBox showStateDevicesCheckBox_;
    private JCheckBox showOtherCheckBox_;
    private JCheckBox showReadonlyCheckBox_;
-   private final JScrollPane scrollPane_;
-   private Studio gui_;
-   
+   private JScrollPane scrollPane_;
+   private Studio studio_;
+   private CMMCore core_;
 
-   @Subscribe
-   public void onPropertiesChanged(PropertiesChangedEvent event) {
-      // avoid re-executing a refresh because of callbacks while we are
-      // updating
-      if (!data_.updating()) {
-         refresh();
-      }
-   }
-
-   @Subscribe
-   public void onPropertyChanged(PropertyChangedEvent event) {
-      String device = event.getDevice();
-      String property = event.getProperty();
-      String value = event.getValue();
-      data_.update(device, property, value);
-   }
-
-   public void setGui(Studio gui) {
-      gui_ = gui;
-      gui_.events().registerForEvents(this);
-   }
-
-
-
-   public PropertyEditor() {
+   public PropertyEditor(Studio studio) {
       super("property editor");
-      
-      final DefaultUserProfile profile = DefaultUserProfile.getInstance();
+
+      studio_ = studio;
+      studio_.events().registerForEvents(this);
+      core_ = studio_.core();
+
       flags_ = new ShowFlags();
       flags_.load(PropertyEditor.class);
-      
+
+      createTable();
+      createComponents();
+   }
+
+   private void createTable() {
+      data_ = new PropertyEditorTableData(
+            core_, "", "", 1, 2, getContentPane());
+      data_.gui_ = studio_;
+      data_.flags_ = flags_;
+      data_.showUnused_ = true;
+      data_.setColumnNames("Property", "Value", "");
+
+      table_ = new DaytimeNighttime.Table();
+      table_.setAutoCreateColumnsFromModel(false);
+      table_.setModel(data_);
+
+      table_.addColumn(new TableColumn(0, 200, new PropertyNameCellRenderer(), null));
+      table_.addColumn(new TableColumn(1, 200, new PropertyValueCellRenderer(false), new PropertyValueCellEditor(false)));
+   }
+
+   private void createComponents() {
+      final DefaultUserProfile profile = DefaultUserProfile.getInstance();
+
       setIconImage(Toolkit.getDefaultToolkit().getImage(
               getClass().getResource("/org/micromanager/icons/microscope.gif") ) );
-      springLayout = new SpringLayout();
-      getContentPane().setLayout(springLayout);
-      setSize(551, 514);
+
+      setLayout(new MigLayout("fill, insets 2"));
+
       addWindowListener(new WindowAdapter() {
          @Override
          public void windowClosing(WindowEvent e) {
@@ -149,35 +149,14 @@ public class PropertyEditor extends MMFrame {
       loadAndRestorePosition(100, 100, 400, 300);
       setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-      scrollPane_ = new JScrollPane();
-      scrollPane_.setFont(new Font("Arial", Font.PLAIN, 10));
-      scrollPane_.setBorder(new BevelBorder(BevelBorder.LOWERED));
-      getContentPane().add(scrollPane_);
-      springLayout.putConstraint(SpringLayout.EAST, scrollPane_, -5, SpringLayout.EAST, getContentPane());
-      springLayout.putConstraint(SpringLayout.WEST, scrollPane_, 5, SpringLayout.WEST, getContentPane());
-      
-      table_ = new DaytimeNighttime.Table();
-      table_.setAutoCreateColumnsFromModel(false);
-      
-      final JButton refreshButton = new JButton();
-      refreshButton.setIcon(new ImageIcon(getClass().getResource( 
-              "/org/micromanager/icons/arrow_refresh.png")) );
-      refreshButton.setFont(new Font("Arial", Font.PLAIN, 10));
-      getContentPane().add(refreshButton);
-      springLayout.putConstraint(SpringLayout.EAST, refreshButton, 285, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.WEST, refreshButton, 185, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.SOUTH, refreshButton, 32, SpringLayout.NORTH, getContentPane());
-      springLayout.putConstraint(SpringLayout.NORTH, refreshButton, 9, SpringLayout.NORTH, getContentPane());
-      refreshButton.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            refresh();
-         }
-      });
-      refreshButton.setText("Refresh! ");
+      add(new ShowFlagsPanel(data_, flags_, core_,
+               core_.getSystemStateCache()),
+            "split 2, flowy");
 
-      showReadonlyCheckBox_ = new JCheckBox();
-      showReadonlyCheckBox_.setFont(new Font("Arial", Font.PLAIN, 10));
+      Font defaultFont = new Font("Arial", Font.PLAIN, 10);
+
+      showReadonlyCheckBox_ = new JCheckBox("Show Read-Only Properties");
+      showReadonlyCheckBox_.setFont(defaultFont);
       showReadonlyCheckBox_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
@@ -187,154 +166,74 @@ public class PropertyEditor extends MMFrame {
             data_.fireTableStructureChanged();
           }
       });
-      showReadonlyCheckBox_.setText("Show read-only properties");
-      getContentPane().add(showReadonlyCheckBox_);
-      springLayout.putConstraint(SpringLayout.EAST, showReadonlyCheckBox_, 358, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.WEST, showReadonlyCheckBox_, 185, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.SOUTH, showReadonlyCheckBox_, 63, SpringLayout.NORTH, getContentPane());
-      springLayout.putConstraint(SpringLayout.NORTH, showReadonlyCheckBox_, 40, SpringLayout.NORTH, getContentPane());
-      
       // restore values from the previous session
       showReadonlyCheckBox_.setSelected(profile.getBoolean(
                PropertyEditor.class, PREF_SHOW_READONLY, true));
+      data_.setShowReadOnly(showReadonlyCheckBox_.isSelected());
+      add(showReadonlyCheckBox_);
 
-      showCamerasCheckBox_ = new JCheckBox();
-      showCamerasCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-      showCamerasCheckBox_.addActionListener(new ActionListener() {
+      final JButton refreshButton = new JButton("Refresh",
+            new ImageIcon(getClass().getResource(
+              "/org/micromanager/icons/arrow_refresh.png")));
+      refreshButton.setFont(defaultFont);
+      refreshButton.addActionListener(new ActionListener() {
          @Override
-         public void actionPerformed(ActionEvent arg0) {
-            flags_.cameras_ = showCamerasCheckBox_.isSelected();
-            data_.update(false);
+         public void actionPerformed(ActionEvent e) {
+            refresh();
          }
       });
-      showCamerasCheckBox_.setText("Show cameras");
-      getContentPane().add(showCamerasCheckBox_);
-      springLayout.putConstraint(SpringLayout.SOUTH, showCamerasCheckBox_, 28, SpringLayout.NORTH, getContentPane());
-      springLayout.putConstraint(SpringLayout.WEST, showCamerasCheckBox_, 10, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.EAST, showCamerasCheckBox_, 111, SpringLayout.WEST, getContentPane());
+      add(refreshButton, "width 100!, alignx left, aligny top, gaptop 20, gapbottom push, wrap");
 
-      showShuttersCheckBox_ = new JCheckBox();
-      showShuttersCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-      showShuttersCheckBox_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            flags_.shutters_ = showShuttersCheckBox_.isSelected();
-            data_.update(false);
-         }
-      });
-      showShuttersCheckBox_.setText("Show shutters");
-      getContentPane().add(showShuttersCheckBox_);
-      springLayout.putConstraint(SpringLayout.EAST, showShuttersCheckBox_, 111, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.WEST, showShuttersCheckBox_, 10, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.SOUTH, showShuttersCheckBox_, 50, SpringLayout.NORTH, getContentPane());
-
-      showStagesCheckBox_ = new JCheckBox();
-      showStagesCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-      showStagesCheckBox_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            flags_.stages_ = showStagesCheckBox_.isSelected();
-            data_.update(false);
-         }
-      });
-      showStagesCheckBox_.setText("Show stages");
-      getContentPane().add(showStagesCheckBox_);
-      springLayout.putConstraint(SpringLayout.EAST, showStagesCheckBox_, 111, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.WEST, showStagesCheckBox_, 10, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.SOUTH, showStagesCheckBox_, 73, SpringLayout.NORTH, getContentPane());
-      springLayout.putConstraint(SpringLayout.NORTH, showStagesCheckBox_, 50, SpringLayout.NORTH, getContentPane());
-
-      showStateDevicesCheckBox_ = new JCheckBox();
-      showStateDevicesCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-      showStateDevicesCheckBox_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            flags_.state_ = showStateDevicesCheckBox_.isSelected();
-            data_.update(false);
-         }
-      });
-      showStateDevicesCheckBox_.setText("Show discrete changers");
-      getContentPane().add(showStateDevicesCheckBox_);
-      springLayout.putConstraint(SpringLayout.EAST, showStateDevicesCheckBox_, 200, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.WEST, showStateDevicesCheckBox_, 10, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.SOUTH, showStateDevicesCheckBox_, 95, SpringLayout.NORTH, getContentPane());
-      springLayout.putConstraint(SpringLayout.NORTH, showStateDevicesCheckBox_, 72, SpringLayout.NORTH, getContentPane());
-
-      showOtherCheckBox_ = new JCheckBox();
-      showOtherCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-      showOtherCheckBox_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            flags_.other_ = showOtherCheckBox_.isSelected();
-            data_.update(false);
-         }
-      });
-      showOtherCheckBox_.setText("Show other devices");
-      getContentPane().add(showOtherCheckBox_);
-      springLayout.putConstraint(SpringLayout.EAST, showOtherCheckBox_, 155, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.WEST, showOtherCheckBox_, 10, SpringLayout.WEST, getContentPane());
-      springLayout.putConstraint(SpringLayout.NORTH, showOtherCheckBox_, 95, SpringLayout.NORTH, getContentPane());
-      springLayout.putConstraint(SpringLayout.SOUTH, scrollPane_, -5, SpringLayout.SOUTH, getContentPane());
-      springLayout.putConstraint(SpringLayout.NORTH, scrollPane_, 5, SpringLayout.SOUTH, showOtherCheckBox_);
+      scrollPane_ = new JScrollPane();
+      scrollPane_.setViewportView(table_);
+      scrollPane_.setFont(defaultFont);
+      scrollPane_.setBorder(new BevelBorder(BevelBorder.LOWERED));
+      add(scrollPane_, "span, grow, wrap");
    }
-   
-
 
    protected void refresh() {
-      data_.gui_ = gui_;
+      data_.gui_ = studio_;
       data_.flags_ = flags_;
       data_.showUnused_ = true;
       data_.refresh(false);
    }
 
-   public void updateStatus() {
-      if (data_ != null)
-         data_.update(false);
+   @Subscribe
+   public void onPropertiesChanged(PropertiesChangedEvent event) {
+      // avoid re-executing a refresh because of callbacks while we are
+      // updating
+      if (!data_.updating()) {
+         refresh();
+      }
    }
 
-    public void setCore(CMMCore core) {
-        data_ = new PropertyEditorTableData(core, "", "", 1, 2, getContentPane());
-        data_.gui_ = gui_;
-        data_.flags_ = flags_;
-        data_.showUnused_ = true;
-        data_.setColumnNames("Property", "Value", "");
+   @Subscribe
+   public void onPropertyChanged(PropertyChangedEvent event) {
+      String device = event.getDevice();
+      String property = event.getProperty();
+      String value = event.getValue();
+      data_.update(device, property, value);
+   }
 
-        table_ = new DaytimeNighttime.Table();
-        table_.setAutoCreateColumnsFromModel(false);
-        table_.setModel(data_);
-        scrollPane_.setViewportView(table_);
-
-        table_.addColumn(new TableColumn(0, 200, new PropertyNameCellRenderer(), null));
-        table_.addColumn(new TableColumn(1, 200, new PropertyValueCellRenderer(false), new PropertyValueCellEditor(false)));
-
-        showCamerasCheckBox_.setSelected(flags_.cameras_);
-        showStagesCheckBox_.setSelected(flags_.stages_);
-        showShuttersCheckBox_.setSelected(flags_.shutters_);
-        showStateDevicesCheckBox_.setSelected(flags_.state_);
-        showOtherCheckBox_.setSelected(flags_.other_);
-
-        data_.setShowReadOnly(showReadonlyCheckBox_.isSelected());
-    }
-   
     public class PropertyEditorTableData extends PropertyTableData {
       public PropertyEditorTableData(CMMCore core, String groupName, String presetName,
          int PropertyValueColumn, int PropertyUsedColumn, Component parentComponent) {
 
          super(core, groupName, presetName, PropertyValueColumn, PropertyUsedColumn, false);
       }
-   
+
       private static final long serialVersionUID = 1L;
 
       @Override
       public void setValueAt(Object value, int row, int col) {
          PropertyItem item = propListVisible_.get(row);
-         gui_.logs().logMessage("Setting value " + value + " at row " + row);
+         studio_.logs().logMessage("Setting value " + value + " at row " + row);
          if (col == PropertyValueColumn_) {
             setValueInCore(item,value);
          }
          core_.updateSystemStateCache();
          refresh(true);
-         gui_.compat().refreshGUIFromCache();
+         studio_.compat().refreshGUIFromCache();
          fireTableCellUpdated(row, col);
       }
 
@@ -346,7 +245,7 @@ public class PropertyEditor extends MMFrame {
             fireTableDataChanged();
          }
       }
-      
+
       @Override
       public void update(ShowFlags flags, String groupName, String presetName, boolean fromCache) {
          try {
@@ -356,12 +255,12 @@ public class PropertyEditor extends MMFrame {
             if (!fromCache) {
                // Some properties may not be readable if we are
                // mid-acquisition.
-               gui_.live().setSuspended(true);
+               studio_.live().setSuspended(true);
             }
-            for (int i=0; i<devices.size(); i++) { 
+            for (int i = 0; i < devices.size(); i++) {
                if (data_.showDevice(flags, devices.get(i))) {
                   StrVector properties = core_.getDevicePropertyNames(devices.get(i));
-                  for (int j=0; j<properties.size(); j++){
+                  for (int j = 0; j < properties.size(); j++){
                      PropertyItem item = new PropertyItem();
                      item.readFromCore(core_, devices.get(i), properties.get(j), fromCache);
 
@@ -372,23 +271,17 @@ public class PropertyEditor extends MMFrame {
                }
             }
 
-            updateRowVisibility(flags); 
+            updateRowVisibility(flags);
 
             if (!fromCache) {
-               gui_.live().setSuspended(false);
+               studio_.live().setSuspended(false);
             }
          } catch (Exception e) {
-            handleException(e);
+            ReportingUtils.showError(e, "Error updating Device Property Browser");
          }
          this.fireTableStructureChanged();
 
       }
    }
-
- 
-   private void handleException (Exception e) {
-      ReportingUtils.showError(e, this);
-   }
-   
 }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
@@ -1000,9 +1000,9 @@ public class CalibrationEditor extends MMDialog {
          lab.setHorizontalAlignment(JLabel.LEFT);
          lab.setOpaque(true);
          if (item_.readOnly) {
-            lab.setBackground(Color.LIGHT_GRAY);
+            lab.setBackground(DaytimeNighttime.getDisabledBackgroundColor());
          } else {
-            lab.setBackground(Color.WHITE);
+            lab.setBackground(DaytimeNighttime.getBackgroundColor());
          }
          
          if (hasFocus) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
@@ -233,7 +233,7 @@ public abstract class ConfigDialog extends MMDialog {
          } catch (Exception e) {
             ReportingUtils.showError(e);
          }
-         add(showFlagsPanel_);
+         add(showFlagsPanel_, "growx");
       }
 
       okButton_ = new JButton("OK");

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
@@ -23,6 +23,35 @@
 
 package org.micromanager.internal.dialogs;
 
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.Font;
+
+import javax.swing.AbstractAction;
+import javax.swing.ActionMap;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.ListSelectionModel;
+import javax.swing.SpringLayout;
+import javax.swing.SwingConstants;
+
+import javax.swing.border.BevelBorder;
+import javax.swing.table.TableColumn;
+
+import mmcorej.CMMCore;
+import mmcorej.Configuration;
+
 import org.micromanager.internal.utils.DaytimeNighttime;
 import org.micromanager.internal.utils.ShowFlags;
 import org.micromanager.internal.utils.PropertyUsageCellRenderer;
@@ -34,14 +63,7 @@ import org.micromanager.internal.utils.PropertyUsageCellEditor;
 import org.micromanager.internal.utils.ShowFlagsPanel;
 import org.micromanager.internal.utils.PropertyTableData;
 import org.micromanager.internal.utils.PropertyValueCellRenderer;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.border.BevelBorder;
-import javax.swing.table.TableColumn;
-import mmcorej.CMMCore;
-import mmcorej.Configuration;
+
 import org.micromanager.Studio;
 
 /*

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
@@ -37,13 +37,13 @@ import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
-import javax.swing.SpringLayout;
 import javax.swing.SwingConstants;
 
 import javax.swing.border.BevelBorder;
@@ -51,6 +51,8 @@ import javax.swing.table.TableColumn;
 
 import mmcorej.CMMCore;
 import mmcorej.Configuration;
+
+import net.miginfocom.swing.MigLayout;
 
 import org.micromanager.internal.utils.DaytimeNighttime;
 import org.micromanager.internal.utils.ShowFlags;
@@ -69,7 +71,7 @@ import org.micromanager.Studio;
 /*
  * A base class from which GroupEditor and PresetEditor are derived.
  */
-public class ConfigDialog extends MMDialog {
+public abstract class ConfigDialog extends MMDialog {
 
    private static final long serialVersionUID = 5819669941239786807L;
 
@@ -83,8 +85,7 @@ public class ConfigDialog extends MMDialog {
    private ShowFlags flags_;
    private ShowFlagsPanel showFlagsPanel_;
 
-   private final SpringLayout springLayout_;
-   private JTextArea textArea_;
+   private JTextArea instructionsTextArea_;
    private JCheckBox showReadonlyCheckBox_;
    protected boolean showShowReadonlyCheckBox_ = false;
    protected JTextField nameField_;
@@ -105,7 +106,7 @@ public class ConfigDialog extends MMDialog {
    protected int numColumns_ = 3;
 
    protected boolean newItem_ = true;
-   protected boolean showFlagsPanelVisible = true;
+   protected boolean showFlagsPanelVisible_ = true;
 
    protected int scrollPaneTop_;
 
@@ -116,16 +117,17 @@ public class ConfigDialog extends MMDialog {
       newItem_ = newItem;
       gui_ = gui;
       core_ = core;
-      springLayout_ = new SpringLayout();
-      getContentPane().setLayout(springLayout_);
+      setLayout(new MigLayout("fill, insets 2, gap 2"));
       loadAndRestorePosition(100, 100, 550, 600);
       setMinimumSize(new Dimension(400, 200));
    }
 
    public void initialize() {
-      initializePropertyTable();
+      flags_ = new ShowFlags();
+      data_.setFlags(flags_);
+
       initializeWidgets();
-      initializeFlags();
+      initializePropertyTable();
       setupKeys();
       setVisible(true);
       this.setTitle(TITLE);
@@ -133,25 +135,27 @@ public class ConfigDialog extends MMDialog {
       setFocusable(true);
       update();
    }
-   
-   
-   /*
-    * Assign ENTER and ESCAPE keystrokes to be equivalent to OK and Cancel buttons, respectively.
+
+
+   /**
+    * Assign ENTER and ESCAPE keystrokes to be equivalent to OK and Cancel
+    * buttons, respectively.
     */
    @SuppressWarnings("serial")
    protected void setupKeys() {
       // Get the InputMap and ActionMap of the RootPane of this JDialog.
-      InputMap inputMap = getRootPane().getInputMap( JComponent.WHEN_IN_FOCUSED_WINDOW);
+      InputMap inputMap = getRootPane().getInputMap(
+            JComponent.WHEN_IN_FOCUSED_WINDOW);
       ActionMap actionMap = getRootPane().getActionMap();
-      
+
       // Setup ENTER key.
       inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "enter");
-      actionMap.put("enter", new AbstractAction()  {
+      actionMap.put("enter", new AbstractAction() {
          @Override
-         public void actionPerformed(ActionEvent e)
-         {
-            if (table_.isEditing() && table_.getCellEditor() != null)
+         public void actionPerformed(ActionEvent e) {
+            if (table_.isEditing() && table_.getCellEditor() != null) {
                table_.getCellEditor().stopCellEditing();
+            }
             okChosen();
          }
       });
@@ -160,14 +164,15 @@ public class ConfigDialog extends MMDialog {
       inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "escape");
       actionMap.put("escape", new AbstractAction() {
          @Override
-         public void actionPerformed(ActionEvent e)
-         {
-            cancelChosen();
+         public void actionPerformed(ActionEvent e) {
+            dispose();
          }
       });
 
-      // Stop table_ from consuming the ENTER keystroke and preventing it from being received by this (JDialog).
-      table_.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "none");
+      // Stop table_ from consuming the ENTER keystroke and preventing it from
+      // being received by this (JDialog).
+      table_.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
+            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "none");
    }
 
    public void initializeData() {
@@ -176,20 +181,18 @@ public class ConfigDialog extends MMDialog {
    }
 
    protected void initializeWidgets() {
-      textArea_ = new JTextArea();
-      textArea_.setFont(new Font("Arial", Font.PLAIN, 12));
-      textArea_.setWrapStyleWord(true);
-      textArea_.setText(instructionsText_);
-      textArea_.setEditable(false);
-      textArea_.setOpaque(false);
-      getContentPane().add(textArea_);
-      springLayout_.putConstraint(SpringLayout.EAST, textArea_, 250, SpringLayout.WEST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.WEST, textArea_, 5, SpringLayout.WEST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.SOUTH, textArea_, 37, SpringLayout.NORTH, getContentPane());
-      springLayout_.putConstraint(SpringLayout.NORTH, textArea_, 5, SpringLayout.NORTH, getContentPane());
+      JPanel leftPanel = new JPanel(
+            new MigLayout("filly, flowy, insets 0 6 0 0, gap 2"));
+      instructionsTextArea_ = new JTextArea();
+      instructionsTextArea_.setFont(new Font("Arial", Font.PLAIN, 12));
+      instructionsTextArea_.setWrapStyleWord(true);
+      instructionsTextArea_.setText(instructionsText_);
+      instructionsTextArea_.setEditable(false);
+      instructionsTextArea_.setOpaque(false);
+      leftPanel.add(instructionsTextArea_, "gaptop 2, gapbottom push");
 
       if (showShowReadonlyCheckBox_) {
-         showReadonlyCheckBox_ = new JCheckBox();
+         showReadonlyCheckBox_ = new JCheckBox("Show read-only properties");
          showReadonlyCheckBox_.setFont(new Font("Arial", Font.PLAIN, 10));
          showReadonlyCheckBox_.addActionListener(new ActionListener() {
             @Override
@@ -200,99 +203,66 @@ public class ConfigDialog extends MMDialog {
                data_.fireTableStructureChanged();
              }
          });
-         showReadonlyCheckBox_.setText("Show read-only properties");
-         getContentPane().add(showReadonlyCheckBox_);
-         springLayout_.putConstraint(SpringLayout.EAST, showReadonlyCheckBox_, 250, SpringLayout.WEST, getContentPane());
-         springLayout_.putConstraint(SpringLayout.WEST, showReadonlyCheckBox_, 5, SpringLayout.WEST, getContentPane());
-         springLayout_.putConstraint(SpringLayout.NORTH, showReadonlyCheckBox_, 45, SpringLayout.NORTH, getContentPane());
-         springLayout_.putConstraint(SpringLayout.SOUTH, showReadonlyCheckBox_, 70, SpringLayout.NORTH, getContentPane());
+         leftPanel.add(showReadonlyCheckBox_, "gaptop 5, gapbottom 10");
       }
+
+      nameFieldLabel_ = new JLabel(nameFieldLabelText_);
+      nameFieldLabel_.setFont(new Font("Arial", Font.BOLD, 12));
+      leftPanel.add(nameFieldLabel_, "split 2, flowx, alignx right");
 
       nameField_ = new JTextField();
       nameField_.setText(initName_);
       nameField_.setEditable(true);
       nameField_.setSelectionStart(0);
       nameField_.setSelectionEnd(nameField_.getText().length());
-      getContentPane().add(nameField_);
-      springLayout_.putConstraint(SpringLayout.EAST, nameField_, 280, SpringLayout.WEST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.WEST, nameField_, 95, SpringLayout.WEST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.SOUTH, nameField_, -3, SpringLayout.NORTH, scrollPane_);
-      springLayout_.putConstraint(SpringLayout.NORTH, nameField_, -30, SpringLayout.NORTH, scrollPane_);
+      leftPanel.add(nameField_, "width 180!");
 
-      nameFieldLabel_ = new JLabel();
-      nameFieldLabel_.setText(nameFieldLabelText_);
-      nameFieldLabel_.setFont(new Font("Arial",Font.BOLD,12));
-      nameFieldLabel_.setHorizontalAlignment(SwingConstants.RIGHT);
-      getContentPane().add(nameFieldLabel_);
-      springLayout_.putConstraint(SpringLayout.EAST, nameFieldLabel_, 90, SpringLayout.WEST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.WEST, nameFieldLabel_, 5, SpringLayout.WEST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.SOUTH, nameFieldLabel_, -3, SpringLayout.NORTH, scrollPane_);
-      springLayout_.putConstraint(SpringLayout.NORTH, nameFieldLabel_, -30, SpringLayout.NORTH, scrollPane_);
+      add(leftPanel, "growy, gapright push");
 
-      okButton_ = new JButton("OK");
-      getContentPane().add(okButton_);
-      springLayout_.putConstraint(SpringLayout.EAST, okButton_, -5, SpringLayout.EAST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.WEST, okButton_, -105, SpringLayout.EAST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.SOUTH, okButton_, 30, SpringLayout.NORTH, getContentPane());
-      springLayout_.putConstraint(SpringLayout.NORTH, okButton_, 5, SpringLayout.NORTH, getContentPane());
-      okButton_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            if (table_.isEditing() && table_.getCellEditor() != null)
-               table_.getCellEditor().stopCellEditing();
-            okChosen();
-         }
-      });
-
-
-      cancelButton_ = new JButton("Cancel");
-      getContentPane().add(cancelButton_);
-      springLayout_.putConstraint(SpringLayout.EAST, cancelButton_, -5, SpringLayout.EAST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.WEST, cancelButton_, -105, SpringLayout.EAST, getContentPane());
-      springLayout_.putConstraint(SpringLayout.SOUTH, cancelButton_, 57, SpringLayout.NORTH, getContentPane());
-      springLayout_.putConstraint(SpringLayout.NORTH, cancelButton_, 32, SpringLayout.NORTH, getContentPane());
-      cancelButton_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            cancelChosen();
-         }
-      });
-   }
-
-   protected void initializeFlags() {
-      flags_ = new ShowFlags();
-
-      if (showFlagsPanelVisible ) {
+      if (showFlagsPanelVisible_ ) {
          flags_.load(ConfigDialog.class);
          Configuration cfg;
          try {
-            if (presetName_.length()==0)
+            if (presetName_.length() == 0) {
                cfg = new Configuration();
-            else
+            }
+            else {
                cfg = core_.getConfigState(groupName_, presetName_);
-            showFlagsPanel_ = new ShowFlagsPanel(data_,flags_,core_,cfg);
+            }
+            showFlagsPanel_ = new ShowFlagsPanel(data_, flags_, core_, cfg);
          } catch (Exception e) {
             ReportingUtils.showError(e);
          }
-         getContentPane().add(showFlagsPanel_);
-         springLayout_.putConstraint(SpringLayout.EAST, showFlagsPanel_, 440, SpringLayout.WEST, getContentPane());
-         springLayout_.putConstraint(SpringLayout.WEST, showFlagsPanel_, 290, SpringLayout.WEST, getContentPane());
-         springLayout_.putConstraint(SpringLayout.SOUTH, showFlagsPanel_, 135, SpringLayout.NORTH, getContentPane());
-         springLayout_.putConstraint(SpringLayout.NORTH, showFlagsPanel_, 5, SpringLayout.NORTH, getContentPane());
+         add(showFlagsPanel_);
       }
 
-      data_.setFlags(flags_);
+      okButton_ = new JButton("OK");
+      okButton_.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            if (table_.isEditing() && table_.getCellEditor() != null) {
+               table_.getCellEditor().stopCellEditing();
+            }
+            okChosen();
+         }
+      });
+      add(okButton_, "gapleft push, split 2, flowy, width 90!");
+
+      cancelButton_ = new JButton("Cancel");
+      cancelButton_.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            dispose();
+         }
+      });
+      add(cancelButton_, "gapleft push, gapbottom push, wrap, width 90!");
    }
 
    public void initializePropertyTable() {
         scrollPane_ = new JScrollPane();
         scrollPane_.setFont(new Font("Arial", Font.PLAIN, 10));
         scrollPane_.setBorder(new BevelBorder(BevelBorder.LOWERED));
-        getContentPane().add(scrollPane_);
-        springLayout_.putConstraint(SpringLayout.SOUTH, scrollPane_, -5, SpringLayout.SOUTH, getContentPane());
-        springLayout_.putConstraint(SpringLayout.NORTH, scrollPane_, scrollPaneTop_, SpringLayout.NORTH, getContentPane());
-        springLayout_.putConstraint(SpringLayout.EAST, scrollPane_, -5, SpringLayout.EAST, getContentPane());
-        springLayout_.putConstraint(SpringLayout.WEST, scrollPane_, 5, SpringLayout.WEST, getContentPane());
+        add(scrollPane_, "span, growx, growy, wrap");
 
         table_ = new DaytimeNighttime.Table();
         table_.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -311,15 +281,10 @@ public class ConfigDialog extends MMDialog {
             table_.addColumn(new TableColumn(0, 200, new PropertyNameCellRenderer(), null));
             table_.addColumn(new TableColumn(1, 200, new PropertyValueCellRenderer(false), new PropertyValueCellEditor(false)));
         }
- 
+
    }
 
-   public void okChosen() {
-   }
-
-   public void cancelChosen() {
-      this.dispose();
-   }
+   public abstract void okChosen();
 
    @Override
    public void dispose() {
@@ -332,7 +297,7 @@ public class ConfigDialog extends MMDialog {
       data_.update(false);
    }
 
-   
+
    public void showMessageDialog(String message) {
       JOptionPane.showMessageDialog(this, message);
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
@@ -43,9 +43,6 @@ import org.micromanager.internal.utils.SortFunctionObjects;
 
 public class GroupEditor extends ConfigDialog {
 
-   /**
-    * 
-    */
    private static final long serialVersionUID = 8281144157746745260L;
    private static final String DISPLAY_SHUTTER_WARNING = "Warn user before saving a config group that includes shutter state.";
 
@@ -56,7 +53,7 @@ public class GroupEditor extends ConfigDialog {
       initName_ = groupName_;
       TITLE = "Group Editor";
       showUnused_ = true;
-      showFlagsPanelVisible = true;
+      showFlagsPanelVisible_ = true;
       scrollPaneTop_ = 140;
       numColumns_ = 3;
       data_ = new PropertyTableData(core_, groupName_, presetName_, 2, 1, false);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
 //PROJECT:       Micro-Manager
 //SUBSYSTEM:     mmstudio
 //-----------------------------------------------------------------------------
@@ -41,7 +41,7 @@ public class PresetEditor extends ConfigDialog {
       initName_ = presetName_;
       TITLE = "Preset editor for the \"" + groupName + "\" configuration group";
       showUnused_ = false;
-      showFlagsPanelVisible = false;
+      showFlagsPanelVisible_ = false;
       scrollPaneTop_ = 70;
       numColumns_=2;
       data_ = new PropertyTableData(core_,groupName_,presetName_,1,2, true);

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyTableData.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyTableData.java
@@ -286,10 +286,17 @@ public class PropertyTableData extends AbstractTableModel implements MMPropertyT
       for (PropertyItem item : propList_) {
          // select which devices to display
 
-         showDevice = showDevice(flags, item.device);;
+         showDevice = showDevice(flags, item.device);
 
          if (showUnused_ == false && item.confInclude == false) {
             showDevice = false;
+         }
+
+         if (showDevice && !flags.searchFilter_.isEmpty()) {
+            // Check the device/property name against the search filter.
+            String name = String.format("%s-%s", item.device, item.name);
+            showDevice = name.toLowerCase().contains(
+                  flags.searchFilter_.toLowerCase());
          }
 
          if (showDevice) {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlags.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlags.java
@@ -17,15 +17,12 @@
 //               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
-//
-// CVS:          $Id$
-//
+
 package org.micromanager.internal.utils;
 
 /**
  * Utility class for the PropertyBrowser to specify which devices
  * are currently visible.
- *
  */
 public class ShowFlags {
    public boolean cameras_ = true;
@@ -33,13 +30,15 @@ public class ShowFlags {
    public boolean stages_ = true;
    public boolean state_ = true;
    public boolean other_ = true;
-   
+   public String searchFilter_ = "";
+
    private static final String SHOW_CAMERAS = "show_cameras";
    private static final String SHOW_SHUTTERS = "show_shutters";
    private static final String SHOW_STAGES = "show_stages";
    private static final String SHOW_STATE = "show_state";
    private static final String SHOW_OTHER = "show_other";
-   
+   private static final String SEARCH_FILTER = "search_filter";
+
    public void load(Class<?> c) {
       DefaultUserProfile profile = DefaultUserProfile.getInstance();
       cameras_ = profile.getBoolean(c, SHOW_CAMERAS, cameras_);
@@ -47,8 +46,9 @@ public class ShowFlags {
       stages_ = profile.getBoolean(c, SHOW_STAGES, stages_);
       state_ = profile.getBoolean(c, SHOW_STATE, state_);
       other_ = profile.getBoolean(c, SHOW_OTHER, other_);
+      searchFilter_ = profile.getString(c, SEARCH_FILTER, searchFilter_);
    }
-   
+
    public void save(Class<?> c) {
       DefaultUserProfile profile = DefaultUserProfile.getInstance();
       profile.setBoolean(c, SHOW_CAMERAS, cameras_);
@@ -56,5 +56,6 @@ public class ShowFlags {
       profile.setBoolean(c, SHOW_STAGES, stages_);
       profile.setBoolean(c, SHOW_STATE, state_);
       profile.setBoolean(c, SHOW_OTHER, other_);
+      profile.setString(c, SEARCH_FILTER, searchFilter_);
    }
- }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlagsPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlagsPanel.java
@@ -26,7 +26,10 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 import javax.swing.BorderFactory;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.JCheckBox;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
@@ -58,7 +61,7 @@ public class ShowFlagsPanel extends JPanel {
       initialCfg_ = initialCfg;
       setBorder(BorderFactory.createTitledBorder("Show"));
       // We need very little vertical space between components.
-      setLayout(new MigLayout("insets 0, gap -3"));
+      setLayout(new MigLayout("fill, insets 0, gap -3"));
       createComponents();
       initializeComponents();
    }
@@ -119,6 +122,28 @@ public class ShowFlagsPanel extends JPanel {
          }
       });
       add(showOtherCheckBox_, "wrap");
+
+      add(new JLabel("Filter by name:"), "gaptop 1, gapbottom 1, wrap");
+      searchFilterText_ = new JTextField();
+      searchFilterText_.getDocument().addDocumentListener(
+            new DocumentListener() {
+         @Override
+         public void changedUpdate(DocumentEvent e) {
+            updateSearchFilter();
+         }
+         public void insertUpdate(DocumentEvent e) {
+            updateSearchFilter();
+         }
+         public void removeUpdate(DocumentEvent e) {
+            updateSearchFilter();
+         }
+      });
+      add(searchFilterText_, "growx, wrap");
+   }
+
+   private void updateSearchFilter() {
+      flags_.searchFilter_ = searchFilterText_.getText();
+      data_.updateRowVisibility(flags_);
    }
 
    protected void initializeComponents() {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlagsPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlagsPanel.java
@@ -27,146 +27,139 @@ import java.awt.event.ActionListener;
 
 import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
-import javax.swing.JLayeredPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
 
 import mmcorej.CMMCore;
 import mmcorej.Configuration;
 import mmcorej.DeviceType;
 
-public class ShowFlagsPanel extends JLayeredPane {
+import net.miginfocom.swing.MigLayout;
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 2414705031299832388L;
-	private JCheckBox showCamerasCheckBox_;
-	private JCheckBox showShuttersCheckBox_;
-	private JCheckBox showStagesCheckBox_;
-	private JCheckBox showStateDevicesCheckBox_;
-	private JCheckBox showOtherCheckBox_;
-	private Configuration initialCfg_;
+public class ShowFlagsPanel extends JPanel {
 
-	private ShowFlags flags_;
-	private PropertyTableData data_;
-	private CMMCore core_;
+   private static final long serialVersionUID = 2414705031299832388L;
+   private JCheckBox showCamerasCheckBox_;
+   private JCheckBox showShuttersCheckBox_;
+   private JCheckBox showStagesCheckBox_;
+   private JCheckBox showStateDevicesCheckBox_;
+   private JCheckBox showOtherCheckBox_;
+   private JTextField searchFilterText_;
+   private Configuration initialCfg_;
 
+   private ShowFlags flags_;
+   private PropertyTableData data_;
+   private CMMCore core_;
 
-	public ShowFlagsPanel(PropertyTableData data, ShowFlags flags, CMMCore core, Configuration initialCfg) {
-		data_ = data;
-		flags_ = flags;
-		core_ = core;
-		initialCfg_ = initialCfg;
-		setBorder(BorderFactory.createTitledBorder("Show"));
-		createCheckboxes();
-		initializeCheckboxes();
-	}
+   public ShowFlagsPanel(PropertyTableData data, ShowFlags flags, CMMCore core, Configuration initialCfg) {
+      data_ = data;
+      flags_ = flags;
+      core_ = core;
+      initialCfg_ = initialCfg;
+      setBorder(BorderFactory.createTitledBorder("Show"));
+      // We need very little vertical space between components.
+      setLayout(new MigLayout("insets 0, gap -3"));
+      createComponents();
+      initializeComponents();
+   }
 
-	public void createCheckboxes() {
-		showCamerasCheckBox_ = new JCheckBox();
-		showCamerasCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-		showCamerasCheckBox_.addActionListener(new ActionListener() {
+   public void createComponents() {
+      Font font = new Font("", Font.PLAIN, 10);
+      showCamerasCheckBox_ = new JCheckBox("cameras");
+      showCamerasCheckBox_.setFont(font);
+      showCamerasCheckBox_.addActionListener(new ActionListener() {
          @Override
-			public void actionPerformed(ActionEvent arg0) {
-				flags_.cameras_ = showCamerasCheckBox_.isSelected();
-				data_.updateRowVisibility(flags_);
-			}
-		});
-		showCamerasCheckBox_.setText("cameras");
-		add(showCamerasCheckBox_);
-		showCamerasCheckBox_.setBounds(5,20,130,20);
+         public void actionPerformed(ActionEvent arg0) {
+            flags_.cameras_ = showCamerasCheckBox_.isSelected();
+            data_.updateRowVisibility(flags_);
+         }
+      });
+      add(showCamerasCheckBox_, "wrap");
 
-		showShuttersCheckBox_ = new JCheckBox();
-		showShuttersCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-		showShuttersCheckBox_.addActionListener(new ActionListener() {
+      showShuttersCheckBox_ = new JCheckBox("shutters");
+      showShuttersCheckBox_.setFont(font);
+      showShuttersCheckBox_.addActionListener(new ActionListener() {
          @Override
-			public void actionPerformed(ActionEvent arg0) {
-				flags_.shutters_ = showShuttersCheckBox_.isSelected();
-				data_.updateRowVisibility(flags_);
-			}
-		});
-		showShuttersCheckBox_.setText("shutters");
-		add(showShuttersCheckBox_);
-		showShuttersCheckBox_.setBounds(5,40,130,20);
+         public void actionPerformed(ActionEvent arg0) {
+            flags_.shutters_ = showShuttersCheckBox_.isSelected();
+            data_.updateRowVisibility(flags_);
+         }
+      });
+      add(showShuttersCheckBox_, "wrap");
 
-		showStagesCheckBox_ = new JCheckBox();
-		showStagesCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-		showStagesCheckBox_.addActionListener(new ActionListener() {
+      showStagesCheckBox_ = new JCheckBox("stages");
+      showStagesCheckBox_.setFont(font);
+      showStagesCheckBox_.addActionListener(new ActionListener() {
          @Override
-			public void actionPerformed(ActionEvent arg0) {
-				flags_.stages_ = showStagesCheckBox_.isSelected();
-				data_.updateRowVisibility(flags_);
-			}
-		});
-		showStagesCheckBox_.setText("stages");
-		add(showStagesCheckBox_);
-		showStagesCheckBox_.setBounds(5,60,130,20);
+         public void actionPerformed(ActionEvent arg0) {
+            flags_.stages_ = showStagesCheckBox_.isSelected();
+            data_.updateRowVisibility(flags_);
+         }
+      });
+      add(showStagesCheckBox_, "wrap");
 
-		showStateDevicesCheckBox_ = new JCheckBox();
-		showStateDevicesCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-		showStateDevicesCheckBox_.addActionListener(new ActionListener() {
+      showStateDevicesCheckBox_ = new JCheckBox("wheels, turrets, etc.");
+      showStateDevicesCheckBox_.setFont(font);
+      showStateDevicesCheckBox_.addActionListener(new ActionListener() {
          @Override
-			public void actionPerformed(ActionEvent arg0) {
-				flags_.state_ = showStateDevicesCheckBox_.isSelected();
-				data_.updateRowVisibility(flags_);
-			}
-		});
-		showStateDevicesCheckBox_.setText("wheels, turrets, etc.");
-		add(showStateDevicesCheckBox_);
-		showStateDevicesCheckBox_.setBounds(5,80,130,20);
+         public void actionPerformed(ActionEvent arg0) {
+            flags_.state_ = showStateDevicesCheckBox_.isSelected();
+            data_.updateRowVisibility(flags_);
+         }
+      });
+      add(showStateDevicesCheckBox_, "wrap");
 
-		showOtherCheckBox_ = new JCheckBox();
-		showOtherCheckBox_.setFont(new Font("", Font.PLAIN, 10));
-		showOtherCheckBox_.addActionListener(new ActionListener() {
+      showOtherCheckBox_ = new JCheckBox("other devices");
+      showOtherCheckBox_.setFont(font);
+      showOtherCheckBox_.addActionListener(new ActionListener() {
          @Override
-			public void actionPerformed(ActionEvent arg0) {
-				flags_.other_ = showOtherCheckBox_.isSelected();
-				data_.updateRowVisibility(flags_);
-			}
-		});
-		showOtherCheckBox_.setText("other devices");
-		add(showOtherCheckBox_);
-		showOtherCheckBox_.setBounds(5,100,130,20);
-	}
+         public void actionPerformed(ActionEvent arg0) {
+            flags_.other_ = showOtherCheckBox_.isSelected();
+            data_.updateRowVisibility(flags_);
+         }
+      });
+      add(showOtherCheckBox_, "wrap");
+   }
 
-	protected void initializeCheckboxes() {
-		try {
+   protected void initializeComponents() {
+      try {
 
-			// Setup checkboxes to reflect saved flags_ settings 
-			showCamerasCheckBox_.setSelected(flags_.cameras_);
-			showStagesCheckBox_.setSelected(flags_.stages_);
-			showShuttersCheckBox_.setSelected(flags_.shutters_);
-			showStateDevicesCheckBox_.setSelected(flags_.state_);
-			showOtherCheckBox_.setSelected(flags_.other_);
+         // Setup checkboxes to reflect saved flags_ settings 
+         showCamerasCheckBox_.setSelected(flags_.cameras_);
+         showStagesCheckBox_.setSelected(flags_.stages_);
+         showShuttersCheckBox_.setSelected(flags_.shutters_);
+         showStateDevicesCheckBox_.setSelected(flags_.state_);
+         showOtherCheckBox_.setSelected(flags_.other_);
 
-			// get properties contained in the current config
+         // get properties contained in the current config
 
-			// change 'show' flags to always show contained devices
-			for (int i=0; i< initialCfg_.size(); i++) {
-				DeviceType dtype = core_.getDeviceType(initialCfg_.getSetting(i).getDeviceLabel());
-				if (dtype == DeviceType.CameraDevice) {
-					flags_.cameras_ = true;
-					showCamerasCheckBox_.setSelected(true);
-				} else if (dtype == DeviceType.ShutterDevice) {
-					flags_.shutters_ = true;
-					showShuttersCheckBox_.setSelected(true);
-				} else if (dtype == DeviceType.StageDevice) {
-					flags_.stages_ = true;
-					showStagesCheckBox_.setSelected(true);
-				} else if (dtype == DeviceType.StateDevice) {
-					flags_.state_ = true;
-					showStateDevicesCheckBox_.setSelected(true);
-				} else {
-					showOtherCheckBox_.setSelected(true);
-					flags_.other_ = true;;
-				}
-			}
-		} catch (Exception e) {
-			handleException(e);
-		}
-	}
-	
-	private void handleException(Exception e) {
-		ReportingUtils.logError(e);
-	}
+         // change 'show' flags to always show contained devices
+         for (int i=0; i< initialCfg_.size(); i++) {
+            DeviceType dtype = core_.getDeviceType(initialCfg_.getSetting(i).getDeviceLabel());
+            if (dtype == DeviceType.CameraDevice) {
+               flags_.cameras_ = true;
+               showCamerasCheckBox_.setSelected(true);
+            } else if (dtype == DeviceType.ShutterDevice) {
+               flags_.shutters_ = true;
+               showShuttersCheckBox_.setSelected(true);
+            } else if (dtype == DeviceType.StageDevice) {
+               flags_.stages_ = true;
+               showStagesCheckBox_.setSelected(true);
+            } else if (dtype == DeviceType.StateDevice) {
+               flags_.state_ = true;
+               showStateDevicesCheckBox_.setSelected(true);
+            } else {
+               showOtherCheckBox_.setSelected(true);
+               flags_.other_ = true;;
+            }
+         }
+      } catch (Exception e) {
+         handleException(e);
+      }
+   }
+   
+   private void handleException(Exception e) {
+      ReportingUtils.logError(e);
+   }
 
 }


### PR DESCRIPTION
This adds a text box to the Device Property Browser/Config Group Editor which can be used to find specific properties by searching by name. The search is case-insensitive and can include device names (using the standard "devicename-propertyname" construction).

This change also converts the GUI for those dialogs to use MigLayout instead of SpringLayout, and makes a number of style changes.

I wanted to use the same system for the Pixel Calibration Editor, but unfortunately it uses a different backing data for its property table that isn't compatible with the `ShowFlagsPanel` that the other entities use. Its GUI appears to be a largely copied one-off of the existing GUIs; maybe future work can bring it up to speed. For the time being I've settled for just fixing a longstanding legibility issue with rendering in "night mode".