### PR TITLE
OBIS/Coherent Scientific Remote support added

### DIFF
--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.cpp
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.cpp
@@ -1,0 +1,788 @@
+///////////////////////////////////////////////////////////////////////////////
+// FILE:          CoherentScientificRemote.cpp
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     DeviceAdapters
+//-----------------------------------------------------------------------------
+// DESCRIPTION:   Coherent Scientific Remote controller adapter for up to 6 Coherent Obis lasers
+//    
+// COPYRIGHT:     35037 Marburg, Germany
+//                Max Planck Institute for Terrestrial Microbiology, 2017 
+//
+// AUTHOR:        Raimo Hartmann
+//                Adapted from CoherentScientificRemote driver written by Forrest Collman
+//
+// LICENSE:       This file is distributed under the BSD license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+#ifdef WIN32
+   #include <windows.h>
+   #define snprintf _snprintf 
+#endif
+
+#include "CoherentScientificRemote.h"
+
+#include "../../MMDevice/MMDevice.h"
+#include "../../MMDevice/ModuleInterface.h"
+#include "../../MMDevice/DeviceUtils.h"
+
+#include <algorithm>
+#include <math.h>
+#include <sstream>
+#include <string>
+#include <cstring>
+
+
+
+// Controller
+const char* g_ControllerName = "Coherent-Scientific Remote";
+const char* g_Keyword_PowerSetpointPercent = "PowerSetpoint (%)";
+const char* g_Keyword_PowerReadback = "PowerReadback (mW)";
+const char* g_Keyword_TriggerNum = "Shutter Laser";
+
+const char * carriage_return = "\n";
+const char * line_feed = "\n";
+
+const char* const g_Msg_LASERS_MISSING = "Label not defined";
+
+///////////////////////////////////////////////////////////////////////////////
+// Exported MMDevice API
+///////////////////////////////////////////////////////////////////////////////
+MODULE_API void InitializeModuleData()
+{
+   RegisterDevice(g_ControllerName, MM::ShutterDevice, "CoherentScientificRemote Laser");
+}
+
+MODULE_API MM::Device* CreateDevice(const char* deviceName)
+{
+   if (deviceName == 0)
+      return 0;
+
+   if (strcmp(deviceName, g_ControllerName) == 0)
+   {
+      // create Controller
+      CoherentScientificRemote* pCoherentScientificRemote = new CoherentScientificRemote(g_ControllerName);
+      return pCoherentScientificRemote;
+   }
+
+   return 0;
+}
+
+MODULE_API void DeleteDevice(MM::Device* pDevice)
+{
+   delete pDevice;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Controller implementation
+// ~~~~~~~~~~~~~~~~~~~~
+
+CoherentScientificRemote::CoherentScientificRemote(const char* name) :
+   initialized_(false), 
+   state_(0),
+   modulation_("Extern-Digital"),
+   name_(name), 
+   error_(0),
+   changedTime_(0.0),
+   queryToken_("?"),
+   powerSetpointToken_("SOUR{laserNum}:POW:LEV:IMM:AMPL"),
+   powerReadbackToken_("SOUR{laserNum}:POW:LEV:IMM:AMPL"),
+   CDRHToken_("CDRH"),  // if this is on, laser delays 5 SEC before turning on
+   CWToken_("CW"),
+   laserOnToken_("SOUR{laserNum}:AM:STATE"),
+   TECServoToken_("T"),
+   headSerialNoToken_("SYST{laserNum}:INF:SNUM"),
+   headUsageHoursToken_("SYST{laserNum}:DIOD:HOUR"),
+   wavelengthToken_("SYST{laserNum}:INF:WAV"),
+   modulationReadbackToken_("SOUR{laserNum}:AM:SOUR"),
+   modulationSetpointEXTToken_("SOUR{laserNum}:AM:EXT"),
+   modulationSetpointINTToken_("SOUR{laserNum}:AM:INT"),
+   temperatureDiodeToken_("SOUR{laserNum}:TEMP:DIOD"),
+   temperatureInternalToken_("SOUR{laserNum}:TEMP:INT"),
+   temperatureBaseToken_("SOUR{laserNum}:TEMP:BAS"),
+   externalPowerControlToken_("SOUR{laserNum}:POW:LEV:IMM:AMPL"),
+   maxPowerToken_("SOUR{laserNum}:POW:LIM:HIGH"),
+   minPowerToken_("SOUR{laserNum}:POW:LIM:LOW"),
+   laserHandToken_("SYST{laserNum}:COMM:HAND"),
+   laserPromToken_("SYST{laserNum}:COMM:PROM"),
+   laserErrorToken_("SYST{laserNum}:ERR:CLE"),
+   triggerNum_(0),
+   g_LaserStr_("Laser 1:")
+   
+
+{
+   assert(strlen(name) < (unsigned int) MM::MaxStrLength);
+
+   InitializeDefaultErrorMessages();
+   SetErrorText(ERR_DEVICE_NOT_FOUND, "No answer received. Is the Coherent Scientific Remote connected to this serial port?");
+   SetErrorText(DEVICE_ERR, "Coherent Scientific Remote found, but without connected lasers... Please turn off the remote, connect a laser and restart everything.");
+
+   // create pre-initialization properties
+   // ------------------------------------
+
+   // Description
+   CreateProperty(MM::g_Keyword_Description, g_ControllerName, MM::String, true);
+   
+   // Port
+   CPropertyAction* pAct = new CPropertyAction (this, &CoherentScientificRemote::OnPort);
+   CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
+
+   EnableDelay(); // signals that the delay setting will be used
+   UpdateStatus();
+
+}
+
+CoherentScientificRemote::~CoherentScientificRemote()
+{
+   Shutdown();
+}
+
+bool CoherentScientificRemote::Busy()
+{
+   MM::MMTime interval = GetCurrentMMTime() - changedTime_;
+   MM::MMTime delay(GetDelayMs()*1000.0);
+   if (interval < delay)
+      return true;
+   else
+      return false;
+}
+
+void CoherentScientificRemote::GetName(char* name) const
+{
+   assert(name_.length() < CDeviceUtils::GetMaxStringLength());
+   CDeviceUtils::CopyLimitedString(name, name_.c_str());
+}
+
+std::string CoherentScientificRemote::replaceLaserNum(std::string inputToken, long laserNum)
+{
+	std::string toReplace;
+	std::ostringstream replaceWith;
+	toReplace = "{laserNum}";
+	replaceWith << laserNum;
+
+    return(inputToken.replace(inputToken.find(toReplace), toReplace.length(), replaceWith.str()));
+}
+
+int CoherentScientificRemote::Initialize()
+{
+   LogMessage("CoherentScientificRemote::Initialize()yes??");
+   
+   long laserCount;
+   std::string init, laserName, laserErr;
+   int connectedLasers;
+
+   // Check COM-Port
+   init = this->queryLaser("*IDN");
+   std::transform(init.begin(), init.end(), init.begin(), ::tolower);
+   if (init.find("coherent") != 0) {
+	   error_ = ERR_DEVICE_NOT_FOUND;
+	   return HandleErrors();
+   }
+   // Add selector for trigger
+   CPropertyAction* pAct = new CPropertyAction(this, &CoherentScientificRemote::OnTriggerNum);
+   CreateProperty(g_Keyword_TriggerNum, "None", MM::String, false, pAct);
+
+   //Initialize laser
+   //Loop over lasers
+   connectedLasers = 0;
+   for( laserCount = 1; laserCount <=6; laserCount++)
+    {
+	   std::stringstream laserCountStr;
+	   laserName = this->queryLaser(replaceLaserNum("SYST{laserNum}:INF:MOD", laserCount).c_str());
+	   if (laserName.find("ERR") != 0) {
+			//
+		   setLaser(replaceLaserNum(laserHandToken_, laserCount).c_str(),"On");
+		   setLaser(replaceLaserNum(laserPromToken_, laserCount).c_str(),"Off");
+		   laserErr = this->queryLaser(replaceLaserNum(laserErrorToken_, laserCount).c_str());
+
+		   g_LaserStr_ = laserName;
+		   GeneratePowerProperties(laserCount);
+		   GeneratePropertyState(laserCount);
+		   GenerateReadOnlyIDProperties(laserCount);
+			
+		   laserCountStr << laserCount << " (" << g_LaserStr_ << ")";
+
+		   AddAllowedValue(g_Keyword_TriggerNum, laserCountStr.str().c_str());
+		   triggerNum_ = (int) laserCount;
+		   connectedLasers = connectedLasers + 1;
+	   }
+    }
+   if (connectedLasers == 0)
+   {
+	   error_ = DEVICE_ERR;
+	   return HandleErrors();
+   } 
+
+   initialized_ = true;
+
+   return HandleErrors();
+}
+
+
+/////////////////////////////////////////////
+// Property Generators
+/////////////////////////////////////////////
+
+void CoherentScientificRemote::GeneratePropertyState(long laserNum)
+{
+   std::stringstream parameterName, laserNumField;
+
+   CPropertyActionEx* pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnState, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << MM::g_Keyword_State;
+   CreateProperty(parameterName.str().c_str(), "Off", MM::String, false, pActEx);
+   AddAllowedValue(parameterName.str().c_str(), "Off");
+   AddAllowedValue(parameterName.str().c_str(), "On");
+
+   pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnModulation, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << "Modulation/Trigger";
+   CreateProperty(parameterName.str().c_str(), "CW (constant power)", MM::String, false, pActEx);
+   AddAllowedValue(parameterName.str().c_str(), "CW (constant power)");
+   AddAllowedValue(parameterName.str().c_str(), "CW (constant current)");
+   AddAllowedValue(parameterName.str().c_str(), "External/Digital");
+   AddAllowedValue(parameterName.str().c_str(), "External/Analog");
+   AddAllowedValue(parameterName.str().c_str(), "External/Mixed");
+}
+
+
+void CoherentScientificRemote::GeneratePowerProperties(long laserNum)
+{
+   std::stringstream parameterName;
+
+   // Power Setpoint %
+   CPropertyActionEx* pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnPowerSetpointPercent, laserNum);
+   parameterName << "Laser " << g_LaserStr_ << " - " << g_Keyword_PowerSetpointPercent;
+   CreateProperty(parameterName.str().c_str(), "0", MM::Float, false, pActEx);
+   SetPropertyLimits(parameterName.str().c_str(), 0, 100); 
+
+   // Power Readback
+   pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnPowerReadback, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << g_Keyword_PowerReadback;
+   CreateProperty(parameterName.str().c_str(), "0", MM::Float, true, pActEx);
+}
+
+
+void CoherentScientificRemote::GenerateReadOnlyIDProperties(long laserNum)
+{
+   std::stringstream parameterName, laserNumStr;
+
+   CPropertyActionEx* pActEx; 
+
+   pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnHeadUsageHours, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << "Head Usage (h)";
+   CreateProperty(parameterName.str().c_str(), "", MM::Float, true, pActEx);
+
+   pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnLaserPort, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << "Port";
+   laserNumStr << laserNum;
+   CreateProperty(parameterName.str().c_str(), laserNumStr.str().c_str(), MM::String, true, pActEx);
+
+   pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnMinimumLaserPower, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << "Minimum Laser Power (mW)";
+   CreateProperty(parameterName.str().c_str(), "", MM::Float, true, pActEx);
+   
+   pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnMaximumLaserPower, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << "Maximum Laser Power (mW)";
+   CreateProperty(parameterName.str().c_str(), "", MM::Float, true, pActEx);
+
+   pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnWaveLength, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << "Wavelength (nm)";
+   CreateProperty(parameterName.str().c_str(), "", MM::Float, true, pActEx);
+
+   //pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnTemperatureDiode, laserNum);
+   //parameterName.str("");
+   //parameterName << "Laser " << g_LaserStr_ << " - " << "Temperature Diode (C)";
+   //CreateProperty(parameterName.str().c_str(), "", MM::Float, true, pActEx);
+
+   //pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnTemperatureInternal, laserNum);
+   //parameterName.str("");
+   //parameterName << "Laser " << g_LaserStr_ << " - " << "Temperature Internal (C)";
+   //CreateProperty(parameterName.str().c_str(), "", MM::Float, true, pActEx);
+
+   pActEx = new CPropertyActionEx(this, &CoherentScientificRemote::OnTemperatureBase, laserNum);
+   parameterName.str("");
+   parameterName << "Laser " << g_LaserStr_ << " - " << "Temperature Baseplate (C)";
+   CreateProperty(parameterName.str().c_str(), "", MM::Float, true, pActEx);
+}
+
+int CoherentScientificRemote::Shutdown()
+{
+   if (initialized_)
+   {
+      initialized_ = false;
+   }
+   return HandleErrors();
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Action handlers
+///////////////////////////////////////////////////////////////////////////////
+
+int CoherentScientificRemote::OnPort(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(port_.c_str());
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      if (initialized_)
+      {
+         // revert
+         pProp->Set(port_.c_str());
+         return ERR_PORT_CHANGE_FORBIDDEN;
+      }
+
+      pProp->Get(port_);
+   }
+
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnLaserPort(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnPowerReadback(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   double powerReadback;
+   if (eAct == MM::BeforeGet)
+   {
+      GetPowerReadback(powerReadback, laserNum);
+      pProp->Set(powerReadback);
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnPowerSetpointPercent(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   double powerSetpointPercent;
+   if (eAct == MM::BeforeGet)
+   {
+      GetPowerSetpointPercent(powerSetpointPercent, laserNum);
+      pProp->Set(powerSetpointPercent);
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      pProp->Get(powerSetpointPercent);
+      double achievedSetpointPercent;
+      SetPowerSetpointPercent(powerSetpointPercent, achievedSetpointPercent, laserNum);
+      if( 0. != powerSetpointPercent)
+      {
+         double fractionError = fabs(achievedSetpointPercent - powerSetpointPercent) / powerSetpointPercent;
+         if (( 0.05 < fractionError ) && (fractionError  < 0.10))
+            pProp->Set(achievedSetpointPercent);
+      }
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnState(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      GetState(state_, laserNum);
+	  if (state_ == 1) {
+		pProp->Set("On");
+	  } 
+	  if (state_ == 0) {
+		pProp->Set("Off");
+	  }
+	  if (state_ == 2) {
+		pProp->Set("Error: no laser connected");
+	  }
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      long requestedState;
+	  std::string requestedStateString;
+
+      pProp->Get(requestedStateString);
+	  if (requestedStateString.compare("On") == 0) {
+		  requestedState = 1;
+	  } else {
+		  requestedState = 0;
+	  }
+      SetState(requestedState, laserNum);
+      if (state_ != requestedState)
+      {
+         // error
+      }
+   }
+   
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnTriggerNum(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+	    std::string laserName;
+	    std::stringstream laserCountStr;
+		laserName = this->queryLaser(replaceLaserNum("SYST{laserNum}:INF:MOD", (long)triggerNum_).c_str());
+		laserCountStr << triggerNum_ << " (" << g_LaserStr_ << ")";
+
+		pProp->Set(laserCountStr.str().c_str());
+   }
+   else if (eAct == MM::AfterSet)
+   {
+	  std::string requestedStateString;
+      pProp->Get(requestedStateString);
+
+	  if (requestedStateString.compare("None") == 0) {
+		  triggerNum_ = 0;
+	  } else {
+		  triggerNum_ = atoi(requestedStateString.substr(0,1).c_str());
+	  }
+   }
+   
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnModulation(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+	   string ans = this->queryLaser(replaceLaserNum(modulationReadbackToken_, laserNum).c_str());
+	   std::transform(ans.begin(), ans.end(), ans.begin(), ::tolower);
+	   if (ans.find("cwp") == 0) {
+		  modulation_ = "CW (constant power)";
+	   }
+	   else if (ans.find("cwc") == 0) {
+		  modulation_ = "CW (constant current)";
+	   }
+	   else if (ans.find("digital") == 0) {
+		  modulation_ = "External/Digital";
+	   }
+	   else if (ans.find("analog") == 0) {
+		  modulation_ = "External/Analog";
+	   }
+	   else if (ans.find("mixed") == 0) {
+		  modulation_ = "External/Mixed";
+	   }
+	   else{
+		  modulation_ = "CW (constant power)";
+		  setLaser(replaceLaserNum(modulationSetpointINTToken_, laserNum).c_str(), "CWP");
+	   }
+		  
+	   pProp->Set(modulation_.c_str());
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      pProp->Get(modulation_);
+
+	   if (modulation_.compare("CW (constant power)") == 0) {
+		  setLaser(replaceLaserNum(modulationSetpointINTToken_, laserNum).c_str(), "CWP");
+	   }
+	   if (modulation_.compare("CW (constant current)") == 0) {
+		  setLaser(replaceLaserNum(modulationSetpointINTToken_, laserNum).c_str(), "CWC");
+	   }
+	   if (modulation_.compare("External/Digital") == 0) {
+		  setLaser(replaceLaserNum(modulationSetpointEXTToken_, laserNum).c_str(), "DIG");
+	   }
+	   if (modulation_.compare("External/Analog") == 0) {
+		  setLaser(replaceLaserNum(modulationSetpointEXTToken_, laserNum).c_str(), "ANAL");
+	   }
+	   else if (modulation_.compare("External/Mixed") == 0) {
+		  setLaser(replaceLaserNum(modulationSetpointEXTToken_, laserNum).c_str(), "MIX");
+	   }
+   }
+
+	   
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnHeadID(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set((this->queryLaser(replaceLaserNum(headSerialNoToken_, laserNum).c_str())).c_str());
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnHeadUsageHours(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      std::string svalue = this->queryLaser(replaceLaserNum(headUsageHoursToken_, laserNum).c_str());
+      double dvalue = atof(svalue.c_str());
+      pProp->Set(dvalue);
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnMinimumLaserPower(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(POWERCONVERSION*atof((this->queryLaser(replaceLaserNum(minPowerToken_, laserNum).c_str())).c_str()));
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnMaximumLaserPower(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(POWERCONVERSION*atof((this->queryLaser(replaceLaserNum(maxPowerToken_, laserNum).c_str())).c_str()));
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnWaveLength(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(atof((this->queryLaser(replaceLaserNum(wavelengthToken_, laserNum).c_str())).c_str()));
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnTemperatureDiode(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(atof((this->queryLaser(replaceLaserNum(temperatureDiodeToken_, laserNum).c_str())).c_str()));
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnTemperatureInternal(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(atof((this->queryLaser(replaceLaserNum(temperatureInternalToken_, laserNum).c_str())).c_str()));
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnTemperatureBase(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(atof((this->queryLaser(replaceLaserNum(temperatureBaseToken_, laserNum).c_str())).c_str()));
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+void CoherentScientificRemote::GetPowerReadback(double& value, long laserNum)
+{
+   string ans = this->queryLaser(replaceLaserNum(powerReadbackToken_, laserNum).c_str());
+   value = POWERCONVERSION*atof(ans.c_str());
+}
+
+void CoherentScientificRemote::SetPowerSetpointPercent(double requestedPowerSetpointPercent, double& achievedPowerSetpointPercent, long laserNum)
+{
+   double llimit = POWERCONVERSION*atof((this->queryLaser(replaceLaserNum(minPowerToken_, laserNum).c_str())).c_str());
+   double ulimit = POWERCONVERSION*atof((this->queryLaser(replaceLaserNum(maxPowerToken_, laserNum).c_str())).c_str());
+   
+   // Calculate percentage
+   std::string result;
+   std::ostringstream setpointString;
+ 
+   requestedPowerSetpointPercent = requestedPowerSetpointPercent/100*(ulimit-llimit)+llimit;
+         
+   setpointString << setprecision(6) << requestedPowerSetpointPercent/POWERCONVERSION;
+   result = this->setLaser(replaceLaserNum(powerSetpointToken_, laserNum).c_str(), setpointString.str());
+   
+   //compare quantized setpoint to requested setpoint
+   // the difference can be rather large
+   achievedPowerSetpointPercent = POWERCONVERSION*atof( result.c_str());
+
+   // if device echos a setpoint more the 10% of full scale from requested setpoint, log a warning message
+   if ( ulimit/10. < fabs( achievedPowerSetpointPercent-POWERCONVERSION*requestedPowerSetpointPercent))
+   {
+      std::ostringstream messs;
+      messs << "requested setpoint: " << requestedPowerSetpointPercent << " but echo setpoint is: " << achievedPowerSetpointPercent;
+      LogMessage(messs.str().c_str());
+   }
+   
+}
+
+void CoherentScientificRemote::GetPowerSetpointPercent(double& value, long laserNum)
+{
+   string ans = this->queryLaser(replaceLaserNum(powerSetpointToken_, laserNum).c_str());
+   // Calculate the percentage
+   double llimit = POWERCONVERSION*atof((this->queryLaser(replaceLaserNum(minPowerToken_, laserNum).c_str())).c_str());
+   double ulimit = POWERCONVERSION*atof((this->queryLaser(replaceLaserNum(maxPowerToken_, laserNum).c_str())).c_str());
+   value = 100*(POWERCONVERSION*atof(ans.c_str()))/(ulimit-llimit)-llimit;
+}
+
+void CoherentScientificRemote::SetState(long state, long laserNum)
+{
+   std::ostringstream atoken;
+   if (state==1){
+      atoken << "On";
+   }
+   else{
+      atoken << "Off";
+   }
+   this->setLaser(replaceLaserNum(laserOnToken_, laserNum).c_str(), atoken.str());
+   // Set timer for the Busy signal
+   changedTime_ = GetCurrentMMTime();
+}
+
+void CoherentScientificRemote::GetState(long &value, long laserNum)
+{
+   string ans = this->queryLaser(replaceLaserNum(laserOnToken_, laserNum).c_str());
+   std::transform(ans.begin(), ans.end(), ans.begin(), ::tolower);
+   if (ans.find("on") == 0) {
+      value = 1;
+   }
+   else if (ans.find("off") == 0) {
+      value = 0;
+   }
+   else{
+      value = 2;
+   }
+}
+
+void CoherentScientificRemote::SetExternalLaserPowerControl(int value, long laserNum)
+{
+   std::ostringstream atoken;
+   atoken << value;
+   this->setLaser(replaceLaserNum(externalPowerControlToken_, laserNum).c_str(), atoken.str());
+}
+
+void CoherentScientificRemote::GetExternalLaserPowerControl(int& value, long laserNum)
+{
+   string ans = this->queryLaser(replaceLaserNum(externalPowerControlToken_, laserNum).c_str());
+   value = atol(ans.c_str());
+}
+
+int CoherentScientificRemote::HandleErrors()
+{
+   int lastError = error_;
+   error_ = 0;
+   return lastError;
+}
+
+
+
+/////////////////////////////////////
+//  Communications
+/////////////////////////////////////
+
+
+void CoherentScientificRemote::Send(std::string cmd)
+{
+   std::ostringstream messs;
+   messs << "CoherentScientificRemote::Send           " << cmd;
+   LogMessage( messs.str().c_str(), true);
+
+   int ret = SendSerialCommand(port_.c_str(), cmd.c_str(), carriage_return);
+   if (ret!=DEVICE_OK)
+      error_ = DEVICE_SERIAL_COMMAND_FAILED;
+}
+
+
+int CoherentScientificRemote::ReceiveOneLine()
+{
+   buf_string_ = "";
+   int ret = GetSerialAnswer(port_.c_str(), line_feed, buf_string_);
+   if (ret != DEVICE_OK)
+      return ret;
+   std::ostringstream messs;
+   messs << "CoherentScientificRemote::ReceiveOneLine " << buf_string_;
+   LogMessage( messs.str().c_str(), true);
+
+   return DEVICE_OK;
+}
+
+void CoherentScientificRemote::Purge()
+{
+   int ret = PurgeComPort(port_.c_str());
+   if (ret!=0)
+      error_ = DEVICE_SERIAL_COMMAND_FAILED;
+}
+
+//********************
+// Shutter API
+//********************
+
+int CoherentScientificRemote::SetOpen(bool open)
+{
+   SetState((long) open, (int)triggerNum_);
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::GetOpen(bool& open)
+{
+	long laserNum;
+	laserNum = 1;
+   long state;
+   GetState(state, (int)triggerNum_);
+   if (state==1)
+      open = true;
+   else if (state==0)
+      open = false;
+   else
+      error_ = DEVICE_UNKNOWN_POSITION;
+
+   return HandleErrors();
+}
+
+// ON for deltaT milliseconds
+// other implementations of Shutter don't implement this
+// is this perhaps because this blocking call is not appropriate
+int CoherentScientificRemote::Fire(double deltaT)
+{
+   SetOpen(true);
+   CDeviceUtils::SleepMs((long)(deltaT+.5));
+   SetOpen(false);
+   return HandleErrors();
+}
+

--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.h
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.h
@@ -1,0 +1,191 @@
+///////////////////////////////////////////////////////////////////////////////
+// FILE:          CoherentScientificRemote.h
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     DeviceAdapters
+//-----------------------------------------------------------------------------
+// DESCRIPTION:   Coherent Scientific Remote controller adapter for up to 6 Coherent Obis lasers
+//    
+// COPYRIGHT:     35037 Marburg, Germany
+//                Max Planck Institute for Terrestrial Microbiology, 2017 
+//
+// AUTHOR:        Raimo Hartmann
+//                Adapted from CoherentScientificRemote driver written by Forrest Collman
+//
+// LICENSE:       This file is distributed under the BSD license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+#ifndef _CoherentScientificRemote_H_
+#define _CoherentScientificRemote_H_
+
+#include "../../MMDevice/MMDevice.h"
+#include "../../MMDevice/DeviceBase.h"
+#include "../../MMDevice/DeviceUtils.h"
+#include <string>
+//#include <iostream>
+#include <vector>
+using namespace std;
+
+//////////////////////////////////////////////////////////////////////////////
+// Error codes
+//
+#define ERR_PORT_CHANGE_FORBIDDEN    10004
+#define ERR_DEVICE_NOT_FOUND         10005
+
+#define POWERCONVERSION              1000 //convert the power into mW from the W it wants the commands in
+
+// MM::DeviceDetectionStatus CheckConnection(MM::Device& device, MM::Core& core, std::string port, double ato);
+
+class CoherentScientificRemote : public CShutterBase<CoherentScientificRemote>
+{
+
+public:
+   // bool SupportsDeviceDetection(void);
+   // MM::DeviceDetectionStatus DetectDevice(void);
+   // for any queriable token X such as P, SP, E, etc.
+   // send the string ?X to the laser and then read a response such as
+   // X=xyzzy, just return the result token xyzzy.
+   std::string queryLaser( std::string thisToken )
+   {
+      std::string result;
+      std::stringstream msg;
+      msg <<  thisToken << "?";
+
+      Purge();
+      Send(msg.str());
+      ReceiveOneLine();
+      string buf_string = currentIOBuffer();
+      return buf_string;
+   }
+
+   // for any settable token X, such as P, T, etc.
+   // send the string X=value, then query ?X and return the string result
+   std::string  setLaser( std::string thisToken, std::string thisValue)
+   {
+      stringstream msg;
+      std::string result;
+
+      msg << thisToken << " " << thisValue;
+      Purge();
+      Send(msg.str());
+      ReceiveOneLine();
+      string buf_string = currentIOBuffer();
+
+      result = queryLaser(thisToken);
+      return result;
+   }
+
+   CoherentScientificRemote(const char* name);
+   ~CoherentScientificRemote();
+  
+   // MMDevice API
+   // ------------
+   int Initialize();
+   int Shutdown();
+  
+   void GetName(char* pszName) const;
+   bool Busy();
+   const std::string currentIOBuffer() { return buf_string_; }
+   
+   // action interface
+   // ----------------
+   int OnPort(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnTriggerNum(MM::PropertyBase* pProp, MM::ActionType eAct);
+
+   int OnPowerSetpointPercent(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnPowerReadback(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnState(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnModulation(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+
+   // some important read-only properties
+   int OnHeadID(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnLaserPort(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnHeadUsageHours(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnMinimumLaserPower(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnMaximumLaserPower(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnWaveLength(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnTemperatureDiode(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnTemperatureInternal(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+   int OnTemperatureBase(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum);
+
+   // Shutter API
+   int SetOpen(bool open = true);
+   int GetOpen(bool& open);
+   int Fire(double deltaT);
+
+   void SetLaserNumber(std::string LaserNumber);
+
+private:
+   bool initialized_;
+   long state_;
+   std::string name_;
+   int error_;
+   MM::MMTime changedTime_;
+   std::string modulation_;
+
+   std::string queryToken_;
+   std::string powerSetpointToken_;
+   std::string powerReadbackToken_;
+   std::string CDRHToken_;  // if this is on, laser delays 5 SEC before turning on
+   std::string CWToken_;
+   std::string laserOnToken_;
+   std::string TECServoToken_;
+   std::string headSerialNoToken_;
+   std::string headUsageHoursToken_;
+   std::string wavelengthToken_;
+   std::string externalPowerControlToken_;
+   std::string maxPowerToken_;
+   std::string minPowerToken_;
+   std::string laserHandToken_;
+   std::string laserPromToken_;
+   std::string laserErrorToken_;
+   std::string temperatureDiodeToken_;
+   std::string temperatureInternalToken_;
+   std::string temperatureBaseToken_;
+   std::string modulationReadbackToken_;
+   std::string modulationSetpointEXTToken_;
+   std::string modulationSetpointINTToken_;
+   std::string g_LaserStr_;
+
+   double triggerNum_;
+
+   std::string port_;
+   std::string laserNumber_;
+
+   string buf_string_;
+
+   std::string replaceLaserNum(std::string inputToken, long laserNum);
+
+   void SetPowerSetpointPercent(double powerSetpointPercent__, double& achievedSetpointPercent__, long laserNum);
+   
+   void GetPowerSetpointPercent(double& powerSetpoint__, long laserNum);
+   void GetPowerReadback(double& value__, long laserNum);
+
+   void GeneratePowerProperties(long laserNum);
+   void GeneratePropertyState(long laserNum);
+   void GenerateReadOnlyIDProperties(long laserNum);
+
+   void SetState(long state, long laserNum);
+   void GetState(long &state, long laserNum);
+
+   void GetExternalLaserPowerControl(int& control__, long laserNum);
+   void SetExternalLaserPowerControl(int control__, long laserNum);
+
+   void Send(string cmd);
+   int ReceiveOneLine();
+   void Purge();
+   int HandleErrors();
+   
+
+   CoherentScientificRemote& operator=(CoherentScientificRemote& /*rhs*/) {assert(false); return *this;}
+};
+
+
+#endif // _CoherentScientificRemote_H_

--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.sln
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual C++ Express 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CoherentScientificRemote", "CoherentScientificRemote.vcxproj", "{D8296B7C-9580-4AD6-A79C-A5660680A9FF}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MMDevice-SharedRuntime", "..\..\MMDevice\MMDevice-SharedRuntime.vcxproj", "{B8C95F39-54BF-40A9-807B-598DF2821D55}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D8296B7C-9580-4AD6-A79C-A5660680A9FF}.Debug|Win32.ActiveCfg = Debug|Win32
+		{D8296B7C-9580-4AD6-A79C-A5660680A9FF}.Debug|Win32.Build.0 = Debug|Win32
+		{D8296B7C-9580-4AD6-A79C-A5660680A9FF}.Debug|x64.ActiveCfg = Debug|x64
+		{D8296B7C-9580-4AD6-A79C-A5660680A9FF}.Debug|x64.Build.0 = Debug|x64
+		{D8296B7C-9580-4AD6-A79C-A5660680A9FF}.Release|Win32.ActiveCfg = Release|Win32
+		{D8296B7C-9580-4AD6-A79C-A5660680A9FF}.Release|Win32.Build.0 = Release|Win32
+		{D8296B7C-9580-4AD6-A79C-A5660680A9FF}.Release|x64.ActiveCfg = Release|x64
+		{D8296B7C-9580-4AD6-A79C-A5660680A9FF}.Release|x64.Build.0 = Release|x64
+		{B8C95F39-54BF-40A9-807B-598DF2821D55}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B8C95F39-54BF-40A9-807B-598DF2821D55}.Debug|Win32.Build.0 = Debug|Win32
+		{B8C95F39-54BF-40A9-807B-598DF2821D55}.Debug|x64.ActiveCfg = Debug|x64
+		{B8C95F39-54BF-40A9-807B-598DF2821D55}.Debug|x64.Build.0 = Debug|x64
+		{B8C95F39-54BF-40A9-807B-598DF2821D55}.Release|Win32.ActiveCfg = Release|Win32
+		{B8C95F39-54BF-40A9-807B-598DF2821D55}.Release|Win32.Build.0 = Release|Win32
+		{B8C95F39-54BF-40A9-807B-598DF2821D55}.Release|x64.ActiveCfg = Release|x64
+		{B8C95F39-54BF-40A9-807B-598DF2821D55}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.vcxproj
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.vcxproj
@@ -1,0 +1,151 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D8296B7C-9580-4AD6-A79C-A5660680A9FF}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>CoherentOBIS</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;COHERENTOBIS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;COHERENTOBIS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;COHERENTOBIS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;COHERENTOBIS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MMDevice\MMDevice-SharedRuntime.vcxproj">
+      <Project>{b8c95f39-54bf-40a9-807b-598df2821d55}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="CoherentScientificRemote.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="CoherentScientificRemote.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.vcxproj.filters
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="CoherentScientificRemote.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="CoherentScientificRemote.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/DeviceAdapters/CoherentScientificRemote/Makefile.am
+++ b/DeviceAdapters/CoherentScientificRemote/Makefile.am
@@ -1,0 +1,5 @@
+AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS)
+deviceadapter_LTLIBRARIES = libmmgr_dal_CoherentOBIS.la
+libmmgr_dal_CoherentOBIS_la_SOURCES = CoherentOBIS.cpp CoherentOBIS.h
+libmmgr_dal_CoherentOBIS_la_LIBADD = $(MMDEVAPI_LIBADD)
+libmmgr_dal_CoherentOBIS_la_LDFLAGS = $(MMDEVAPI_LDFLAGS)


### PR DESCRIPTION
Added new device adaptor to support the OBIS/Coherent Scientific Remote
for up to 6 lasers
(https://www.coherent.com/lasers/laser/cw-solid-state-lasers/obis-scientific-remote).
The adaptor is based on the already existing adator "CoherentOBIS" which
supports the OBIS/Coherent Single Laser Remote only. It would be great to have this device adaptor included in MM!