### PR TITLE
Set channelGroup fix

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -320,8 +320,11 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
                acquisitionSettings.channels.add(channel);
             }
          }
-         acquisitionSettings.channelGroup = core_.getChannelGroup();
       }
+      //since we're just getting this from the core, it should be safe to get 
+      //regardless of whether we're using any channels. This also makes the 
+      //behavior more consisitent with the setting behavior.
+      acquisitionSettings.channelGroup = getChannelGroup();
 
       //timeFirst = true means that time points are collected at each position
       acquisitionSettings.timeFirst = (acqOrderMode_ == AcqOrderMode.POS_TIME_CHANNEL_SLICE
@@ -388,11 +391,10 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
          useChannels_ = false;
          
       channels_ = ss.channels;
-       try {
-           core_.setChannelGroup(ss.channelGroup);
-       } catch (Exception e) {
-           ReportingUtils.logError(e, "Couldn't set core channelGroup from SequenceSettings.");
-       }
+      //should check somewhere that channels actually belong to channelGroup
+      //currently it is possible to set channelGroup to a group other than that
+      //which channels belong to.
+      setChannelGroup(ss.channelGroup);
 
       //timeFirst = true means that time points are collected at each position      
       if (ss.timeFirst && ss.slicesFirst) {

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -388,7 +388,11 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
          useChannels_ = false;
          
       channels_ = ss.channels;
-       // no channel group
+       try {
+           core_.setChannelGroup(ss.channelGroup);
+       } catch (Exception e) {
+           ReportingUtils.logError(e, "Couldn't set core channelGroup from SequenceSettings.");
+       }
 
       //timeFirst = true means that time points are collected at each position      
       if (ss.timeFirst && ss.slicesFirst) {


### PR DESCRIPTION
This fixes issue #475 by setting the channelGroup when setAcquisitionSettings is called. I also changed getAcquisitionSettings to return channelGroup even when no channels are selected, because calling setAcquisitionSettings with no channels currently sets useChannels_ to false, so that the channelGroup was not being returned. This better mirrors the behavior of the UI which allows channelGroup to be set with no channels.