### PR TITLE
Add DoubleVector to enable loadXYStageSequence()

### DIFF
--- a/MMCorePy_wrap/MMCorePy.i
+++ b/MMCorePy_wrap/MMCorePy.i
@@ -55,16 +55,6 @@ import_array();
 #include "string.h"
 %}
 
-
-// output arguments
-%apply double &OUTPUT { double &x };
-%apply double &OUTPUT { double &y };
-%apply int &OUTPUT { int &x };
-%apply int &OUTPUT { int &y };
-%apply int &OUTPUT { int &xSize };
-%apply int &OUTPUT { int &ySize };
-
-
 %typemap(out) void*
 {
    npy_intp dims[2];
@@ -204,11 +194,19 @@ import_array();
 namespace std {
     %template(CharVector)   vector<char>;
     %template(LongVector)   vector<long>;
+    %template(DoubleVector) vector<double>;
     %template(StrVector)    vector<string>;
     %template(pair_ss)      pair<string, string>;
     %template(StrMap)       map<string, string>;
 }
 
+// output arguments
+%apply double &OUTPUT { double &x };
+%apply double &OUTPUT { double &y };
+%apply int &OUTPUT { int &x };
+%apply int &OUTPUT { int &y };
+%apply int &OUTPUT { int &xSize };
+%apply int &OUTPUT { int &ySize };
 
 %include "../MMDevice/MMDeviceConstants.h"
 %include "../MMCore/Error.h"


### PR DESCRIPTION
loadXYStageSequence() requires a vector<double>

lines 203-209 needed to be moved down because SWIG %apply works indiscriminately and will match types inside the source code for std::vector causing failure to compile. It may be better in the future to use %apply and then %clear, or use a more specific name & type matching, but this works for now.

This bug was discovered by @fcollman and myself at the Allen Institute for Brain Science.
