### PR TITLE
Add Application and ApplicationSkin APIs

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/Application.java
+++ b/mmstudio/src/main/java/org/micromanager/Application.java
@@ -1,0 +1,145 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Nenad Amodaj, nenad@amodaj.com, December 3, 2006
+//               Chris Weisiger, 2015
+//
+// COPYRIGHT:    University of California, San Francisco, 2006-2015
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+
+package org.micromanager;
+
+
+import java.awt.geom.AffineTransform;
+import java.awt.Rectangle;
+import javax.swing.JFrame;
+
+import org.micromanager.data.Datastore;
+
+
+/**
+ * Provides access to and control of various aspects of the user interface,
+ * allowing code to directly update and control the GUI. This interface can
+ * be accessed from the Studio by calling Studio.getApplication() or
+ * Studio.app().
+ */
+public interface Application {
+   /**
+    * Updates the GUI so that its state reflects the current state of the
+    * hardware (as understood by the Micro-Manager Core). This method will
+    * poll each device in the system for its current state, which may take
+    * significant time. Compare refreshGUIFromCache().
+    */
+   public void refreshGUI();
+
+   /**
+    * Updates the GUI so that its state reflects the current state of the
+    * hardware (as understood by the Micro-Manager Core). This method will
+    * pull values from the Core's System State Cache, which is fast but may not
+    * necessarily reflect the actual state of hardware.
+    */
+   public void refreshGUIFromCache();
+
+   /**
+    * Set the exposure time for the current channel (if any). Equivalent to
+    * updating the exposure time field in the main window.
+    * @param exposureMs Exposure time, in milliseconds.
+    */
+   public void setExposure(double exposureMs);
+
+   /**
+    * Updates the exposure time associated with the given preset. If the
+    * channel-group and channel name match the current active channel settings,
+    * then the displayed exposure time will also be updated.
+    *
+    * @param channelGroup Name of the config group used to control the channel.
+    * @param channel Name of the preset in the config group that refers to the
+    *        channel that should be updated.
+    * @param exposure New exposure time to set.
+    */
+   public void setChannelExposureTime(String channelGroup, String channel,
+           double exposure);
+
+   /**
+    * Retrieve the exposure time that has been set for the specified channel.
+    *
+    * @param channelGroup Name of the config group used to control the channel.
+    * @param channel Name of the preset in the config group that refers to the
+    *        channel whose exposure time is desired.
+    * @param defaultExp Default value to return if no exposure time is found.
+    * @return Exposure time for the channel, or the provided default value.
+    */
+   public double getChannelExposureTime(String channelGroup, String channel,
+           double defaultExp);
+
+   /**
+    * Pop up a dialog prompting the user to save their config file, which has
+    * presumably been updated to include new config groups and/or presets.
+    */
+   public void saveConfigPresets();
+
+   /**
+    * Pop up the dialog used to configure the autofocus settings for the
+    * current autofocus device.
+    */
+   public void showAutofocusDialog();
+
+   /**
+    * Display the position list dialog.
+    */
+   public void showPositionList();
+
+   /**
+    * Set the default camera's ROI -- a convenience function. Will stop and
+    * start Live mode for you, and update the GUI's display of values such as
+    * the view dimensions.
+    * @param rect Rectangle defining the ROI
+    * @throws Exception if there is an error in the Core when setting the ROI
+    */
+   public void setROI(Rectangle rect) throws Exception;
+
+   /**
+    * Move the main Micro-Manager window to the top of the user interface.
+    */
+   public void makeActive();
+
+   /**
+    * Returns true if user has chosen to hide MDA window when it runs.
+    * @return true if user has chosen to hide MDA window
+    */
+   public boolean getHideMDADisplayOption();
+
+   /**
+    * Provide access to the main window of the program. This is largely
+    * intended to allow client code to position their windows with respect
+    * to the main window.
+    */
+   public JFrame getMainWindow();
+
+   /**
+    * Provides access to the application skin API for determining colors for
+    * various GUI components.
+    * @return ApplicationSkin instance.
+    */
+   public ApplicationSkin skin();
+
+   /**
+    * Provides access to the application skin API for determining colors for
+    * various GUI components. Identical to skin() except in name.
+    * @return ApplicationSkin instance.
+    */
+   public ApplicationSkin getApplicationSkin();
+}

--- a/mmstudio/src/main/java/org/micromanager/Application.java
+++ b/mmstudio/src/main/java/org/micromanager/Application.java
@@ -25,6 +25,8 @@ package org.micromanager;
 
 import java.awt.geom.AffineTransform;
 import java.awt.Rectangle;
+import java.io.IOException;
+
 import javax.swing.JFrame;
 
 import org.micromanager.data.Datastore;
@@ -86,10 +88,16 @@ public interface Application {
            double defaultExp);
 
    /**
-    * Pop up a dialog prompting the user to save their config file, which has
-    * presumably been updated to include new config groups and/or presets.
+    * Save the current state of the config file to the specified path. If you
+    * have generated new config groups and/or presets, they will be included
+    * in the new file.
+    * @param path Path to save the file to.
+    * @param allowOverwrite If true, any existing file at the specified path
+    *        will be overwritten.
+    * @throws IOException If shouldOverwrite is false and there is already a
+    *         file at the chosen path.
     */
-   public void saveConfigPresets();
+   public void saveConfigPresets(String path, boolean allowOverwrite) throws IOException;
 
    /**
     * Pop up the dialog used to configure the autofocus settings for the
@@ -115,12 +123,6 @@ public interface Application {
     * Move the main Micro-Manager window to the top of the user interface.
     */
    public void makeActive();
-
-   /**
-    * Returns true if user has chosen to hide MDA window when it runs.
-    * @return true if user has chosen to hide MDA window
-    */
-   public boolean getHideMDADisplayOption();
 
    /**
     * Provide access to the main window of the program. This is largely

--- a/mmstudio/src/main/java/org/micromanager/ApplicationSkin.java
+++ b/mmstudio/src/main/java/org/micromanager/ApplicationSkin.java
@@ -23,6 +23,7 @@
 package org.micromanager;
 
 
+import java.awt.Color;
 import java.awt.geom.AffineTransform;
 import java.awt.Rectangle;
 import javax.swing.JFrame;
@@ -32,8 +33,14 @@ import org.micromanager.data.Datastore;
 
 /**
  * Provides access to methods dealing with the "skin" or "look and feel" of the
- * user interface. This interface can be accessed via the Studio by
- * calling Studio.getSkin() or Studio.skin().
+ * user interface. In the majority of situations, you should not need to worry
+ * about what skin the GUI is using; it is set by the user and automatically
+ * applies to most GUI elements without any special effort on your part. This
+ * module allows you to change the skin programmatically, and provides manual
+ * access to certain color information for when you have a GUI element that
+ * does not automatically respect the current skin.
+ * This interface can be accessed via the Studio by calling Studio.getSkin() or
+ * Studio.skin().
  */
 public interface ApplicationSkin {
    /**
@@ -73,4 +80,35 @@ public interface ApplicationSkin {
     * @return the current Micro-Manager skin.
     */
    public SkinMode getSkin();
+
+   /**
+    * Return the current background color for normal GUI elements.
+    * @return current background color
+    */
+   public Color getBackgroundColor();
+
+   /**
+    * Return the current "lighter" background color for highlighted or
+    * otherwise differentiated GUI elements.
+    * @return light background color
+    */
+   public Color getLightBackgroundColor();
+
+   /**
+    * Return the current "disabled" background color.
+    * @return "disabled" background color
+    */
+   public Color getDisabledBackgroundColor();
+
+   /**
+    * Return the current color for enabled text.
+    * @return current color for enabled text
+    */
+   public Color getEnabledTextColor();
+
+   /**
+    * Return the current color for disabled text.
+    * @return current color for disabled text.
+    */
+   public Color getDisabledTextColor();
 }

--- a/mmstudio/src/main/java/org/micromanager/ApplicationSkin.java
+++ b/mmstudio/src/main/java/org/micromanager/ApplicationSkin.java
@@ -39,8 +39,8 @@ import org.micromanager.data.Datastore;
  * module allows you to change the skin programmatically, and provides manual
  * access to certain color information for when you have a GUI element that
  * does not automatically respect the current skin.
- * This interface can be accessed via the Studio by calling Studio.getSkin() or
- * Studio.skin().
+ * This interface can be accessed via the Application by calling
+ * Application.getSkin() or Application.skin().
  */
 public interface ApplicationSkin {
    /**

--- a/mmstudio/src/main/java/org/micromanager/ApplicationSkin.java
+++ b/mmstudio/src/main/java/org/micromanager/ApplicationSkin.java
@@ -1,0 +1,76 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Nenad Amodaj, nenad@amodaj.com, December 3, 2006
+//               Chris Weisiger, 2015
+//
+// COPYRIGHT:    University of California, San Francisco, 2006-2015
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+
+package org.micromanager;
+
+
+import java.awt.geom.AffineTransform;
+import java.awt.Rectangle;
+import javax.swing.JFrame;
+
+import org.micromanager.data.Datastore;
+
+
+/**
+ * Provides access to methods dealing with the "skin" or "look and feel" of the
+ * user interface. This interface can be accessed via the Studio by
+ * calling Studio.getSkin() or Studio.skin().
+ */
+public interface ApplicationSkin {
+   /**
+    * Available skins used by the application.
+    */
+   public enum SkinMode {
+      DAY("Day"), NIGHT("Night");
+      private final String desc_;
+
+      SkinMode(String desc) {
+         desc_ = desc;
+      }
+
+      public String getDesc() {
+         return desc_;
+      }
+
+      public static SkinMode fromString(String desc) {
+         for (SkinMode mode : SkinMode.values()) {
+            if (mode.getDesc().contentEquals(desc)) {
+               return mode;
+            }
+         }
+         throw new IllegalArgumentException("Invalid skin mode " + desc);
+      }
+   }
+
+   /**
+    * Sets the background color of the GUI to the selected mode. This will
+    * provoke a refresh of the GUI and post a ApplicationSkinEvent to the
+    * application-wide event bus.
+    * @param mode The mode to use.
+    */
+   public void setSkin(SkinMode mode);
+
+   /**
+    * @return the current Micro-Manager skin.
+    */
+   public SkinMode getSkin();
+}

--- a/mmstudio/src/main/java/org/micromanager/CompatibilityInterface.java
+++ b/mmstudio/src/main/java/org/micromanager/CompatibilityInterface.java
@@ -37,74 +37,6 @@ import org.micromanager.data.Datastore;
  */
 public interface CompatibilityInterface {
    /**
-    * Brings GUI up to date with the recent changes in the mmcore.
-    */
-   public void refreshGUI();
-   
-    /**
-    * Brings GUI up to date with the recent changes in the mmcore.
-    * Does not communicate with hardware, only checks Cache
-    */
-   public void refreshGUIFromCache();
-
-   /**
-    * Set the exposure time for the current channel (if any). Equivalent to
-    * updating the exposure time field in the main window.
-    * @param exposureMs Exposure time, in milliseconds.
-    */
-   public void setExposure(double exposureMs);
-
-   /**
-    * Updates the exposure time associated with the given preset
-    * If the channel-group and channel name match the current state
-    * the exposure time will also be updated
-    * 
-    * @param channelGroup - 
-    * 
-    * @param channel - preset for which to change exposure time
-    * @param exposure - desired exposure time
-    */
-   public void setChannelExposureTime(String channelGroup, String channel,
-           double exposure);
-   
-    /**
-    * Returns exposure time for the desired preset in the given channelgroup
-    * Acquires its info from the preferences
-    * Same thing is used in MDA window, but this class keeps its own copy
-    * 
-    * @param channelGroup
-    * @param channel - 
-    * @param defaultExp - default value
-    * @return exposure time
-    */
-   public double getChannelExposureTime(String channelGroup, String channel,
-           double defaultExp);
-   
-   /**
-    * Save current configuration
-    */
-   public void saveConfigPresets();
-
-   /**
-    * Shows the dialog with options for the currently active autofocus device.
-    */
-   public void showAutofocusDialog();
-
-   /**
-    * Shows the position list dialog
-    */
-   public void showPositionList();
-
-   /**
-    * Set the default camera's ROI -- a convenience function. Will stop and
-    * start Live mode for you, and update the GUI's display of values such as
-    * the view dimensions.
-    * @param rect Rectangle defining the ROI
-    * @throws Exception if there is an error in the Core when setting the ROI
-    */
-   public void setROI(Rectangle rect) throws Exception;
-
-   /**
     * Displays an error message and returns true if the run-time Micro-Manager
     * version is less than the one specified.
     * Versions in Micro-Manager are of the format:
@@ -124,38 +56,9 @@ public interface CompatibilityInterface {
    public boolean versionLessThan(String version) throws NumberFormatException;
 
    /**
-    * Write various properties of MM and the OS to the log.
-    */
-   public void logStartupProperties();
-
-   /*
-    * Make the main window the frontmost, active window again
-    */
-   public void makeActive();
-
-   /**
     * @return the currently running Micro-Manager version
     */
    public String getVersion();
-
-   /**
-    * Returns true if user has chosen to hide MDA window when it runs.
-    * @return true if user has chosen to hide MDA window
-    */
-   public boolean getHideMDADisplayOption();
-
-   /**
-    * lets the GUI know that the current configuration has been changed.  Activates
-    * the save button it status is true
-    * @param status 
-    */
-   public void setConfigChanged(boolean status);
-
-   /**
-    * Enabled or disable the ROI buttons on the main window.
-    * @param enabled true: enable, false: disable ROI buttons
-    */
-   public void enableRoiButtons(final boolean enabled);
 
    /**
     * Retrieve the affine transform describing how the camera image maps to
@@ -176,11 +79,4 @@ public interface CompatibilityInterface {
     *        to set the affine transform for.
     */
    public void setCameraTransform(AffineTransform transform, String config);
-
-   /**
-    * Provide access to the main window of the program. This is largely
-    * intended to allow client code to position their windows with respect
-    * to the main window.
-    */
-   public JFrame getMainWindow();
 }

--- a/mmstudio/src/main/java/org/micromanager/CompatibilityInterface.java
+++ b/mmstudio/src/main/java/org/micromanager/CompatibilityInterface.java
@@ -145,37 +145,6 @@ public interface CompatibilityInterface {
    public boolean getHideMDADisplayOption();
 
    /**
-    * One of the allowed inputs to setBackgroundStyle(), to set the program
-    * to a bright, high-contrast "daytime" mode.
-    */
-   public static final String DAY = "Day";
-   /**
-    * One of the allowed inputs to setBackgroundStyle(), to set the program
-    * to a dark, low-contrast "nighttime" mode.
-    */
-   public static final String NIGHT = "Night";
-   /**
-    * A list compiling all of the possible inputs to setBackgroundStyle().
-    */
-   public static final String[] BACKGROUND_OPTIONS = new String[] {
-      DAY, NIGHT
-   };
-
-   /**
-    * Sets the background color of the GUI to the selected mode. Will throw an
-    * IllegalArgumentException if the provided input is not an item from
-    * BACKGROUND_OPTIONS.
-    * @param backgroundType One of the values from the BACKGROUND_OPTIONS list.
-    */
-   public void setBackgroundStyle(String backgroundType);
-
-   /**
-    * @return the current Micro-Manager background style, which will be one
-    * of ScriptInterface.DAY or ScriptInterface.NIGHT.
-    */
-   public String getBackgroundStyle();
-
-   /**
     * lets the GUI know that the current configuration has been changed.  Activates
     * the save button it status is true
     * @param status 

--- a/mmstudio/src/main/java/org/micromanager/Studio.java
+++ b/mmstudio/src/main/java/org/micromanager/Studio.java
@@ -250,4 +250,18 @@ public interface Studio {
     * @return ShutterManager instance.
     */
    public ShutterManager getShutterManager();
+
+   /**
+    * Provides access to the application skin API for determining colors for
+    * various GUI components.
+    * @return ApplicationSkin instance.
+    */
+   public ApplicationSkin skin();
+
+   /**
+    * Provides access to the application skin API for determining colors for
+    * various GUI components. Identical to skin() except in name.
+    * @return ApplicationSkin instance.
+    */
+   public ApplicationSkin getApplicationSkin();
 }

--- a/mmstudio/src/main/java/org/micromanager/Studio.java
+++ b/mmstudio/src/main/java/org/micromanager/Studio.java
@@ -252,16 +252,16 @@ public interface Studio {
    public ShutterManager getShutterManager();
 
    /**
-    * Provides access to the application skin API for determining colors for
-    * various GUI components.
-    * @return ApplicationSkin instance.
+    * Provides access to the application API for controlling and updating the
+    * GUI.
+    * @return Application instance.
     */
-   public ApplicationSkin skin();
+   public Application app();
 
    /**
-    * Provides access to the application skin API for determining colors for
-    * various GUI components. Identical to skin() except in name.
-    * @return ApplicationSkin instance.
+    * Provides access to the application API for controlling and updating the
+    * GUI. Identical to app() except in name.
+    * @return Application instance.
     */
-   public ApplicationSkin getApplicationSkin();
+   public Application getApplication();
 }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionSelector.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionSelector.java
@@ -133,7 +133,7 @@ public class AcquisitionSelector {
          setIcon(label.getIcon());
          setFont(label.getFont());
          // TODO this color is wrong in daytime mode.
-         setBackground(isSelected ? DaytimeNighttime.getLightBackgroundColor() : DaytimeNighttime.getBackgroundColor());
+         setBackground(isSelected ? DaytimeNighttime.getInstance().getLightBackgroundColor() : DaytimeNighttime.getInstance().getBackgroundColor());
          return this;
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/StatusDisplay.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/StatusDisplay.java
@@ -110,7 +110,7 @@ public class StatusDisplay extends JFrame {
       add(contents);
       pack();
       // Put us centered, on the same display as the main window.
-      GUIUtils.centerFrameWithFrame(this, studio_.compat().getMainWindow());
+      GUIUtils.centerFrameWithFrame(this, studio_.app().getMainWindow());
       setVisible(true);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
@@ -221,7 +221,7 @@ public class ConfigGroupPad extends JScrollPane {
                   // Associate exposure time with presets in current channel group
                   if (item.group.equals(core_.getChannelGroup())) {
                      core_.setExposure(
-                           parentGUI_.compat().getChannelExposureTime(
+                           parentGUI_.app().getChannelExposureTime(
                              item.group, value.toString(), core_.getExposure()) );
                   }
                   
@@ -241,7 +241,7 @@ public class ConfigGroupPad extends JScrollPane {
                         parentGUI.updateGUI(false);
                      }
                      else {
-                        parentGUI_.compat().refreshGUI();
+                        parentGUI_.app().refreshGUI();
                      }
                   }
                   

--- a/mmstudio/src/main/java/org/micromanager/internal/ConfigPadButtonPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/ConfigPadButtonPanel.java
@@ -38,6 +38,7 @@ import javax.swing.SwingConstants;
 import mmcorej.CMMCore;
 
 import org.micromanager.Studio;
+import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.dialogs.GroupEditor;
 import org.micromanager.internal.dialogs.PresetEditor;
 import org.micromanager.internal.utils.ReportingUtils;
@@ -161,7 +162,7 @@ public final class ConfigPadButtonPanel extends JPanel {
          removePreset();
       if (e.getSource() == editPresetButton_)
          editPreset();
-      studio_.compat().refreshGUI();
+      studio_.app().refreshGUI();
    }
 
    @SuppressWarnings("ResultOfObjectAllocationIgnored")
@@ -179,7 +180,7 @@ public final class ConfigPadButtonPanel extends JPanel {
          if (result == JOptionPane.OK_OPTION) {
             try {
                core_.deleteConfigGroup(groupName);
-               studio_.compat().setConfigChanged(true);
+               ((MMStudio) studio_).setConfigChanged(true);
             } catch (Exception e) {
                handleException(e);
             }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -61,6 +61,7 @@ import mmcorej.StrVector;
 import org.micromanager.acquisition.AcquisitionManager;
 import org.micromanager.acquisition.internal.DefaultAcquisitionManager;
 import org.micromanager.Album;
+import org.micromanager.Application;
 import org.micromanager.ApplicationSkin;
 import org.micromanager.AutofocusManager;
 import org.micromanager.AutofocusPlugin;
@@ -144,7 +145,7 @@ import org.micromanager.internal.utils.WaitDialog;
  * Implements the Studio (i.e. primary API) and does various other
  * tasks that should probably be refactored out at some point.
  */
-public class MMStudio implements Studio, CompatibilityInterface, PositionListManager {
+public class MMStudio implements Studio, CompatibilityInterface, PositionListManager, Application {
 
    private static final long serialVersionUID = 3556500289598574541L;
    private static final String OPEN_ACQ_DIR = "openDataDir";
@@ -1319,7 +1320,6 @@ public class MMStudio implements Studio, CompatibilityInterface, PositionListMan
    /**
     * Inserts version info for various components in the Corelog
     */
-   @Override
    public void logStartupProperties() {
       core_.logMessage("User: " + System.getProperty("user.name"));
       String hostname;
@@ -1354,8 +1354,6 @@ public class MMStudio implements Studio, CompatibilityInterface, PositionListMan
       posListDlg_.setVisible(true);
    }
 
-   
-   @Override
    public void setConfigChanged(boolean status) {
       configChanged_ = status;
       frame_.setConfigSaveButtonStatus(configChanged_);
@@ -1408,8 +1406,7 @@ public class MMStudio implements Studio, CompatibilityInterface, PositionListMan
                  + channelGroup + ", channel: " + channel + ", exposure: " + exposure);
       }
    }
-     
-   @Override
+
    public void enableRoiButtons(final boolean enabled) {
       frame_.enableRoiButtons(enabled);
    }
@@ -1652,6 +1649,16 @@ public class MMStudio implements Studio, CompatibilityInterface, PositionListMan
    @Override
    public PositionListManager getPositionListManager() {
       return positions();
+   }
+
+   @Override
+   public Application app() {
+      return this;
+   }
+
+   @Override
+   public Application getApplication() {
+      return app();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -61,6 +61,7 @@ import mmcorej.StrVector;
 import org.micromanager.acquisition.AcquisitionManager;
 import org.micromanager.acquisition.internal.DefaultAcquisitionManager;
 import org.micromanager.Album;
+import org.micromanager.ApplicationSkin;
 import org.micromanager.AutofocusManager;
 import org.micromanager.AutofocusPlugin;
 import org.micromanager.CompatibilityInterface;
@@ -262,7 +263,7 @@ public class MMStudio implements Studio, CompatibilityInterface, PositionListMan
          startupScriptFile_ = "";
       }
 
-      setBackgroundStyle(DaytimeNighttime.getBackgroundMode());
+      DaytimeNighttime.getInstance().loadStoredSkin();
 
       RegistrationDlg.showIfNecessary();
 
@@ -1413,19 +1414,6 @@ public class MMStudio implements Studio, CompatibilityInterface, PositionListMan
       frame_.enableRoiButtons(enabled);
    }
 
-   /*
-    * Changes background color of this window and all other MM windows
-    */
-   @Override
-   public final void setBackgroundStyle(String backgroundType) {
-      DaytimeNighttime.setMode(backgroundType);
-   }
-
-   @Override
-   public String getBackgroundStyle() {
-      return DaytimeNighttime.getBackgroundMode();
-   }
-
    @Override
    public void setPositionList(PositionList pl) {
       // use serialization to clone the PositionList object
@@ -1664,6 +1652,16 @@ public class MMStudio implements Studio, CompatibilityInterface, PositionListMan
    @Override
    public PositionListManager getPositionListManager() {
       return positions();
+   }
+
+   @Override
+   public ApplicationSkin skin() {
+      return DaytimeNighttime.getInstance();
+   }
+
+   @Override
+   public ApplicationSkin getApplicationSkin() {
+      return skin();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -573,7 +573,7 @@ public class MainFrame extends MMFrame implements LiveModeListener {
             new Runnable() {
                @Override
                public void run() {
-                  studio_.compat().showPositionList();
+                  studio_.app().showPositionList();
                }
             });
       stagePanel.add(listButton, SMALLBUTTON_SIZE);

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -141,6 +141,7 @@ public class MainFrame extends MMFrame implements LiveModeListener {
 
    private AbstractButton setRoiButton_;
    private AbstractButton clearRoiButton_;
+   private AbstractButton centerQuadButton_;
 
    @SuppressWarnings("LeakingThisInConstructor")
    public MainFrame(MMStudio studio, CMMCore core, SnapLiveManager manager,
@@ -509,7 +510,7 @@ public class MainFrame extends MMFrame implements LiveModeListener {
             }
          });
       roiPanel.add(setRoiButton_, SMALLBUTTON_SIZE);
-      JButton centerQuadButton = createButton(null, "center_quad.png",
+      centerQuadButton_ = createButton(null, "center_quad.png",
          "Set Region Of Interest to center quad of camera",
          new Runnable() {
             @Override
@@ -517,7 +518,7 @@ public class MainFrame extends MMFrame implements LiveModeListener {
                studio_.setCenterQuad();
             }
          });
-      roiPanel.add(centerQuadButton, SMALLBUTTON_SIZE);
+      roiPanel.add(centerQuadButton_, SMALLBUTTON_SIZE);
 
       clearRoiButton_ = createButton(null, "arrow_out.png",
          "Reset Region of Interest to full frame",
@@ -845,6 +846,7 @@ public class MainFrame extends MMFrame implements LiveModeListener {
            public void run() {
                setRoiButton_.setEnabled(enabled);
                clearRoiButton_.setEnabled(enabled);
+               centerQuadButton_.setEnabled(enabled);
            }
        });
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -367,7 +367,7 @@ public class MainFrame extends MMFrame implements LiveModeListener {
          new Runnable() {
             @Override
             public void run() {
-               studio_.saveConfigPresets();
+               studio_.promptToSaveConfigPresets();
             }
          });
       subPanel.add(saveConfigButton_,

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -245,7 +245,7 @@ public class PropertyEditor extends MMFrame {
          }
          core_.updateSystemStateCache();
          refresh(true);
-         studio_.compat().refreshGUIFromCache();
+         studio_.app().refreshGUIFromCache();
          fireTableCellUpdated(row, col);
       }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -372,7 +372,7 @@ public class AcqControlDlg extends MMFrame implements PropertyChangeListener,
       listButton_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            studio_.compat().showPositionList();
+            studio_.app().showPositionList();
          }
       });
 
@@ -719,7 +719,7 @@ public class AcqControlDlg extends MMFrame implements PropertyChangeListener,
             saveSettings();
             saveAcqSettings();
             AcqControlDlg.this.dispose();
-            studio_.compat().makeActive();
+            studio_.app().makeActive();
          }
       });
       return closeButton;
@@ -1079,7 +1079,7 @@ public class AcqControlDlg extends MMFrame implements PropertyChangeListener,
             String channel = studio_.core().getCurrentConfig(channelGroup);
             double exposure = getChannelExposureTime(
                   channelGroup, channel, 10.0);
-            studio_.compat().setChannelExposureTime(channelGroup, channel,
+            studio_.app().setChannelExposureTime(channelGroup, channel,
                   exposure);
          }
          catch (Exception e) {
@@ -1109,7 +1109,7 @@ public class AcqControlDlg extends MMFrame implements PropertyChangeListener,
    }
 
    protected void afOptions() {
-      studio_.compat().showAutofocusDialog();
+      studio_.app().showAutofocusDialog();
    }
 
    public boolean inArray(String member, String[] group) {
@@ -1152,7 +1152,7 @@ public class AcqControlDlg extends MMFrame implements PropertyChangeListener,
       }
       if (null != studio_) {
          try {
-            studio_.compat().makeActive();
+            studio_.app().makeActive();
          } catch (Throwable t) {
             ReportingUtils.logError(t, "in makeActive");
          }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
@@ -1000,9 +1000,9 @@ public class CalibrationEditor extends MMDialog {
          lab.setHorizontalAlignment(JLabel.LEFT);
          lab.setOpaque(true);
          if (item_.readOnly) {
-            lab.setBackground(DaytimeNighttime.getDisabledBackgroundColor());
+            lab.setBackground(DaytimeNighttime.getInstance().getDisabledBackgroundColor());
          } else {
-            lab.setBackground(DaytimeNighttime.getBackgroundColor());
+            lab.setBackground(DaytimeNighttime.getInstance().getBackgroundColor());
          }
          
          if (hasFocus) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
@@ -630,7 +630,7 @@ public class CalibrationEditor extends MMDialog {
                refresh();
 
                if (parentGUI_ != null)
-                  parentGUI_.compat().refreshGUI();              
+                  parentGUI_.app().refreshGUI();
                fireTableCellUpdated(row, col);
             } catch (Exception e) {
                ReportingUtils.showError(e);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
@@ -31,6 +31,7 @@ import javax.swing.table.AbstractTableModel;
 import mmcorej.CMMCore;
 import mmcorej.Configuration;
 import org.micromanager.Studio;
+import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.Calibration;
 import org.micromanager.internal.utils.CalibrationList;
 import org.micromanager.internal.utils.DaytimeNighttime;
@@ -98,8 +99,8 @@ public class CalibrationListDlg extends MMDialog {
                double val = Double.parseDouble(value.toString());
                core_.setPixelSizeUm(cal.getLabel(), val);
                cal.setPixelSizeUm(val);
-               parentGUI_.compat().setConfigChanged(true);
-               parentGUI_.compat().refreshGUI();
+               ((MMStudio) parentGUI_).setConfigChanged(true);
+               parentGUI_.app().refreshGUI();
             } catch (Exception e) {                                                              
                handleException(e);                                                               
             }  
@@ -275,8 +276,8 @@ public class CalibrationListDlg extends MMDialog {
          calibrationList_.getCalibrationsFromCore();
          CalTableModel ptm = (CalTableModel)calTable_.getModel();
          ptm.fireTableDataChanged();
-         parentGUI_.compat().setConfigChanged(true);
-         parentGUI_.compat().refreshGUI();
+         ((MMStudio) parentGUI_).setConfigChanged(true);
+         parentGUI_.app().refreshGUI();
       }
    }
 
@@ -292,15 +293,15 @@ public class CalibrationListDlg extends MMDialog {
       if (editPreset(label, size)) {
          calibrationList_.getCalibrationsFromCore();
          ptm.fireTableDataChanged();
-         parentGUI_.compat().setConfigChanged(true);
-         parentGUI_.compat().refreshGUI();
+         ((MMStudio) parentGUI_).setConfigChanged(true);
+         parentGUI_.app().refreshGUI();
       }
    }
 
    public void updateCalibrations() {
       refreshCalibrations();
-      parentGUI_.compat().setConfigChanged(true);
-      parentGUI_.compat().refreshGUI();
+      ((MMStudio) parentGUI_).setConfigChanged(true);
+      parentGUI_.app().refreshGUI();
    }
    
    public void refreshCalibrations() {
@@ -331,8 +332,8 @@ public class CalibrationListDlg extends MMDialog {
          }
          calibrationList_.getCalibrationsFromCore();
          ptm.fireTableDataChanged();
-         parentGUI_.compat().refreshGUI();
-         parentGUI_.compat().setConfigChanged(true);
+         parentGUI_.app().refreshGUI();
+         ((MMStudio) parentGUI_).setConfigChanged(true);
       }
    }
 
@@ -351,8 +352,8 @@ public class CalibrationListDlg extends MMDialog {
          calibrationList_.getCalibrationsFromCore();
          CalTableModel ptm = (CalTableModel)calTable_.getModel();
          ptm.fireTableDataChanged();
-         parentGUI_.compat().refreshGUI();
-         parentGUI_.compat().setConfigChanged(true);
+         parentGUI_.app().refreshGUI();
+         ((MMStudio) parentGUI_).setConfigChanged(true);
       }
    }
 
@@ -367,7 +368,7 @@ public class CalibrationListDlg extends MMDialog {
          dlg.setCore(core_);
          dlg.setVisible(true);
          if (dlg.isChanged()) {
-            parentGUI_.compat().setConfigChanged(true);
+            ((MMStudio) parentGUI_).setConfigChanged(true);
          }
          return dlg.isChanged();
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -123,7 +123,7 @@ public class ChannelTableModel extends AbstractTableModel implements TableModelL
          AcqControlDlg.storeChannelExposure(acqEng_.getChannelGroup(),
                channel.config, channel.exposure);
          if (AcqControlDlg.getShouldSyncExposure()) {
-            studio_.compat().setChannelExposureTime(acqEng_.getChannelGroup(), 
+            studio_.app().setChannelExposureTime(acqEng_.getChannelGroup(),
                     channel.config, channel.exposure);
          }
       } else if (col == 3) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
@@ -290,7 +290,7 @@ public abstract class ConfigDialog extends MMDialog {
    public void dispose() {
       super.dispose();
       savePosition();
-      gui_.compat().refreshGUI();
+      gui_.app().refreshGUI();
    }
 
    public void update() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
@@ -36,6 +36,7 @@ import mmcorej.StrVector;
 import net.miginfocom.swing.MigLayout;
 
 import org.micromanager.Studio;
+import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.PropertyItem;
 import org.micromanager.internal.utils.PropertyTableData;
 import org.micromanager.internal.utils.ReportingUtils;
@@ -290,7 +291,7 @@ public class GroupEditor extends ConfigDialog {
          }
       }
 
-      gui_.compat().setConfigChanged(true);
+      ((MMStudio) gui_).setConfigChanged(true);
       return true;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -341,7 +341,7 @@ public class OptionsDlg extends MMDialog {
    private void changeBackground() {
       String background = (String) comboDisplayBackground_.getSelectedItem();
 
-      parent_.skin().setSkin(SkinMode.fromString(background));
+      parent_.app().skin().setSkin(SkinMode.fromString(background));
    }
 
    private void closeRequested() {
@@ -362,7 +362,7 @@ public class OptionsDlg extends MMDialog {
       MMStudio.setCoreLogLifetimeDays(deleteLogDays);
 
       ScriptPanel.setStartupScript(startupScriptFile_.getText());
-      parent_.compat().makeActive();
+      parent_.app().makeActive();
       dispose();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -38,7 +38,8 @@ import javax.swing.WindowConstants;
 
 import mmcorej.CMMCore;
 
-import org.micromanager.CompatibilityInterface;
+import org.micromanager.ApplicationSkin;
+import org.micromanager.ApplicationSkin.SkinMode;
 import org.micromanager.data.internal.multipagetiff.StorageMultipageTiff;
 import org.micromanager.Studio;
 import org.micromanager.internal.logging.LogFileManager;
@@ -204,9 +205,13 @@ public class OptionsDlg extends MMDialog {
       bufSizeField_ = new JTextField(
             Integer.toString(MMStudio.getCircularBufferSize()), 5);
 
-      comboDisplayBackground_ = new JComboBox(CompatibilityInterface.BACKGROUND_OPTIONS);
+      String[] options = new String[SkinMode.values().length];
+      for (int i = 0; i < SkinMode.values().length; ++i) {
+         options[i] = SkinMode.values()[i].getDesc();
+      }
+      comboDisplayBackground_ = new JComboBox(options);
       comboDisplayBackground_.setMaximumRowCount(2);
-      comboDisplayBackground_.setSelectedItem(DaytimeNighttime.getBackgroundMode());
+      comboDisplayBackground_.setSelectedItem(DaytimeNighttime.getInstance().getSkin().getDesc());
       comboDisplayBackground_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
@@ -336,7 +341,7 @@ public class OptionsDlg extends MMDialog {
    private void changeBackground() {
       String background = (String) comboDisplayBackground_.getSelectedItem();
 
-      parent_.compat().setBackgroundStyle(background);
+      parent_.skin().setSkin(SkinMode.fromString(background));
    }
 
    private void closeRequested() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
@@ -26,6 +26,7 @@ import mmcorej.Configuration;
 import mmcorej.StrVector;
 
 import org.micromanager.Studio;
+import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.PropertyItem;
 import org.micromanager.internal.utils.PropertyTableData;
 import org.micromanager.internal.utils.ReportingUtils;
@@ -123,7 +124,7 @@ public class PresetEditor extends ConfigDialog {
          }
       }
 
-      gui_.compat().setConfigChanged(true);
+      ((MMStudio) gui_).setConfigChanged(true);
       return true;
 
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/RegistrationDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/RegistrationDlg.java
@@ -101,7 +101,7 @@ public class RegistrationDlg extends JDialog {
       // DaytimeNighttime returns here gets overridden as soon as setVisible()
       // is called, for unknown reasons.
       welcomeTextArea_.setBackground(new Color(
-            DaytimeNighttime.getDisabledBackgroundColor().getRGB()));
+            DaytimeNighttime.getInstance().getDisabledBackgroundColor().getRGB()));
       welcomeTextArea_.setFocusable(false);
       welcomeTextArea_.setEditable(false);
       welcomeTextArea_.setFont(new Font("Arial", Font.PLAIN, 12));

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
@@ -149,7 +149,7 @@ public class ConfigMenu {
 
          // Show a "please wait" dialog.
          JDialog waiter = GUIUtils.createBareMessageDialog(
-               studio_.compat().getMainWindow(),
+               studio_.app().getMainWindow(),
                "Loading Wizard; please wait...");
          waiter.setVisible(true);
 

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
@@ -107,7 +107,7 @@ public class ConfigMenu {
               new Runnable() {
                  @Override
                  public void run() {
-                    studio_.saveConfigPresets();
+                    studio_.promptToSaveConfigPresets();
                     studio_.updateChannelCombos();
                  }
               });
@@ -140,7 +140,7 @@ public class ConfigMenu {
                   JOptionPane.QUESTION_MESSAGE, null, options,
                   options[0]);
             if (n == JOptionPane.YES_OPTION) {
-               studio_.saveConfigPresets();
+               studio_.promptToSaveConfigPresets();
             }
             studio_.setConfigChanged(false);
          }

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
@@ -101,7 +101,7 @@ public class ToolsMenu {
               new Runnable() {
                  @Override
                  public void run() {
-                    studio_.compat().showPositionList();
+                    studio_.app().showPositionList();
                  }
               },
               "application_view_list.png");

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/FirstRowRenderer.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/FirstRowRenderer.java
@@ -28,8 +28,8 @@ class FirstRowRenderer extends JLabel implements TableCellRenderer {
       setText((String) text);
       // HACK: use the "disabled" color for this row to differentiate it from
       // other rows.
-      setBackground(DaytimeNighttime.getDisabledBackgroundColor());
-      setForeground(DaytimeNighttime.getEnabledTextColor());
+      setBackground(DaytimeNighttime.getInstance().getDisabledBackgroundColor());
+      setForeground(DaytimeNighttime.getInstance().getEnabledTextColor());
       return this;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -1240,7 +1240,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
           ReportingUtils.logError(e);
         promptStr = "bsh % ";
       } 
-     cons_.print("\n"+promptStr, DaytimeNighttime.getEnabledTextColor());
+     cons_.print("\n"+promptStr, DaytimeNighttime.getInstance().getEnabledTextColor());
    }
    
    /**
@@ -1441,7 +1441,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       messagePane_.setCharacterAttributes(
          sc_.getStyle(blackStyleName_), false);
       messagePane_.replaceSelection(text + "\n");
-      cons_.print("\n" + text, DaytimeNighttime.getEnabledTextColor());
+      cons_.print("\n" + text, DaytimeNighttime.getInstance().getEnabledTextColor());
       showPrompt();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -577,11 +577,11 @@ public class AutofocusPropertyEditor extends MMDialog {
          }
          
          if (item_.readOnly) {
-            comp.setBackground(DaytimeNighttime.getDisabledBackgroundColor());
-            comp.setForeground(DaytimeNighttime.getDisabledTextColor());
+            comp.setBackground(DaytimeNighttime.getInstance().getDisabledBackgroundColor());
+            comp.setForeground(DaytimeNighttime.getInstance().getDisabledTextColor());
          } else {
-            comp.setBackground(DaytimeNighttime.getBackgroundColor());
-            comp.setForeground(DaytimeNighttime.getEnabledTextColor());
+            comp.setBackground(DaytimeNighttime.getInstance().getBackgroundColor());
+            comp.setForeground(DaytimeNighttime.getInstance().getEnabledTextColor());
          }         
          return comp;
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
@@ -260,6 +260,7 @@ public class DaytimeNighttime implements ApplicationSkin {
     * Return the current background color.
     * @return current background color
     */
+   @Override
    public Color getBackgroundColor() {
       return background_.get(getSkin());
    }
@@ -268,6 +269,7 @@ public class DaytimeNighttime implements ApplicationSkin {
     * Return the current "lighter" background color.
     * @return light background color
     */
+   @Override
    public Color getLightBackgroundColor() {
       return lightBackground_.get(getSkin());
    }
@@ -276,6 +278,7 @@ public class DaytimeNighttime implements ApplicationSkin {
     * Return a proper "disabled" background color based on the current mode.
     * @return "disabled" background color based on the current mode
     */
+   @Override
    public Color getDisabledBackgroundColor() {
       return disabledBackground_.get(getSkin());
    }
@@ -284,6 +287,7 @@ public class DaytimeNighttime implements ApplicationSkin {
     * Return the current color for enabled text.
     * @return current color for enabled text
     */
+   @Override
    public Color getEnabledTextColor() {
       return enabledTextColor_.get(getSkin());
    }
@@ -292,6 +296,7 @@ public class DaytimeNighttime implements ApplicationSkin {
     * Return the current color for disabled text.
     * @return current color for disabled text.
     */
+   @Override
    public Color getDisabledTextColor() {
       return disabledTextColor_.get(getSkin());
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
@@ -33,7 +33,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.table.TableModel;
 import javax.swing.UIManager;
 
-import org.micromanager.CompatibilityInterface;
+import org.micromanager.ApplicationSkin;
+import org.micromanager.ApplicationSkin.SkinMode;
 
 /*
  * This class controls the colors of the user interface
@@ -41,10 +42,10 @@ import org.micromanager.CompatibilityInterface;
  * interact well with Look and Feel; see
  * http://stackoverflow.com/questions/27933017/cant-update-look-and-feel-on-the-fly
  */
-public class DaytimeNighttime {
+public class DaytimeNighttime implements ApplicationSkin {
 
    // Key into the user's profile for the current display mode.
-   private static final String BACKGROUND_MODE = "current window style (as per CompatibilityInterface.BACKGROUND_OPTIONS)";
+   private static final String BACKGROUND_MODE = "current window style (as per ApplicationSkin.SkinMode)";
    // List of keys to UIManager.put() method for setting the background color
    // look and feel. Selected from this page:
    // http://alvinalexander.com/java/java-uimanager-color-keys-list
@@ -95,63 +96,69 @@ public class DaytimeNighttime {
    };
 
    // background color of the UI
-   private static final HashMap<String, ColorUIResource> background_;
+   private final HashMap<SkinMode, ColorUIResource> background_;
    // background color of disabled UI elements.
-   private static final HashMap<String, ColorUIResource> disabledBackground_;
+   private final HashMap<SkinMode, ColorUIResource> disabledBackground_;
    // Lighter background colors, for certain elements.
-   private static final HashMap<String, ColorUIResource> lightBackground_;
+   private final HashMap<SkinMode, ColorUIResource> lightBackground_;
    // background color of pads in the UI
-   private static final HashMap<String, ColorUIResource> padBackground_;
+   private final HashMap<SkinMode, ColorUIResource> padBackground_;
    // Color of enabled text.
-   private static final HashMap<String, ColorUIResource> enabledTextColor_;
+   private final HashMap<SkinMode, ColorUIResource> enabledTextColor_;
    // Color of disabled text.
-   private static final HashMap<String, ColorUIResource> disabledTextColor_;
+   private final HashMap<SkinMode, ColorUIResource> disabledTextColor_;
 
    // Mode we were in before suspendToMode() was called.
-   private static String suspendedMode_ = null;
+   private SkinMode suspendedMode_ = null;
 
+   private static DaytimeNighttime staticInstance_;
    static {
+      staticInstance_ = new DaytimeNighttime();
+   }
+
+   private DaytimeNighttime() {
       // Possible: make UI to let user set these colors
-      background_ = new HashMap<String, ColorUIResource>();
-      background_.put(CompatibilityInterface.DAY,
+      background_ = new HashMap<SkinMode, ColorUIResource>();
+      background_.put(SkinMode.DAY,
             new ColorUIResource(java.awt.SystemColor.control));
-      background_.put(CompatibilityInterface.NIGHT,
+      background_.put(SkinMode.NIGHT,
             new ColorUIResource(new Color(64, 64, 64)));
 
-      disabledBackground_ = new HashMap<String, ColorUIResource>();
-      disabledBackground_.put(CompatibilityInterface.DAY,
+      disabledBackground_ = new HashMap<SkinMode, ColorUIResource>();
+      disabledBackground_.put(SkinMode.DAY,
             new ColorUIResource(Color.LIGHT_GRAY));
-      disabledBackground_.put(CompatibilityInterface.NIGHT,
+      disabledBackground_.put(SkinMode.NIGHT,
             new ColorUIResource(new Color(32, 32, 32)));
 
-      lightBackground_ = new HashMap<String, ColorUIResource>();
-      lightBackground_.put(CompatibilityInterface.DAY,
+      lightBackground_ = new HashMap<SkinMode, ColorUIResource>();
+      lightBackground_.put(SkinMode.DAY,
             new ColorUIResource(java.awt.SystemColor.control));
       // 37.5% gray; dodging both the OSX checkmark (25% gray) and disabled
       // text (50% gray).
-      lightBackground_.put(CompatibilityInterface.NIGHT,
+      lightBackground_.put(SkinMode.NIGHT,
             new ColorUIResource(new Color(96, 96, 96)));
 
-      padBackground_ = new HashMap<String, ColorUIResource>();
-      padBackground_.put(CompatibilityInterface.DAY,
+      padBackground_ = new HashMap<SkinMode, ColorUIResource>();
+      padBackground_.put(SkinMode.DAY,
             new ColorUIResource(Color.white));
-      padBackground_.put(CompatibilityInterface.NIGHT,
+      padBackground_.put(SkinMode.NIGHT,
             new ColorUIResource(java.awt.SystemColor.control));
 
-      enabledTextColor_ = new HashMap<String, ColorUIResource>();
-      enabledTextColor_.put(CompatibilityInterface.DAY,
+      enabledTextColor_ = new HashMap<SkinMode, ColorUIResource>();
+      enabledTextColor_.put(SkinMode.DAY,
             new ColorUIResource(20, 20, 20));
-      enabledTextColor_.put(CompatibilityInterface.NIGHT,
+      enabledTextColor_.put(SkinMode.NIGHT,
             new ColorUIResource(200, 200, 200));
 
-      disabledTextColor_ = new HashMap<String, ColorUIResource>();
-      disabledTextColor_.put(CompatibilityInterface.DAY,
+      disabledTextColor_ = new HashMap<SkinMode, ColorUIResource>();
+      disabledTextColor_.put(SkinMode.DAY,
             new ColorUIResource(100, 100, 100));
-      disabledTextColor_.put(CompatibilityInterface.NIGHT,
+      disabledTextColor_.put(SkinMode.NIGHT,
             new ColorUIResource(120, 120, 120));
    }
 
-   public static void setMode(String mode) {
+   @Override
+   public void setSkin(SkinMode mode) {
       setMode(mode, true);
    }
 
@@ -161,13 +168,8 @@ public class DaytimeNighttime {
     * wanted in cases where a one-off component must be created that doesn't
     * adhere to our custom look and feel; see suspendToMode() below.
     */
-   private static void setMode(String mode, boolean shouldUpdateUI) {
-      if (!(mode.contentEquals(CompatibilityInterface.DAY) ||
-            mode.contentEquals(CompatibilityInterface.NIGHT))) {
-         throw new IllegalArgumentException("Invalid background style \"" +
-               mode + "\"");
-      }
-      storeBackgroundMode(mode);
+   private void setMode(SkinMode mode, boolean shouldUpdateUI) {
+      storeSkin(mode);
 
       // Ensure every GUI object type gets the right background color.
       for (String key : BACKGROUND_COLOR_KEYS) {
@@ -206,11 +208,9 @@ public class DaytimeNighttime {
     * If the specified mode is not currently active, then we switch to that
     * mode without updating the UI. Useful if a component must be generated
     * with a nonstandard look-and-feel.
-    * @param mode String indicating the mode, e.g. CompatibilityInterface.DAY
-    *        or CompatibilityInterface.NIGHT.
     */
-   public static void suspendToMode(String mode) {
-      suspendedMode_ = getBackgroundMode();
+   public void suspendToMode(SkinMode mode) {
+      suspendedMode_ = getSkin();
       if (suspendedMode_.equals(mode)) {
          // Already in the desired mode.
          suspendedMode_ = null;
@@ -222,7 +222,7 @@ public class DaytimeNighttime {
    /**
     * Restores the mode that was active before suspendToMode was called.
     */
-   public static void resume() {
+   public void resume() {
       if (suspendedMode_ != null) {
          setMode(suspendedMode_, false);
          suspendedMode_ = null;
@@ -233,58 +233,71 @@ public class DaytimeNighttime {
     * Set a new default background mode in the user's profile.
     * @param mode new default background mode
     */
-   public static void storeBackgroundMode(String mode) {
+   private void storeSkin(SkinMode mode) {
       DefaultUserProfile.getInstance().setString(DaytimeNighttime.class,
-            BACKGROUND_MODE, mode);
+            BACKGROUND_MODE, mode.getDesc());
    }
 
    /**
     * Return the current stored background mode from the profile.
     * @return current stored background mode from the profile
     */
-   public static String getBackgroundMode() {
-      return DefaultUserProfile.getInstance().getString(DaytimeNighttime.class,
-            BACKGROUND_MODE, CompatibilityInterface.NIGHT);
+   @Override
+   public SkinMode getSkin() {
+      return SkinMode.fromString(DefaultUserProfile.getInstance().getString(
+               DaytimeNighttime.class,
+            BACKGROUND_MODE, SkinMode.NIGHT.getDesc()));
+   }
+
+   /**
+    * Load the stored skin from the profile and apply it.
+    */
+   public void loadStoredSkin() {
+      setSkin(getSkin());
    }
 
    /**
     * Return the current background color.
     * @return current background color
     */
-   public static Color getBackgroundColor() {
-      return background_.get(getBackgroundMode());
+   public Color getBackgroundColor() {
+      return background_.get(getSkin());
    }
 
    /**
     * Return the current "lighter" background color.
     * @return light background color
     */
-   public static Color getLightBackgroundColor() {
-      return lightBackground_.get(getBackgroundMode());
+   public Color getLightBackgroundColor() {
+      return lightBackground_.get(getSkin());
    }
 
    /**
     * Return a proper "disabled" background color based on the current mode.
     * @return "disabled" background color based on the current mode
     */
-   public static Color getDisabledBackgroundColor() {
-      return disabledBackground_.get(getBackgroundMode());
+   public Color getDisabledBackgroundColor() {
+      return disabledBackground_.get(getSkin());
    }
 
    /**
     * Return the current color for enabled text.
     * @return current color for enabled text
     */
-   public static Color getEnabledTextColor() {
-      return enabledTextColor_.get(getBackgroundMode());
+   public Color getEnabledTextColor() {
+      return enabledTextColor_.get(getSkin());
    }
 
    /**
     * Return the current color for disabled text.
     * @return current color for disabled text.
     */
-   public static Color getDisabledTextColor() {
-      return disabledTextColor_.get(getBackgroundMode());
+   public Color getDisabledTextColor() {
+      return disabledTextColor_.get(getSkin());
+   }
+
+   public static DaytimeNighttime getInstance() {
+      return staticInstance_;
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/DefaultUserProfile.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/DefaultUserProfile.java
@@ -688,7 +688,7 @@ public class DefaultUserProfile implements UserProfile {
       if (!isFirstProfile) {
          // Update a few things that have already pulled values from the
          // default user profile by the time this has happened.
-         DaytimeNighttime.setMode(DaytimeNighttime.getBackgroundMode());
+         DaytimeNighttime.getInstance().loadStoredSkin();
          MMStudio.getInstance().getFrame().resetPosition();
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/FileDialogs.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/FileDialogs.java
@@ -22,7 +22,7 @@ import java.awt.Window;
 import java.io.File;
 import javax.swing.JFileChooser;
 
-import org.micromanager.CompatibilityInterface;
+import org.micromanager.ApplicationSkin.SkinMode;
 
 public class FileDialogs {
 
@@ -149,7 +149,7 @@ public class FileDialogs {
          // the "night" UI. So we temporarily force the "Daytime" look and
          // feel, without redrawing the entire program UI, just for as long as
          // it takes us to create this chooser.
-         DaytimeNighttime.suspendToMode(CompatibilityInterface.DAY);
+         DaytimeNighttime.getInstance().suspendToMode(SkinMode.DAY);
          JFileChooser fc = new JFileChooser();
          if (startFile != null) {
             if ((!load && suggestFileName) || startFile.isDirectory()) {
@@ -158,7 +158,7 @@ public class FileDialogs {
                fc.setSelectedFile(startFile.getParentFile());
             }
          }
-         DaytimeNighttime.resume();
+         DaytimeNighttime.getInstance().resume();
          fc.setDialogTitle(title);
          if (selectDirectories) {
             fc.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyNameCellRenderer.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyNameCellRenderer.java
@@ -45,11 +45,11 @@ public class PropertyNameCellRenderer implements TableCellRenderer {
        lab.setText((String) value);
 
        if (item_.readOnly) {
-           lab.setBackground(DaytimeNighttime.getDisabledBackgroundColor());
-           lab.setForeground(DaytimeNighttime.getDisabledTextColor());
+           lab.setBackground(DaytimeNighttime.getInstance().getDisabledBackgroundColor());
+           lab.setForeground(DaytimeNighttime.getInstance().getDisabledTextColor());
         } else {
-           lab.setBackground(DaytimeNighttime.getBackgroundColor());
-           lab.setForeground(DaytimeNighttime.getEnabledTextColor());
+           lab.setBackground(DaytimeNighttime.getInstance().getBackgroundColor());
+           lab.setForeground(DaytimeNighttime.getInstance().getEnabledTextColor());
         }    
         return lab;
     }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyTableData.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyTableData.java
@@ -175,7 +175,7 @@ public class PropertyTableData extends AbstractTableModel implements MMPropertyT
             setValueInCore(item, value);
             core_.updateSystemStateCache();
             refresh(true);
-            gui_.compat().refreshGUIFromCache();
+            gui_.app().refreshGUIFromCache();
          }
       } else if (col == PropertyUsedColumn_) {
          item.confInclude = ((Boolean) value).booleanValue();

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyUsageCellRenderer.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyUsageCellRenderer.java
@@ -24,7 +24,7 @@ public class PropertyUsageCellRenderer implements TableCellRenderer {
       item_ = data.getPropertyItem(rowIndex);
 
       cb_.setSelected(item_.confInclude);
-      cb_.setBackground(DaytimeNighttime.getBackgroundColor());
+      cb_.setBackground(DaytimeNighttime.getInstance().getBackgroundColor());
       if (item_.readOnly) {
          cb_.setEnabled(false);
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellRenderer.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellRenderer.java
@@ -57,17 +57,17 @@ public class PropertyValueCellRenderer implements TableCellRenderer {
       }
 
       if (item_.readOnly) {
-         comp.setBackground(DaytimeNighttime.getDisabledBackgroundColor());
-         comp.setForeground(DaytimeNighttime.getDisabledTextColor());
+         comp.setBackground(DaytimeNighttime.getInstance().getDisabledBackgroundColor());
+         comp.setForeground(DaytimeNighttime.getInstance().getDisabledTextColor());
       } else {
-         comp.setBackground(DaytimeNighttime.getBackgroundColor());
-         comp.setForeground(DaytimeNighttime.getEnabledTextColor());
+         comp.setBackground(DaytimeNighttime.getInstance().getBackgroundColor());
+         comp.setForeground(DaytimeNighttime.getInstance().getEnabledTextColor());
       }
 
       if (disable_) {
          comp.setEnabled(false);
          // For legibility's sake, we always use the "enabled" color.
-         comp.setForeground(DaytimeNighttime.getEnabledTextColor());
+         comp.setForeground(DaytimeNighttime.getInstance().getEnabledTextColor());
       }
 
       return comp;

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/StateGroupCellRenderer.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/StateGroupCellRenderer.java
@@ -48,8 +48,8 @@ public class StateGroupCellRenderer extends PropertyValueCellRenderer {
             comp.setForeground(Color.BLACK);
         } else {
             // HACK: manually set the colors.
-            comp.setBackground(DaytimeNighttime.getBackgroundColor());
-            comp.setForeground(DaytimeNighttime.getEnabledTextColor());
+            comp.setBackground(DaytimeNighttime.getInstance().getBackgroundColor());
+            comp.setForeground(DaytimeNighttime.getInstance().getEnabledTextColor());
         }
 
         return comp;

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellRenderer.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellRenderer.java
@@ -67,8 +67,8 @@ public class StatePresetCellRenderer implements TableCellRenderer {
             comp.setForeground(Color.BLACK);
         } else {
             // HACK: manually set day/night colors. 
-            comp.setBackground(DaytimeNighttime.getBackgroundColor());
-            comp.setForeground(DaytimeNighttime.getEnabledTextColor());
+            comp.setBackground(DaytimeNighttime.getInstance().getBackgroundColor());
+            comp.setForeground(DaytimeNighttime.getInstance().getEnabledTextColor());
         }
 
         return comp;

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/PresetButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/PresetButton.java
@@ -127,7 +127,7 @@ public class PresetButton extends WidgetPlugin implements SciJavaPlugin {
             try {
                studio_.core().setConfig(group, preset);
                studio_.core().waitForConfig(group, preset);
-               studio_.compat().refreshGUI();
+               studio_.app().refreshGUI();
             }
             catch (Exception e) {
                studio_.logs().showError(e, "Error setting config group " +

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/RefreshButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/RefreshButton.java
@@ -94,6 +94,6 @@ public class RefreshButton extends SimpleButtonPlugin implements SciJavaPlugin {
 
    @Override
    public void activate() {
-      studio_.compat().refreshGUI();
+      studio_.app().refreshGUI();
    }
 }

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/AcquisitionPanel.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/AcquisitionPanel.java
@@ -704,7 +704,7 @@ public class AcquisitionPanel extends ListeningJPanel implements DevicesListener
       editPositionListButton.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            gui_.getCompatibilityInterface().showPositionList();
+            gui_.getApplication().showPositionList();
          }
       });
       positionPanel.add(editPositionListButton, "span 2, center");

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/data/Cameras.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/data/Cameras.java
@@ -153,7 +153,7 @@ public class Cameras {
             }
             currentCameraKey_ = key;
             core_.setCameraDevice(mmDevice);
-            gui_.compat().refreshGUIFromCache();
+            gui_.app().refreshGUIFromCache();
             if (liveEnabled) {
                enableLiveMode(true);
             }

--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
@@ -236,7 +236,7 @@ public class AcquireMultipleRegionsForm extends javax.swing.JFrame {
 //                gui_.compat().setImageSavingFormat(org.micromanager.acquisition.internal.TaggedImageStorageMultipageTiff.class);
                 //update positionlist with grid
                 gui_.positions().setPositionList(currRegion.tileGrid(getXFieldSize(), getYFieldSize(), axisList_, zGenType_));               
-                gui_.compat().refreshGUI();
+                gui_.app().refreshGUI();
                 Datastore store = gui_.acquisitions().runAcquisition(currRegion.filename, currRegion.directory);
                 gui_.displays().closeDisplaysFor(store);
             } catch (Exception ex) {

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
@@ -501,7 +501,7 @@ public class PlatePanel extends JPanel {
       labelBoxY.width = xMargin_;
       labelBoxY.x = 0;
 
-      g.setColor(app_.skin().getEnabledTextColor());
+      g.setColor(app_.app().skin().getEnabledTextColor());
       for (int i=0; i<plate_.getNumColumns(); i++) {
          labelBoxX.x = (int)(i*wellX + 0.5 + xMargin_ + xOffset);
          TextLayout tl = new TextLayout(plate_.getColumnLabel(i+1), f, frc);

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
@@ -27,7 +27,6 @@ import javax.swing.JPanel;
 
 import org.micromanager.PositionList;
 import org.micromanager.Studio;
-import org.micromanager.internal.utils.DaytimeNighttime;
 import org.micromanager.internal.utils.MMScriptException;
 
 
@@ -502,7 +501,7 @@ public class PlatePanel extends JPanel {
       labelBoxY.width = xMargin_;
       labelBoxY.x = 0;
 
-      g.setColor(DaytimeNighttime.getEnabledTextColor());
+      g.setColor(app_.skin().getEnabledTextColor());
       for (int i=0; i<plate_.getNumColumns(); i++) {
          labelBoxX.x = (int)(i*wellX + 0.5 + xMargin_ + xOffset);
          TextLayout tl = new TextLayout(plate_.getColumnLabel(i+1), f, frc);

--- a/plugins/MultiAndor/src/main/java/org/micromanager/multicamera/MultiCameraFrame.java
+++ b/plugins/MultiAndor/src/main/java/org/micromanager/multicamera/MultiCameraFrame.java
@@ -487,7 +487,7 @@ public class MultiCameraFrame extends MMFrame {
          for (String camera : camerasInUse_) {
             setPropertyIfPossible(camera, EMGAIN, NumberUtils.intToCoreString(val));
          }
-         gui_.compat().refreshGUI();
+         gui_.app().refreshGUI();
       } catch (Exception ex) {
          gui_.logs().showError(ex, MultiCameraFrame.class.getName() + " encountered an error.");
       }
@@ -619,7 +619,7 @@ public class MultiCameraFrame extends MMFrame {
 
     private void EMGainSliderMouseReleased(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_EMGainSliderMouseReleased
        setEMGain();
-       gui_.compat().refreshGUI();
+       gui_.app().refreshGUI();
     }//GEN-LAST:event_EMGainSliderMouseReleased
 
     private void tempButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_tempButtonActionPerformed
@@ -662,7 +662,7 @@ public class MultiCameraFrame extends MMFrame {
           updateItems(gainComboBox, AMPGAIN);
           updateItems(speedComboBox, SPEED);
 
-          gui_.compat().refreshGUI();
+          gui_.app().refreshGUI();
        } catch (Exception ex) {
           gui_.logs().showError(ex, MultiCameraFrame.class.getName() + " encountered an error.");
        }
@@ -676,7 +676,7 @@ public class MultiCameraFrame extends MMFrame {
           return;
        }
        setComboSelection(gainComboBox, AMPGAIN);
-       gui_.compat().refreshGUI();
+       gui_.app().refreshGUI();
     }//GEN-LAST:event_gainComboBoxItemStateChanged
 
     private void speedComboBoxItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_speedComboBoxItemStateChanged
@@ -684,7 +684,7 @@ public class MultiCameraFrame extends MMFrame {
           return;
        }
        setComboSelection(speedComboBox, SPEED);
-       gui_.compat().refreshGUI();
+       gui_.app().refreshGUI();
     }//GEN-LAST:event_speedComboBoxItemStateChanged
 
     private void frameTransferComboBoxItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_frameTransferComboBoxItemStateChanged
@@ -692,7 +692,7 @@ public class MultiCameraFrame extends MMFrame {
           return;
        }
        setComboSelection(frameTransferComboBox, FRAMETRANSFER);
-       gui_.compat().refreshGUI();
+       gui_.app().refreshGUI();
     }//GEN-LAST:event_frameTransferComboBoxItemStateChanged
 
     private void triggerComboBoxItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_triggerComboBoxItemStateChanged
@@ -700,7 +700,7 @@ public class MultiCameraFrame extends MMFrame {
           return;
        }
        setComboSelection(triggerComboBox, TRIGGER);
-       gui_.compat().refreshGUI();
+       gui_.app().refreshGUI();
     }//GEN-LAST:event_triggerComboBoxItemStateChanged
 
    private void updateCamerasInUse(String camera) {
@@ -788,7 +788,7 @@ public class MultiCameraFrame extends MMFrame {
           gui_.live().setSuspended(false);
        }
 
-       gui_.compat().refreshGUI();
+       gui_.app().refreshGUI();
     }//GEN-LAST:event_cameraSelectComboBoxItemStateChanged
 
     private void modeComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_modeComboBoxActionPerformed

--- a/plugins/SlideExplorer/src/main/java/org/micromanager/slideexplorer/Hub.java
+++ b/plugins/SlideExplorer/src/main/java/org/micromanager/slideexplorer/Hub.java
@@ -318,7 +318,7 @@ public class Hub {
       roiManager_.updateMappings();
       try {
          app_.positions().setPositionList(roiManager_.convertRoiManagerToPositionList());
-         app_.compat().showPositionList();
+         app_.app().showPositionList();
       } catch (Exception ex) {
          ex.printStackTrace();
       }

--- a/plugins/WhiteBalance/src/main/java/PMQI/WhiteBalance_UI.java
+++ b/plugins/WhiteBalance/src/main/java/PMQI/WhiteBalance_UI.java
@@ -844,7 +844,7 @@ public class WhiteBalance_UI extends javax.swing.JFrame {
         //disable color mode in MM before the WB algorithm
         try {
             core_.setProperty(CameraLabel, "Color", "OFF");
-            gui_.compat().refreshGUI();
+            gui_.app().refreshGUI();
             WBexposure = FindExposureForWB();
         } catch (Exception ex) {
             Logger.getLogger(WhiteBalance_UI.class.getName()).log(Level.SEVERE, null, ex);
@@ -871,14 +871,14 @@ public class WhiteBalance_UI extends javax.swing.JFrame {
                 core_.setProperty(CameraLabel, GREEN_SCALE_LABEL, GreenScale);
                 core_.setProperty(CameraLabel, BLUE_SCALE_LABEL, BlueScale);
                 core_.setProperty(CameraLabel, "Color", "ON");
-                gui_.compat().refreshGUI();
+                gui_.app().refreshGUI();
                 gui_.live().snap(true);
             } else {
                 core_.setProperty(CameraLabel, RED_SCALE_LABEL, 1.0);
                 core_.setProperty(CameraLabel, GREEN_SCALE_LABEL, 1.0);
                 core_.setProperty(CameraLabel, BLUE_SCALE_LABEL, 1.0);
                 core_.setProperty(CameraLabel, "Color", "ON");
-                gui_.compat().refreshGUI();
+                gui_.app().refreshGUI();
             }
         } catch (Exception ex) {
             Logger.getLogger(WhiteBalance_UI.class.getName()).log(Level.SEVERE, null, ex);


### PR DESCRIPTION
This splits out almost all of the methods that were in `CompatibilityInterface` into either `Application` (most methods) or `ApplicationSkin` (methods specifically dealing with the "day/night" look and feel). Remaining in `CompatibilityInterface` is four methods: `getVersion`, `versionLessThan`, `getCameraTransform`, and `setCameraTransform`.

The following methods were removed as they are, as far as I can tell, unused by all external code: `enableRoiButtons`, `logStartupProperties`, `setConfigChanged`. The behavior of `saveConfigPresets` was changed to take a path to save to instead of popping up a save dialog.

Additionally, `ApplicationSkin` (which is implemented by `org.micromanager.internal.utils.DaytimeNighttime` for the time being) exposes additional methods for accessing color information, for when the automatic look-and-feel system doesn't work. It does not yet expose the special `JTable` implementation (that manually sets the table's background and foreground colors) that's in `DaytimeNighttime` and which is used extensively by the main program GUI, though.