### PR TITLE
HCS plugin: Implement calibration on any well, and add ability to use the well edges.

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -58,7 +58,7 @@ import org.micromanager.Studio;
  * @author Nico Stuurman
  */
 public class CalibrationFrame extends JFrame {
-   private final String NOTSET = "Not Set";
+   private final String NOTSET = "Not Set Yet";
    
    public CalibrationFrame(final Studio studio, final SBSPlate plate, 
            final SiteGenerator siteGenerator) {
@@ -67,10 +67,10 @@ public class CalibrationFrame extends JFrame {
       super.setTitle("Calibrate XY Stage");
       
       JPanel contents = new JPanel(
-            new MigLayout("align, center, fillx, gap 10"));
+            new MigLayout("align, center, fillx, gap 12"));
       
       JLabel warningLabel1 = new JLabel("Wrong calibrations can result in damaged equipment! ");
-      JLabel warningLabel2 = new JLabel("Always make sure the calibration is correct!");
+      JLabel warningLabel2 = new JLabel("Always check that the calibration is correct!");
       Font warningFont = new Font(warningLabel1.getFont().getName(), Font.PLAIN, 16);
       warningLabel1.setFont(warningFont);
       warningLabel2.setFont(warningFont);
@@ -88,16 +88,16 @@ public class CalibrationFrame extends JFrame {
       }
       SpinnerModel model = new SpinnerListModel(rows);
       final JSpinner rowSpinner = new JSpinner(model);
-      contents.add(new JLabel("row:"), "grow, gap 40");
-      contents.add(rowSpinner, "width 50");
+      contents.add(new JLabel("row:"), "span 2, split 2, gap 60");
+      contents.add(rowSpinner, "width 50, center, pushx, gap 5");
       
       model = new SpinnerNumberModel((int) 1, (int) 1, plate.getNumColumns(), (int) 1);
       final JSpinner columnSpinner = new JSpinner(model);
-      contents.add(new JLabel("column"), "grow, gap 40");
-      contents.add(columnSpinner, "width 50, wrap");
+      contents.add(new JLabel("column:"), "span 2, split 2, gap 60");
+      contents.add(columnSpinner, "width 50, center, pushx, gap 5, wrap");
       
       contents.add(new JLabel("Either position the XY stage at the center of " + 
-              "the selected well and press OK"), "span 4, wrap");
+              "the selected well and press OK."), "span 4, wrap");
         
       contents.add(new JSeparator(), "span4, grow, wrap");
       
@@ -131,10 +131,10 @@ public class CalibrationFrame extends JFrame {
       
       contents.add(topButton, "span 4, center, wrap");
       contents.add(topLabel, "span 4, center, wrap");
-      contents.add(leftButton, "center");
-      contents.add(rightButton, "center, skip 2, wrap");
-      contents.add(leftLabel, "center");
-      contents.add(rightLabel, "center, skip 2, wrap");
+      contents.add(leftButton, "span 2, center");
+      contents.add(rightButton, "span 2, center, wrap");
+      contents.add(leftLabel, "span 2, center");
+      contents.add(rightLabel, "span 2, center, wrap");
       contents.add(bottomLabel, "span 4, center, wrap");
       contents.add(bottomButton, "span 4, center, wrap");
         
@@ -226,6 +226,7 @@ public class CalibrationFrame extends JFrame {
       super.add(contents);
       super.pack();
       super.setLocationRelativeTo(siteGenerator);
+      super.setResizable(false);
       super.setVisible(true);
       
    }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -209,7 +209,7 @@ public class CalibrationFrame extends JFrame {
                studio.getCMMCore().setAdapterOriginXY(
                        plate.getFirstWellX() + (colNr - 1) * plate.getWellSpacingX(), 
                        plate.getFirstWellY() + (rowNr  - 1) * plate.getWellSpacingY() );
-               siteGenerator.regenerate();
+               siteGenerator.finishCalibration();
                Point2D.Double pt = studio.getCMMCore().getXYStagePosition();
                JOptionPane.showMessageDialog(ourFrame, 
                        "XY Stage set at position: " + pt.x + "," + pt.y);

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -25,13 +25,18 @@ package org.micromanager.hcs;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.JButton;
+import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JSeparator;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerListModel;
 import javax.swing.SpinnerModel;
@@ -40,23 +45,22 @@ import javax.swing.SpinnerNumberModel;
 import net.miginfocom.swing.MigLayout;
 
 import org.micromanager.Studio;
-import org.micromanager.internal.utils.MMFrame;
 
 
 /**
  *
  * @author Nico Stuurman
  */
-public class CalibrationFrame extends MMFrame {
+public class CalibrationFrame extends JFrame {
+   private final String NOTSET = "Not Set";
+   
    public CalibrationFrame(final Studio studio, final SBSPlate plate, 
            final SiteGenerator siteGenerator) {
-      super.loadAndRestorePosition(100, 100);
+      
       super.setTitle("Calibrate XY Stage");
       
       JPanel contents = new JPanel(
-            new MigLayout("align, center, fillx"));
-      contents.add(new JLabel("Manually position the XY stage at the center of " + 
-              "the selected well and press OK"), "span 4, wrap");
+            new MigLayout("align, center, fillx, gap 10"));
       
       final List<String> rows = new ArrayList<String>();
       final Map<String, Integer> rowNumbers = new HashMap<String, Integer>();
@@ -66,13 +70,53 @@ public class CalibrationFrame extends MMFrame {
       }
       SpinnerModel model = new SpinnerListModel(rows);
       final JSpinner rowSpinner = new JSpinner(model);
-      contents.add(new JLabel("row:"), "grow");
-      contents.add(rowSpinner, "width 60");
+      contents.add(new JLabel("row:"), "grow, gap 40");
+      contents.add(rowSpinner, "width 50");
       
       model = new SpinnerNumberModel((int) 1, (int) 1, plate.getNumColumns(), (int) 1);
       final JSpinner columnSpinner = new JSpinner(model);
-      contents.add(new JLabel("column"), "grow");
-      contents.add(columnSpinner, "width 60, wrap");
+      contents.add(new JLabel("column"), "grow, gap 40");
+      contents.add(columnSpinner, "width 50, wrap");
+      
+      contents.add(new JLabel("Either position the XY stage at the center of " + 
+              "the selected well and press OK"), "span 4, wrap");
+        
+      contents.add(new JSeparator(), "span4, grow, wrap");
+      
+      contents.add(new JLabel("Or mark the top, right, bottom, and left edge " + 
+              "of the selected well and press OK"), "span 4, wrap");
+      
+      final Point2D.Double[] edges = new Point2D.Double[4];
+      for (int i = 0; i < 4; i++) {
+         edges[i] = new Point2D.Double();
+      }
+      
+      JLabel topLabel = new JLabel(NOTSET);
+      JButton topButton = new JButton("Top");
+      topButton.addActionListener(new EdgeListener(studio, topLabel, edges[0]));
+     
+      JLabel leftLabel = new JLabel(NOTSET);
+      JButton leftButton = new JButton("Left");
+      leftButton.addActionListener(new EdgeListener(studio, leftLabel, edges[1]));
+      
+      JLabel rightLabel = new JLabel(NOTSET);
+      JButton rightButton = new JButton("Right");
+      rightButton.addActionListener(new EdgeListener(studio, rightLabel, edges[2]));
+                 
+      JLabel bottomLabel = new JLabel(NOTSET);
+      JButton bottomButton = new JButton("Bottom");
+      bottomButton.addActionListener(new EdgeListener(studio, bottomLabel, edges[3]));
+      
+      contents.add(topButton, "span 4, center, wrap");
+      contents.add(topLabel, "span 4, center, wrap");
+      contents.add(leftButton, "center");
+      contents.add(rightButton, "center, skip 2, wrap");
+      contents.add(leftLabel, "center");
+      contents.add(rightLabel, "center, skip 2, wrap");
+      contents.add(bottomLabel, "span 4, center, wrap");
+      contents.add(bottomButton, "span 4, center, wrap");
+        
+      contents.add(new JSeparator(), "span4, grow, wrap");
       
       JButton cancelButton = new JButton ("Cancel");
       cancelButton.addActionListener(new ActionListener() {
@@ -89,6 +133,7 @@ public class CalibrationFrame extends MMFrame {
          public void actionPerformed(ActionEvent e) {
             int rowNr = rowNumbers.get( (String) rowSpinner.getValue());
             int colNr = (Integer) columnSpinner.getValue();
+            // TODO: check for edges and be smart about it
             try {
                studio.getCMMCore().setAdapterOriginXY(
                        plate.getFirstWellX() + (rowNr - 1) * plate.getWellSpacingX(), 
@@ -101,10 +146,35 @@ public class CalibrationFrame extends MMFrame {
          }
       });
       contents.add(OKButton, "tag ok, wrap");
-      
+            
       super.add(contents);
       super.pack();
+      super.setLocationRelativeTo(siteGenerator);
       super.setVisible(true);
       
    }
+   
+   private class EdgeListener implements ActionListener {
+      private final Studio studio_;
+      private final JLabel label_;
+      final private Point2D.Double pos_;
+      public EdgeListener(Studio studio, JLabel label, Point2D.Double pos) {
+         studio_ = studio;
+         label_ = label;
+         pos_ = pos;
+      }
+      @Override
+      public void actionPerformed(ActionEvent e) {
+         try {
+            Point2D.Double xyStagePosition = studio_.getCMMCore().getXYStagePosition();
+            label_.setText("" + xyStagePosition.x + ", " + xyStagePosition.y);
+            pos_.x = xyStagePosition.x;
+            pos_.y = xyStagePosition.y;
+         } catch (Exception ex) {
+            studio_.logs().showError(ex, "Failed to get XYStage position");
+         }
+      }
+      
+   }
+   
 }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -55,6 +55,7 @@ public class CalibrationFrame extends JFrame {
    public CalibrationFrame(final Studio studio, final SBSPlate plate, 
            final SiteGenerator siteGenerator) {
       
+      final JFrame ourFrame = this;
       super.setTitle("Calibrate XY Stage");
       
       JPanel contents = new JPanel(
@@ -122,7 +123,8 @@ public class CalibrationFrame extends JFrame {
       cancelButton.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            dispose();
+            cleanup (edgeLabels);
+            ourFrame.dispose();
          }
       });
       contents.add(cancelButton, "span 4, split 2, tag cancel");
@@ -189,6 +191,7 @@ public class CalibrationFrame extends JFrame {
             } catch (Exception ex) {
                studio.logs().showError(ex, "Failed to reset the stage's coordinates");
             }
+            cleanup (edgeLabels);
             dispose();
          }
       });
@@ -223,7 +226,12 @@ public class CalibrationFrame extends JFrame {
             studio_.logs().showError(ex, "Failed to get XYStage position");
          }
       }
-      
+   }
+   
+   private void cleanup (JLabel[] edges) {
+      for (JLabel edge : edges) {
+         edge.setText(NOTSET);
+      }
    }
    
 }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -1,0 +1,110 @@
+/*//////////////////////////////////////////////////////////////////////////////
+//FILE:           CalibrationFrame.java
+//PROJECT:        Micro-Manager
+//SUBSYSTEM:      high content screening
+//-----------------------------------------------------------------------------
+//
+//AUTHOR:         Nico Stuurman
+//
+//COPYRIGHT:      Regents of the University of California, 2014-2016
+//
+//LICENSE:        This file is distributed under the BSD license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+*/
+
+package org.micromanager.hcs;
+
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerListModel;
+import javax.swing.SpinnerModel;
+import javax.swing.SpinnerNumberModel;
+
+import net.miginfocom.swing.MigLayout;
+
+import org.micromanager.Studio;
+import org.micromanager.internal.utils.MMFrame;
+
+
+/**
+ *
+ * @author Nico Stuurman
+ */
+public class CalibrationFrame extends MMFrame {
+   public CalibrationFrame(final Studio studio, final SBSPlate plate, 
+           final SiteGenerator siteGenerator) {
+      super.loadAndRestorePosition(100, 100);
+      super.setTitle("Calibrate XY Stage");
+      
+      JPanel contents = new JPanel(
+            new MigLayout("align, center, fillx"));
+      contents.add(new JLabel("Manually position the XY stage at the center of " + 
+              "the selected well and press OK"), "span 4, wrap");
+      
+      final List<String> rows = new ArrayList<String>();
+      final Map<String, Integer> rowNumbers = new HashMap<String, Integer>();
+      for (int i = 1; i < plate.getNumRows() + 1; i++) {
+         rows.add(plate.getRowLabel(i));
+         rowNumbers.put(plate.getRowLabel(i), i);
+      }
+      SpinnerModel model = new SpinnerListModel(rows);
+      final JSpinner rowSpinner = new JSpinner(model);
+      contents.add(new JLabel("row:"), "grow");
+      contents.add(rowSpinner, "width 60");
+      
+      model = new SpinnerNumberModel((int) 1, (int) 1, plate.getNumColumns(), (int) 1);
+      final JSpinner columnSpinner = new JSpinner(model);
+      contents.add(new JLabel("column"), "grow");
+      contents.add(columnSpinner, "width 60, wrap");
+      
+      JButton cancelButton = new JButton ("Cancel");
+      cancelButton.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            dispose();
+         }
+      });
+      contents.add(cancelButton, "span 4, split 2, tag cancel");
+      
+      JButton OKButton = new JButton ("OK");
+      OKButton.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            int rowNr = rowNumbers.get( (String) rowSpinner.getValue());
+            int colNr = (Integer) columnSpinner.getValue();
+            try {
+               studio.getCMMCore().setAdapterOriginXY(
+                       plate.getFirstWellX() + (rowNr - 1) * plate.getWellSpacingX(), 
+                       plate.getFirstWellY() + (colNr - 1) * plate.getWellSpacingY() );
+               siteGenerator.regenerate();
+            } catch (Exception ex) {
+               studio.logs().showError(ex, "Failed to reset the stage's coordinates");
+            }
+            dispose();
+         }
+      });
+      contents.add(OKButton, "tag ok, wrap");
+      
+      super.add(contents);
+      super.pack();
+      super.setVisible(true);
+      
+   }
+}

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -23,6 +23,8 @@
 package org.micromanager.hcs;
 
 
+import java.awt.Color;
+import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.geom.Point2D;
@@ -48,7 +50,11 @@ import org.micromanager.Studio;
 
 
 /**
- *
+ * Displays a dialog that lets the user select the well that the objective
+ * is currently positioned on.
+ * The user can either define the current position as the center of that well
+ * or select the 4 edges and let the application calculate the center.
+ * 
  * @author Nico Stuurman
  */
 public class CalibrationFrame extends JFrame {
@@ -62,6 +68,17 @@ public class CalibrationFrame extends JFrame {
       
       JPanel contents = new JPanel(
             new MigLayout("align, center, fillx, gap 10"));
+      
+      JLabel warningLabel1 = new JLabel("Wrong calibrations can result in damaged equipment! ");
+      JLabel warningLabel2 = new JLabel("Always make sure the calibration is correct!");
+      Font warningFont = new Font(warningLabel1.getFont().getName(), Font.PLAIN, 16);
+      warningLabel1.setFont(warningFont);
+      warningLabel2.setFont(warningFont);
+      warningLabel1.setForeground(Color.red);
+      warningLabel2.setForeground(Color.red);
+      contents.add(warningLabel1, "span 4, center, wrap");
+      contents.add(warningLabel2, "span 4, center, wrap");
+      contents.add (new JSeparator(), "span 4, grow, wrap");
       
       final List<String> rows = new ArrayList<String>();
       final Map<String, Integer> rowNumbers = new HashMap<String, Integer>();
@@ -86,6 +103,8 @@ public class CalibrationFrame extends JFrame {
       
       contents.add(new JLabel("Or mark the top, right, bottom, and left edge " + 
               "of the selected well and press OK"), "span 4, wrap");
+      contents.add(new JLabel("Use live mode and a Pattern Overlay to position " +
+              " edges in the center of the image."), "span 4, wrap");
       
       final Point2D.Double[] edges = new Point2D.Double[4];
       for (int i = 0; i < 4; i++) {
@@ -188,8 +207,8 @@ public class CalibrationFrame extends JFrame {
             }     
             try {
                studio.getCMMCore().setAdapterOriginXY(
-                       plate.getFirstWellX() + (rowNr - 1) * plate.getWellSpacingX(), 
-                       plate.getFirstWellY() + (colNr - 1) * plate.getWellSpacingY() );
+                       plate.getFirstWellX() + (colNr - 1) * plate.getWellSpacingX(), 
+                       plate.getFirstWellY() + (rowNr  - 1) * plate.getWellSpacingY() );
                siteGenerator.regenerate();
                Point2D.Double pt = studio.getCMMCore().getXYStagePosition();
                JOptionPane.showMessageDialog(ourFrame, 

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -33,12 +33,14 @@ import java.util.Map;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerListModel;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
+import mmcorej.DeviceType;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -157,9 +159,9 @@ public class CalibrationFrame extends JFrame {
             }
             // when we have all edges, move the stage to the center
             if (allEdges) {
-               double leftX = edges[0].x;
+               double leftX = edges[1].x;
                double rightX = edges[2].x;
-               double topY = edges[1].y;
+               double topY = edges[0].y;
                double bottomY = edges[3].y;
                // Sanity checks:
                if (Math.abs(rightX - leftX) > plate.getWellSpacingX()) {
@@ -177,6 +179,7 @@ public class CalibrationFrame extends JFrame {
                double middleY = (topY + bottomY) / 2.0;
                try {
                   studio.getCMMCore().setXYPosition(middleX, middleY);
+                  studio.getCMMCore().waitForDeviceType(DeviceType.XYStageDevice);
                } catch (Exception ex) {
                   studio.logs().showError(ex, "Failed to reset the stage's coordinates");
                   dispose();
@@ -188,6 +191,9 @@ public class CalibrationFrame extends JFrame {
                        plate.getFirstWellX() + (rowNr - 1) * plate.getWellSpacingX(), 
                        plate.getFirstWellY() + (colNr - 1) * plate.getWellSpacingY() );
                siteGenerator.regenerate();
+               Point2D.Double pt = studio.getCMMCore().getXYStagePosition();
+               JOptionPane.showMessageDialog(ourFrame, 
+                       "XY Stage set at position: " + pt.x + "," + pt.y);
             } catch (Exception ex) {
                studio.logs().showError(ex, "Failed to reset the stage's coordinates");
             }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CustomSettingsFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CustomSettingsFrame.java
@@ -4,6 +4,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -17,28 +18,31 @@ import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.ReportingUtils;
 
 public class CustomSettingsFrame extends JFrame {
-   private JTextField id_;
-   private JTextField description_;
-   private JTextField rows_;
-   private JTextField cols_;
-   private JTextField wellSpacingX_;
-   private JTextField wellSpacingY_;
-   private JTextField sizeXUm_;
-   private JTextField sizeYUm_;
-   private JTextField firstWellX_;
-   private JTextField firstWellY_;
-   private JTextField wellSizeX_;
-   private JTextField wellSizeY_;
-   private JCheckBox circular_;
+   private final JTextField id_;
+   private final JTextField description_;
+   private final JTextField rows_;
+   private final JTextField cols_;
+   private final JTextField wellSpacingX_;
+   private final JTextField wellSpacingY_;
+   private final JTextField sizeXUm_;
+   private final JTextField sizeYUm_;
+   private final JTextField firstWellX_;
+   private final JTextField firstWellY_;
+   private final JTextField wellSizeX_;
+   private final JTextField wellSizeY_;
+   private final JCheckBox circular_;
 
-   private SiteGenerator parent_;
+   private final SiteGenerator parent_;
 
    public CustomSettingsFrame(SiteGenerator parent) {
       super();
       parent_ = parent;
-      setLayout(new MigLayout("flowx"));
+      super.setLayout(new MigLayout("flowx"));
 
-      add(new JLabel("<html><body>If you believe your settings would be useful to other labs, please consider sharing<br>the settings file on the &#956;Manager mailing list micro-manager-general@lists.sourceforge.net</body></html>"), "span, wrap");
+      super.add(new JLabel(
+              "<html><body>If you believe your settings would be useful to other labs, " +
+               "please consider sharing<br>the settings file on the &#956;Manager mailing list " +
+               "micro-manager-general@lists.sourceforge.net</body></html>"), "span, wrap");
 
       id_ = createText("Layout name: ", 10, false);
       description_ = createText("Layout description: ", 25, true);
@@ -59,7 +63,7 @@ public class CustomSettingsFrame extends JFrame {
       wellSizeY_ = createText("<html>Well height (&#956;m): </html>", 10, true);
 
       circular_ = new JCheckBox("<html>Circular: ");
-      add(circular_, "wrap");
+      super.add(circular_, "wrap");
 
       JButton cancel = new JButton("Cancel");
       cancel.addActionListener(new ActionListener() {
@@ -68,7 +72,7 @@ public class CustomSettingsFrame extends JFrame {
             dispose();
          }
       });
-      add(cancel, "align right");
+      super.add(cancel, "align right");
 
       JButton save = new JButton("Save to file");
       save.addActionListener(new ActionListener() {
@@ -81,10 +85,10 @@ public class CustomSettingsFrame extends JFrame {
             }
          }
       });
-      add(save, "align right");
+      super.add(save, "align right");
 
-      pack();
-      setVisible(true);
+      super.pack();
+      super.setVisible(true);
    }
 
    private JTextField createText(String label, int width, boolean shouldWrap) {
@@ -111,8 +115,12 @@ public class CustomSettingsFrame extends JFrame {
          dispose();
          parent_.loadCustom(target);
       }
-      catch (Exception e) {
-         ReportingUtils.showError(e, "There was an error trying to save your settings");
+      catch (IOException e) {
+         ReportingUtils.showError(e, "There was an IO error trying to save your settings");
+      } catch (NumberFormatException e) {
+         ReportingUtils.showError(e, "There was a NumberFormat Error trying to save your settings");
+      } catch (HCSException e) {
+         ReportingUtils.showError(e, "There was an HCS error trying to save your settings");
       }
    }
 }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/HCSPlugin.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/HCSPlugin.java
@@ -1,21 +1,28 @@
-/**
- * SequenceBufferMonitor plugin
- *
- * Display Core sequence buffer usage in real time.
- *
- * AUTHOR:       Mark Tsuchida
- * COPYRIGHT:    University of California, San Francisco, 2014
- * LICENSE:      This file is distributed under the BSD license.
- *               License text is included with the source distribution.
- *
- *               This file is distributed in the hope that it will be useful,
- *               but WITHOUT ANY WARRANTY; without even the implied warranty
- *               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
- *               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- *               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
- */
+///////////////////////////////////////////////////////////////////////////////
+//FILE:           HCSPlugin.java
+//PROJECT:        Micro-Manager
+//SUBSYSTEM:      high content screening
+//-----------------------------------------------------------------------------
+//
+//AUTHOR:         Nenad Amodaj, nenad@amodaj.com, June 3, 2008
+//                Mark Tsuchida
+//                Nico Stuurman
+//
+//COPYRIGHT:      100X Imaging Inc, www.100ximaging.com, 2008
+//                Regents of the University of California, 2014-2016
+//
+//LICENSE:        This file is distributed under the BSD license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+
 
 package org.micromanager.hcs;
 

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
@@ -37,7 +37,7 @@ public class PlatePanel extends JPanel {
    private final int yMargin_ = 30;
    private final int fontSizePt_ = 12;
 
-   private SBSPlate plate_;
+   private final SBSPlate plate_;
    private WellPositionList[] wells_;
    private Hashtable<String, Integer> wellMap_;
    private WellBox[] wellBoxes_;
@@ -71,7 +71,7 @@ public class PlatePanel extends JPanel {
       public boolean active;
 
       private DrawingParams params_;
-      private PositionList sites_;
+      private final PositionList sites_;
 
       public WellBox(PositionList pl) {
          label = "undef";

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -667,6 +667,8 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       if (app_ == null) {
          return;
       }
+      new CalibrationFrame(app_, plate_, this);
+      /*
       int ret = JOptionPane.showConfirmDialog(this, "Manually position the XY stage over the center of the well A01 and press OK",
               "XYStage origin setup", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE);
       if (ret == JOptionPane.OK_OPTION) {
@@ -681,9 +683,10 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
             displayError(e.getMessage());
          }
       }
+      */
    }
 
-   private void regenerate() {
+   public void regenerate() {
       WellPositionList[] selectedWells = platePanel_.getSelectedWellPositions();
       updateXySpacing();
       PositionList sites = generateSites();

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -26,8 +26,6 @@ import org.micromanager.StagePosition;
 import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.TextUtils;
 
-import com.swtdesigner.SwingResourceManager;
-
 import javax.swing.border.LineBorder;
 
 import java.awt.Color;
@@ -38,7 +36,6 @@ import net.miginfocom.swing.MigLayout;
 
 import mmcorej.CMMCore;
 
-import javax.swing.JRadioButton;
 import javax.swing.ButtonGroup;
 
 import java.awt.Dimension;
@@ -83,14 +80,7 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    private final String SITE_OVERLAP    = "site_overlap"; //in µm
    private final String SITE_ROWS       = "site_rows";
    private final String SITE_COLS       = "site_cols";
-   private final String LOCK_ASPECT = "lock_aspect";
-   private final String POINTER_MOVE = "Move";
-   private final String POINTER_SELECT = "Select";
-   private final String ROOT_DIR = "root";
-   private final String PLATE_DIR = "plate";
-   public static final String menuName = "HCS Site Generator";
-   public static final String tooltipDescription =
-           "Generate position list for multi-well plates";
+
    private final JLabel statusLabel_;
    private final JCheckBox chckbxThreePt_;
    private final ButtonGroup toolButtonGroup = new ButtonGroup();
@@ -159,12 +149,13 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
     */
    /**
     *
+    * @param app Micro-Manager api
     */
    public SiteGenerator(Studio app) {
       super();
       app_ = app;
-      setMinimumSize(new Dimension(815, 600));
-      addWindowListener(new WindowAdapter() {
+      super.setMinimumSize(new Dimension(815, 600));
+      super.addWindowListener(new WindowAdapter() {
          @Override
          public void windowClosing(final WindowEvent e) {
             saveSettings();
@@ -173,7 +164,7 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
 
       JPanel contentsPanel = new JPanel(
             new MigLayout("fill, flowx, insets 0, gap 0"));
-      add(contentsPanel);
+      super.add(contentsPanel);
       plate_ = new SBSPlate();
 
       xyStagePos_ = new Point2D.Double(0.0, 0.0);
@@ -185,8 +176,8 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       threePtList_ = null;
       focusPlane_ = null;
 
-      setTitle("HCS Site Generator " + HCSPlugin.VERSION_INFO);
-      loadAndRestorePosition(100, 100, 1000, 640);
+      super.setTitle("HCS Site Generator " + HCSPlugin.VERSION_INFO);
+      super.loadAndRestorePosition(100, 100, 1000, 640);
 
       platePanel_ = new PlatePanel(plate_, null, this, app);
       contentsPanel.add(platePanel_, "grow, push");

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -91,6 +91,8 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    private double ySpacing_ = 0.0;
    
    private CalibrationFrame calFrame_ = null;
+   private final JToggleButton moveStage_;
+   private final JToggleButton selectWells_;
 
 
    private void updateXySpacing() {
@@ -188,49 +190,50 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       contentsPanel.add(sidebar, "growprio 0, shrinkprio 200, gap 0, wrap");
 
       // Mutually-exclusive toggle buttons for what the mouse does.
-      final JToggleButton selectWells = new JToggleButton("Select",
+      selectWells_ = new JToggleButton("Select",
             IconLoader.getIcon("/org/micromanager/icons/mouse_cursor_on.png"));
-      final JToggleButton moveStage = new JToggleButton("Move",
+      moveStage_ = new JToggleButton("Move",
             IconLoader.getIcon("/org/micromanager/icons/move_hand.png"));
 
-      selectWells.setToolTipText("Click and drag to select wells.");
-      selectWells.addActionListener(new ActionListener() {
+      selectWells_.setToolTipText("Click and drag to select wells.");
+      selectWells_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent arg0) {
-            if (selectWells.isSelected()) {
+            if (selectWells_.isSelected()) {
                platePanel_.setTool(PlatePanel.Tool.SELECT);
-               selectWells.setIcon(IconLoader.getIcon("/org/micromanager/icons/mouse_cursor_on.png"));
-               moveStage.setIcon(IconLoader.getIcon("/org/micromanager/icons/move_hand.png"));
+               selectWells_.setIcon(IconLoader.getIcon("/org/micromanager/icons/mouse_cursor_on.png"));
+               moveStage_.setIcon(IconLoader.getIcon("/org/micromanager/icons/move_hand.png"));
             }
             else {
-               selectWells.setIcon(IconLoader.getIcon("/org/micromanager/icons/mouse_cursor.png"));
-               moveStage.setIcon(IconLoader.getIcon("/org/micromanager/icons/move_hand_on.png"));
+               selectWells_.setIcon(IconLoader.getIcon("/org/micromanager/icons/mouse_cursor.png"));
+               moveStage_.setIcon(IconLoader.getIcon("/org/micromanager/icons/move_hand_on.png"));
             }
          }
       });
-      toolButtonGroup.add(selectWells);
+      toolButtonGroup.add(selectWells_);
       // set default tool
       platePanel_.setTool(PlatePanel.Tool.SELECT);
-      sidebar.add(selectWells, "split 2, alignx center, flowx");
+      sidebar.add(selectWells_, "split 2, alignx center, flowx");
 
-      moveStage.setToolTipText("Click to move the stage");
-      moveStage.addActionListener(new ActionListener() {
+      moveStage_.setToolTipText("Click to move the stage");
+      moveStage_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            if (moveStage.isSelected()) {
+            if (moveStage_.isSelected()) {
                platePanel_.setTool(PlatePanel.Tool.MOVE);
-               moveStage.setIcon(IconLoader.getIcon("/org/micromanager/icons/move_hand_on.png"));
-               selectWells.setIcon(IconLoader.getIcon("/org/micromanager/icons/mouse_cursor.png"));
+               moveStage_.setIcon(IconLoader.getIcon("/org/micromanager/icons/move_hand_on.png"));
+               selectWells_.setIcon(IconLoader.getIcon("/org/micromanager/icons/mouse_cursor.png"));
             }
             else {
-               moveStage.setIcon(IconLoader.getIcon("/org/micromanager/icons/move_hand.png"));
-               selectWells.setIcon(IconLoader.getIcon("/org/micromanager/icons/mouse_cursor_on.png"));
+               moveStage_.setIcon(IconLoader.getIcon("/org/micromanager/icons/move_hand.png"));
+               selectWells_.setIcon(IconLoader.getIcon("/org/micromanager/icons/mouse_cursor_on.png"));
             }
          }
       });
-      toolButtonGroup.add(moveStage);
-      selectWells.setSelected(true);
-      sidebar.add(moveStage);
+      toolButtonGroup.add(moveStage_);
+      selectWells_.setSelected(true);
+      moveStage_.setEnabled(false);
+      sidebar.add(moveStage_);
 
       final JLabel plateFormatLabel = new JLabel();
       plateFormatLabel.setAlignmentY(Component.TOP_ALIGNMENT);
@@ -674,25 +677,14 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       } else {
          calFrame_ = new CalibrationFrame(app_, plate_, this);
       }
-      /*
-      int ret = JOptionPane.showConfirmDialog(this, "Manually position the XY stage over the center of the well A01 and press OK",
-              "XYStage origin setup", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE);
-      if (ret == JOptionPane.OK_OPTION) {
-         try {
-
-            app_.getCMMCore().setAdapterOriginXY(
-                  plate_.getFirstWellX(), plate_.getFirstWellY());
-            regenerate();
-            Point2D.Double pt = app_.getCMMCore().getXYStagePosition();
-            JOptionPane.showMessageDialog(this, "XY Stage set at position: " + pt.x + "," + pt.y);
-         } catch (Exception e) {
-            displayError(e.getMessage());
-         }
-      }
-      */
    }
 
-   public void regenerate() {
+   public void finishCalibration() {
+      regenerate();
+      moveStage_.setEnabled(true);
+   }
+   
+   private void regenerate() {
       WellPositionList[] selectedWells = platePanel_.getSelectedWellPositions();
       updateXySpacing();
       PositionList sites = generateSites();

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -89,6 +89,8 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
 
    private double xSpacing_ = 0.0;
    private double ySpacing_ = 0.0;
+   
+   private CalibrationFrame calFrame_ = null;
 
 
    private void updateXySpacing() {
@@ -667,7 +669,11 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       if (app_ == null) {
          return;
       }
-      new CalibrationFrame(app_, plate_, this);
+      if (calFrame_ != null) {
+         calFrame_.setVisible(true);
+      } else {
+         calFrame_ = new CalibrationFrame(app_, plate_, this);
+      }
       /*
       int ret = JOptionPane.showConfirmDialog(this, "Manually position the XY stage over the center of the well A01 and press OK",
               "XYStage origin setup", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE);


### PR DESCRIPTION
Addresses issue #302.  Calibration can now be executed on any well of the plate.  Either the center of the 
current well can be set directly, or the four edges of the well can be located to define the center of the well (Two edge calibration was not implemented because data on well dimensions may not be accurate and the UI would be more complicated).  
In addition, this code makes it impossible to use the 'Move' mode before calibration (which was a very dangerous operation mode). 