### PR TITLE
Beanshell startup script, fix for issue with inspect function.

### DIFF
--- a/mmstudio/src/main/scripts/org/micromanager/scriptpanel_startup.bsh
+++ b/mmstudio/src/main/scripts/org/micromanager/scriptpanel_startup.bsh
@@ -203,6 +203,7 @@ inspect(obj) {
    }
 
    Vector getFieldRow(obj, cls, field) {
+      value = "null";
       try {
          v = eval("obj." + field.getName());
          value = (v != null ? v.toString() : "null");


### PR DESCRIPTION
The inspect function declared in scriptpanel_startup.bsh no longer
worked and barfed in line 216 in which a null value for the String
value was used.  By setting the variable value to a String "null", this
error is avoided.  It is a bit unclear why the problem occurred to begin
with, but I do not think that warrants the time to figure out an explanation.