### PR TITLE
Two fixes for the PrecisExcite adapter (MM2)

### DIFF
--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -470,7 +470,7 @@ void Controller::Illuminate()
    {
       if (triggerMode_ == OFF) {
          msg << "SQZ" << carriage_return;
-         for (unsigned int i=0; i<channelLetters_.size(); i++) {
+         for (int i=0; i<channelLetters_.size(); i++) {
             msg << "C" << channelLetters_[i];
             if (i == currentChannel_)
                msg << "N";

--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -190,8 +190,10 @@ int Controller::ReadChannelLabels()
          string label = buf_tokens_[i].substr(6);
          StripString(label);
 
-         //This skips invalid channels
-         if (label.compare("----") == 0)
+         //This skips invalid channels.
+	 //Invalid names seem to have a different number of dashes.
+	 //pe2: First invalid is called ----, then second is -----
+         if (label.substr(0,4).compare("----") == 0)
             continue;
 
          channelLetters_.push_back(buf_tokens_[i][4]); // Read 4th character

--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -184,14 +184,17 @@ int Controller::ReadChannelLabels()
    }
       while(! buf_string_.empty());
    
-   
    for (unsigned int i=0;i<buf_tokens_.size();i++)
    {
       if (buf_tokens_[i].substr(0,3).compare("LAM")==0) {
-         channelLetters_.push_back(buf_tokens_[i][4]); // Read 4th character
          string label = buf_tokens_[i].substr(6);
          StripString(label);
 
+         //This skips invalid channels
+         if (label.compare("----") == 0)
+            continue;
+
+         channelLetters_.push_back(buf_tokens_[i][4]); // Read 4th character
          // This is a temporary log entry to debug an issue with channel labels
          // that appear to contain an invalid character at the end.
          std::ostringstream ss;
@@ -358,7 +361,7 @@ int Controller::OnChannelLabel(MM::PropertyBase* pProp, MM::ActionType eAct)
    {
       GetState(state_);
       pProp->Get(currentChannelLabel_);
-      for (unsigned i=0;i<channelLabels_.size();i++)
+      for (unsigned int i=0;i<channelLabels_.size();i++)
          if (channelLabels_[i].compare(currentChannelLabel_) == 0)
          {
             currentChannel_ = i;
@@ -440,7 +443,7 @@ void Controller::SetTrigger()
    stringstream msg;
    msg << "SQX" << carriage_return;
 
-   for (unsigned i=0;i<triggerSequence_.size();i++)
+   for (unsigned int i=0;i<triggerSequence_.size();i++)
    {
       msg << "SQ" << triggerSequence_[i] << carriage_return;
    }
@@ -527,7 +530,7 @@ void Controller::GetState(long &state)
       Send("C?");
       long stateTmp = 0;
 
-      for (unsigned int i=1;i<=channelLetters_.size();i++)
+      for (unsigned int i=0;i<channelLetters_.size();i++)
       {
          ReceiveOneLine();
 
@@ -574,10 +577,8 @@ void Controller::ReceiveOneLine()
 void Controller::Purge()
 {
    int ret = PurgeComPort(port_.c_str());
-   /*
    if (ret!=0)
       error_ = DEVICE_SERIAL_COMMAND_FAILED;
-      */
 }
 
 //********************

--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -463,8 +463,17 @@ void Controller::Illuminate()
    }
    else if (state_==1)
    {
-      if (triggerMode_ == OFF)
-         msg << "SQZ" << carriage_return << "C" << channelLetters_[currentChannel_] << "N";
+      if (triggerMode_ == OFF) {
+         msg << "SQZ" << carriage_return;
+         for (unsigned int i=0; i<channelLetters_.size(); i++) {
+            msg << "C" << channelLetters_[i];
+            if (i == currentChannel_)
+               msg << "N";
+            else
+               msg << "F";
+            msg << carriage_return;
+         }
+      }
       else if (triggerMode_ == FOLLOW_PULSE)
          msg << "SQZ" << carriage_return << "A" << channelLetters_[currentChannel_] << "#";
       else
@@ -565,8 +574,10 @@ void Controller::ReceiveOneLine()
 void Controller::Purge()
 {
    int ret = PurgeComPort(port_.c_str());
+   /*
    if (ret!=0)
       error_ = DEVICE_SERIAL_COMMAND_FAILED;
+      */
 }
 
 //********************

--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -158,6 +158,7 @@ int Controller::Initialize()
    GeneratePropertyState();
    GeneratePropertyTrigger();
    GeneratePropertyTriggerSequence();
+   GetState(state_);
    
    initialized_ = true;
    return HandleErrors();
@@ -357,6 +358,10 @@ int Controller::OnChannelLabel(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::BeforeGet)
    {
+      GetState(state_);
+      if (state_ == 1) {
+         currentChannelLabel_ = channelLabels_[currentChannel_];
+      }
       pProp->Set(currentChannelLabel_.c_str());
    }
    else if (eAct == MM::AfterSet)
@@ -537,8 +542,11 @@ void Controller::GetState(long &state)
          ReceiveOneLine();
 
          if (! buf_string_.empty())
-            if (buf_string_[5]=='N')
-               stateTmp = 1;       
+            if (buf_string_[5]=='N') {
+               stateTmp = 1;
+               currentChannel_ = i;
+               break;
+            }
       }
       state = stateTmp;
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -1486,7 +1486,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
          message("Reset of BeanShell interpreter failed");
       }
       // Apparently clear() also erases bsh.console, which we need
-      beanshellREPLint_.setConsole(cons_);
+      //beanshellREPLint_.setConsole(cons_);
 
       initializeInterpreter();
    }


### PR DESCRIPTION
I have tested this with my pe-300 light source. I will check this with the pe-2 later.

**First fix** concerns the erroneous behaviour (when shutter open) of turning on any selected channel via the PrecisExcite.ChannelLabel property *without* switching off the deselected channels. With shutter closed however, single LED channels were selected as expected.

**Second fix** concerns the population of PreciseExcite.ChannelLabel with invalid channel names. This has the effect of delaying any PreciseExcite property read-out, since the adapter needs to wait for the serial communication to timeout for invalid channels.

I will check if I can backport these changes to master.

According to my logs, there are still two timeouts left during the adapter initialisation, but I think we can live with those for now.

Cheers,
Egor