### PR TITLE
ZProjector: add missing entry to Makefile.am.

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -33,6 +33,7 @@ nobase_mmplugin_DATA = \
 	SnapOnMove.jar \
 	SplitView.jar \
 	WhiteBalance.jar \
+	ZProjector.jar \
 	pgFocus.jar
 
 .PHONY: plugins.stamp


### PR DESCRIPTION
Hopefully this will bring this useful plugin back to the unix distribution.