### PR TITLE
Remove trailing separator characters from argument to getUniqueSaveDirectory

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -112,6 +112,14 @@ public final class DefaultDataManager implements DataManager {
       if (path == null) {
          return null;
       }
+      
+      // Remove trailing file system separator from argument because
+      // this method assumes input does not end in separator character
+      String lastChar = path.substring(path.length() - 1);
+      if (lastChar.equals(File.separator)) {
+	  path = path.substring(0, path.length() - 1);
+      }
+	  
       File dir = new File(path);
       if (!(dir.exists())) {
          // Path is already unique


### PR DESCRIPTION
This PR fixes #551 by checking whether the input argument ends in the file system's separator character. If it does, the trailing character is removed and the method proceeds as before.