### PR TITLE
Fix 'ordered comparison between pointer and zero'

### DIFF
--- a/DeviceAdapters/USBManager/USBManager.cpp
+++ b/DeviceAdapters/USBManager/USBManager.cpp
@@ -281,7 +281,7 @@ int MDUSBDevice::Open(const char* /*portName*/)
          if ( (dev->descriptor.idVendor == g_knownDevices[i].idVendor) &&
             (dev->descriptor.idProduct == g_knownDevices[i].idProduct) ) {
                deviceHandle_ = usb_open(dev);
-               if (deviceHandle_ <= 0)
+               if (deviceHandle_ <= (void*)0)
                   printf ("Received bad deviceHandle\n");
                if (TakeOverDevice(0) != DEVICE_OK) {
                   printf ("Failed taking over device \n");


### PR DESCRIPTION
When I try to compile Micro-manager, I trouble into `  ordered comparison between pointer and zero ('usb_dev_handle *' and 'int')`. Then I find same error in [here](https://github.com/ZoneMinder/ZoneMinder/issues/1760). It work. 


Error: 


      Making all in USBManager
      make[2]: Entering directory '/home/igem/Downloads/mm/micro-manager/DeviceAdapters/USBManager'
      /bin/sh ../libtool  --tag=CXX   --mode=compile clang++ -DPACKAGE_NAME=\"Micro-
       Manager\" -DPACKAGE_TARNAME=\"micro-manager\" -DPACKAGE_VERSION=\"1.4\" -
       DPACKAGE_STRING=\"Micro-Manager\ 1.4\" -DPACKAGE_BUGREPORT=\"info@micro-
       manager.org\" -DPACKAGE_URL=\"\" -DPACKAGE=\"micro-manager\" -
        DVERSION=\"1.4\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -
        DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -
        DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -
        DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" 
        -DHAVE_BOOST=/\*\*/ -DHAVE_BOOST_THREAD=/\*\*/ -DHAVE_BOOST_ASIO=/\*\*/ -
        DHAVE_BOOST_SYSTEM=/\*\*/ -DHAVE_BOOST_CHRONO=/\*\*/ -
        DHAVE_BOOST_DATE_TIME=/\*\*/ -DHAVE__BOOL=1 -DHAVE_STDBOOL_H=1 -
        DSTDC_HEADERS=1 -DHAVE_MEMSET=1 -I.  -I/usr/include/libusb-1.0  -
         I/home/igem/Downloads/mm/micro-manager/DeviceAdapters/../MMDevice -pthread -
         I/usr/include  -g -O2 -MT USBManager.lo -MD -MP -MF .deps/USBManager.Tpo -c -o 
         USBManager.lo USBManager.cpp
         libtool: compile:  clang++ -DPACKAGE_NAME=\"Micro-Manager\" -
         DPACKAGE_TARNAME=\"micro-manager\" -DPACKAGE_VERSION=\"1.4\" "-
         DPACKAGE_STRING=\"Micro-Manager 1.4\"" -DPACKAGE_BUGREPORT=\"info@micro-
         manager.org\" -DPACKAGE_URL=\"\" -DPACKAGE=\"micro-manager\" -
         DVERSION=\"1.4\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -
         DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -
         DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -
         DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -
         DLT_OBJDIR=\".libs/\" "-DHAVE_BOOST=/**/" "-DHAVE_BOOST_THREAD=/**/" "-
         DHAVE_BOOST_ASIO=/**/" "-DHAVE_BOOST_SYSTEM=/**/" "-
         DHAVE_BOOST_CHRONO=/**/" "-DHAVE_BOOST_DATE_TIME=/**/" -DHAVE__BOOL=1 -
         DHAVE_STDBOOL_H=1 -DSTDC_HEADERS=1 -DHAVE_MEMSET=1 -I. -
         I/usr/include/libusb-1.0 -I/home/igem/Downloads/mm/micro-
         manager/DeviceAdapters/../MMDevice -pthread -I/usr/include -g -O2 -MT 
         USBManager.lo -MD -MP -MF .deps/USBManager.Tpo -c USBManager.cpp  -fPIC -DPIC -o 
         .libs/USBManager.o
         USBManager.cpp:284:34: error: ordered comparison between pointer and zero 
         ('usb_dev_handle *' and 'int')
                          if (deviceHandle_ <= 0)
                       ~~~~~~~~~~~~~ ^  ~
        1 error generated.
        make[2]: *** [Makefile:524: USBManager.lo] Error 1
        make[2]: Leaving directory '/home/igem/Downloads/mm/micro-
        manager/DeviceAdapters/USBManager'
        make[1]: *** [Makefile:615: all-recursive] Error 1
        make[1]: Leaving directory '/home/igem/Downloads/mm/micro-
        manager/DeviceAdapters'
        make: *** [Makefile:518: all-recursive] Error 1