### PR TITLE
Duplicator plugin: Fixes problems caused by wrong channelnames in metadata

### DIFF
--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
@@ -210,7 +210,7 @@ public class DuplicatorPluginFrame extends MMDialog {
          int max = maxes.get(Coords.CHANNEL);
          List<String> chNameList = new ArrayList<String>();
          for (int index = min; index <= max; index++) {
-            if (channelNames == null) {
+            if (channelNames == null || index >= channelNames.length) {
                chNameList.add("channel " + index);
             } else {
                chNameList.add(channelNames[index]);


### PR DESCRIPTION
I encountered a situation where the function metadat.getChannelNames() returned fewer names than the number of channels in the datastore.  This was accompanies by an error reading in the file (see below).  Even though this does not fix the underlying cause, this change will make the code more robust (and makes it workable with this specific file).  

  [       ] java.io.IOException: Offset header incorrect, expected: 99384722   found: 0 in Thread[Thread-7,6,main]
                                             [       ]   at org.micromanager.data.internal.multipagetiff.MultipageTiffReader.readOffsetHeaderAndOffset(MultipageTiffReader.java:432)
                                             [       ]   at org.micromanager.data.internal.multipagetiff.MultipageTiffReader.readComments(MultipageTiffReader.java:380)
                                             [       ]   at org.micromanager.data.internal.multipagetiff.MultipageTiffReader.<init>(MultipageTiffReader.java:138)
                                             [       ]   at org.micromanager.data.internal.multipagetiff.StorageMultipageTiff.loadFile(StorageMultipageTiff.java:232)
                                             [       ]   at org.micromanager.data.internal.multipagetiff.StorageMultipageTiff.openExistingDataSet(StorageMultipageTiff.java:205)
                                             [       ]   at org.micromanager.data.internal.multipagetiff.StorageMultipageTiff.<init>(StorageMultipageTiff.java:146)
                                             [       ]   at org.micromanager.data.internal.multipagetiff.StorageMultipageTiff.<init>(StorageMultipageTiff.java:107)
                                             [       ]   at org.micromanager.data.internal.DefaultDataManager.loadData(DefaultDataManager.java:167)
                                             [       ]   at org.micromanager.internal.menus.FileMenu$7$1.run(FileMenu.java:145)
                                             [       ]   at java.lang.Thread.run(Thread.java:695)