### PR TITLE
QuickAccess Panels: Fixes naming bugs

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/DefaultQuickAccessManager.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/DefaultQuickAccessManager.java
@@ -19,6 +19,7 @@
 
 package org.micromanager.quickaccess.internal;
 
+import com.bulenkov.iconloader.IconLoader;
 import com.google.common.base.Charsets;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.io.Files;
@@ -200,9 +201,8 @@ public final class DefaultQuickAccessManager implements QuickAccessManager {
          }
          else if (iconType.equals(JAR_ICON)) {
             // Load the icon from our jar.
-            return new ImageIcon (
-               getClass().getResource("/org/micromanager/icons/" +
-                  json.getString(ICON_PATH) + ".png") );
+             return IconLoader.getIcon("/org/micromanager/icons/" +
+                    json.getString(ICON_PATH) + ".png");
          }
          else {
             studio_.logs().logError("Unsupported icon type " + iconType);

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/QuickAccessFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/QuickAccessFrame.java
@@ -19,6 +19,7 @@
 
 package org.micromanager.quickaccess.internal;
 
+import com.bulenkov.iconloader.IconLoader;
 import com.google.common.eventbus.Subscribe;
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -133,10 +134,8 @@ public final class QuickAccessFrame extends JFrame {
 
       contentsPanel_.add(controlsPanel_);
 
-      ImageIcon gearIcon = new ImageIcon (
-               getClass().getResource("/org/micromanager/icons/gear.png"));
-      configureButton_ = new JToggleButton(gearIcon);
-           // IconLoader.getIcon("/org/micromanager/icons/gear.png"));
+      configureButton_ = new JToggleButton(
+              IconLoader.getIcon("/org/micromanager/icons/gear.png"));
       configureButton_.setToolTipText("Open the configuration UI for this panel");
       configureButton_.addActionListener(new ActionListener() {
          @Override

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/QuickAccessFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/QuickAccessFrame.java
@@ -19,7 +19,7 @@
 
 package org.micromanager.quickaccess.internal;
 
-import com.bulenkov.iconloader.IconLoader;
+import com.google.common.eventbus.Subscribe;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -29,6 +29,8 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
@@ -38,6 +40,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -49,14 +52,13 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import net.miginfocom.swing.MigLayout;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
+import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.quickaccess.QuickAccessPlugin;
 import org.micromanager.quickaccess.WidgetPlugin;
@@ -70,23 +72,23 @@ public final class QuickAccessFrame extends JFrame {
    private static final String OPEN_REMEMBER = "Remember";
    private static final String DEFAULT_TITLE = "Quick Access Panel";
 
-   private Studio studio_;
+   private final Studio studio_;
    // Holds everything.
-   private JPanel contentsPanel_;
+   private final JPanel contentsPanel_;
    // Holds the active controls.
-   private GridPanel controlsPanel_;
+   private final GridPanel controlsPanel_;
    // Holds icons representing the current active controls.
-   private GridPanel configuringControlsPanel_;
+   private final GridPanel configuringControlsPanel_;
    // Holds the "source" icons that can be added to the active controls, as
    // well as the rows/columns configuration fields.
-   private ConfigurationPanel configurePanel_;
+   private final ConfigurationPanel configurePanel_;
    // Switches between normal and configure modes.
    private JToggleButton configureButton_;
    // List of visual dividers in the grid.
-   private HashSet<Divider> dividers_;
+   private final HashSet<Divider> dividers_;
 
    // All of the controls we have in the grid.
-   private HashSet<ControlCell> controls_;
+   private final HashSet<ControlCell> controls_;
    // Dimensions of the grid.
    private int numCols_ = 3;
    private int numRows_ = 3;
@@ -100,6 +102,7 @@ public final class QuickAccessFrame extends JFrame {
    private int iconOffsetX_ = -1;
    private int iconOffsetY_ = -1;
 
+   
    public QuickAccessFrame(Studio studio, JSONObject config) {
       setAlwaysOnTop(true);
 
@@ -130,8 +133,10 @@ public final class QuickAccessFrame extends JFrame {
 
       contentsPanel_.add(controlsPanel_);
 
-      configureButton_ = new JToggleButton(
-            IconLoader.getIcon("/org/micromanager/icons/gear.png"));
+      ImageIcon gearIcon = new ImageIcon (
+               getClass().getResource("/org/micromanager/icons/gear.png"));
+      configureButton_ = new JToggleButton(gearIcon);
+           // IconLoader.getIcon("/org/micromanager/icons/gear.png"));
       configureButton_.setToolTipText("Open the configuration UI for this panel");
       configureButton_.addActionListener(new ActionListener() {
          @Override
@@ -142,14 +147,16 @@ public final class QuickAccessFrame extends JFrame {
       contentsPanel_.add(configureButton_);
 
       // We'll add this later, when the configure button is toggled.
-      configurePanel_ = new ConfigurationPanel(
-            config.optString("title", DEFAULT_TITLE));
+      configurePanel_ = new ConfigurationPanel( 
+                  config.optString("title", DEFAULT_TITLE) );
 
       add(contentsPanel_);
 
       loadConfig(config);
 
       pack();
+      
+      studio_.events().registerForEvents(this);
    }
 
    /**
@@ -158,7 +165,9 @@ public final class QuickAccessFrame extends JFrame {
    private void loadConfig(JSONObject config) {
       if (config.length() == 0) {
          // Empty config; create a default (i.e. empty) window.
-         setTitle(DEFAULT_TITLE);
+         setTitle(DefaultQuickAccessManager.getUniqueTitle(this,DEFAULT_TITLE));
+         super.setBounds(100, 100, 100, 100);
+         super.pack();
          setVisible(true);
          return;
       }
@@ -198,6 +207,7 @@ public final class QuickAccessFrame extends JFrame {
 
    /**
     * Create a JSONObject for storing our settings to the profile.
+    * @return JSONObject containing the settings for this Quick Access Panel
     */
    public JSONObject getConfig() {
       try {
@@ -249,6 +259,8 @@ public final class QuickAccessFrame extends JFrame {
    /**
     * Start dragging the specified DraggableIcon, which was clicked on
     * according to the provided MouseEvent.
+    * @param icon - Icon being dragged
+    * @param e - The MouseEvent that started all of this
     */
    public void startDragging(DraggableIcon icon, MouseEvent e) {
       draggedIcon_ = icon;
@@ -276,7 +288,7 @@ public final class QuickAccessFrame extends JFrame {
       }
       // Default to 1x1 cell.
       Rectangle rect = new Rectangle(p.x, p.y, 1, 1);
-      if (p != null && plugin != null) {
+      if (plugin != null) {
          PropertyMap config = null;
          try {
             if (plugin instanceof WidgetPlugin) {
@@ -372,6 +384,9 @@ public final class QuickAccessFrame extends JFrame {
       contentsPanel_.add(panel);
       contentsPanel_.add(configureButton_);
       if (isShown) {
+         // Update the configure panels titel, since it may have changed since
+         // the panel was created.
+         configurePanel_.setUserTitle(this.getTitle());
          String paramString = "growx";
          // Depending on the grid shape, we either put the configure panel
          // below or to the right of the grid. We prefer having the panel
@@ -440,11 +455,13 @@ public final class QuickAccessFrame extends JFrame {
    /**
     * Update the title of this window according to the provided string.
     */
-   private void updateTitle(String title) {
-      setTitle(DefaultQuickAccessManager.getUniqueTitle(this, title));
+   private String updateTitle(String title) {
+      String newTitle = DefaultQuickAccessManager.getUniqueTitle(this, title);
+      setTitle(newTitle);
       // This is mostly to let the Tools menu know it needs to regenerate its
       // submenu for the quick access panels.
       studio_.events().post(new QuickAccessPanelEvent());
+      return newTitle;
    }
 
    /**
@@ -581,6 +598,7 @@ public final class QuickAccessFrame extends JFrame {
          }
       }
 
+      @Override
       public Dimension getPreferredSize() {
          return new Dimension(numCols_ * QuickAccessPlugin.CELL_WIDTH,
                numRows_ * QuickAccessPlugin.CELL_HEIGHT);
@@ -593,12 +611,12 @@ public final class QuickAccessFrame extends JFrame {
     */
    private class ConfigurationPanel extends JPanel {
       // Dimensionality controls.
-      private JSpinner colsControl_;
-      private JSpinner rowsControl_;
+      private final JSpinner colsControl_;
+      private final JSpinner rowsControl_;
       // Title input text field
       private JTextField titleField_;
       // Dropdown menu for selecting the open mode.
-      private JComboBox openSelect_;
+      private final JComboBox openSelect_;
 
       /**
        * We take the title as a parameter because, at the time that this
@@ -637,18 +655,16 @@ public final class QuickAccessFrame extends JFrame {
 
          subPanel.add(new JLabel("Panel title:"), "split 2, span");
          titleField_ = new JTextField(title, 20);
-         titleField_.getDocument().addDocumentListener(new DocumentListener() {
+         titleField_.addFocusListener(new FocusListener(){
             @Override
-            public void insertUpdate(DocumentEvent e) {
-               updateTitle(titleField_.getText());
+            public void focusGained(FocusEvent fe) {
+               // Nothing to be done
             }
+
             @Override
-            public void removeUpdate(DocumentEvent e) {
-               updateTitle(titleField_.getText());
-            }
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-               updateTitle(titleField_.getText());
+            public void focusLost(FocusEvent fe) {
+               String newTitle = updateTitle(titleField_.getText());
+               titleField_.setText(newTitle);
             }
          });
          subPanel.add(titleField_, "wrap");
@@ -718,6 +734,10 @@ public final class QuickAccessFrame extends JFrame {
        */
       public String getUserTitle() {
          return titleField_.getText();
+      }
+      
+      public void setUserTitle(String newTitle) {
+         titleField_.setText(newTitle);
       }
 
       /**
@@ -829,5 +849,12 @@ public final class QuickAccessFrame extends JFrame {
       int x2 = json.getInt("x2");
       int y2 = json.getInt("y2");
       return new Divider(new Point(x1, y1), new Point(x2, y2));
+   }
+   
+   @Subscribe
+   public void onShutdownEvent(InternalShutdownCommencingEvent isce) {
+      if (!isce.getIsCancelled()) {
+         this.dispose();
+      }
    }
 }


### PR DESCRIPTION
Addresses issue #423.  Makes sure that new Panels have unique names, and that changed names are unique.  Also removes the use of com.bulenkov.iconloader.IconLoader (which should be removed everywhere since it is trivial code), makes variables final whenever possible and add some Javadoc.