### PR TITLE
MultiChannelShading: post an alert when flatfield image is wrong size.

### DIFF
--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ImageCollection.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ImageCollection.java
@@ -124,6 +124,11 @@ public class ImageCollection {
       try {
          ImageProcessor dp;
          if (bg != null) {
+            if (bg.getWidth() != ip.getWidth() || bg.getHeight() != ip.getHeight()) {
+               gui_.getAlertManager().postAlert("Flatfield Error", this.getClass(), 
+                       preset + " flatfield image size differs from background image size.");
+               throw new ShadingException("Faltfield image and background image differ in size");
+            }
             dp = ImageUtils.subtractImageProcessors(
                     ip.getProcessor(), bg.getProcessor());
          } else {

--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ShadingProcessor.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ShadingProcessor.java
@@ -209,7 +209,8 @@ public class ShadingProcessor extends Processor {
                String value = ps.getPropertyValue();
                if (scopeData.containsKey(key)
                        && scopeData.getPropertyType(key) == String.class) {
-                  if (!value.equals(scopeData.getString(key))) {
+                  String scopeSetting = scopeData.getString(key);
+                  if (!value.equals(scopeSetting)) {
                      presetMatch = false;
                      break;
                   }


### PR DESCRIPTION
Flatfield images should be the full size of the camera (i.e., unbinned, no ROI).  So far,
this was not checked, the code simply ran into exceptions.  This change only compares 
the image with the size of the background image.  May need
to compare to the image size of the current camera.  There are certainly
problems in this plugin when using multiple cameras that differ in size.
This change should help make the user realize that there is a problem
and help figure out what that problem may be.