### PR TITLE
mmstudio: Store unknown summary metadata tags in userData, rather than ignoring them

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultSummaryMetadata.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultSummaryMetadata.java
@@ -22,11 +22,14 @@ package org.micromanager.data.internal;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Iterator;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.micromanager.MultiStagePosition;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMap.PropertyMapBuilder;
 import org.micromanager.StagePosition;
 import org.micromanager.data.Coords;
 import org.micromanager.data.SummaryMetadata;
@@ -595,13 +598,42 @@ public final class DefaultSummaryMetadata implements SummaryMetadata {
       }
       catch (JSONException e) {}
 
+      
       if (tags.has("UserData")) {
          try {
             builder.userData(
-                  DefaultPropertyMap.fromJSON(tags.getJSONObject("UserData")));
-         }
-         catch (JSONException e) {}
-      }
+                       DefaultPropertyMap.fromJSON(tags.getJSONObject("UserData")));
+           } catch (JSONException e) {
+           }
+       } else { //1.4. did not have the field UserData but User Data were 
+           // interpersed with other metadata.
+           String[] reservedNames = {"Prefix", "UserName", "ProfileName", "MicroManagerVersion",
+               "MetadataVersion", "ComputerName", "Directory", "ChannelGroup", "ChNames",
+               "WaitInterval", "Interval_ms", "CustomIntervals_ms", "AxisOrder", "IntendedDimensions",
+               "StartTime", "Time", "StagePositions", "InitialPositionList", "KeepShutterOpenSlices",
+               "UserData", "Frames", "Slices", "Channels", "PixelSize_um", "z-step_um",
+                "ChContrastMax", "ChContrastMin"};
+
+           PropertyMapBuilder pmb = MMStudio.getInstance().data().getPropertyMapBuilder();
+
+               Iterator<String> keys = tags.keys();
+               while (keys.hasNext()) {
+                   String key = keys.next();
+                   if (!Arrays.asList(reservedNames).contains(key)) {
+                       try {
+                           //JSONArray uds = tags.getJSONArray(key);
+                           //JSONObject obj = tags.optJSONObject(key);
+                           pmb.putString(key, tags.getString(key));
+                       } catch (JSONException ex) {
+                       } catch (ClassCastException ex2) {
+                       }
+                   }
+
+               }
+               builder.userData(pmb.build());
+
+
+       }
 
       return builder.build();
    }


### PR DESCRIPTION
When reading Summary metadata from old datasets, all unknown tags are now stored in UserData rather than being discarded.

Fixes issue #433