### PR TITLE
Fixes bug: "closing a datastore does not always close filehandle"

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -454,6 +454,7 @@ public class DefaultDatastore implements Datastore {
          freeze();
          duplicate.setSavePath(path);
          duplicate.freeze();
+         duplicate.close();
          // Save our annotations now.
          for (DefaultAnnotation annotation : annotations_.values()) {
             annotation.save();

--- a/scripts/datastoreExample.bsh
+++ b/scripts/datastoreExample.bsh
@@ -12,8 +12,11 @@ import org.micromanager.display.DisplayWindow;
 
 import mmcorej.TaggedImage;
 
+String saveLocation = "C:\\tmp2";
+
 Datastore store = mm.data().createRAMDatastore();
 DisplayWindow display = mm.displays().createDisplay(store);
+mm.displays().manage(store);
 
 mm.getCore().snapImage();
 TaggedImage tmp = mm.getCore().getTaggedImage();
@@ -27,4 +30,6 @@ image2 = image2.copyAtCoords(image1.getCoords().copy().channel(1).build());
 
 store.putImage(image1);
 store.putImage(image2);
-store.save(Datastore.SaveMode.MULTIPAGE_TIFF, display);
+store.freeze();
+store.save(Datastore.SaveMode.MULTIPAGE_TIFF, saveLocation);
+store.close();


### PR DESCRIPTION
Addresses issue #470.  Also fixes broken datastore example script.