### PR TITLE
TileCreator: Fix typo and remove superfluous call. that could potentiall…

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
@@ -377,10 +377,9 @@ public final class TileCreatorDlg extends MMDialog {
    }
 
    @Subscribe
-   public void stuttingDown(ShutdownCommencingEvent se) {
+   public void shuttingDown(ShutdownCommencingEvent se) {
       studio_.profile().setString(TileCreatorDlg.class,
               OVERLAP_PREF, overlapField_.getText());
-      positionListDlg_.activateAxisTable(true);
       dispose();
    }
 


### PR DESCRIPTION
 This may avoid a null pointer exception while shutting down.