### PR TITLE
Modbus DeviceAdapter using libmodbus

### DIFF
--- a/DeviceAdapters/Makefile.am
+++ b/DeviceAdapters/Makefile.am
@@ -29,6 +29,9 @@ endif
 if BUILD_OPENCV
    OPENCVGRABBER = OpenCVgrabber
 endif
+if BUILD_MODBUS
+   MODBUS = Modbus
+endif
 if BUILD_PVCAM
    PVCAM = PVCAM PrincetonInstruments
 endif
@@ -68,6 +71,7 @@ SUBDIRS = \
 	$(IIDC) \
 	$(ITC) \
 	$(NIDAQ) \
+	$(MODBUS) \
 	$(OPENCVGRABBER) \
 	$(PVCAM) \
 	$(QCAM) \

--- a/DeviceAdapters/Modbus/Makefile.am
+++ b/DeviceAdapters/Modbus/Makefile.am
@@ -1,0 +1,8 @@
+AM_CXXFLAGS = $(MMDEVAPI_CXXFLAGS) $(MODBUS_CPPFLAGS)
+deviceadapter_LTLIBRARIES = libmmgr_dal_Modbus.la
+libmmgr_dal_Modbus_la_SOURCES = ModbusModule.cpp ModbusModule.h ../../MMDevice/MMDevice.h
+libmmgr_dal_Modbus_la_LDFLAGS = $(MMDEVAPI_LDFLAGS) $(MODBUS_LIBS)
+libmmgr_dal_Modbus_la_LIBADD = $(MMDEVAPI_LIBADD)
+
+EXTRA_DIST = Modbus.vcproj
+

--- a/DeviceAdapters/Modbus/Modbus.vcxproj
+++ b/DeviceAdapters/Modbus/Modbus.vcxproj
@@ -1,0 +1,180 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{93B23968-DB73-4209-9D19-613A00BFE6B0}</ProjectGuid>
+    <RootNamespace>Modbus</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v100</PlatformToolset>
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v100</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMCommon.props" />
+    <Import Project="..\..\buildscripts\VisualStudio\MMDeviceAdapter.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>.\lib\libmodbus\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+      <AdditionalDependencies>.\lib\libmodbus\src\win32\x64\Release\modbus.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ModbusModule.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="ModbusModule.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MMDevice\MMDevice-SharedRuntime.vcxproj">
+      <Project>{b8c95f39-54bf-40a9-807b-598df2821d55}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DeviceAdapters/Modbus/ModbusModule.cpp
+++ b/DeviceAdapters/Modbus/ModbusModule.cpp
@@ -1,0 +1,354 @@
+///////////////////////////////////////////////////////////////////////////////
+// FILE:          ModbusModule.cpp
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     DeviceAdapters
+//-----------------------------------------------------------------------------
+// DESCRIPTION:   Modbus Adapter using libmodbus
+//                
+// AUTHOR:        Christian Sachs <c.sachs@fz-juelich.de>
+//
+// COPYRIGHT:     Forschungszentrum Jülich
+// LICENSE:       BSD (2-clause/FreeBSD license)
+
+#define _WINSOCK2API_
+#define _WINSOCKAPI_
+#include "ModbusModule.h"
+
+#include <string>
+#include <iostream>
+#include "../../MMDevice/ModuleInterface.h"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////////
+// Exported MMDevice API
+///////////////////////////////////////////////////////////////////////////////
+
+const char* g_ModbusDeviceName = "Modbus";
+
+MODULE_API void InitializeModuleData()
+{
+	RegisterDevice(g_ModbusDeviceName, MM::GenericDevice, g_ModbusDeviceName);
+}
+
+MODULE_API MM::Device* CreateDevice(const char* deviceName)
+{
+   if (deviceName == 0)
+      return 0;
+
+   if (strcmp(deviceName, g_ModbusDeviceName) == 0)
+   {
+	  return new CModbusDevice();
+   }
+
+   return 0;
+}
+
+MODULE_API void DeleteDevice(MM::Device* pDevice)
+{
+   delete pDevice;
+}
+
+//
+
+void CModbusDevice::GetName(char* pszName) const {
+	CDeviceUtils::CopyLimitedString(pszName, g_ModbusDeviceName);
+}
+
+bool CModbusDevice::Busy() {
+	return false;
+}
+
+//
+
+CModbusDevice::CModbusDevice() {
+
+	
+	coilBuffer = NULL;
+	registerBuffer = NULL;
+
+	ready = false;
+	debugFlag = 0;
+
+	connectionURI = "tcp://127.0.0.1:502";
+
+	deviceString = "name=device type=coils write_address=0 read_address=0 count=8";
+
+	CreateProperty("ConnectionURI", "", MM::String, false, new DeviceAction(this, &CModbusDevice::OnConnectionURI), true);
+	CreateProperty("Devices", "", MM::String, false, new DeviceAction(this, &CModbusDevice::OnDeviceString), true);
+	CreateProperty("DebugFlag", "0", MM::Integer, false, new DeviceAction(this, &CModbusDevice::OnDebugFlag), true);
+	AddAllowedValue("DebugFlag", "0");
+	AddAllowedValue("DebugFlag", "1");
+
+}
+
+CModbusDevice::~CModbusDevice() {
+	// nop
+}
+
+
+int CModbusDevice::OnConnectionURI(MM::PropertyBase *pProp, MM::ActionType eAct) {
+	if(eAct == MM::BeforeGet)
+	{
+		pProp->Set(connectionURI.c_str());
+	}
+	else if(eAct == MM::AfterSet)
+	{
+		pProp->Get(connectionURI);
+	}
+
+	return DEVICE_OK;
+}
+
+int CModbusDevice::OnDeviceString(MM::PropertyBase *pProp, MM::ActionType eAct) {
+	if(eAct == MM::BeforeGet)
+	{
+		pProp->Set(deviceString.c_str());
+	}
+	else if(eAct == MM::AfterSet)
+	{
+		pProp->Get(deviceString);
+	}
+
+	return DEVICE_OK;
+}
+
+int CModbusDevice::OnDebugFlag(MM::PropertyBase *pProp, MM::ActionType eAct) {
+	if(eAct == MM::BeforeGet)
+	{
+		pProp->Set(debugFlag);
+	}
+	else if(eAct == MM::AfterSet)
+	{
+		pProp->Get(debugFlag);
+	}
+
+	return DEVICE_OK;
+}
+
+inline int CModbusDevice::checkContextAndContinue() {
+	if(ctx == NULL)
+		return DEVICE_ERR;
+
+	modbus_set_debug(ctx, (int)debugFlag);
+
+	if(modbus_connect(ctx) == -1) {
+		LogMessage(string("libmodbus returned the following error: ") + modbus_strerror(errno)); // WHY is errno a global variable? ...
+		modbus_free(ctx);
+		return DEVICE_ERR;
+	}
+
+	return DEVICE_OK;
+}
+
+int CModbusDevice::Initialize() {
+
+	URI conuri(connectionURI);
+
+	if(conuri.protocol == "tcp") {
+		int port = MODBUS_TCP_DEFAULT_PORT;
+		if(conuri.port != "")
+			port = atoi(conuri.port.c_str());
+
+		LogMessage(string("Trying to perform a tcp connection to ") + conuri.hostandaddress + ", port: " + CDeviceUtils::ConvertToString(port));
+
+		ctx = modbus_new_tcp(conuri.hostandaddress.c_str(), port);
+	} else if(conuri.protocol == "tcp+pi") {
+		if(conuri.port == "")
+			conuri.port = "1502";
+
+		LogMessage(string("Trying to perform a tcp+pi connection to ") + conuri.hostandaddress + ", port: " + conuri.port);
+		ctx = modbus_new_tcp_pi(conuri.hostandaddress.c_str(), conuri.port.c_str());
+	} else if(conuri.protocol == "rtu") {
+		int baud = 115200;
+		char parity = 'N';
+		int data_bit = 8;
+		int stop_bit = 1;
+
+		map<string, string>::iterator it;
+
+		if((it = conuri.parameters.find("baud")) != conuri.parameters.end())
+			baud = atoi(it->second.c_str());
+
+		if((it = conuri.parameters.find("data_bit")) != conuri.parameters.end())
+			data_bit = atoi(it->second.c_str());
+
+		if((it = conuri.parameters.find("stop_bit")) != conuri.parameters.end())
+			stop_bit = atoi(it->second.c_str());
+
+		if((it = conuri.parameters.find("parity")) != conuri.parameters.end())
+			parity = it->second[0];
+
+      char parityChars[2] = {0, 0};
+      parityChars[0] = parity;
+
+		LogMessage(string("Trying to perform a rtu connection via ") + conuri.hostandaddress + " baud: " + CDeviceUtils::ConvertToString(baud) + " parity: " + parityChars + " data_bit: " + CDeviceUtils::ConvertToString(data_bit) + " stop_bit: " + CDeviceUtils::ConvertToString(stop_bit));
+
+		ctx = modbus_new_rtu(conuri.hostandaddress.c_str(), baud, parity, data_bit, stop_bit);
+
+		
+	} else {
+		LogMessage("Unsupported protocol part passed as connectionURI (supported is tcp, tcp+pi, rtu)");
+		return DEVICE_ERR;
+	}
+
+	if(checkContextAndContinue() == DEVICE_ERR) {
+		return DEVICE_ERR;
+	}
+
+	LogMessage("Modbus connected. Adding devices ...");
+
+	pair<string, string> splits, innerSplits, kv;
+	splits.second = deviceString;
+
+
+	//name=valves type=coils write_address=0 read_address=512 count=8
+
+
+
+	while((splits=split(splits.second, ";")).first != "") {
+		ModbusDevice d;
+
+		innerSplits.second = splits.first;
+
+		while((innerSplits=split(innerSplits.second, " ")).first != "") {
+			kv = split(innerSplits.first, "=");
+			if(kv.first == "name") {
+				d.name = kv.second;
+			} else if(kv.first == "type") {
+				d.typeStr = kv.second;
+				if(kv.second == "coils") {
+					d.type = MD_COILS;
+				} else if(kv.second == "registers") { 
+					LogMessage("Not yet implemented.");
+					return DEVICE_ERR;
+				} else {
+					LogMessage("Unsupported type passed.");
+				}
+			} else if(kv.first == "read_address") {
+				d.read_address = atoi(kv.second.c_str());
+			} else if(kv.first == "write_address") {
+				d.write_address = atoi(kv.second.c_str());
+			} else if(kv.first == "count") {
+				d.count = atoi(kv.second.c_str());
+			}
+		}
+
+		if(d.name != "") {
+			deviceConfiguration.push_back(d);
+		} else {
+			LogMessage("Device without name encountered?! Ignoring.");
+		}
+	}
+	
+	CreateProperty("general-connURI", connectionURI.c_str(), MM::String, true, NULL, false);
+	CreateProperty("general-libmodbus-version", LIBMODBUS_VERSION_STRING, MM::String, true, NULL, false);
+
+
+	string devicesToAdd = "";
+
+	for(vector<ModbusDevice>::iterator i = deviceConfiguration.begin(); i != deviceConfiguration.end(); i++) {
+		devicesToAdd += "," + i->name;
+	}
+
+	devicesToAdd = devicesToAdd.substr(1);
+	CreateProperty("general-devices", devicesToAdd.c_str(), MM::String, true, NULL, false);
+
+
+	int currentNumber = 0;
+
+	largestCount = 0;
+
+	for(vector<ModbusDevice>::iterator i = deviceConfiguration.begin(); i != deviceConfiguration.end(); i++) {
+		largestCount = largestCount > i->count ? largestCount : i->count;
+
+		string prefix = "";
+		prefix += i->name;
+
+		CreateProperty((prefix + "-name").c_str(), i->name.c_str(), MM::String, true, NULL, false);
+		CreateProperty((prefix + "-type").c_str(), i->typeStr.c_str(), MM::String, true, NULL, false);
+		CreateProperty((prefix + "-read-address").c_str(), CDeviceUtils::ConvertToString(i->read_address), MM::Integer, true, NULL, false);
+		CreateProperty((prefix + "-write-address").c_str(), CDeviceUtils::ConvertToString(i->write_address), MM::Integer, true, NULL, false);
+		CreateProperty((prefix + "-count").c_str(), CDeviceUtils::ConvertToString(i->count), MM::Integer, true, NULL, false);
+
+		CreateProperty((prefix).c_str(), "", MM::String, false, new DeviceActionEx(this, &CModbusDevice::OnDeviceValue, currentNumber), false);
+
+		currentNumber ++;
+	}
+
+	coilBuffer = new unsigned char[largestCount];
+	registerBuffer = new unsigned short[largestCount];
+
+	return DEVICE_OK;
+}
+
+
+
+int CModbusDevice::OnDeviceValue(MM::PropertyBase *pProp, MM::ActionType eAct, long data) {
+	string helper;
+
+	ModbusDevice d = deviceConfiguration[data];
+
+	if(d.type == MD_COILS) {
+		memset(coilBuffer, 0, sizeof(unsigned char) * (largestCount));
+
+		if(eAct == MM::BeforeGet)
+		{
+			int result;
+			result = modbus_read_bits(ctx, d.read_address, d.count, coilBuffer);
+			for(int i = 0; i < d.count; i++) {
+				if(coilBuffer[i]) {
+					helper += "1";
+				} else {
+					helper += "0";
+				}
+			}
+			//
+			pProp->Set(helper.c_str());
+		}
+		else if(eAct == MM::AfterSet)
+		{
+			pProp->Get(helper);
+
+			if(helper == "off") {
+				for(int i = 0; i < d.count; i++) coilBuffer[i] = 0;
+			} else if(helper == "on") {
+				for(int i = 0; i < d.count; i++) coilBuffer[i] = 1;
+			} else {
+				if(helper.size() != d.count) {
+					LogMessage("ERROR. Malfomed Value set! Rereading from device.");
+					return OnDeviceValue(pProp, MM::BeforeGet, data);
+				} 
+
+				for(int i = 0; i < d.count; i++) {
+					if(helper[i] == '1') {
+						coilBuffer[i] = 1;
+					} else if(helper[i] == '0') {
+						coilBuffer[i] = 0;
+					} else {
+						LogMessage("ERROR. Malfomed Value set! Rereading from device.");
+						return OnDeviceValue(pProp, MM::BeforeGet, data);
+					}
+				}
+			}
+
+			modbus_write_bits(ctx, d.write_address, d.count, coilBuffer);
+
+		}
+
+		return DEVICE_OK;
+	} else {
+		return DEVICE_ERR;
+	}
+}
+
+int CModbusDevice::Shutdown() {
+	ready = false;
+
+	if(coilBuffer != NULL)
+		delete coilBuffer;
+	if(registerBuffer != NULL)
+		delete registerBuffer;
+
+	return DEVICE_OK;
+}

--- a/DeviceAdapters/Modbus/ModbusModule.h
+++ b/DeviceAdapters/Modbus/ModbusModule.h
@@ -1,0 +1,136 @@
+///////////////////////////////////////////////////////////////////////////////
+// FILE:          ModbusModule.h
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     DeviceAdapters
+//-----------------------------------------------------------------------------
+// see ModbusModule.cpp
+
+#ifndef _MODBUS_MODULE_H_
+#define _MODBUS_MODULE_H_
+
+#include "../../MMDevice/DeviceBase.h"
+#include <string>
+#include <sstream>
+#include <map>
+#include <vector>
+#include <algorithm>
+
+#include <errno.h>
+
+#include <modbus.h>
+
+using namespace std;
+
+inline pair<string, string> split(string input, string sep) {
+    pair<string, string> result;
+    size_t position = input.find(sep);
+    if(position == string::npos) {
+        result.first = input;
+    } else {
+        result.first = input.substr(0, position);
+        if(position != input.size()) {
+            result.second = input.substr(position + sep.size());
+        }
+    }
+    return result;
+}
+
+struct URI {
+    inline URI(string input) {
+        pair<string, string> splitter, innersplitter;
+        splitter = split(input, "://");
+        protocol = splitter.first;
+
+        splitter = split(splitter.second, "?");
+
+        input = splitter.first;
+                
+        while((splitter=split(splitter.second, "&")).first.size() > 0) {
+            innersplitter = split(splitter.first, "=");
+            parameters[innersplitter.first] = innersplitter.second;
+        }
+
+        if(input[0] == '[') {
+            splitter = split(input.substr(1), "]:");
+        } else {
+            splitter = split(input, ":");
+        }
+
+        port = splitter.second;
+        hostandaddress = splitter.first;
+    }
+
+    string protocol, hostandaddress, port;
+    map<string, string> parameters;
+};
+
+
+typedef enum {
+	MD_COILS = 0,
+	MD_REGISTER
+} ModbusDeviceType;
+
+
+struct ModbusDevice {
+	string name;
+	int read_address;
+	int write_address;
+	int write_only;
+	int read_only;
+	ModbusDeviceType type;
+	string typeStr;
+	int count;
+
+	string valueCache;
+
+	inline ModbusDevice() : read_address(0), write_address(0), type(MD_COILS), count(0), write_only(0), read_only(0) {};
+};
+
+class CModbusDevice: public CGenericBase<CModbusDevice>
+{
+public:
+	CModbusDevice();
+	~CModbusDevice();
+
+	int Initialize();
+	int Shutdown();
+
+	void GetName(char* pszName) const;
+	bool Busy();
+
+	int OnConnectionURI(MM::PropertyBase *, MM::ActionType eAct);
+	int OnDeviceString(MM::PropertyBase *, MM::ActionType eAct);
+	int OnDebugFlag(MM::PropertyBase *pProp, MM::ActionType eAct);
+
+	int OnDeviceValue(MM::PropertyBase *pProp, MM::ActionType eAct, long data);
+
+private:
+
+	int checkContextAndContinue();
+
+	modbus_t *ctx;
+
+	string connectionURI;
+	string deviceString;
+
+	
+	vector<ModbusDevice> deviceConfiguration;
+
+	int ready;
+
+	long debugFlag;
+
+	int retriesLeft;
+	long retries;
+
+	int largestCount;
+	unsigned char *coilBuffer;
+	unsigned short *registerBuffer;
+
+};
+
+
+typedef MM::ActionEx<CModbusDevice> DeviceActionEx;
+typedef MM::Action<CModbusDevice> DeviceAction;
+
+#endif //_MODBUS_MODULE_H_

--- a/DeviceAdapters/Modbus/lib/README
+++ b/DeviceAdapters/Modbus/lib/README
@@ -1,0 +1,1 @@
+git clone https://github.com/stephane/libmodbus.git

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -239,6 +239,23 @@ AS_IF([test "x$want_gphoto2" != xno],
 [use_gphoto2=no])
 
 
+MM_ARG_WITH_OPTIONAL_LIB([libmodbus], [modbus], [MODBUS])
+AS_IF([test "x$want_modbus" != xno],
+[
+   MM_LIB_MODBUS([$MODBUS_PREFIX],
+   [
+      use_modbus=yes
+   ],
+   [
+      use_modbus=no
+      AS_IF([test "x$want_modbus" = xyes],
+            [MM_MSG_OPTIONAL_LIB_FAILURE([libmodbus], [modbus])])
+   ])
+],
+[use_modbus=no])
+AM_CONDITIONAL([BUILD_MODBUS], [test "x$use_modbus" = xyes])
+
+
 MM_ARG_WITH_OPTIONAL_LIB([FreeImagePlus], [freeimageplus], [FREEIMAGEPLUS])
 AS_IF([test "x$want_freeimageplus" != xno],
 [
@@ -440,6 +457,7 @@ m4_define([device_adapter_dirs], [m4_strip([
    Marzhauser-LStep
    MarzhauserLStepOld
    MicroPoint
+   Modbus
    Motic_mac
    Neos
    NewportCONEX

--- a/m4/mm_libs.m4
+++ b/m4/mm_libs.m4
@@ -40,6 +40,13 @@ AC_DEFUN([MM_LIB_GPHOTO2], [
 ])
 
 
+AC_DEFUN([MM_LIB_MODBUS], [
+   MM_LIB_WITH_PKG_CONFIG([MODBUS], [libmodbus], [libmodbus >= 3.0.6], [],
+      [$1], [-lmodbus], [modbus.h], [modbus_connect],
+      [$2], [$3])
+])
+
+
 # Check for HIDAPI library
 #
 # MM_LIB_HIDAPI([HIDAPI prefix], [action-if-found], [action-if-not-found])


### PR DESCRIPTION
A little thing I've been working on. A DeviceAdapter (BSD-licensed) allowing [Modbus](https://en.wikipedia.org/wiki/Modbus)-connected devices to be controlled, via [libmodbus](http://libmodbus.org/) (LGPL licensed).

We're using this to control a valve system controlling a microfluidic setup (valve hardware setup as designed by Dr. Christopher Probst (@chrisp87), Thanks!).

Modbus allows for data I/O via two data types: binary "coils", and 16-bit wide "registers" holding arbitrary data.
As for our setup only "coils" are currently necessary, only access to these has been implemented and tested, however registers can easily be added, and I might work on this in the future…
Nonetheless, it works quite well for our purposes and could serve as a general starting point for a modbus device adapter in MM, allowing access to a plethora of modbus-controlled periphery.

For usage, on adding the adapter, the user sets the connection by a connection URI, and defines modbus devices by a configuration string (e.g. `name=valves type=coils write_address=0 read_address=512 count=8`), and after the device adapter has initialized, has the properties they named at their disposal for IO with the modbus device.

For building it under *NIX, I've added the (hopefully) appropriate lines to the autotools files to auto detect a distribution installed libmodbus; for Windows, unfortunately no official binary builds exist. It is however straightforward to `git clone` it into the `lib` subfolder, build it there according to its documentation, and then build the VS project. (If you want to add it to MM, you could probably build libmodbus once, and add the binary to 3rdpartypublic, and change the links accordingly).

If you want to include this adapter in MM, I can write documentation for it on the Wiki.

What do you think?
Best regards,
Christian