### PR TITLE
Improved error reporting for Beanshell.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/script/BeanshellEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/BeanshellEngine.java
@@ -39,7 +39,8 @@ public class BeanshellEngine implements ScriptingEngine {
             // special handling of the parse errors beacuse beanshell error object
             // has bugs and does not return line numbers
             String msg = e.getMessage();
-            String lineNumberTxt = msg.substring(20, msg.indexOf(','));
+            String lineNumberTxt = msg.substring(0, msg.indexOf(','));
+            lineNumberTxt = lineNumberTxt.substring(lineNumberTxt.lastIndexOf(' ') + 1);
             panel_.displayError("Parse error: " + msg, Integer.parseInt(lineNumberTxt));
          } catch (EvalError e) {
             int lineNo = e.getErrorLineNumber(); 


### PR DESCRIPTION
The code catching a ParseException parses out the line number at which the
parse error happened from the eror message.  It had a hard-coded offset of
20 in the string, hence any error message that had the line number at
a different position would cause an uncaught exception in the Integer.parseInt 
function, and no output to the user.  This change has a somewhat better approach 
(albeit still feeble and easily breakable) to finding the line number.  
A full fix requires fixing the Beanshell code that causes the line numbers to be unreliable.