### PR TITLE
mmstudio and plugins: Windows now listen for the ShutdownCommencing Event.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
@@ -22,6 +22,7 @@
 package org.micromanager.alerts.internal;
 
 
+import com.google.common.eventbus.Subscribe;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -36,6 +37,7 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
+import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.utils.MMFrame;
 
 
@@ -45,6 +47,7 @@ public final class AlertsWindow extends MMFrame {
    private static void ensureWindowExists(Studio studio) {
       if (staticInstance_ == null) {
          staticInstance_ = new AlertsWindow(studio);
+         studio.events().registerForEvents(staticInstance_);
       }
    }
 
@@ -219,4 +222,14 @@ public final class AlertsWindow extends MMFrame {
    public void textUpdated(DefaultAlert alert) {
       studio_.events().post(new AlertUpdatedEvent(alert));
    }
+   
+   @Subscribe
+   public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
+      if (!event.getIsCancelled()) {
+         if (staticInstance_ != null) {
+            staticInstance_.dispose();
+         }
+      }
+   }
+   
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/inspector/InspectorFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/inspector/InspectorFrame.java
@@ -62,6 +62,7 @@ import org.micromanager.display.internal.DefaultDisplayManager;
 import org.micromanager.display.internal.events.DisplayActivatedEvent;
 import org.micromanager.events.DisplayAboutToShowEvent;
 import org.micromanager.events.internal.DefaultEventManager;
+import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.pluginmanagement.PluginSorter;
 import org.micromanager.internal.utils.DefaultUserProfile;
@@ -419,6 +420,8 @@ public final class InspectorFrame extends MMFrame implements Inspector {
       });
 
       refillContents();
+      
+      MMStudio.getInstance().events().registerForEvents(this);
    }
 
    /**
@@ -742,5 +745,13 @@ public final class InspectorFrame extends MMFrame implements Inspector {
    private static void setDefaultWidth(int width) {
       DefaultUserProfile.getInstance().setInt(
             InspectorFrame.class, WINDOW_WIDTH, width);
+   }
+   
+      
+   @Subscribe
+   public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
+      if (!event.getIsCancelled()) {
+         this.dispose();
+      }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -46,6 +46,7 @@ import org.micromanager.Studio;
 import org.micromanager.events.StagePositionChangedEvent;
 import org.micromanager.events.SystemConfigurationLoadedEvent;
 import org.micromanager.events.XYStagePositionChangedEvent;
+import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.TextUtils;
 
@@ -131,7 +132,7 @@ public final class StageControlFrame extends MMFrame {
 
       initComponents();
 
-      loadAndRestorePosition(frameXPos_, frameYPos_);
+      super.loadAndRestorePosition(frameXPos_, frameYPos_);
    }
 
    /**
@@ -216,6 +217,7 @@ public final class StageControlFrame extends MMFrame {
       setResizable(false);
       setLayout(new MigLayout("fill, insets 5, gap 2"));
       addWindowListener(new WindowAdapter() {
+         @Override
          public void windowClosing(WindowEvent evt) {
             for (int i = 0; i < 3; ++i) {
                studio_.profile().setDouble(StageControlFrame.class,
@@ -622,6 +624,16 @@ public final class StageControlFrame extends MMFrame {
    public void onXYStagePositionChanged(XYStagePositionChangedEvent event) {
       if (event.getDeviceName().contentEquals(core_.getXYStageDevice())) {
          setXYPosLabel(event.getXPos(), event.getYPos());
+      }
+   }
+   
+      
+   @Subscribe
+   public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
+      if (!event.getIsCancelled()) {
+         if (staticFrame_ != null) {
+            staticFrame_.dispose();
+         }
       }
    }
 

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIM.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIM.java
@@ -26,6 +26,7 @@ import java.awt.event.WindowEvent;
 
 import org.micromanager.MenuPlugin;
 import org.micromanager.Studio;
+import org.micromanager.events.ShutdownCommencingEvent;
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.SciJavaPlugin;
 
@@ -83,6 +84,7 @@ public class ASIdiSPIM implements MenuPlugin, SciJavaPlugin {
    @Override
    public void setContext(Studio studio) {
       gui_ = studio;
+      gui_.events().registerForEvents(this);
    }
 
    @Override
@@ -93,5 +95,11 @@ public class ASIdiSPIM implements MenuPlugin, SciJavaPlugin {
    @Override
    public String getHelpText() {
       return TOOLTIPDESCRIPTION;
+   }
+   
+   public void closeRequested( ShutdownCommencingEvent sce){
+      if (myFrame_ != null) {
+         myFrame_.dispose();
+      }
    }
 }

--- a/plugins/Gaussian/src/main/java/GaussianTrack_.java
+++ b/plugins/Gaussian/src/main/java/GaussianTrack_.java
@@ -8,11 +8,13 @@
  * @author nico
  */
 
+import com.google.common.eventbus.Subscribe;
 import edu.valelab.gaussianfit.MainForm;
 
 import ij.plugin.*;
 import org.micromanager.MenuPlugin;
 import org.micromanager.Studio;
+import org.micromanager.events.ShutdownCommencingEvent;
 
 import org.scijava.plugin.SciJavaPlugin;
 
@@ -22,15 +24,15 @@ import org.scijava.plugin.SciJavaPlugin;
  */
 @org.scijava.plugin.Plugin(type = MenuPlugin.class)
 public class GaussianTrack_ implements PlugIn, MenuPlugin, SciJavaPlugin {
-    public static final String menuName = "Localization Microscopy";
-    public static final String tooltipDescription =
+    public static final String MENUNAME = "Localization Microscopy";
+    public static final String TOOLTIPDESCRIPTION =
        "Toolbox for analyzing spots using Gaussian fitting";
 
-    private MainForm theForm_;
+   private MainForm theForm_;
 
    @Override
    public String getName() {
-      return menuName;
+      return MENUNAME;
    }
 
    @Override
@@ -44,20 +46,14 @@ public class GaussianTrack_ implements PlugIn, MenuPlugin, SciJavaPlugin {
          theForm_ = new MainForm();
       }
       theForm_.setVisible(true);
-      /*
-      if (gui_ != null) {
-         theForm_.setBackground(gui_.getBackgroundColor());
-         gui_.addMMBackgroundListener(theForm_);
-      }
-       */
       theForm_.formWindowOpened();
       theForm_.toFront();
    }
 
 
-
    @Override
-   public void setContext(Studio app) {      
+   public void setContext(Studio app) {
+      app.events().registerForEvents(this);
    }
 
    @Override
@@ -83,6 +79,11 @@ public class GaussianTrack_ implements PlugIn, MenuPlugin, SciJavaPlugin {
    @Override
    public String getCopyright() {
       return "University of California, 2010-2014";
+   }
+   
+   @Subscribe
+   public void closeRequested( ShutdownCommencingEvent sce){
+      dispose();
    }
 
 }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/HCSPlugin.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/HCSPlugin.java
@@ -26,8 +26,10 @@
 
 package org.micromanager.hcs;
 
+import com.google.common.eventbus.Subscribe;
 import org.micromanager.MenuPlugin;
 import org.micromanager.Studio;
+import org.micromanager.events.ShutdownCommencingEvent;
 
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.SciJavaPlugin;
@@ -45,6 +47,7 @@ public class HCSPlugin implements MenuPlugin, SciJavaPlugin {
    @Override
    public void setContext(Studio studio) {
       studio_ = studio;
+      studio_.events().registerForEvents(this);
    }
 
    @Override
@@ -78,6 +81,15 @@ public class HCSPlugin implements MenuPlugin, SciJavaPlugin {
    @Override
    public String getVersion() {
       return VERSION_INFO;
+   }
+   
+   @Subscribe
+   public void closeRequested( ShutdownCommencingEvent sce){
+      if (frame_ != null) {
+         if (!sce.getIsCancelled()) {
+            frame_.dispose();
+         }
+      }
    }
 
 }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -176,6 +176,7 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    public SiteGenerator(Studio app) {
       super();
       app_ = app;
+      
       super.setMinimumSize(new Dimension(815, 600));
       super.addWindowListener(new WindowAdapter() {
          @Override

--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
@@ -21,6 +21,7 @@
 
 package org.micromanager.multichannelshading;
 
+import com.google.common.eventbus.Subscribe;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Insets;
@@ -46,6 +47,7 @@ import net.miginfocom.swing.MigLayout;
 import org.micromanager.data.ProcessorConfigurator;
 import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
+import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.MMDialog;
 
@@ -243,6 +245,8 @@ public class MultiChannelShadingMigForm extends MMDialog implements ProcessorCon
       add(statusLabel_, "span 3, wrap");
       updateAddAndRemoveButtons(addButton, removeButton);
       pack();
+      
+      studio_.events().registerForEvents(this);
    }
    
    @Override
@@ -357,6 +361,9 @@ public class MultiChannelShadingMigForm extends MMDialog implements ProcessorCon
       }
     }
 
-   
+   @Subscribe
+   public void closeRequested( ShutdownCommencingEvent sce){
+      this.dispose();
+   }
     
 }


### PR DESCRIPTION

By listening to this event, these windows will close when shutdown starts and do not rely on a 
System.ext(0) to close.  The plugins that I changed (not all yet), listen to the external event.  It 
may be good to add this function to the MMPlugin interface so that plugin writers realize that they
may want to implements this.

Addresses issue #419