### PR TITLE
HCS plugin: Prevent several NumberFormatExceptions

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -41,6 +41,7 @@ import javax.swing.ButtonGroup;
 import java.awt.Dimension;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
+import org.micromanager.internal.utils.NumberUtils;
 
 /**
  * This is the primary user interface for the plugin.
@@ -98,24 +99,41 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    private void updateXySpacing() {
       String mode = (String) spacingMode_.getSelectedItem();
       if (mode.equals(VIEW_SPACING)) {
-       core_ = app_.getCMMCore();
-       long width  = core_.getImageWidth();
-       long height = core_.getImageHeight();
-       double cameraXFieldOfView = core_.getPixelSizeUm() * width;
-       double cameraYFieldOfView = core_.getPixelSizeUm() * height;
-       double overlap = Double.parseDouble(overlapField_.getText().replace(',', '.'));
-       xSpacing_ = cameraXFieldOfView - overlap;
-       ySpacing_ = cameraYFieldOfView - overlap;
-     }
-     else {
-       xSpacing_ = Double.parseDouble(spacingFieldX_.getText().replace(',','.'));
-       if (mode.equals(EQUAL_SPACING)) {
-          ySpacing_ = xSpacing_;
+         core_ = app_.getCMMCore();
+         long width = core_.getImageWidth();
+         long height = core_.getImageHeight();
+         double cameraXFieldOfView = core_.getPixelSizeUm() * width;
+         double cameraYFieldOfView = core_.getPixelSizeUm() * height;
+         double overlap;
+         try {
+            overlap = NumberUtils.displayStringToDouble(overlapField_.getText());
+         } catch (java.text.ParseException nfe) {
+            overlap = 0.0;
+            overlapField_.setText(NumberUtils.doubleToDisplayString(0.0));
+            app_.logs().logError("NumberFormat error in updateXYSpacing in HCS generator");
          }
-       else {
-          ySpacing_ = Double.parseDouble(spacingFieldY_.getText().replace(',', '.'));
-       }
-     }
+         xSpacing_ = cameraXFieldOfView - overlap;
+         ySpacing_ = cameraYFieldOfView - overlap;
+      } else {
+         try {
+            xSpacing_ = NumberUtils.displayStringToDouble(spacingFieldX_.getText());
+         } catch (java.text.ParseException nfe) {
+            xSpacing_ = 0.0;
+            spacingFieldX_.setText(NumberUtils.doubleToDisplayString(0.0));
+            app_.logs().logError("NumberFormat error in updateXYSpacing in HCS generator");
+         }
+         if (mode.equals(EQUAL_SPACING)) {
+            ySpacing_ = xSpacing_;
+         } else {
+            try {
+               ySpacing_ = NumberUtils.displayStringToDouble(spacingFieldY_.getText());
+            } catch (java.text.ParseException nfe) {
+               ySpacing_ = 0.0;
+               spacingFieldY_.setText(NumberUtils.doubleToDisplayString(0.0));
+               app_.logs().logError("NumberFormat error in updateXYSpacing in HCS generator");
+            }
+         }
+      }
    }
 
    public AffineTransform getCurrentAffineTransform() {


### PR DESCRIPTION
 and ensure that the code works as expected in different locales.  I had an exception in one of these that somehow caused the application to quit altogether (not sure how that is possible, but it happened).  We have had horrible problems in the past with different locales that were prevented by consistently using the static functions in NumberUtils.  Their use will at the very l;east guarantee consistent interpretation of input of numbers in Micro-Manager.  It may be good at one point to do a search for all "parseDouble" instances and replace them all.