### PR TITLE
MultiShading plugin: Add missing code and fix negative ROIs.

### DIFF
--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ImageCollection.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ImageCollection.java
@@ -250,6 +250,16 @@ public class ImageCollection {
       } else {
          resultProcessor = ipi.getProcessor().duplicate();
       }
+      // HACK/Fix: The Andor Zyla often returns an ROI with roi.x ==-1 pr roi.y == -1
+      // That creates problems because the image after setRoi will be one pixel
+      // to small (i.e., the image should always have the correct height and width
+      // This can be removed once ROIs can be trusted to have all number >= 0
+      if (roi.x < 0) {
+         roi.x = 0;
+      }
+      if (roi.y < 0) {
+         roi.y = 0;
+      }
       resultProcessor.setRoi(roi);
       ImagePlusInfo newIp = new ImagePlusInfo(new ImagePlus("", resultProcessor.crop()), 
               binning, roi);

--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ImageUtils.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ImageUtils.java
@@ -22,6 +22,7 @@
 package org.micromanager.multichannelshading;
 
 import ij.process.ByteProcessor;
+import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
 import ij.process.ShortProcessor;
 
@@ -44,6 +45,14 @@ public class ImageUtils {
             return subtractShortProcessors((ShortProcessor) proc1, (ShortProcessor) proc2);
          } else if (proc1 instanceof ShortProcessor && proc2 instanceof ByteProcessor) {
             return subtractShortByteProcessors((ShortProcessor) proc1, (ByteProcessor) proc2);
+         } else if (proc1 instanceof ShortProcessor && proc2 instanceof FloatProcessor) {
+            return subtractShortFloatProcessors((ShortProcessor) proc1, (FloatProcessor) proc2);
+         } else if (proc1 instanceof FloatProcessor && proc2 instanceof ByteProcessor) {
+             return subtractFloatProcessors((FloatProcessor) proc1, (ByteProcessor) proc2);
+         } else if (proc1 instanceof FloatProcessor && proc2 instanceof ShortProcessor) {
+             return subtractFloatProcessors((FloatProcessor) proc1, (ShortProcessor) proc2);
+         } else if (proc1 instanceof FloatProcessor) {
+            return subtractFloatProcessors((FloatProcessor) proc1, (FloatProcessor) proc2);
          } else {
              throw new ShadingException("Types of images to be subtracted were not compatible");
          }
@@ -68,6 +77,34 @@ public class ImageUtils {
       return new ShortProcessor(proc1.getWidth(), proc1.getHeight(),
               subtractPixelArrays((short []) proc1.getPixels(), (short []) proc2.getPixels()),
               null);
+   }
+      
+   private static ShortProcessor subtractShortFloatProcessors(ShortProcessor proc1, FloatProcessor proc2) {
+       return new ShortProcessor(proc1.getWidth(), proc1.getHeight(),
+               subtractPixelArrays( (short[]) proc1.getPixels(), (float []) proc2.getPixels() ),
+                null);
+   }
+   
+   public static ImageProcessor subtractFloatProcessors(FloatProcessor proc1, 
+           ByteProcessor proc2) {
+       return new FloatProcessor(proc1.getWidth(), proc1.getHeight(),
+               subtractPixelArrays((float[]) proc1.getPixels(), 
+               (byte[]) proc2.getPixels() ),
+               null);
+   }
+   
+   public static ImageProcessor subtractFloatProcessors(FloatProcessor proc1, 
+           ShortProcessor proc2) {
+       return new FloatProcessor(proc1.getWidth(), proc1.getHeight(),
+               subtractPixelArrays((float[]) proc1.getPixels(), 
+               (short[]) proc2.getPixels() ),
+               null);
+   }
+   
+   public static ImageProcessor subtractFloatProcessors(FloatProcessor proc1, FloatProcessor proc2) {
+       return new FloatProcessor(proc1.getWidth(), proc1.getHeight(),
+               subtractPixelArrays((float[]) proc1.getPixels(), (float[]) proc2.getPixels()),
+               null);
    }
       
    public static byte[] subtractPixelArrays(byte[] array1, byte[] array2) {
@@ -97,6 +134,41 @@ public class ImageUtils {
       }
       return result;
    }
+   public static short[] subtractPixelArrays(short[] array1, float[] array2) {
+      int l = array1.length;
+      short[] result = new short[l];
+      for (int i=0; i < l; i++) {
+         result[i] = (short) Math.max (0, unsignedValue(array1[i]) - unsignedValue( (short) array2[i]));
+      }
+      return result;
+   }
+   public static float[] subtractPixelArrays(float[] array1, byte[] array2) {
+      int l = array1.length;
+      float[] result = new float[l];
+      for (int i=0;i<l;++i) {
+         result[i] = array1[i] - unsignedValue(array2[i]);
+      }
+      return result;
+   }
+   
+   public static float[] subtractPixelArrays(float[] array1, short[] array2) {
+      int l = array1.length;
+      float[] result = new float[l];
+      for (int i=0;i<l;++i) {
+         result[i] = array1[i] - unsignedValue(array2[i]);
+      }
+      return result;
+   }
+   
+   public static float[] subtractPixelArrays(float[] array1, float[] array2) {
+      int l = array1.length;
+      float[] result = new float[l];
+      for (int i=0;i<l;++i) {
+         result[i] = array1[i] - array2[i];
+      }
+      return result;
+   }
+   
    
    public static int unsignedValue(byte b) {
       // Sign-extend, then mask


### PR DESCRIPTION
Previous refactoring left out processing of Floatprocessors, which
is needed at runtime.  Also, negative ROIs that now make it though to
this plugin cause problems with image dimensions due to the way they
are handles by the ImageJ setROI function.  Therefore, negative x and y
positions are moved to 0, which works around this porblem, possible at
cost of a slightly offset flatfield (not sure if that is really the case).