### PR TITLE
Provide option to set Inspector Window always on top choice

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/internal/inspector/InspectorFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/inspector/InspectorFrame.java
@@ -29,7 +29,6 @@ import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.GraphicsConfiguration;
 import java.awt.Insets;
-import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -44,9 +43,7 @@ import java.io.File;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Stack;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -122,14 +119,14 @@ public class InspectorFrame extends MMFrame implements Inspector {
     * the panel itself.
     */
    private class WrapperPanel extends JPanel {
-      private JPanel header_;
+      private final JPanel header_;
       private InspectorPanel panel_;
       private boolean shouldOverrideSize_ = false;
       private Dimension overrideSize_ = null;
-      private String title_;
+      private final String title_;
       public WrapperPanel(String title, InspectorPanel panel) {
          super(new MigLayout("flowy, insets 0, fill"));
-         setBorder(BorderFactory.createRaisedBevelBorder());
+         super.setBorder(BorderFactory.createRaisedBevelBorder());
          panel_ = panel;
          title_ = title;
 
@@ -185,8 +182,8 @@ public class InspectorFrame extends MMFrame implements Inspector {
                refillContents();
             }
          });
-         add(header_, "growx, pushy 0");
-         add(panel_, "grow, gap 0, hidemode 2, pushy 100");
+         super.add(header_, "growx, pushy 0");
+         super.add(panel_, "grow, gap 0, hidemode 2, pushy 100");
          // HACK: the specific panel with the "Contrast" title is automatically
          // visible.
          if (title.contentEquals(CONTRAST_TITLE)) {
@@ -270,6 +267,7 @@ public class InspectorFrame extends MMFrame implements Inspector {
    /**
     * This method simply makes certain that newly-created inspector windows
     * are created on the EDT.
+    * @param viewer - viewer that wants an inspector attached
     */
    public static void createInspector(final DataViewer viewer) {
       if (!SwingUtilities.isEventDispatchThread()) {
@@ -298,7 +296,7 @@ public class InspectorFrame extends MMFrame implements Inspector {
    // Maps InspectorPanels to the WrapperPanels that contain them in our UI.
    private ArrayList<WrapperPanel> wrapperPanels_;
    private final JPanel contents_;
-   private JScrollPane scroller_;
+   private final JScrollPane scroller_;
    private JComboBox displayChooser_;
    private JButton raiseButton_;
    private final JLabel curDisplayTitle_;
@@ -307,11 +305,11 @@ public class InspectorFrame extends MMFrame implements Inspector {
       super();
       haveCreatedInspector_ = true;
       wrapperPanels_ = new ArrayList<WrapperPanel>();
-      setTitle("Image Inspector");
+      super.setTitle("Image Inspector");
       if (alwaysOnTop_)
          setAlwaysOnTop(true);
       // Use a small title bar.
-      getRootPane().putClientProperty("Window.style", "small");
+      super.getRootPane().putClientProperty("Window.style", "small");
 
       // Initialize all of our components; they'll be inserted into our frame
       // in refillContents().
@@ -372,8 +370,8 @@ public class InspectorFrame extends MMFrame implements Inspector {
       scroller_ = new JScrollPane(contents_,
             ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
             ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-      add(scroller_);
-      setVisible(true);
+      super.add(scroller_);
+      super.setVisible(true);
 
       // Hard-coded initial panels.
       addPanel(CONTRAST_TITLE, new HistogramsPanel());
@@ -396,14 +394,14 @@ public class InspectorFrame extends MMFrame implements Inspector {
       // We want to be in the upper-right corner of the primary display.
       GraphicsConfiguration config = GUIUtils.getGraphicsConfigurationContaining(1, 1);
       // Allocate enough width that the histograms look decent.
-      setMinimumSize(new Dimension(400, 50));
+      super.setMinimumSize(new Dimension(400, 50));
       // HACK: don't know our width; just choose a vaguely-correct offset.
-      loadAndRestorePosition(config.getBounds().width - 450, 0);
-      setSize(new Dimension(getDefaultWidth(), getHeight()));
+      super.loadAndRestorePosition(config.getBounds().width - 450, 0);
+      super.setSize(new Dimension(getDefaultWidth(), super.getHeight()));
 
       DefaultEventManager.getInstance().registerForEvents(this);
       // Cleanup when window closes.
-      addWindowListener(new WindowAdapter() {
+      super.addWindowListener(new WindowAdapter() {
          @Override
          public void windowClosing(WindowEvent event) {
             cleanup();
@@ -411,7 +409,7 @@ public class InspectorFrame extends MMFrame implements Inspector {
       });
       // Save the size when the user resizes the window, and the
       // position when the user moves it.
-      addComponentListener(new ComponentAdapter() {
+      super.addComponentListener(new ComponentAdapter() {
          @Override
          public void componentResized(ComponentEvent e) {
             setDefaultWidth((int) getSize().getWidth());
@@ -465,7 +463,7 @@ public class InspectorFrame extends MMFrame implements Inspector {
     * @param title Title of the panel
     * @param panel Inspector Panel to be added
     */
-   private final void addPanel(String title, final InspectorPanel panel) {
+   private void addPanel(String title, final InspectorPanel panel) {
       panel.setInspector(this);
       wrapperPanels_.add(new WrapperPanel(title, panel));
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/inspector/InspectorFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/inspector/InspectorFrame.java
@@ -86,7 +86,8 @@ import org.micromanager.internal.utils.ReportingUtils;
  * consists of a set of expandable panels in a vertical configuration.
  */
 public class InspectorFrame extends MMFrame implements Inspector {
-
+   
+   
    /**
     * This class is used to represent entries in the dropdown menu the user
     * uses to select which DataViewer the InspectorFrame is controlling.
@@ -249,8 +250,11 @@ public class InspectorFrame extends MMFrame implements Inspector {
 
    private static final String TOPMOST_DISPLAY = "Topmost Window";
    private static final String CONTRAST_TITLE = "Histograms and Settings";
-   private static final String WINDOW_WIDTH = "width of the inspector frame";
-
+   private static final String WINDOW_WIDTH = "width of the inspector frame"; 
+   private static final String ALWAYS_ON_TOP = "Always on top";
+   private static boolean alwaysOnTop_ = DefaultUserProfile.getInstance().getBoolean(
+           InspectorFrame.class, ALWAYS_ON_TOP, true);
+   
    // This boolean is used to create a new Inspector frame only on the first
    // time that we create a new DisplayWindow in any given session of the
    // program.
@@ -279,6 +283,16 @@ public class InspectorFrame extends MMFrame implements Inspector {
       }
       new InspectorFrame(viewer);
    }
+   
+   public static void setShouldBeAlwaysOnTop(boolean state) {
+      alwaysOnTop_ = state;
+      DefaultUserProfile.getInstance().setBoolean(
+              InspectorFrame.class, ALWAYS_ON_TOP, state);    
+   }
+   
+   public static boolean getShouldBeAlwaysOnTop() {
+      return alwaysOnTop_;
+   }
 
    private DataViewer display_;
    // Maps InspectorPanels to the WrapperPanels that contain them in our UI.
@@ -294,7 +308,8 @@ public class InspectorFrame extends MMFrame implements Inspector {
       haveCreatedInspector_ = true;
       wrapperPanels_ = new ArrayList<WrapperPanel>();
       setTitle("Image Inspector");
-      setAlwaysOnTop(true);
+      if (alwaysOnTop_)
+         setAlwaysOnTop(true);
       // Use a small title bar.
       getRootPane().putClientProperty("Window.style", "small");
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/inspector/InspectorFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/inspector/InspectorFrame.java
@@ -282,10 +282,18 @@ public class InspectorFrame extends MMFrame implements Inspector {
       new InspectorFrame(viewer);
    }
    
+   /**
+    * Sets the desired window behavior
+    * TODO: propagate this choice to already opened inspector frames
+    * To do so will need code to discover existing instances from a static
+    * context.  A quick search showed this could be done using a list
+    * with weak references, but that seems a bit ugly.
+    * @param state desired op top behavior of the inspector frame
+    */
    public static void setShouldBeAlwaysOnTop(boolean state) {
       alwaysOnTop_ = state;
       DefaultUserProfile.getInstance().setBoolean(
-              InspectorFrame.class, ALWAYS_ON_TOP, state);    
+              InspectorFrame.class, ALWAYS_ON_TOP, state); 
    }
    
    public static boolean getShouldBeAlwaysOnTop() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -42,6 +42,7 @@ import org.micromanager.ApplicationSkin;
 import org.micromanager.ApplicationSkin.SkinMode;
 import org.micromanager.data.internal.multipagetiff.StorageMultipageTiff;
 import org.micromanager.Studio;
+import org.micromanager.display.internal.inspector.InspectorFrame;
 import org.micromanager.internal.logging.LogFileManager;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.script.ScriptPanel;
@@ -274,6 +275,16 @@ public class OptionsDlg extends MMDialog {
             AcqControlDlg.setShouldHideMDADisplay(hideMDAdisplay.isSelected());
          }
       });
+      
+      final JCheckBox inspectorOnTop = new JCheckBox();
+      inspectorOnTop.setText("Inspector Window always on top");
+      inspectorOnTop.setSelected(InspectorFrame.getShouldBeAlwaysOnTop());
+      inspectorOnTop.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            InspectorFrame.setShouldBeAlwaysOnTop(inspectorOnTop.isSelected());
+         }
+      });
 
       final JButton closeButton = new JButton();
       closeButton.setText("Close");
@@ -328,6 +339,7 @@ public class OptionsDlg extends MMDialog {
 
       add(syncExposureMainAndMDA, "wrap");
       add(hideMDAdisplay, "wrap");
+      add(inspectorOnTop, "wrap");
 
       add(new JSeparator(), "wrap");
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -38,7 +38,6 @@ import javax.swing.WindowConstants;
 
 import mmcorej.CMMCore;
 
-import org.micromanager.ApplicationSkin;
 import org.micromanager.ApplicationSkin.SkinMode;
 import org.micromanager.data.internal.multipagetiff.StorageMultipageTiff;
 import org.micromanager.Studio;
@@ -80,15 +79,15 @@ public class OptionsDlg extends MMDialog {
       parent_ = parent;
       core_ = core;
 
-      setResizable(false);
-      setModal(true);
-      setAlwaysOnTop(true);
-      setTitle("Micro-Manager Options");
+      super.setResizable(false);
+      super.setModal(true);
+      super.setAlwaysOnTop(true);
+      super.setTitle("Micro-Manager Options");
       
-      loadAndRestorePosition(100, 100);     
+      super.loadAndRestorePosition(100, 100);     
 
-      setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-      addWindowListener(new WindowAdapter() {
+      super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+      super.addWindowListener(new WindowAdapter() {
          @Override
          public void windowClosing(final WindowEvent e) {
             closeRequested();
@@ -296,58 +295,58 @@ public class OptionsDlg extends MMDialog {
       });
 
 
-      setLayout(new net.miginfocom.swing.MigLayout(
+      super.setLayout(new net.miginfocom.swing.MigLayout(
                "fill, insets dialog",
                "[fill]"));
 
-      add(new JLabel("Display Background:"), "split 2, gapright push");
-      add(comboDisplayBackground_, "wrap");
+      super.add(new JLabel("Display Background:"), "split 2, gapright push");
+      super.add(comboDisplayBackground_, "wrap");
 
-      add(new JSeparator(), "wrap");
+      super.add(new JSeparator(), "wrap");
 
-      add(new JLabel("Sequence Buffer Size:"), "split 3, gapright push");
-      add(bufSizeField_, "gapright related");
-      add(new JLabel("MB"), "wrap");
+      super.add(new JLabel("Sequence Buffer Size:"), "split 3, gapright push");
+      super.add(bufSizeField_, "gapright related");
+      super.add(new JLabel("MB"), "wrap");
 
-      add(new JSeparator(), "wrap");
+      super.add(new JSeparator(), "wrap");
 
-      add(metadataFileWithMultipageTiffCheckBox, "wrap");
-      add(separateFilesForPositionsMPTiffCheckBox, "wrap");
+      super.add(metadataFileWithMultipageTiffCheckBox, "wrap");
+      super.add(separateFilesForPositionsMPTiffCheckBox, "wrap");
 
-      add(new JSeparator(), "wrap");
+      super.add(new JSeparator(), "wrap");
 
-      add(askForConfigFileCheckBox, "wrap");
-      add(alwaysUseDefaultProfileCheckBox, "wrap");
+      super.add(askForConfigFileCheckBox, "wrap");
+      super.add(alwaysUseDefaultProfileCheckBox, "wrap");
 
-      add(new JLabel("Startup Script:"), "split 2, grow 0, gapright related");
-      add(startupScriptFile_, "wrap");
+      super.add(new JLabel("Startup Script:"), "split 2, grow 0, gapright related");
+      super.add(startupScriptFile_, "wrap");
 
-      add(closeOnExitCheckBox, "wrap");
+      super.add(closeOnExitCheckBox, "wrap");
 
-      add(new JSeparator(), "wrap");
+      super.add(new JSeparator(), "wrap");
 
-      add(debugLogEnabledCheckBox, "wrap");
+      super.add(debugLogEnabledCheckBox, "wrap");
 
-      add(deleteLogCheckBox, "split 3, gapright related");
-      add(logDeleteDaysField_, "gapright related");
-      add(new JLabel("days"), "gapright push, wrap");
+      super.add(deleteLogCheckBox, "split 3, gapright related");
+      super.add(logDeleteDaysField_, "gapright related");
+      super.add(new JLabel("days"), "gapright push, wrap");
 
-      add(deleteLogFilesButton,
+      super.add(deleteLogFilesButton,
             "split 3, gapleft push, gapright push, wrap");
 
-      add(new JSeparator(), "wrap");
+      super.add(new JSeparator(), "wrap");
 
-      add(syncExposureMainAndMDA, "wrap");
-      add(hideMDAdisplay, "wrap");
-      add(inspectorOnTop, "wrap");
+      super.add(syncExposureMainAndMDA, "wrap");
+      super.add(hideMDAdisplay, "wrap");
+      super.add(inspectorOnTop, "wrap");
 
-      add(new JSeparator(), "wrap");
+      super.add(new JSeparator(), "wrap");
 
-      add(clearPreferencesButton,
+      super.add(clearPreferencesButton,
             "split 2, sizegroup bottomBtns, gapright unrelated");
-      add(closeButton, "sizegroup bottomBtns");
+      super.add(closeButton, "sizegroup bottomBtns");
 
-      pack();
+      super.pack();
    }
 
    private void changeBackground() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -277,6 +277,7 @@ public class OptionsDlg extends MMDialog {
       
       final JCheckBox inspectorOnTop = new JCheckBox();
       inspectorOnTop.setText("Inspector Window always on top");
+      inspectorOnTop.setToolTipText("This choice applies to all new Inspector Windows (existing ones will not change behavior)");
       inspectorOnTop.setSelected(InspectorFrame.getShouldBeAlwaysOnTop());
       inspectorOnTop.addActionListener(new ActionListener() {
          @Override


### PR DESCRIPTION
This addresses issue #274 by creating an option to have the inspector window always on top.

The option is set to true by default, and the user's choice will be remembered in the profile.
This will keep the current behavior for novel users, but users in the know who are bothered by
an inspector window that is always in the way, can change it.
Currently, the choice will not propagate to inspector windows that are currently open. This could
be added, but does not seem very important.