### PR TITLE
Two fixes for the PrecisExcite adapter (master)

### DIFF
--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -470,7 +470,7 @@ void Controller::Illuminate()
    {
       if (triggerMode_ == OFF) {
          msg << "SQZ" << carriage_return;
-         for (unsigned int i=0; i<channelLetters_.size(); i++) {
+         for (int i=0; i<channelLetters_.size(); i++) {
             msg << "C" << channelLetters_[i];
             if (i == currentChannel_)
                msg << "N";

--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -190,8 +190,10 @@ int Controller::ReadChannelLabels()
          string label = buf_tokens_[i].substr(6);
          StripString(label);
 
-         //This skips invalid channels
-         if (label.compare("----") == 0)
+         //This skips invalid channels.
+	 //Invalid names seem to have a different number of dashes.
+	 //pe2: First invalid is called ----, then second is -----
+         if (label.substr(0,4).compare("----") == 0)
             continue;
 
          channelLetters_.push_back(buf_tokens_[i][4]); // Read 4th character


### PR DESCRIPTION
These are the changes pushed to master instead of MM2.

To recap:

**First fix** concerns the erroneous behaviour (when shutter open) of turning on any selected channel via the PrecisExcite.ChannelLabel property without switching off the deselected channels. With shutter closed however, single LED channels were selected as expected.

**Second fix** concerns the population of PreciseExcite.ChannelLabel with invalid channel names. This has the effect of delaying any PreciseExcite property read-out, since the adapter needs to wait for the serial communication to timeout for invalid channels.

I have tested this with my pe-300 light source. I will check this with the pe-2 later.

According to my logs, there are still two timeouts left during the adapter initialisation, but I think we can live with those for now.

Cheers,
Egor
