### PR TITLE
Duplicator plugin: Fix null pointer exception that occurs when metadata do not contain channel names

### DIFF
--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
@@ -210,7 +210,11 @@ public class DuplicatorPluginFrame extends MMDialog {
          int max = maxes.get(Coords.CHANNEL);
          List<String> chNameList = new ArrayList<String>();
          for (int index = min; index <= max; index++) {
-            chNameList.add(channelNames[index]);
+            if (channelNames == null) {
+               chNameList.add("channel " + index);
+            } else {
+               chNameList.add(channelNames[index]);
+            }  
          }
          channelNames = chNameList.toArray(new String[chNameList.size()]);
       }


### PR DESCRIPTION
Such situations can arise when plugins or scripts generate MM datasets and should be handled gracefully.  There may be more problems like this, but they may be hard to find.