### PR TITLE
Reload available serial ports each time DeviceSetupDlg is shown

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
@@ -269,6 +269,7 @@ public final class DeviceSetupDlg extends MMDialog {
 
       // setup com ports
       ArrayList<Device> ports = new ArrayList<Device>();
+      model_.rescanSerialPorts(core_);
       Device avPorts[] = model_.getAvailableSerialPorts();
       for(int i=0; i<avPorts.length; i++) {
 //         if (!model_.isPortInUse(avPorts[i]))
@@ -361,8 +362,8 @@ public final class DeviceSetupDlg extends MMDialog {
       Iterator<String> lp = loadedPorts.iterator();
       boolean loaded = false;
       while (lp.hasNext()) {
-         lp.next().compareTo(portName);
-         loaded = true;
+         if (lp.next().compareTo(portName) == 0)
+            loaded = true;
       }
       if (!loaded) {
          try {


### PR DESCRIPTION
This is a first attempt to fix the shortcomings of the current handling of serial ports I've described [here](https://sourceforge.net/p/micro-manager/mailman/message/36088954/).

### What is fixed
The issue is that serial ports were originally designed to handle COM ports only but have since been (ab)used to handle other types of ports. In my specific case of a serial-over-TCP/IP port (I plan to make a separate PR for this once it's finished), I need a way to dynamically add new ports should all the current ones be in use at the moment.

### How is it done
This PR makes it so that each time the Device setup dialog is shown, the libraries are rescanned for new serial ports.

### Testing
I have tested this with my TCP/IP port which simply registers a new port (with incrementing index) each time the currently last port is initialized and it works as expected, always providing a new one when the last one is actually used for a device.

### Closing remarks
This might not be the best way to achieve the desired result, but it only requires localized changes and I thought I'd provide one possible solution before discussing any further.
