### PR TITLE
Fixes for some typos in MMCore (mainly) comments

### DIFF
--- a/MMCore/CircularBuffer.cpp
+++ b/MMCore/CircularBuffer.cpp
@@ -5,8 +5,8 @@
 //-----------------------------------------------------------------------------
 // DESCRIPTION:   Generic implementation of the circular buffer. The buffer
 //                allows only one thread to enter at a time by using a mutex lock.
-//                This makes the buffer succeptible to race conditions if the
-//                calling threads are mutally dependent.
+//                This makes the buffer susceptible to race conditions if the
+//                calling threads are mutually dependent.
 //              
 // COPYRIGHT:     University of California, San Francisco, 2007,
 //

--- a/MMCore/Configuration.h
+++ b/MMCore/Configuration.h
@@ -87,8 +87,8 @@ private:
 };
 
 /**
- * Property pair defined as dublet:
- * dproperty - value.
+ * Property pair defined as doublet:
+ * property - value.
  */
 struct PropertyPair
 {
@@ -152,7 +152,7 @@ private:
 };
 
 /**
- * Encapsulation of the proeprty collection. Designed to be wrapped
+ * Encapsulation of the property collection. Designed to be wrapped
  * by SWIG. A collection of property pairs.
  */
 class PropertyBlock

--- a/MMCore/CoreCallback.cpp
+++ b/MMCore/CoreCallback.cpp
@@ -7,7 +7,7 @@
 //                (bottom) internal API for calls going from devices to the 
 //                core.
 //
-//                This class is essentialy an extension of the CMMCore class
+//                This class is essentially an extension of the CMMCore class
 //                and has full access to CMMCore private members.
 //              
 // AUTHOR:        Nenad Amodaj, nenad@amodaj.com, 01/05/2007
@@ -446,7 +446,7 @@ int CoreCallback::OnPropertyChanged(const MM::Device* device, const char* propNa
 
       // Find all configs that contain this property and callback to indicate 
       // that the config group changed
-      // TODO: Assess whether performace is better by maintaining a map tying 
+      // TODO: Assess whether performance is better by maintaining a map tying
       // property to configurations
       std::vector<std::string> configGroups = 
          core_->getAvailableConfigGroups ();

--- a/MMCore/CoreCallback.h
+++ b/MMCore/CoreCallback.h
@@ -84,7 +84,7 @@ public:
 
    void Sleep(const MM::Device* caller, double intervalMs);
 
-   // continous acquisition support
+   // continuous acquisition support
    int InsertImage(const MM::Device* caller, const ImgBuffer& imgBuf); // Note: _not_ mm::ImgBuffer
    int InsertImage(const MM::Device* caller, const unsigned char* buf, unsigned width, unsigned height, unsigned byteDepth, const char* serializedMetadata, const bool doProcess = true);
 

--- a/MMCore/DeviceManager.cpp
+++ b/MMCore/DeviceManager.cpp
@@ -104,7 +104,7 @@ DeviceManager::UnloadAllDevices()
    // We plan unloading, and then carry it out, so as not to iterate
    // over a changing collection. Down with mutable collections.
    // XXX This ordering should be handled by strong references from device to
-   // device. Also, peripehrals should explicitly be unloaded before hubs
+   // device. Also, peripherals should explicitly be unloaded before hubs
    // instead of relying on the load order.
 
    std::vector< boost::shared_ptr<DeviceInstance> > nonSerialDevices;
@@ -121,7 +121,7 @@ DeviceManager::UnloadAllDevices()
       }
    }
 
-   // Call Shutdown before removing devices from index, so that the deivce's
+   // Call Shutdown before removing devices from index, so that the device's
    // Shutdown() has access (through the CoreCallback) to its own
    // DeviceInstance.
    // TODO We need a mechanism to ensure automatic Shutdown (1:1 with

--- a/MMCore/DeviceManager.h
+++ b/MMCore/DeviceManager.h
@@ -85,7 +85,7 @@ public:
    ///@}
 
    /**
-    * \brief Get a device by label, requring a specific type.
+    * \brief Get a device by label, requiring a specific type.
     */
    ///@{
    template <class TDeviceInstance>

--- a/MMCore/Devices/DeviceInstance.h
+++ b/MMCore/Devices/DeviceInstance.h
@@ -162,7 +162,7 @@ public:
     *
     * Note that, at least for now, these are all non-virtual, because there is
     * no case under which they will be overridden by derived classes. It may
-    * become necessary to make these virtual if the need arrises to e.g. handle
+    * become necessary to make these virtual if the need arises to e.g. handle
     * synchronization with methods specific to derived classes.
     *
     * TODO Error handling

--- a/MMCore/Error.h
+++ b/MMCore/Error.h
@@ -143,7 +143,7 @@ public:
 
    /// Access the underlying error.
    /**
-    * This is intended for code that wants to perform custum formatting or
+    * This is intended for code that wants to perform custom formatting or
     * analysis of the chained errors.
     *
     * The returned pointer is valid until the instance on which this method was

--- a/MMCore/FrameBuffer.cpp
+++ b/MMCore/FrameBuffer.cpp
@@ -78,7 +78,7 @@ void ImgBuffer::SetMetadata(const Metadata& md)
 {
    //metadata_ = md;
    // Serialize/Restore instead of =operator used to avoid object new/delete
-   // issues accross the DLL boundary (on Windows)
+   // issues across the DLL boundary (on Windows)
    // TODO: this is inefficient and should be revised
     metadata_.Restore(md.Serialize().c_str());
 }

--- a/MMCore/LoadableModules/LoadedDeviceAdapter.cpp
+++ b/MMCore/LoadableModules/LoadedDeviceAdapter.cpp
@@ -143,7 +143,7 @@ LoadedDeviceAdapter::LoadDevice(CMMCore* core, const std::string& name,
    }
    catch (const CMMError&)
    {
-      // The type of a device that was not explictily registered (e.g. a
+      // The type of a device that was not explicitly registered (e.g. a
       // peripheral device or a device provided only for backward
       // compatibility) will not be available.
       expectedType = MM::UnknownType;

--- a/MMCore/LogManager.cpp
+++ b/MMCore/LogManager.cpp
@@ -94,7 +94,7 @@ LogManager::SetPrimaryLogFilename(const std::string& filename, bool truncate)
    {
       if (primaryFileSink_)
       {
-         LOG_INFO(internalLogger_) << "Disableing primary log file";
+         LOG_INFO(internalLogger_) << "Disabling primary log file";
          loggingCore_->RemoveSink(primaryFileSink_, PrimarySinkMode);
          primaryFileSink_.reset();
       }

--- a/MMCore/Logging/GenericLoggingCore.h
+++ b/MMCore/Logging/GenericLoggingCore.h
@@ -156,7 +156,7 @@ public:
     * Add and/or remove multiple sinks, atomically.
     *
     * This function should be used for example to switch files when performing
-    * log rotation, because it ensures that no entries are lossed during the
+    * log rotation, because it ensures that no entries are lost during the
     * switch.
     *
     * SinkModePairIterator should be an iterator type over

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -6834,11 +6834,11 @@ void CMMCore::InitializeErrorMessages()
    errorText_[MMERR_SetPropertyFailed] = "Property does not exist, or value not allowed.";
    errorText_[MMERR_LoadLibraryFailed] = "Unable to load library: file not accessible or corrupted.";
    errorText_[MMERR_LibraryFunctionNotFound] =
-      "Unable to identify expected interface: the library is not comaptible or corrupted.";
+      "Unable to identify expected interface: the library is not compatible or corrupted.";
    errorText_[MMERR_CreateNotFound] =
-      "Unable to identify CreateDevice function: the library is not comaptible or corrupted.";
+      "Unable to identify CreateDevice function: the library is not compatible or corrupted.";
    errorText_[MMERR_DeleteNotFound] =
-      "Unable to identify DeleteDevice function: the library is not comaptible or corrupted.";
+      "Unable to identify DeleteDevice function: the library is not compatible or corrupted.";
    errorText_[MMERR_CreateFailed] = "DeviceCreate function failed.";
    errorText_[MMERR_DeleteFailed] = "DeviceDelete function failed.";
    errorText_[MMERR_UnknownModule] = "Current device can't be unloaded: using unknown library.";
@@ -6876,9 +6876,9 @@ void CMMCore::InitializeErrorMessages()
       "Failed to initialize circular buffer - memory requirements not adequate.";
    errorText_[MMERR_CircularBufferEmpty] = "Circular buffer is empty.";
    errorText_[MMERR_ContFocusNotAvailable] = "Auto-focus focus device not defined.";
-   errorText_[MMERR_BadConfigName] = "Configuration name contains illegale characters (/\\*!')";
+   errorText_[MMERR_BadConfigName] = "Configuration name contains illegal characters (/\\*!')";
    errorText_[MMERR_NotAllowedDuringSequenceAcquisition] =
-      "This operation can not be executed while sequence acquisition is runnning.";
+      "This operation can not be executed while sequence acquisition is running.";
    errorText_[MMERR_OutOfMemory] = "Out of memory.";
    errorText_[MMERR_InvalidImageSequence] = "Issue snapImage before getImage.";
    errorText_[MMERR_NullPointerException] = "Null Pointer Exception.";

--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -83,7 +83,7 @@ using namespace std;
  *
  * The following (major, minor, patch) triplet is the MMCore API version. Since
  * 3.0.0, this is maintained according to the rules outlined at
- * http://semver.org/ . Briefely,
+ * http://semver.org/ . Briefly,
  *
  * - Increment the major version when making backward-incompatible changes
  *   (changes that will require any existing code to be modified, or that may
@@ -110,7 +110,7 @@ const int MMCore_versionMajor = 8, MMCore_versionMinor = 5, MMCore_versionPatch 
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// CMMcore class
+// CMMCore class
 // -------------
 
 /**
@@ -558,11 +558,11 @@ Configuration CMMCore::getConfigGroupState(const char* group, bool fromCache) th
 
 /**
  * Sets all properties contained in the Configuration object.
- * The procedure will attempt to set each property it enocunters, but won't stop
+ * The procedure will attempt to set each property it encounters, but won't stop
  * if any of the properties fail or if the requested device is not present. It will
  * just quietly continue.
  *
- * @param conf    the configuration object represeting the desired system state
+ * @param conf    the configuration object representing the desired system state
  */
 void CMMCore::setSystemState(const Configuration& conf)
 {
@@ -646,7 +646,7 @@ void CMMCore::addSearchPath(const char *path)
  * Returns a list of library names available in the search path.
  *
  * Do not use in new code. For backward compatibility, this method returns the
- * list of device adapters availbable in the default search path(s) and the
+ * list of device adapters available in the default search path(s) and the
  * paths added via addSearchPath(). For obvious reasons (since this method is
  * static), it will not return device adapters found in the search paths set by
  * setDeviceAdapterSearchPaths(). Thus, this method will only work as expected
@@ -816,7 +816,7 @@ void CMMCore::unloadAllDevices() throw (CMMError)
 }
 
 /**
- * Unloads all devices from the core, clears all configration data and property blocks.
+ * Unloads all devices from the core, clears all configuration data and property blocks.
  */
 void CMMCore::reset() throw (CMMError)
 {
@@ -1220,7 +1220,7 @@ void CMMCore::waitForSystem() throw (CMMError)
 
 /**
  * Checks the busy status for all devices of the specific type.
- * The system will report busy if any of the devices of the spefified type are busy.
+ * The system will report busy if any of the devices of the specified type are busy.
  *
  * @return true on busy
  * @param devType   a constant specifying the device type
@@ -2132,7 +2132,7 @@ long CMMCore::getStageSequenceMaxLength(const char* label) throw (CMMError)
  * Transfer a sequence of events/states/whatever to the device
  * This should only be called for device-properties that are sequenceable
  * @param label              the device label
- * @param positionSequence   a sequence of positions that the stage will execute in reponse to external triggers
+ * @param positionSequence   a sequence of positions that the stage will execute in response to external triggers
  */
 void CMMCore::loadStageSequence(const char* label, std::vector<double> positionSequence) throw (CMMError)
 {
@@ -2239,8 +2239,8 @@ long CMMCore::getXYStageSequenceMaxLength(const char* label) throw (CMMError)
  * xSequence and ySequence must have the same length.
  * This should only be called for XY stages that are sequenceable
  * @param label        the XY stage device label
- * @param xSequence    the sequence of x positions that the stage will execute in reponse to external triggers
- * @param ySequence    the sequence of y positions that the stage will execute in reponse to external triggers
+ * @param xSequence    the sequence of x positions that the stage will execute in response to external triggers
+ * @param ySequence    the sequence of y positions that the stage will execute in response to external triggers
  */
 void CMMCore::loadXYStageSequence(const char* label,
                                   std::vector<double> xSequence,
@@ -2375,7 +2375,7 @@ namespace
 } // anonymous namespace
 
 /**
- * Add device to the image-synchro list. Image acquistion waits for all devices
+ * Add device to the image-synchro list. Image acquisition waits for all devices
  * in this list.
  * @param label   the device label
  */
@@ -2697,9 +2697,9 @@ void CMMCore::startSequenceAcquisition(long numImages, double intervalMs, bool s
 
 /**
  * Starts streaming camera sequence acquisition for a specified camera.
- * This command does not block the calling thread for the uration of the acquisition.
+ * This command does not block the calling thread for the duration of the acquisition.
  * The difference between this method and the one with the same name but operating on the "default"
- * camera is that it does not automatically intitialize the circular buffer.
+ * camera is that it does not automatically initialize the circular buffer.
  */
 void CMMCore::startSequenceAcquisition(const char* label, long numImages, double intervalMs, bool stopOnOverflow) throw (CMMError)
 {
@@ -2770,7 +2770,7 @@ void CMMCore::initializeCircularBuffer() throw (CMMError)
 }
 
 /**
- * Stops streming camera sequence acquisition for a specified camera.
+ * Stops streaming camera sequence acquisition for a specified camera.
  * @param label   The camera name
  */
 void CMMCore::stopSequenceAcquisition(const char* label) throw (CMMError)
@@ -3299,7 +3299,7 @@ void CMMCore::setGalvoDevice(const char* galvoLabel) throw (CMMError)
 }
 
 /**
- * Speficies the group determining the channel selection.
+ * Specifies the group determining the channel selection.
  */
 void CMMCore::setChannelGroup(const char* chGroup) throw (CMMError)
 {
@@ -3514,7 +3514,7 @@ vector<string> CMMCore::getLoadedDevicesOfType(MM::DeviceType devType) const
  * Returns all valid values for the specified property.
  * If the array is empty it means that there are no restrictions for values.
  * However, even if all values are allowed it is not guaranteed that all of them will be
- * acually accepted by the device at run time.
+ * actually accepted by the device at run time.
  *
  * @return the array of values
  * @param label     the device label
@@ -3862,7 +3862,7 @@ void CMMCore::stopPropertySequence(const char* label, const char* propName) thro
  * This should only be called for device-properties that are sequenceable
  * @param label           the device name
  * @param propName        the property label
- * @param eventSequence   the sequence of events/states that the device will execute in reponse to external triggers
+ * @param eventSequence   the sequence of events/states that the device will execute in response to external triggers
  */
 void CMMCore::loadPropertySequence(const char* label, const char* propName, std::vector<std::string> eventSequence) throw (CMMError)
 {
@@ -3920,7 +3920,7 @@ unsigned CMMCore::getImageWidth()
 }
 
 /**
- * Vertical dimentsion of the image buffer in pixels.
+ * Vertical dimension of the image buffer in pixels.
  * @return   the height in pixels (an integer)
  */
 unsigned CMMCore::getImageHeight()
@@ -3954,7 +3954,7 @@ unsigned CMMCore::getBytesPerPixel()
 
 /**
  * How many bits of dynamic range are to be expected from the camera. This value should
- * be used only as a guideline - it does not guarante that image buffer will contain
+ * be used only as a guideline - it does not guarantee that image buffer will contain
  * only values from the returned dynamic range.
  *
  * @return the number of bits
@@ -4307,7 +4307,7 @@ bool CMMCore::isMultiROIEnabled() throw (CMMError)
 
 /**
  * Set multiple ROIs for the current camera device. Will fail if the camera
- * does not support multiple ROIs, any widths or heights are nonpositive,
+ * does not support multiple ROIs, any widths or heights are non-positive,
  * or if the vectors do not all have the same length.
  *
  * @param xs X indices for the upper-left corners of each ROI.
@@ -4812,7 +4812,7 @@ void CMMCore::setPixelSizeUm(const char* resolutionID, double pixSize)  throw (C
 }
 
 /**
- * Applies a Pixel Size Configurdation. The command will fail if the
+ * Applies a Pixel Size Configuration. The command will fail if the
  * configuration was not previously defined.
  * 
  * @param groupName   the configuration group name
@@ -5198,7 +5198,7 @@ string CMMCore::getCurrentPixelSizeConfig(bool cached) throw (CMMError)
 }
 
 /**
- * Returns the curent pixel size in microns.
+ * Returns the current pixel size in microns.
  * This method is based on sensing the current pixel size configuration and adjusting
  * for the binning.
  */
@@ -5208,7 +5208,7 @@ double CMMCore::getPixelSizeUm()
 }
 
 /**
- * Returns the curent pixel size in microns.
+ * Returns the current pixel size in microns.
  * This method is based on sensing the current pixel size configuration and adjusting
  * for the binning.
  */
@@ -5317,7 +5317,7 @@ void CMMCore::definePropertyBlock(const char* blockName, const char* propertyNam
    CheckPropertyName(propertyName);
    CheckPropertyValue(propertyValue);
 
-   // check if the block allready exists
+   // check if the block already exists
    CPropBlockMap::const_iterator it = propBlocks_.find(blockName);
    PropertyBlock* pBlock;
    if (it == propBlocks_.end())
@@ -5408,8 +5408,8 @@ PropertyBlock CMMCore::getData(const char* deviceLabel)
 
    // here we could have written simply: 
    // return getStateLabelData(deviceLabel, getStateLabel(deviceLabel).c_str());
-   // but that would be inefficient beacuse of the multiple index lookup, so we'll
-   // do it explicitely:
+   // but that would be inefficient because of the multiple index lookup, so we'll
+   // do it explicitly:
 
    mm::DeviceModuleLockGuard guard(pStateDev);
 
@@ -5447,7 +5447,7 @@ void CMMCore::setSerialProperties(const char* portName,
 
 /**
  * Send string to the serial device and return an answer.
- * This command blocks until it recives an answer fromt he device terminated by the specified
+ * This command blocks until it receives an answer from the device terminated by the specified
  * sequence.
  */
 void CMMCore::setSerialPortCommand(const char* portLabel, const char* command, const char* term) throw (CMMError)
@@ -6071,7 +6071,7 @@ void CMMCore::loadSystemState(const char* fileName) throw (CMMError)
    }
 
    // Process commands
-   const int maxLineLength = 4 * MM::MaxStrLength + 4; // accomodate up to 4 strings and delimiters
+   const int maxLineLength = 4 * MM::MaxStrLength + 4; // accommodate up to 4 strings and delimiters
    char line[maxLineLength+1];
    vector<string> tokens;
    while(is.getline(line, maxLineLength, '\n'))
@@ -6173,7 +6173,7 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
       }
    }
 
-   // save the pre-initlization properties
+   // save the pre-initialization properties
    os << "# Pre-initialization properties" << endl;
    Configuration config = getSystemState();
    for (size_t i=0; i<config.size(); i++)
@@ -6315,9 +6315,9 @@ void CMMCore::saveSystemConfiguration(const char* fileName) throw (CMMError)
  *
  * Format specification:
  * Each line consists of a number of string fields separated by "," (comma) characters.
- * Lines beggining with "#" are ignored (can be used for comments).
+ * Lines beginning with "#" are ignored (can be used for comments).
  * Each line in the file will be parsed by the system and as a result a corresponding command 
- * will be immediately extecuted.
+ * will be immediately executed.
  * The first field in the line always specifies the command from the following set of values:
  *    Device - executes loadDevice()
  *    Label - executes defineStateLabel() command
@@ -6377,7 +6377,7 @@ void CMMCore::loadSystemConfigurationImpl(const char* fileName) throw (CMMError)
    }
 
    // Process commands
-   const int maxLineLength = 4 * MM::MaxStrLength + 4; // accomodate up to 4 strings and delimiters
+   const int maxLineLength = 4 * MM::MaxStrLength + 4; // accommodate up to 4 strings and delimiters
    char line[maxLineLength+1];
    vector<string> tokens;
 
@@ -6496,7 +6496,7 @@ void CMMCore::loadSystemConfigurationImpl(const char* fileName) throw (CMMError)
             }
             else if(tokens[0].compare(MM::g_CFGCommand_ConfigPixelSize) == 0)
             {
-               // define pxiel size configuration command
+               // define pixel size configuration command
                // ---------------------------------------
                if (tokens.size() == 5)
                   definePixelSizeConfig(tokens[1].c_str(), tokens[2].c_str(), tokens[3].c_str(), tokens[4].c_str());
@@ -6528,7 +6528,7 @@ void CMMCore::loadSystemConfigurationImpl(const char* fileName) throw (CMMError)
             }
             else if(tokens[0].compare(MM::g_CFGCommand_ImageSynchro) == 0)
             {
-               // define image sycnhro
+               // define image synchro
                // --------------------
                if (tokens.size() != 2)
                   throw CMMError(getCoreErrorText(MMERR_InvalidCFGEntry) + " (" +
@@ -6641,7 +6641,7 @@ double CMMCore::getCurrentFocusScore()
 
 
 /**
- * Enables or disables the operation of the continouous focusing hardware device.
+ * Enables or disables the operation of the continuous focusing hardware device.
  */
 void CMMCore::enableContinuousFocus(bool enable) throw (CMMError)
 {
@@ -6671,7 +6671,7 @@ void CMMCore::enableContinuousFocus(bool enable) throw (CMMError)
 }
 
 /**
- * Checks if the continouous focusing hardware device is ON or OFF.
+ * Checks if the continuous focusing hardware device is ON or OFF.
  */
 bool CMMCore::isContinuousFocusEnabled() throw (CMMError)
 {
@@ -7028,7 +7028,7 @@ bool CMMCore::IsCoreDeviceLabel(const char* label) const throw (CMMError)
 /**
  * Set all properties in a configuration
  * Upon error, don't stop, but try to set all failed properties again
- * until all succees or no more change takes place
+ * until all success or no more change takes place
  * If errors remain, throw an error 
  */
 void CMMCore::applyConfiguration(const Configuration& config) throw (CMMError)
@@ -7087,10 +7087,10 @@ void CMMCore::applyConfiguration(const Configuration& config) throw (CMMError)
 
 /*
  * Helper function for applyConfiguration
- * It is possible that setting certain properties failed because they are dependend
+ * It is possible that setting certain properties failed because they are dependent
  * on other properties to be set first. As a workaround, continue to apply these failed
  * properties until there are none left or none succeed
- * returns number of properties succefully set
+ * returns number of properties successfully set
  */
 int CMMCore::applyProperties(vector<PropertySetting>& props, string& lastError)
 {
@@ -7286,7 +7286,7 @@ MM::DeviceDetectionStatus CMMCore::detectDevice(char* label)
  * Performs auto-detection and loading of child devices that are attached to a Hub device.
  * For example, if a motorized microscope is represented by a Hub device, it is capable of
  * discovering what specific child devices are currently attached. In that case this call might 
- * report that Z-stage, filter changer and objective turrent are currently installed and return three
+ * report that Z-stage, filter changer and objective turret are currently installed and return three
  * device names in the string list.
  *
  * Currently, this method can only be called once, right after loading the hub

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -716,7 +716,7 @@ public:
    }
 
    /**
-   * Rrefresh the entire state of the device and synchronize property values with
+   * Refresh the entire state of the device and synchronize property values with
    * the actual state of the hardware.
    */
    int UpdateStatus()
@@ -973,7 +973,7 @@ protected:
    
 
    /**
-   * Sends an aray of bytes to the com port.
+   * Sends an array of bytes to the com port.
    */
    int WriteToComPort(const char* portLabel, const unsigned char* buf, unsigned bufLength)
    {

--- a/MMDevice/ImgBuffer.cpp
+++ b/MMDevice/ImgBuffer.cpp
@@ -4,7 +4,7 @@
 // SUBSYSTEM:     MMDevice - Device adapter kit
 // AUTHOR:			Nenad Amodaj, nenad@amodaj.com
 //
-// COPYRIGHT:     Nenad Amodaj, 2005. All rigths reserved.
+// COPYRIGHT:     Nenad Amodaj, 2005. All rights reserved.
 //
 // LICENSE:       This file is free for use, modification and distribution and
 //                is distributed under terms specified in the BSD license
@@ -160,7 +160,7 @@ void ImgBuffer::SetMetadata(const Metadata& md)
 {
    //metadata_ = md;
    // Serialize/Restore instead of =operator used to avoid object new/delete
-   // issues accross the DLL boundary (on Windows)
+   // issues across the DLL boundary (on Windows)
    // TODO: this is inefficient and should be revised
     metadata_.Restore(md.Serialize().c_str());
 }

--- a/MMDevice/ImgBuffer.h
+++ b/MMDevice/ImgBuffer.h
@@ -5,7 +5,7 @@
 //
 // DESCRIPTION:	Basic implementation for the raw image buffer data structure.
 //
-// COPYRIGHT:     Nenad Amodaj, 2005. All rigths reserved.
+// COPYRIGHT:     Nenad Amodaj, 2005. All rights reserved.
 //
 // LICENSE:       This file is free for use, modification and distribution and
 //                is distributed under terms specified in the BSD license

--- a/MMDevice/MMDevice.cpp
+++ b/MMDevice/MMDevice.cpp
@@ -28,7 +28,7 @@ namespace MM {
 // declaration. Because of that nonstandard behavior, VC++ issues a warning
 // (LNK4006) if the initializer is supplied with the declaration _and_ a
 // definition is (correctly) provided. So, to compile correctly with a
-// standards-confomant compiler _and_ avoid warnings from VC++, we need to
+// standards-conformant compiler _and_ avoid warnings from VC++, we need to
 // leave the initializers out of the declarations, and supply them here with
 // the definitions. See:
 // http://connect.microsoft.com/VisualStudio/feedback/details/802091/lnk4006-reported-for-static-const-members-that-is-initialized-in-the-class-definition

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -91,7 +91,7 @@ namespace MM {
 
    /**
     * Utility class used both MMCore and devices to maintain time intervals
-    * in the uniform, platfrom independent way.
+    * in the uniform, platform independent way.
     */
    class MMTime
    {
@@ -256,7 +256,7 @@ namespace MM {
       virtual unsigned GetNumberOfPropertyValues(const char* propertyName) const = 0;
       virtual bool GetPropertyValueAt(const char* propertyName, unsigned index, char* value) const = 0;
       /**
-       * Sequences can be used for fast acquisitions, sycnchronized by TTLs rather than
+       * Sequences can be used for fast acquisitions, synchronized by TTLs rather than
        * computer commands. 
        * Sequences of states can be uploaded to the device.  The device will cycle through
        * the uploaded list of states (triggered by an external trigger - most often coming 
@@ -371,7 +371,7 @@ namespace MM {
        *
        * SnapImage should start the image exposure in the camera and block until
        * the exposure is finished.  It should not wait for read-out and transfer of data.
-       * Return DEVICE_OK on succes, error code otherwise.
+       * Return DEVICE_OK on success, error code otherwise.
        */
       virtual int SnapImage() = 0;
       /**
@@ -382,8 +382,8 @@ namespace MM {
        * Return a pointer to a buffer containing the image data
        * The calling program will assume the size of the buffer based on the values
        * obtained from GetImageBufferSize(), which in turn should be consistent with
-       * values returned by GetImageWidth(), GetImageHight() and GetImageBytesPerPixel().
-       * The calling program allso assumes that camera never changes the size of
+       * values returned by GetImageWidth(), GetImageHeight() and GetImageBytesPerPixel().
+       * The calling program also assumes that camera never changes the size of
        * the pixel buffer on its own. In other words, the buffer can change only if
        * appropriate properties are set (such as binning, pixel type, etc.)
        * Multi-Channel cameras should return the content of the first channel in this call.
@@ -416,8 +416,8 @@ namespace MM {
        */
       virtual int GetComponentName(unsigned component, char* name) = 0;
       /**
-       * Returns the number of simultaneous channels that camera is capaable of.
-       * This should be used by devices capable of generating mutiple channels of imagedata simultanuously.
+       * Returns the number of simultaneous channels that camera is capable of.
+       * This should be used by devices capable of generating multiple channels of imagedata simultaneously.
        * Note: this should not be used by color cameras (use getNumberOfComponents instead).
        */
       virtual int unsigned GetNumberOfChannels() const = 0;
@@ -524,7 +524,7 @@ namespace MM {
       virtual int PrepareSequenceAcqusition() = 0;
       /**
        * Flag to indicate whether Sequence Acquisition is currently running.
-       * Return true when Sequence acquisition is activce, false otherwise
+       * Return true when Sequence acquisition is active, false otherwise
        */
       virtual bool IsCapturing() = 0;
 
@@ -546,7 +546,7 @@ namespace MM {
       virtual void AddTag(const char* key, const char* deviceLabel, const char* value) = 0;
 
       /**
-       * Removes an existing tag from the metadata assoicated with this device
+       * Removes an existing tag from the metadata associated with this device
        * These tags will automatically be add to the metadata of an image inserted 
        * into the circular buffer
        */
@@ -560,7 +560,7 @@ namespace MM {
       virtual int IsExposureSequenceable(bool& isSequenceable) const = 0;
 
       // Sequence functions
-      // Sequences can be used for fast acquisitions, sycnchronized by TTLs rather than
+      // Sequences can be used for fast acquisitions, synchronized by TTLs rather than
       // computer commands. 
       // Sequences of exposures can be uploaded to the camera.  The camera will cycle through
       // the uploaded list of exposures (triggered by either an internal or 
@@ -653,7 +653,7 @@ namespace MM {
       virtual bool IsContinuousFocusDrive() const = 0;
 
       // Sequence functions
-      // Sequences can be used for fast acquisitions, sycnchronized by TTLs rather than
+      // Sequences can be used for fast acquisitions, synchronized by TTLs rather than
       // computer commands. 
       // Sequences of positions can be uploaded to the stage.  The device will cycle through
       // the uploaded list of states (triggered by an external trigger - most often coming 
@@ -738,7 +738,7 @@ namespace MM {
        */
       virtual int IsXYStageSequenceable(bool& isSequenceable) const = 0;     
       // Sequence functions
-      // Sequences can be used for fast acquisitions, sycnchronized by TTLs rather than
+      // Sequences can be used for fast acquisitions, synchronized by TTLs rather than
       // computer commands. 
       // Sequences of positions can be uploaded to the XY stage.  The device will cycle through
       // the uploaded list of states (triggered by an external trigger - most often coming 
@@ -904,7 +904,7 @@ namespace MM {
        */
       virtual int GetDASequenceMaxLength(long& nrEvents) const = 0; 
       /**
-       * Tells the device to start running a sequnece (i.e. start switching between voltages 
+       * Tells the device to start running a sequence (i.e. start switching between voltages
        * send previously, triggered by a TTL
        * @return errorcode (DEVICE_OK if no error)
        */
@@ -915,7 +915,7 @@ namespace MM {
        */
       virtual int StopDASequence() = 0;
       /**
-       * Clears the DA sequnce from the device and the adapter.
+       * Clears the DA sequence from the device and the adapter.
        * If this functions is not called in between running 
        * two sequences, it is expected that the same sequence will run twice.
        * To upload a new sequence, first call this functions, then call AddToDASequence(double
@@ -925,8 +925,8 @@ namespace MM {
       virtual int ClearDASequence() = 0;
 
       /**
-       * Adds a new data point (voltgae) to the sequence
-       * The data point can eithed be added to a representation of the sequence in the 
+       * Adds a new data point (voltage) to the sequence
+       * The data point can either be added to a representation of the sequence in the
        * adapter, or it can be directly written to the device
        * @return errorcode (DEVICE_OK if no error)
        */
@@ -1055,7 +1055,7 @@ namespace MM {
       virtual int GetSLMSequenceMaxLength(long& nrEvents) const = 0; 
 
       /**
-       * Tells the device to start running a sequnece (i.e. start switching between images 
+       * Tells the device to start running a sequence (i.e. start switching between images
        * sent previously, triggered by a TTL or internal clock).
        * @return errorcode (DEVICE_OK if no error)
        */

--- a/MMDevice/ModuleInterface.cpp
+++ b/MMDevice/ModuleInterface.cpp
@@ -3,7 +3,7 @@
 // PROJECT:       Micro-Manager
 // SUBSYSTEM:     MMDevice - Device adapter kit
 //-----------------------------------------------------------------------------
-// DESCRIPTION:   The implemenation for the common plugin functions
+// DESCRIPTION:   The implementation for the common plugin functions
 // AUTHOR:        Nenad Amodaj, nenad@amodaj.com, 08/08/2005
 // NOTE:          Change the implementation of module interface methods in
 //                this file with caution, since the Micro-Manager plugin

--- a/MMDevice/ModuleInterface.h
+++ b/MMDevice/ModuleInterface.h
@@ -8,7 +8,7 @@
 // AUTHOR:        Nenad Amodaj, nenad@amodaj.com, 08/08/2005
 //
 // NOTE:          This file is also used in the main control module MMCore.
-//                Do not change it undless as a part of the MMCore module
+//                Do not change it unless as a part of the MMCore module
 //                revision. Discrepancy between this file and the one used to
 //                build MMCore will cause malfunction and likely crash.
 //

--- a/MMDevice/Property.cpp
+++ b/MMDevice/Property.cpp
@@ -332,7 +332,7 @@ unsigned MM::PropertyCollection::GetSize() const
 
 int MM::PropertyCollection::CreateProperty(const char* pszName, const char* pszValue, MM::PropertyType eType, bool bReadOnly, MM::ActionFunctor* pAct, bool isPreInitProperty)
 {
-   // check if the name allready exists
+   // check if the name already exists
    if (Find(pszName))
       return DEVICE_DUPLICATE_PROPERTY;
 


### PR DESCRIPTION
During developing a device adapter, I've looked at the MMCore/ source for reference.
As my IDE highlights typos, I stumbled upon quite some of them.
In this PR I tried to fix all automatically detectable typos in these files' comments (first commit) - which should not alter behavior in any way, and few typos in error/log messages (second commit).
There's even a typo in the API `Camera::PrepareSequenceAcqusition` (acquisition being properly spelled in three other functions next to it ;)) … which should probably be addressed when incompatible API changes have to be introduced anyways.