### PR TITLE
Generic SLM: avoid exception

### DIFF
--- a/DeviceAdapters/GenericSLM/GenericSLM.h
+++ b/DeviceAdapters/GenericSLM/GenericSLM.h
@@ -38,6 +38,11 @@ using namespace std;
 vector<MonitorDevice> displays_;
 RECT viewBounds;
 
+//////////////////////////////////////////////////////////////////////////////
+// Error codes
+//
+#define ERR_DIRECT_DRAW 12000
+
 class GenericSLMWindowsGUIThread : public MMDeviceThreadBase
 {
    public:
@@ -158,9 +163,9 @@ private:
    HDC windc_;
    long bmWidthBytes_;
 
-   void BlitBitmap();
+   int BlitBitmap();
 
-   void WaitForScreenRefresh();
+   int WaitForScreenRefresh();
    IDirectDraw * ddObject_;
 
    WinClass * winClass_;


### PR DESCRIPTION
Occasional crashes were caused by an exception caused by an
uninitialized variable.  Since it passed the test for NULL, it
was not properly initialized.  Setting it to NULL explicitly
in the constructor avoids that situation (the short title of this
commit is misleading).
Also added some more error testing, error reporting and error
propagation.