### PR TITLE
ZProjector: Allow it to work on ongoing acquisitions.

### DIFF
--- a/plugins/ZProjector/src/main/java/org/micromanager/zprojector/ZProjectorPluginExecutor.java
+++ b/plugins/ZProjector/src/main/java/org/micromanager/zprojector/ZProjectorPluginExecutor.java
@@ -48,11 +48,13 @@ public class ZProjectorPluginExecutor {
       studio_ = studio;
 
       // Not sure if this is needed, be safe for now
+      /*
       if (!window.getDatastore().getIsFrozen()) {
          studio_.logs().showMessage("Can not Z-Project ongoing acquisitions", 
                  window.getAsWindow());
          return;
       }
+      */
       
       // TODO: provide UI to other projection methods and z-ranges
       project(window, window.getName() + "Z-Projection", ZProjector.MAX_METHOD);


### PR DESCRIPTION
Main reason was that some acquisitions (diSPIM ) saved on disk when
re-opened say that they are not saved (which seems a bug in itself,
but not one that I have time investigate).