### PR TITLE
mmstudio ScaleBar improvements.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
@@ -131,17 +131,17 @@ public final class ScaleBarPanel extends OverlayPanel {
       fontSize_.addKeyListener(keyAdapter);
       super.add(fontSize_);
       
-      super.add(new JLabel("Bar height: "));
+      super.add(new JLabel("Bar height: "), "gapleft 10");
       barWidth_ = new JTextField("5", 3);
       barWidth_.addKeyListener(keyAdapter);
       super.add(barWidth_);
 
-      super.add(new JLabel("X offset: "));
+      super.add(new JLabel("X offset: "), "gapleft 10");
       xOffset_ = new JTextField("0", 3);
       xOffset_.addKeyListener(keyAdapter);
       super.add(xOffset_);
             
-      super.add(new JLabel("Y offset: "));
+      super.add(new JLabel("Y offset: "), "gapleft 10");
       yOffset_ = new JTextField("0", 3);
       yOffset_.addKeyListener(keyAdapter);
       super.add(yOffset_, "wrap");

--- a/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
@@ -102,34 +102,39 @@ public final class ScaleBarPanel extends OverlayPanel {
       };
       super.setLayout(new MigLayout("flowx"));
 
-      super.add(new JLabel("Color: "), "span 2");
+      super.add(new JLabel("Color: "), "span 3, split 2");
       color_ = new JComboBox(COLORNAMES);
       color_.addActionListener(changeListener);
-      super.add(color_, "span 2, wrap");
+      super.add(color_);
       
-      super.add(new JLabel("Position: "), "span 2");
+      super.add(new JLabel("Position: "), "span 4, split 2");
       position_ = new JComboBox(new String[] {
             "Upper left", "Upper right", "Lower right", "Lower left"});
       position_.addActionListener(changeListener);
-      super.add(position_, "span 2, wrap");
+      super.add(position_, "wrap");
 
-      shouldDrawText_ = new JCheckBox("Show scale text");
+      shouldDrawText_ = new JCheckBox("Show text");
       shouldDrawText_.addActionListener(changeListener);
       super.add(shouldDrawText_, "span 2");     
       
       isBarFilled_ = new JCheckBox("Solid scale bar");
       isBarFilled_.addActionListener(changeListener);
-      super.add(isBarFilled_, "span 2, wrap");
+      super.add(isBarFilled_, "span 2");
+            
+      super.add(new JLabel("Size (\u00B5m):") );
+      scaleSize_ = new JTextField("80", 3);
+      scaleSize_.addActionListener(changeListener);
+      super.add(scaleSize_, "wrap");
 
       super.add(new JLabel("Font size: "));
       fontSize_ = new JTextField("14", 3);
       fontSize_.addKeyListener(keyAdapter);
       super.add(fontSize_);
       
-      super.add(new JLabel("Size (\u00B5m):") );
-      scaleSize_ = new JTextField("80", 3);
-      scaleSize_.addActionListener(changeListener);
-      super.add(scaleSize_, "wrap");
+      super.add(new JLabel("Bar height: "));
+      barWidth_ = new JTextField("5", 3);
+      barWidth_.addKeyListener(keyAdapter);
+      super.add(barWidth_);
 
       super.add(new JLabel("X offset: "));
       xOffset_ = new JTextField("0", 3);
@@ -141,10 +146,7 @@ public final class ScaleBarPanel extends OverlayPanel {
       yOffset_.addKeyListener(keyAdapter);
       super.add(yOffset_, "wrap");
 
-      super.add(new JLabel("Bar height: "));
-      barWidth_ = new JTextField("5", 3);
-      barWidth_.addKeyListener(keyAdapter);
-      super.add(barWidth_, "wrap");
+
 
 
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
@@ -64,16 +64,16 @@ public final class ScaleBarPanel extends OverlayPanel {
          "Blue", "Cyan", "Green"
    };
 
-   private Studio studio_;
+   private final Studio studio_;
 
    private final JCheckBox shouldDrawText_;
    private final JCheckBox isBarFilled_;
    private final JComboBox color_;
-   private JTextField fontSize_;
+   private final JTextField fontSize_;
    private final JTextField xOffset_;
    private final JTextField yOffset_;
    private final JTextField scaleSize_;
-   private JTextField barWidth_;
+   private final JTextField barWidth_;
    private final JComboBox position_;
 
    private boolean haveLoggedError_ = false;
@@ -100,51 +100,53 @@ public final class ScaleBarPanel extends OverlayPanel {
             }
          }
       };
-      setLayout(new MigLayout("flowy"));
+      super.setLayout(new MigLayout("flowx"));
 
-      add(new JLabel("Color: "));
+      super.add(new JLabel("Color: "), "span 2");
       color_ = new JComboBox(COLORNAMES);
       color_.addActionListener(changeListener);
-      add(color_);
-
-      shouldDrawText_ = new JCheckBox("Show scale text");
-      shouldDrawText_.addActionListener(changeListener);
-      add(shouldDrawText_);
-
-      add(new JLabel("Font size: "), "split 2, flowx");
-      fontSize_ = new JTextField("14", 3);
-      fontSize_.addKeyListener(keyAdapter);
-      add(fontSize_);
-
-      add(new JLabel("X offset: "), "split 2, flowx");
-      xOffset_ = new JTextField("0", 3);
-      xOffset_.addKeyListener(keyAdapter);
-      add(xOffset_, "wrap");
-
-      isBarFilled_ = new JCheckBox("Solid scale bar");
-      isBarFilled_.addActionListener(changeListener);
-      add(isBarFilled_);
-
-      add(new JLabel("Bar thickness: "), "split 2, flowx");
-      barWidth_ = new JTextField("5", 3);
-      barWidth_.addKeyListener(keyAdapter);
-      add(barWidth_);
-
-      add(new JLabel("Position: "));
+      super.add(color_, "span 2, wrap");
+      
+      super.add(new JLabel("Position: "), "span 2");
       position_ = new JComboBox(new String[] {
             "Upper left", "Upper right", "Lower right", "Lower left"});
       position_.addActionListener(changeListener);
-      add(position_);
+      super.add(position_, "span 2, wrap");
 
-      add(new JLabel("Size (\u00B5m):"), "split 2, flowx");
+      shouldDrawText_ = new JCheckBox("Show scale text");
+      shouldDrawText_.addActionListener(changeListener);
+      super.add(shouldDrawText_, "span 2");     
+      
+      isBarFilled_ = new JCheckBox("Solid scale bar");
+      isBarFilled_.addActionListener(changeListener);
+      super.add(isBarFilled_, "span 2, wrap");
+
+      super.add(new JLabel("Font size: "));
+      fontSize_ = new JTextField("14", 3);
+      fontSize_.addKeyListener(keyAdapter);
+      super.add(fontSize_);
+      
+      super.add(new JLabel("Size (\u00B5m):") );
       scaleSize_ = new JTextField("80", 3);
       scaleSize_.addActionListener(changeListener);
-      add(scaleSize_);
+      super.add(scaleSize_, "wrap");
 
-      add(new JLabel("Y offset: "), "split 2, flowx");
+      super.add(new JLabel("X offset: "));
+      xOffset_ = new JTextField("0", 3);
+      xOffset_.addKeyListener(keyAdapter);
+      super.add(xOffset_);
+            
+      super.add(new JLabel("Y offset: "));
       yOffset_ = new JTextField("0", 3);
       yOffset_.addKeyListener(keyAdapter);
-      add(yOffset_);
+      super.add(yOffset_, "wrap");
+
+      super.add(new JLabel("Bar height: "));
+      barWidth_ = new JTextField("5", 3);
+      barWidth_.addKeyListener(keyAdapter);
+      super.add(barWidth_, "wrap");
+
+
    }
 
    /**
@@ -226,28 +228,33 @@ public final class ScaleBarPanel extends OverlayPanel {
       int width = (int) (scaleSize / pixelSize * canvas.getMagnification());
       g.setColor(COLORS[color_.getSelectedIndex()]);
       int fontSize = getText(fontSize_, 14);
-      int xOffset = getText(xOffset_, 0);
-      int yOffset = getText(yOffset_, 0);
-      int barWidth = getText(barWidth_, 5);
+      int xOffset = getText(xOffset_, 10);
+      int yOffset = getText(yOffset_, 10);
+      int barHeight = getText(barWidth_, 5);
+      Font ourFont = new Font("Arial", Font.PLAIN, fontSize);
+      int stringHeight = g.getFontMetrics(g.getFont()).getHeight();
+      yOffset += stringHeight;
 
       String position = (String) position_.getSelectedItem();
       Dimension canvasSize = canvas.getPreferredSize();
       if (position.equals("Upper right") || position.equals("Lower right")) {
-         xOffset = canvasSize.width - xOffset - 80;
+         xOffset = canvasSize.width - xOffset - width;
       }
       if (position.equals("Lower left") || position.equals("Lower right")) {
-         yOffset = canvasSize.height - yOffset - 13;
+         yOffset = canvasSize.height - yOffset - barHeight + stringHeight - 6;
       }
 
       if (shouldDrawText_.isSelected()) {
-         g.setFont(new Font("Arial", Font.PLAIN, fontSize));
-         g.drawString(String.format("%dum", scaleSize), xOffset, yOffset);
+         g.setFont(ourFont);
+         int stringWidth = g.getFontMetrics(g.getFont()).stringWidth(String.format("%dum", scaleSize));
+         int xPosition = xOffset + (int) (0.5 * width) - (int) (0.5 * stringWidth);
+         g.drawString(String.format("%dum", scaleSize), xPosition, yOffset);
       }
       if (isBarFilled_.isSelected()) {
-         g.fillRect(xOffset, yOffset + 6, width, barWidth);
+         g.fillRect(xOffset, yOffset + 6, width, barHeight);
       }
       else {
-         g.drawRect(xOffset, yOffset + 6, width, barWidth);
+         g.drawRect(xOffset, yOffset + 6, width, barHeight);
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
@@ -100,7 +100,7 @@ public final class ScaleBarPanel extends OverlayPanel {
             }
          }
       };
-      super.setLayout(new MigLayout("flowx"));
+      super.setLayout(new MigLayout("ins 2, flowx"));
 
       super.add(new JLabel("Color: "), "span 3, split 2");
       color_ = new JComboBox(COLORNAMES);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/overlays/TimestampPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/overlays/TimestampPanel.java
@@ -97,13 +97,13 @@ public final class TimestampPanel extends OverlayPanel {
       color_.addActionListener(redrawListener);
       super.add(color_);
 
-      super.add(new JLabel("Position: "));
+      super.add(new JLabel("Position: "), "gapleft 10");
       position_ = new JComboBox(new String[] {
             UPPER_LEFT, UPPER_RIGHT, LOWER_RIGHT, LOWER_LEFT});
       position_.addActionListener(redrawListener);
       super.add(position_);
 
-      super.add(new JLabel("Format:"));
+      super.add(new JLabel("Format:"), "gapleft 10");
       format_ = new JComboBox(new String[] {RELATIVE_TIME, ABSOLUTE_TIME});
       format_.addActionListener(redrawListener);
       super.add(format_, "wrap");
@@ -116,10 +116,10 @@ public final class TimestampPanel extends OverlayPanel {
       amMultiChannel_ = new JCheckBox("Per-channel");
       amMultiChannel_.setToolTipText("Draw one timestamp per channel in the display.");
       amMultiChannel_.addActionListener(redrawListener);
-      super.add(amMultiChannel_);
+      super.add(amMultiChannel_, "gapleft 10");
 
 
-      super.add(new JLabel("X offset: "));
+      super.add(new JLabel("X offset: "), "gapleft 10");
       xOffset_ = new JTextField("0", 3);
       xOffset_.addKeyListener(new KeyAdapter() {
          @Override
@@ -129,7 +129,7 @@ public final class TimestampPanel extends OverlayPanel {
       });
       super.add(xOffset_);
 
-      super.add(new JLabel("Y offset: "));
+      super.add(new JLabel("Y offset: "), "gapleft 10" );
       yOffset_ = new JTextField("0", 3);
       yOffset_.addKeyListener(new KeyAdapter() {
          @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/overlays/TimestampPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/overlays/TimestampPanel.java
@@ -80,7 +80,7 @@ public final class TimestampPanel extends OverlayPanel {
 
    public TimestampPanel(Studio studio) {
       studio_ = studio;
-      super.setLayout(new MigLayout("flowx"));
+      super.setLayout(new MigLayout("ins 2, flowx"));
 
       ActionListener redrawListener = new ActionListener() {
          @Override
@@ -101,9 +101,9 @@ public final class TimestampPanel extends OverlayPanel {
       position_ = new JComboBox(new String[] {
             UPPER_LEFT, UPPER_RIGHT, LOWER_RIGHT, LOWER_LEFT});
       position_.addActionListener(redrawListener);
-      super.add(position_);
+      super.add(position_, "wrap");
 
-      super.add(new JLabel("Format:"), "gapleft 10");
+      super.add(new JLabel("Format:"));
       format_ = new JComboBox(new String[] {RELATIVE_TIME, ABSOLUTE_TIME});
       format_.addActionListener(redrawListener);
       super.add(format_, "wrap");

--- a/mmstudio/src/main/java/org/micromanager/display/internal/overlays/TimestampPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/overlays/TimestampPanel.java
@@ -69,7 +69,7 @@ public final class TimestampPanel extends OverlayPanel {
    private static final String COLOR_INDEX = "color";
    private static final String FORMAT_INDEX = "format";
 
-   private Studio studio_;
+   private final Studio studio_;
    private final JCheckBox amMultiChannel_;
    private final JCheckBox shouldDrawBackground_;
    private final JTextField xOffset_;
@@ -80,7 +80,7 @@ public final class TimestampPanel extends OverlayPanel {
 
    public TimestampPanel(Studio studio) {
       studio_ = studio;
-      setLayout(new MigLayout("flowx"));
+      super.setLayout(new MigLayout("flowx"));
 
       ActionListener redrawListener = new ActionListener() {
          @Override
@@ -89,35 +89,37 @@ public final class TimestampPanel extends OverlayPanel {
             redraw();
          }
       };
+      
+      
+      super.add(new JLabel("Color: "));
+      color_ = new JComboBox(new String[] {
+            "White", "Black", "Channel color"});
+      color_.addActionListener(redrawListener);
+      super.add(color_);
 
-      add(new JLabel("Position: "), "split 2, flowy");
+      super.add(new JLabel("Position: "));
       position_ = new JComboBox(new String[] {
             UPPER_LEFT, UPPER_RIGHT, LOWER_RIGHT, LOWER_LEFT});
       position_.addActionListener(redrawListener);
-      add(position_);
+      super.add(position_);
 
-      add(new JLabel("Time format:"), "split 2, flowy");
+      super.add(new JLabel("Format:"));
       format_ = new JComboBox(new String[] {RELATIVE_TIME, ABSOLUTE_TIME});
       format_.addActionListener(redrawListener);
-      add(format_, "wrap");
+      super.add(format_, "wrap");
 
       shouldDrawBackground_ = new JCheckBox("Draw background");
       shouldDrawBackground_.setToolTipText("Draw a background (black, unless black text is selected) underneath the timestamp(s) to improve contrast");
       shouldDrawBackground_.addActionListener(redrawListener);
-      add(shouldDrawBackground_, "wrap");
+      super.add(shouldDrawBackground_, "span 6, split 6");
 
       amMultiChannel_ = new JCheckBox("Per-channel");
       amMultiChannel_.setToolTipText("Draw one timestamp per channel in the display.");
       amMultiChannel_.addActionListener(redrawListener);
-      add(amMultiChannel_);
+      super.add(amMultiChannel_);
 
-      add(new JLabel("Text color: "), "split 2, flowy");
-      color_ = new JComboBox(new String[] {
-            "White", "Black", "Channel color"});
-      color_.addActionListener(redrawListener);
-      add(color_, "wrap");
 
-      add(new JLabel("X offset: "), "split 2");
+      super.add(new JLabel("X offset: "));
       xOffset_ = new JTextField("0", 3);
       xOffset_.addKeyListener(new KeyAdapter() {
          @Override
@@ -125,9 +127,9 @@ public final class TimestampPanel extends OverlayPanel {
             redraw();
          }
       });
-      add(xOffset_);
+      super.add(xOffset_);
 
-      add(new JLabel("Y offset: "), "split 2");
+      super.add(new JLabel("Y offset: "));
       yOffset_ = new JTextField("0", 3);
       yOffset_.addKeyListener(new KeyAdapter() {
          @Override
@@ -135,7 +137,7 @@ public final class TimestampPanel extends OverlayPanel {
             redraw();
          }
       });
-      add(yOffset_, "wrap");
+      super.add(yOffset_, "wrap");
    }
 
    @Override
@@ -291,7 +293,7 @@ public final class TimestampPanel extends OverlayPanel {
 
       String formatMode = (String) format_.getSelectedItem();
       Metadata metadata = image.getMetadata();
-      String text = null;
+      String text;
       if (formatMode.equals(ABSOLUTE_TIME)) {
          text = metadata.getReceivedTime();
          if (text == null) {

--- a/plugins/PatternOverlay/src/main/java/org/micromanager/patternoverlay/PatternOverlayPanel.java
+++ b/plugins/PatternOverlay/src/main/java/org/micromanager/patternoverlay/PatternOverlayPanel.java
@@ -12,7 +12,6 @@ import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JSlider;
-import javax.swing.JToggleButton;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -28,7 +27,6 @@ import org.micromanager.Studio;
  */
 public class PatternOverlayPanel extends OverlayPanel {
    private static final String OVERLAY_MODE = "selected overlay mode";
-   private static final String IS_DISPLAYED = "is the overlay displayed";
    private static final String OVERLAY_SIZE = "size of overlay";
    private static final String OVERLAY_COLOR = "color of overlay";
    private static final String DRAW_SIZE = "draw size";
@@ -45,7 +43,7 @@ public class PatternOverlayPanel extends OverlayPanel {
     * @param studio Micro-Manager Interface
     */
    public PatternOverlayPanel(final Studio studio) {
-      setLayout(new MigLayout("", "[right]10[center]", "[]8[]"));
+      super.setLayout(new MigLayout(""));
       overlaySelector_ = new JComboBox(OverlayOptions.OPTIONS);
       overlaySelector_.addActionListener(new ActionListener() {
          @Override
@@ -56,9 +54,21 @@ public class PatternOverlayPanel extends OverlayPanel {
             redraw();
          }
       });
+      
+      colorSelector_ = new JComboBox(OverlayOptions.COLOR_NAMES);
+      colorSelector_.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            studio.profile().setString(PatternOverlayPanel.class,
+               OVERLAY_COLOR, (String) colorSelector_.getSelectedItem());
+            redraw();
+         }
+      });
+      super.add(new JLabel("Color:"));
+      super.add(colorSelector_);
 
-      add(new JLabel("Type:"));
-      add(overlaySelector_, "wrap");
+      super.add(new JLabel("Type:"), "gapleft 10");
+      super.add(overlaySelector_);
 
       sizeSlider_ = new JSlider();
       sizeSlider_.addChangeListener(new ChangeListener() {
@@ -69,20 +79,8 @@ public class PatternOverlayPanel extends OverlayPanel {
             redraw();
          }
       });
-      add(new JLabel("Size:"));
-      add(sizeSlider_, "wrap, width ::80");
-
-      colorSelector_ = new JComboBox(OverlayOptions.COLOR_NAMES);
-      colorSelector_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            studio.profile().setString(PatternOverlayPanel.class,
-               OVERLAY_COLOR, (String) colorSelector_.getSelectedItem());
-            redraw();
-         }
-      });
-      add(new JLabel("Color:"));
-      add(colorSelector_, "wrap");
+      super.add(new JLabel("Size:"), "gapleft 10");
+      super.add(sizeSlider_, "wrap, width ::80");
 
       shouldDrawSize_ = new JCheckBox("Show pattern size");
       shouldDrawSize_.addActionListener(new ActionListener() {
@@ -93,7 +91,7 @@ public class PatternOverlayPanel extends OverlayPanel {
             redraw();
          }
       });
-      add(shouldDrawSize_, "wrap");
+      super.add(shouldDrawSize_, "span 6, wrap");
 
       // Load initial settings from the profile.
       overlaySelector_.setSelectedItem(studio.profile().getString(

--- a/plugins/PatternOverlay/src/main/java/org/micromanager/patternoverlay/PatternOverlayPanel.java
+++ b/plugins/PatternOverlay/src/main/java/org/micromanager/patternoverlay/PatternOverlayPanel.java
@@ -43,7 +43,7 @@ public class PatternOverlayPanel extends OverlayPanel {
     * @param studio Micro-Manager Interface
     */
    public PatternOverlayPanel(final Studio studio) {
-      super.setLayout(new MigLayout(""));
+      super.setLayout(new MigLayout("ins 0, flowx"));
       overlaySelector_ = new JComboBox(OverlayOptions.OPTIONS);
       overlaySelector_.addActionListener(new ActionListener() {
          @Override


### PR DESCRIPTION
Scalebar no longer disappears on the right side of the image.
Text is centered on top of the scale bar.
Offset settings are interpreted such that placing thr bar in another place does not necitate changing these settings.
UI is improved (it looked raggy and unfinished on Mac OS X, it still may be nice to use more width than height as it currently does).
Addresses issue #542.