### PR TITLE
Changed separator in ROI String.

### DIFF
--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -633,7 +633,7 @@
       int [] xSize = new int[1];
       int [] ySize = new int[1];
       getROI(x, y, xSize, ySize);
-      roi += x[0] + "-" + y[0] + "-" + xSize[0] + "-" + ySize[0];
+      roi += x[0] + "_" + y[0] + "_" + xSize[0] + "_" + ySize[0];
       return roi;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/MDUtils.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/MDUtils.java
@@ -539,7 +539,13 @@ public class MDUtils {
    public static Rectangle getROI(JSONObject tags)
       throws IllegalArgumentException, JSONException {
       String roiString = tags.getString("ROI");
-      String[] xywh = roiString.split("-");
+      String[] xywh = roiString.split("_");
+      // We switched in July 2016 to using "_" as separator from "-"
+      // For backwards compatability, check with the old separator is the 
+      // new one does not work as expected
+      if (xywh.length != 4) {
+         xywh = roiString.split("-");
+      }
       if (xywh.length != 4) {
          throw new IllegalArgumentException("Invalid ROI tag");
       }
@@ -552,7 +558,7 @@ public class MDUtils {
    }
 
    public static void setROI(JSONObject tags, Rectangle r) throws JSONException {
-      String roiString = String.format("%d-%d-%d-%d", 
+      String roiString = String.format("%d_%d_%d_%d", 
             (int) r.getX(), (int) r.getY(), 
             (int) r.getWidth(), (int) r.getHeight());
       tags.put("ROI", roiString);


### PR DESCRIPTION
Micro-Manager internally uses a String to represent an ROI.
Up to now, that string consisted of - separated numbers.  Even
though negative numbers should never show up, they do, and
cause problems because the negative sign is seen as a separator
by the code.  This commit changes the separator to an underscore
and tries to handle old strings with the dash as separator
gracefully.  Note that this is a work-around the separate issue
of ROIs with negative numbers.