### PR TITLE
Coherent Scientific Remote adapter update

### DIFF
--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.cpp
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.cpp
@@ -3,7 +3,8 @@
 // PROJECT:       Micro-Manager
 // SUBSYSTEM:     DeviceAdapters
 //-----------------------------------------------------------------------------
-// DESCRIPTION:   Coherent Scientific Remote controller adapter for up to 6 Coherent Obis lasers
+// DESCRIPTION:   Coherent Scientific Remote laser controller adapter 
+//			      Support for the Coherent Scientific Remote for up to 6 Coherent Obis lasers and the Single Laser Remote 
 //    
 // COPYRIGHT:     35037 Marburg, Germany
 //                Max Planck Institute for Terrestrial Microbiology, 2017 
@@ -47,7 +48,7 @@ const char* g_Keyword_PowerSetpointPercent = "PowerSetpoint (%)";
 const char* g_Keyword_PowerReadback = "PowerReadback (mW)";
 const char* g_Keyword_TriggerNum = "Shutter Laser";
 
-const char * carriage_return = "\n";
+const char * carriage_return = "\n\r";
 const char * line_feed = "\n";
 
 const char* const g_Msg_LASERS_MISSING = "Label not defined";
@@ -87,6 +88,7 @@ MODULE_API void DeleteDevice(MM::Device* pDevice)
 CoherentScientificRemote::CoherentScientificRemote(const char* name) :
    initialized_(false), 
    state_(0),
+   descriptionToken_("*IDN"),
    modulation_("Extern-Digital"),
    name_(name), 
    error_(0),
@@ -128,8 +130,10 @@ CoherentScientificRemote::CoherentScientificRemote(const char* name) :
    // ------------------------------------
 
    // Description
-   CreateProperty(MM::g_Keyword_Description, g_ControllerName, MM::String, true);
-   
+   //CreateProperty(MM::g_Keyword_Description, g_ControllerName, MM::String, true);
+   //CPropertyAction* pAct = new CPropertyAction (this, &CoherentScientificRemote::OnRemoteDescription);
+   //CreateProperty(MM::g_Keyword_Description, g_ControllerName, MM::String, true, pAct);
+
    // Port
    CPropertyAction* pAct = new CPropertyAction (this, &CoherentScientificRemote::OnPort);
    CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
@@ -185,8 +189,12 @@ int CoherentScientificRemote::Initialize()
 	   error_ = ERR_DEVICE_NOT_FOUND;
 	   return HandleErrors();
    }
+   
+   CPropertyAction* pAct = new CPropertyAction (this, &CoherentScientificRemote::OnRemoteDescription);
+   CreateProperty(MM::g_Keyword_Description, g_ControllerName, MM::String, true, pAct);
+   
    // Add selector for trigger
-   CPropertyAction* pAct = new CPropertyAction(this, &CoherentScientificRemote::OnTriggerNum);
+   pAct = new CPropertyAction(this, &CoherentScientificRemote::OnTriggerNum);
    CreateProperty(g_Keyword_TriggerNum, "None", MM::String, false, pAct);
 
    //Initialize laser
@@ -354,7 +362,7 @@ int CoherentScientificRemote::OnPort(MM::PropertyBase* pProp, MM::ActionType eAc
    return HandleErrors();
 }
 
-int CoherentScientificRemote::OnLaserPort(MM::PropertyBase* /* pProp */, MM::ActionType /* eAct */, long /* laserNum */)
+int CoherentScientificRemote::OnLaserPort(MM::PropertyBase* pProp, MM::ActionType eAct, long laserNum)
 {
    return HandleErrors();
 }
@@ -517,6 +525,19 @@ int CoherentScientificRemote::OnHeadID(MM::PropertyBase* pProp, MM::ActionType e
    if (eAct == MM::BeforeGet)
    {
       pProp->Set((this->queryLaser(replaceLaserNum(headSerialNoToken_, laserNum).c_str())).c_str());
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      // never do anything!!
+   }
+   return HandleErrors();
+}
+
+int CoherentScientificRemote::OnRemoteDescription(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set((this->queryLaser(descriptionToken_)).c_str());
    }
    else if (eAct == MM::AfterSet)
    {

--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.h
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.h
@@ -96,6 +96,7 @@ public:
    
    // action interface
    // ----------------
+   int OnRemoteDescription(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnPort(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnTriggerNum(MM::PropertyBase* pProp, MM::ActionType eAct);
 
@@ -131,6 +132,7 @@ private:
    std::string modulation_;
 
    std::string queryToken_;
+   std::string descriptionToken_;
    std::string powerSetpointToken_;
    std::string powerReadbackToken_;
    std::string CDRHToken_;  // if this is on, laser delays 5 SEC before turning on


### PR DESCRIPTION
- added support for the Single Laser Remote
(https://www.coherent.com/lasers/laser/optoskand-beam-delivery-components/obis-single-laser-remote)
- existing device adapter "CoherentOBIS" may now be considered to be
obsolete