### PR TITLE
SlideExplorer: Adjust contrast after first tile acquired

### DIFF
--- a/plugins/SlideExplorer/src/main/java/org/micromanager/slideexplorer/Display.java
+++ b/plugins/SlideExplorer/src/main/java/org/micromanager/slideexplorer/Display.java
@@ -13,7 +13,6 @@ import java.awt.event.WindowEvent;
 import java.awt.Point;
 import java.awt.Rectangle;
 
-import org.micromanager.internal.MMStudio;
 import org.micromanager.slideexplorer.Hub.ModeManager;
 import org.micromanager.internal.utils.ImageUtils;
 import org.micromanager.internal.utils.ReportingUtils;
@@ -32,7 +31,6 @@ public class Display {
     private boolean currentlyPanning_ = false;
     private RoiManager roiManager_;
     private Coordinates coords_;
-	private boolean contrastAutoAdjusted_ = false;
    private boolean windowExists_ = true;
 
 	public Display(Hub hub, int imageType, int width, int height) {
@@ -140,15 +138,14 @@ public class Display {
 		imgp_.setRoi(roiRect);
 	}
 
-	public void updateAndDraw() {
+	public void updateAndDraw(boolean adjustContrast) {
 		imgp_.updateAndDraw();
-      if (! contrastAutoAdjusted_) {// Only do this once.
+      if (adjustContrast) {
          ImageStatistics stats = imgp_.getStatistics();
          double displayRange = imgp_.getDisplayRangeMax()-imgp_.getDisplayRangeMin();
          double actualRange = stats.max - stats.min;
          if ((displayRange < 5) || (displayRange/actualRange < 0.6667) || (displayRange/actualRange > 1.5)) {
             imgp_.setDisplayRange(stats.min, stats.max);
-            contrastAutoAdjusted_ = true;
          }
       }
 	}

--- a/plugins/SlideExplorer/src/main/java/org/micromanager/slideexplorer/Hub.java
+++ b/plugins/SlideExplorer/src/main/java/org/micromanager/slideexplorer/Hub.java
@@ -21,7 +21,6 @@ import org.micromanager.MenuPlugin;
 import org.micromanager.Studio;
 import org.micromanager.UserProfile;
 import org.micromanager.internal.utils.ImageUtils;
-import org.micromanager.internal.utils.JavaUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 
 public class Hub {
@@ -46,6 +45,7 @@ public class Hub {
    private String surveyPixelSizeConfig_ = "";
    private String navigatePixelSizeConfig_ = "";
    private Map<String, OffsetsRow> offsetsData_ = new HashMap<String, OffsetsRow>();
+   private boolean contrastAutoAdjusted_ = false;
 
    /*
     * Hub constructor.
@@ -558,7 +558,10 @@ public class Hub {
          } else {
             drawTile(tileIndex_);
          }
-         display_.updateAndDraw();
+         display_.updateAndDraw(!contrastAutoAdjusted_);
+         if (tileIndex_ != null) {
+            contrastAutoAdjusted_ = true;
+         }
       }
 
       /*


### PR DESCRIPTION
SlideExplorer would always start with the intensity scaling set to an extreme that would make the image appear all white. This change ensures that it is auto-scaled after the first tile is acquired. There may be room for further improvement to the heuristic used to determine intensity range.