### PR TITLE
Scrips: Better reporting of Null Pointer Exceptions

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/script/BeanshellEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/BeanshellEngine.java
@@ -134,6 +134,11 @@ public class BeanshellEngine implements ScriptingEngine {
    private String formatBeanshellError(EvalError e, int line) {
       if (e instanceof TargetError) {
          Throwable t = ((TargetError)e).getTarget();
+         if (t instanceof NullPointerException) {
+            // Null Pointer Exceptions do not seem to have much more information
+            // However, do make clear to the user that this is a npe
+            return "Line " + line + ": Null Pointer Exception"; 
+         }
          return "Line " + line + ": run-time error : " + (t != null ? t.getMessage() : e.getErrorText());       
       } else if (e instanceof ParseException) {
          return "Line " + line + ": syntax error : " + e.getErrorText();  


### PR DESCRIPTION
Previously whenever a null pointer exception (npe) happened, the
Beanshell console would report ```line x: general error: null```.
It helps me to know that a npe ocurred, so I changed the code to
report ```line x: Null Pointer Exception```.