### PR TITLE
Projector: Decrease range of initial calibration search

### DIFF
--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
@@ -514,7 +514,7 @@ public class ProjectorControlForm extends MMFrame implements OnStateListener {
    private AffineTransform generateLinearMapping() {
       double centerX = dev_.getXRange() / 2 + dev_.getXMinimum();
       double centerY = dev_.getYRange() / 2 + dev_.getYMinimum();
-      double spacing = Math.min(dev_.getXRange(), dev_.getYRange()) / 10;  // user 10% of galvo/SLM range
+      double spacing = Math.min(dev_.getXRange(), dev_.getYRange()) / 30;  // user 3% of galvo/SLM range
       Map<Point2D.Double, Point2D.Double> spotMap
             = new HashMap<Point2D.Double, Point2D.Double>();
 


### PR DESCRIPTION
The range for the initial (small) small search can sometimes be too large.  This change reduces the range from 10% to 3%.  It would be best to have an automatic way of minimizing the range (for instance by checking whether or not a calibration point was found, and if not, try again closer to the center)