### PR TITLE
Inspector window overlay fixes

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/internal/inspector/OverlaysPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/inspector/OverlaysPanel.java
@@ -21,6 +21,9 @@
 package org.micromanager.display.internal.inspector;
 
 import com.google.common.eventbus.Subscribe;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -58,12 +61,12 @@ class OverlaysPanel extends InspectorPanel {
    public OverlaysPanel() {
       overlays_ = new ArrayList<OverlayPanel>();
       overlayToEnabled_ = new HashMap<OverlayPanel, Boolean>();
-      setLayout(new MigLayout("flowy"));
+      super.setLayout(new MigLayout("flowy"));
       // Provide a button that, when clicked, shows a popup menu of overlays
       // that can be added.
       // Icon is public domain, taken from
       // https://openclipart.org/detail/16950/add
-      JButton adder = new JButton("Add overlay...",
+       JButton adder = new JButton("Add...", 
             new ImageIcon(getClass().getResource("/org/micromanager/icons/plus_green.png")));
       adder.addMouseListener(new MouseAdapter() {
          @Override
@@ -71,7 +74,10 @@ class OverlaysPanel extends InspectorPanel {
             showPopup(e);
          }
       });
-      add(adder);
+      Dimension buttonSize = new Dimension(90, 20);
+      adder.setFont(new Font("Arial", Font.PLAIN, 9));
+      adder.setMaximumSize(buttonSize);
+      super.add(adder);
    }
 
    private void showPopup(MouseEvent event) {
@@ -125,6 +131,8 @@ class OverlaysPanel extends InspectorPanel {
             display_.requestRedraw();
          }
       });
+      closeButton.setFont(new Font("Arial", Font.PLAIN, 9));
+      closeButton.setMaximumSize(new Dimension(90, 20));
       container.add(closeButton, "gap 0");
 
       final JCheckBox enabledBox = new JCheckBox("Enabled");

--- a/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/overlays/ScaleBarPanel.java
@@ -27,12 +27,12 @@ import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.data.Image;
@@ -91,15 +91,32 @@ public final class ScaleBarPanel extends OverlayPanel {
                }
             }
       };
-      KeyAdapter keyAdapter = new KeyAdapter() {
+      
+      DocumentListener docListener = new DocumentListener() {
          @Override
-         public void keyPressed(KeyEvent event) {
+         public void insertUpdate(DocumentEvent e) {
+            update();
+         }
+
+         @Override
+         public void removeUpdate(DocumentEvent e) {
+            update();
+         }
+
+         @Override
+         public void changedUpdate(DocumentEvent e) {
+            update();
+         }
+         
+         public void update() {
             if (!shouldIgnoreEvents_) {
                saveSettings();
                redraw();
             }
          }
       };
+      
+
       super.setLayout(new MigLayout("ins 2, flowx"));
 
       super.add(new JLabel("Color: "), "span 3, split 2");
@@ -128,26 +145,23 @@ public final class ScaleBarPanel extends OverlayPanel {
 
       super.add(new JLabel("Font size: "));
       fontSize_ = new JTextField("14", 3);
-      fontSize_.addKeyListener(keyAdapter);
+      fontSize_.getDocument().addDocumentListener(docListener);
       super.add(fontSize_);
       
       super.add(new JLabel("Bar height: "), "gapleft 10");
       barWidth_ = new JTextField("5", 3);
-      barWidth_.addKeyListener(keyAdapter);
+      barWidth_.getDocument().addDocumentListener(docListener);
       super.add(barWidth_);
 
       super.add(new JLabel("X offset: "), "gapleft 10");
       xOffset_ = new JTextField("0", 3);
-      xOffset_.addKeyListener(keyAdapter);
+      xOffset_.getDocument().addDocumentListener(docListener);
       super.add(xOffset_);
             
       super.add(new JLabel("Y offset: "), "gapleft 10");
       yOffset_ = new JTextField("0", 3);
-      yOffset_.addKeyListener(keyAdapter);
+      yOffset_.getDocument().addDocumentListener(docListener);
       super.add(yOffset_, "wrap");
-
-
-
 
    }
 


### PR DESCRIPTION
Replaced KeyListeners with DocumentListeners so that the correct values are stored in the preferences (fixing a problem with very wrong values when re-opening overlays).  Made buttons smaller, similar to buttons used elsewhere in the Inspector window, to reduce the size taken up by Overlay UI.