### PR TITLE
Plugins: add DisplayGearMenuPlugin type.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/PluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/PluginManager.java
@@ -22,6 +22,7 @@ package org.micromanager;
 import java.util.HashMap;
 
 import org.micromanager.data.ProcessorPlugin;
+import org.micromanager.display.DisplayGearMenuPlugin;
 import org.micromanager.display.InspectorPlugin;
 import org.micromanager.display.OverlayPlugin;
 import org.micromanager.quickaccess.QuickAccessPlugin;
@@ -82,4 +83,11 @@ public interface PluginManager {
     * instances. InspectorPlugins create the panels in the Inspector windows.
     */
    public HashMap<String, InspectorPlugin> getInspectorPlugins();
+
+   /**
+    * Return a HashMap that maps plugin class names to DisplayGearMenuPlugin
+    * instances. DisplayGearMenuPlugins add entries to the gear menus in
+    * DisplayWindows.
+    */
+   public HashMap<String, DisplayGearMenuPlugin> getDisplayGearMenuPlugins();
 }

--- a/mmstudio/src/main/java/org/micromanager/display/DisplayGearMenuPlugin.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayGearMenuPlugin.java
@@ -1,0 +1,44 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Chris Weisiger, 2015
+//
+// COPYRIGHT:    University of California, San Francisco, 2015
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+package org.micromanager.display;
+
+import org.micromanager.MMPlugin;
+
+/**
+ * DisplayGearMenuPlugins add items to be shown in the "gear menu" shown in
+ * each DisplayWindow.
+ */
+public interface DisplayGearMenuPlugin extends MMPlugin {
+   /**
+    * Indicate which sub-menu of the gear menu this plugin should appear
+    * in. If that sub-menu does not exist, it will be created. If an empty
+    * string is returned, then the plugin will be inserted directly into the
+    * gear menu, instead of into a sub-menu.
+    * @return Sub-menu of the gear menu hosting this entry, or empty string.
+    */
+   public String getSubMenu();
+
+   /**
+    * This method will be called when the plugin is selected from the
+    * gear menu.
+    * @param display The display whose gear menu was interacted with.
+    */
+   public void onPluginSelected(DisplayWindow display);
+}

--- a/mmstudio/src/main/java/org/micromanager/display/internal/ButtonPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/ButtonPanel.java
@@ -39,8 +39,10 @@ import org.micromanager.display.ControlsFactory;
 import org.micromanager.display.DisplayDestroyedEvent;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.internal.events.FullScreenEvent;
+import org.micromanager.display.internal.gearmenu.GearButton;
 import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.Studio;
 
 
 /**
@@ -60,7 +62,7 @@ public class ButtonPanel extends JPanel {
    private final JButton fullButton_;
 
    public ButtonPanel(final DisplayWindow display,
-         ControlsFactory controlsFactory) {
+         ControlsFactory controlsFactory, Studio studio) {
       setLayout(new MigLayout("insets 0"));
       // Add user-supplied custom controls, if any.
       List<Component> customControls = new ArrayList<Component>();
@@ -111,7 +113,7 @@ public class ButtonPanel extends JPanel {
 
       add(new SaveButton(display.getDatastore(), display));
 
-      add(new GearButton(display));
+      add(new GearButton(display, studio));
       display.registerForEvents(this);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayWindow.java
@@ -425,7 +425,7 @@ public class DefaultDisplayWindow extends MMFrame implements DisplayWindow {
       }
       controlsPanel_.add(hyperstackControls_,
             "align center, span, growx, wrap");
-      controlsPanel_.add(new ButtonPanel(this, controlsFactory_));
+      controlsPanel_.add(new ButtonPanel(this, controlsFactory_, studio_));
 
       contentsPanel_.add(controlsPanel_, "align center, wrap, growx, growy 0");
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportImagesItem.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportImagesItem.java
@@ -1,0 +1,70 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     Display implementation
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Chris Weisiger, 2015
+//
+// COPYRIGHT:    University of California, San Francisco, 2015
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+package org.micromanager.display.internal.gearmenu;
+
+import org.micromanager.display.DisplayGearMenuPlugin;
+import org.micromanager.display.DisplayWindow;
+import org.micromanager.display.internal.inspector.InspectorFrame;
+import org.micromanager.display.internal.ExportMovieDlg;
+import org.micromanager.Studio;
+
+import org.scijava.plugin.Plugin;
+import org.scijava.plugin.SciJavaPlugin;
+
+@Plugin(type = DisplayGearMenuPlugin.class)
+public class ExportImagesItem implements DisplayGearMenuPlugin, SciJavaPlugin {
+   private Studio studio_;
+
+   @Override
+   public void setContext(Studio studio) {
+      studio_ = studio;
+   }
+
+   @Override
+   public String getName() {
+      return "Export Images As Displayed";
+   }
+
+   @Override
+   public String getHelpText() {
+      return "Generate a sequence of images showing the display as rendered, including histogram scaling and overlays";
+   }
+
+   @Override
+   public String getVersion() {
+      return "1.0";
+   }
+
+   @Override
+   public String getCopyright() {
+      return "Copyright (c) Regents of the University of California";
+   }
+
+   @Override
+   public String getSubMenu() {
+      return "";
+   }
+
+   @Override
+   public void onPluginSelected(DisplayWindow display) {
+      new ExportMovieDlg(display);
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/GearButton.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/GearButton.java
@@ -18,33 +18,38 @@
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 
-package org.micromanager.display.internal;
+package org.micromanager.display.internal.gearmenu;
 
 import com.bulenkov.iconloader.IconLoader;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import javax.swing.event.MouseInputAdapter;
 import javax.swing.JButton;
 import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
+import javax.swing.JSeparator;
 
+import org.micromanager.display.DisplayGearMenuPlugin;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.internal.inspector.InspectorFrame;
-import org.micromanager.internal.LineProfile;
+import org.micromanager.Studio;
+
+import org.micromanager.internal.utils.SortedPopupMenu;
 
 /**
  * This class provides access to various rarely-used functions (like save or
  * duplicate) via a dropdown menu.
  */
 public class GearButton extends JButton {
-   private JPopupMenu menu_;
+   private SortedPopupMenu menu_;
 
-   public GearButton(final DisplayWindow display) {
+   public GearButton(final DisplayWindow display, Studio studio) {
       setToolTipText("Access additional commands");
-      menu_ = new JPopupMenu();
+      menu_ = new SortedPopupMenu();
       JMenuItem openInspector = new JMenuItem("New Inspector Window");
       openInspector.addActionListener(new ActionListener() {
          @Override
@@ -52,7 +57,7 @@ public class GearButton extends JButton {
             InspectorFrame.createInspector(display);
          }
       });
-      menu_.add(openInspector);
+      menu_.addUnsorted(openInspector);
 
       JMenuItem duplicate = new JMenuItem("New Window For This Data");
       duplicate.addActionListener(new ActionListener() {
@@ -61,29 +66,36 @@ public class GearButton extends JButton {
             display.duplicate();
          }
       });
-      menu_.add(duplicate);
+      menu_.addUnsorted(duplicate);
 
       menu_.addSeparator();
 
-      JMenuItem lineProfile = new JMenuItem("Show Line Profile");
-      lineProfile.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            new LineProfile(display);
+      // Insert plugins. Sorted alphabetically by name/submenu name.
+      HashMap<String, DisplayGearMenuPlugin> plugins = studio.plugins().getDisplayGearMenuPlugins();
+      HashMap<String, SortedPopupMenu> subMenus = new HashMap<String, SortedPopupMenu>();
+      ArrayList<JMenuItem> items = new ArrayList<JMenuItem>();
+      for (final DisplayGearMenuPlugin plugin : plugins.values()) {
+         JMenuItem item = new JMenuItem(plugin.getName());
+         item.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+               plugin.onPluginSelected(display);
+            }
+         });
+         String subMenu = plugin.getSubMenu();
+         if (subMenu.contentEquals("")) {
+            // Add directly to the base menu.
+            menu_.add(item);
          }
-      });
-      menu_.add(lineProfile);
-
-      menu_.addSeparator();
-
-      JMenuItem movieExport = new JMenuItem("Export Images As Displayed");
-      movieExport.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            new ExportMovieDlg(display);
+         else {
+            // Add it to a submenu, creating it if necessary.
+            if (!subMenus.containsKey(subMenu)) {
+               SortedPopupMenu popup = new SortedPopupMenu();
+               subMenus.put(subMenu, popup);
+            }
+            subMenus.get(subMenu).add(item);
          }
-      });
-      menu_.add(movieExport);
+      }
 
       final JButton staticThis = this;
       addMouseListener(new MouseInputAdapter() {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/LineProfileItem.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/LineProfileItem.java
@@ -1,0 +1,70 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     Display implementation
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Chris Weisiger, 2015
+//
+// COPYRIGHT:    University of California, San Francisco, 2015
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+package org.micromanager.display.internal.gearmenu;
+
+import org.micromanager.display.DisplayGearMenuPlugin;
+import org.micromanager.display.DisplayWindow;
+import org.micromanager.display.internal.inspector.InspectorFrame;
+import org.micromanager.internal.LineProfile;
+import org.micromanager.Studio;
+
+import org.scijava.plugin.Plugin;
+import org.scijava.plugin.SciJavaPlugin;
+
+@Plugin(type = DisplayGearMenuPlugin.class)
+public class LineProfileItem implements DisplayGearMenuPlugin, SciJavaPlugin {
+   private Studio studio_;
+
+   @Override
+   public void setContext(Studio studio) {
+      studio_ = studio;
+   }
+
+   @Override
+   public String getName() {
+      return "Line Profile";
+   }
+
+   @Override
+   public String getHelpText() {
+      return "Show a plot of image pixel intensity over the current ROI";
+   }
+
+   @Override
+   public String getVersion() {
+      return "1.0";
+   }
+
+   @Override
+   public String getCopyright() {
+      return "Copyright (c) Regents of the University of California";
+   }
+
+   @Override
+   public String getSubMenu() {
+      return "";
+   }
+
+   @Override
+   public void onPluginSelected(DisplayWindow display) {
+      new LineProfile(display);
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 import org.micromanager.acquisition.internal.AcquisitionDialogPlugin;
 import org.micromanager.AutofocusPlugin;
 import org.micromanager.data.ProcessorPlugin;
+import org.micromanager.display.DisplayGearMenuPlugin;
 import org.micromanager.display.InspectorPlugin;
 import org.micromanager.display.OverlayPlugin;
 import org.micromanager.IntroPlugin;
@@ -48,48 +49,9 @@ import org.micromanager.events.internal.NewPluginEvent;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.JavaUtils;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.SortedMenu;
 
 public class DefaultPluginManager implements PluginManager {
-
-   /**
-    * Simple extension of JMenu whose menu items remained alphabetically
-    * ordered.
-    */
-   private static class SortedMenu extends JMenu {
-      private HashSet<JMenuItem> unsortedItems_;
-      public SortedMenu(String title) {
-         super(title);
-         unsortedItems_ = new HashSet<JMenuItem>();
-      }
-
-      // Allow users to bypass the sorted nature
-      public JMenuItem addUnsorted(JMenuItem item) {
-         unsortedItems_.add(item);
-         return super.add(item);
-      }
-
-      @Override
-      public JMenuItem add(JMenuItem item) {
-         // Find the insertion point.
-         for (int i = 0; i < getItemCount(); ++i) {
-            JMenuItem curItem = getItem(i);
-            if (unsortedItems_.contains(curItem)) {
-               // Skip this item because it's outside the sorted logic.
-               continue;
-            }
-            if (curItem == null) {
-               // Separator.
-               continue;
-            }
-            if (item.getText().compareTo(curItem.getText()) < 0) {
-               insert(item, i);
-               return item;
-            }
-         }
-         // Add it at the end instead.
-         return super.add(item);
-      }
-   }
 
    // List of the types of plugins we allow.
    private static final ArrayList<Class> VALID_CLASSES = new ArrayList<Class>();
@@ -103,6 +65,7 @@ public class DefaultPluginManager implements PluginManager {
       VALID_CLASSES.add(MenuPlugin.class);
       VALID_CLASSES.add(QuickAccessPlugin.class);
       VALID_CLASSES.add(MMPlugin.class);
+      VALID_CLASSES.add(DisplayGearMenuPlugin.class);
    }
 
    private static final String PROCESSOR_MENU = "On-The-Fly Image Processing";
@@ -356,6 +319,15 @@ public class DefaultPluginManager implements PluginManager {
       HashMap<String, AcquisitionDialogPlugin> result = new HashMap<String, AcquisitionDialogPlugin>();
       for (MMPlugin plugin : pluginTypeToPlugins_.get(AcquisitionDialogPlugin.class)) {
          result.put(plugin.getClass().getName(), (AcquisitionDialogPlugin) plugin);
+      }
+      return result;
+   }
+
+   @Override
+   public HashMap<String, DisplayGearMenuPlugin> getDisplayGearMenuPlugins() {
+      HashMap<String, DisplayGearMenuPlugin> result = new HashMap<String, DisplayGearMenuPlugin>();
+      for (MMPlugin plugin : pluginTypeToPlugins_.get(DisplayGearMenuPlugin.class)) {
+         result.put(plugin.getClass().getName(), (DisplayGearMenuPlugin) plugin);
       }
       return result;
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/SortedMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/SortedMenu.java
@@ -1,0 +1,67 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Chris Weisiger, 2015
+//
+// COPYRIGHT:    Regents of the University of California 2015
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+//
+package org.micromanager.internal.utils;
+
+import java.util.HashSet;
+
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+
+/**
+ * Simple extension of JMenu whose menu items remained alphabetically
+ * ordered.
+ */
+public class SortedMenu extends JMenu {
+   private HashSet<JMenuItem> unsortedItems_;
+   public SortedMenu(String title) {
+      super(title);
+      unsortedItems_ = new HashSet<JMenuItem>();
+   }
+
+   // Allow users to bypass the sorted nature
+   public JMenuItem addUnsorted(JMenuItem item) {
+      unsortedItems_.add(item);
+      return super.add(item);
+   }
+
+   @Override
+   public JMenuItem add(JMenuItem item) {
+      // Find the insertion point.
+      for (int i = 0; i < getItemCount(); ++i) {
+         JMenuItem curItem = getItem(i);
+         if (unsortedItems_.contains(curItem)) {
+            // Skip this item because it's outside the sorted logic.
+            continue;
+         }
+         if (curItem == null) {
+            // Separator.
+            continue;
+         }
+         if (item.getText().compareTo(curItem.getText()) < 0) {
+            insert(item, i);
+            return item;
+         }
+      }
+      // Add it at the end instead.
+      return super.add(item);
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/SortedPopupMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/SortedPopupMenu.java
@@ -1,0 +1,88 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Chris Weisiger, 2015
+//
+// COPYRIGHT:    Regents of the University of California 2015
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+//
+package org.micromanager.internal.utils;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import javax.swing.JSeparator;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.MenuElement;
+
+/**
+ * Simple extension of JPopupMenu whose menu items remained alphabetically
+ * ordered. Mostly a copy of SortedMenu except that it extends a different
+ * base class, which requires some subtle changes in how it works internally.
+ */
+public class SortedPopupMenu extends JPopupMenu {
+   private HashSet<JMenuItem> unsortedItems_ = new HashSet<JMenuItem>();
+   private ArrayList<Integer> separatorIndices_ = new ArrayList<Integer>();
+
+   /**
+    * Insert an item whose position will be ignored when sorting items.
+    */
+   public JMenuItem addUnsorted(JMenuItem item) {
+      unsortedItems_.add(item);
+      return super.add(item);
+   }
+
+   @Override
+   public void addSeparator() {
+      // HACK: JPopupMenu does not list separators in its getSubElements()
+      // array but does take them into account when calling insert(), which we
+      // use in add(), below, so we need to apply offsets at times.
+      super.addSeparator();
+      separatorIndices_.add(getSubElements().length);
+   }
+
+   @Override
+   public JMenuItem add(JMenuItem item) {
+      MenuElement[] elements = getSubElements();
+      // Find the insertion point.
+      for (int i = 0; i < elements.length; ++i) {
+         JMenuItem curItem = (JMenuItem) elements[i];
+         if (unsortedItems_.contains(curItem)) {
+            // Skip this item because it's outside the sorted logic.
+            continue;
+         }
+         if (curItem == null) {
+            // Separator.
+            continue;
+         }
+         if (item.getText().compareTo(curItem.getText()) < 0) {
+            // HACK: apply offset based on number of separators that precede
+            // us (see addSeparator() method).
+            int offset = 0;
+            for (Integer index : separatorIndices_) {
+               if (index <= i) {
+                  offset++;
+               }
+            }
+            insert(item, i + offset);
+            return item;
+         }
+      }
+      // Add it at the end instead.
+      return super.add(item);
+   }
+}


### PR DESCRIPTION
This plugin type is used for entries in the gear menu in image display windows.
It is structurally very similar to the MenuPlugin type, but appears in a
different part of the GUI and receives the relevant DisplayWindow in its
onPluginSelected() method.

This also moves SortedMenu out of DefaultPluginManager, and adds a
corresponding SortedPopupMenu class for JPopupMenus.