### PR TITLE
Video4Linux: also use colors and output RGBA32

### DIFF
--- a/DeviceAdapters/Video4Linux/video4linux2.cpp
+++ b/DeviceAdapters/Video4Linux/video4linux2.cpp
@@ -173,8 +173,12 @@ VideoInit(State*state)
 
   if(-1==state->fd)
     {
-    LogMessage("v4l2: ould not open the video device");
+    LogMessage("v4l2: could not open the video device");
     return false;
+    }
+  else
+    {
+    LogMessage("v4l2: opened device");
     }
 
   sleep(3); // let it settle; there is probably an ioctl for this
@@ -248,6 +252,10 @@ VideoInit(State*state)
     LogMessage("v4l2: could not initialize stream");
     return false;
     }
+  else
+    {
+    LogMessage("v4l2: initialized data stream");
+    }
   return true;
 }
 
@@ -286,6 +294,7 @@ VideoInit(State*state)
   {
     if(initialized_)
       return DEVICE_OK;
+    LogMessage("v4l2: initializing device driver");
     CreateProperty(MM::g_Keyword_Name,gName,
 		   MM::String, true);
     CreateProperty(MM::g_Keyword_Description, gDescription,
@@ -315,6 +324,7 @@ VideoInit(State*state)
     assert(nRet == DEVICE_OK);
     
     image = (unsigned char*) malloc(state->W*state->H*4);
+    LogMessage("v4l2: calling video init");
     if(VideoInit(state))
       {
       initialized_=true;
@@ -356,6 +366,7 @@ VideoInit(State*state)
   // blocks until exposure is finished
   int SnapImage()
   {
+    LogMessage("v4l2: snap immage called");
     unsigned char* data = VideoTakeBuffer(state);
   
     /* Convert YUYV to RGBA32, apparently mm does only display colors
@@ -384,6 +395,7 @@ VideoInit(State*state)
     }
   
     VideoReturnBuffer(state);
+    LogMessage("v4l2: snap immage returning data");
     return DEVICE_OK;
   }
 

--- a/DeviceAdapters/WieneckeSinske/CAN29.cpp
+++ b/DeviceAdapters/WieneckeSinske/CAN29.cpp
@@ -29,6 +29,8 @@
 #ifdef WIN32
 #include <windows.h>
 #define snprintf _snprintf 
+#elif __linux__
+#include <arpa/inet.h>
 #endif
 
 #include "CAN29.h"

--- a/DeviceAdapters/WieneckeSinske/WieneckeSinske.cpp
+++ b/DeviceAdapters/WieneckeSinske/WieneckeSinske.cpp
@@ -30,6 +30,8 @@
 #ifdef WIN32
 #include <windows.h>
 #define snprintf _snprintf 
+#elif __linux__
+#include <arpa/inet.h>
 #endif
 
 #include "WieneckeSinske.h"


### PR DESCRIPTION
Hi,

I was trying to get my cheap usb microscope running on linux and was wondering why only grayscale display was working.
Digging into the code it seemed like the correct input format was used but only the luma values were copied into the output image. [line 354](https://github.com/micro-manager/micro-manager/compare/mm2...dedeibel:feature/video4linux2_with_color?expand=1#diff-1c7389b8b9b38ea61f702c3342af5b44L354)

I did not reduce any compatibility with this since the input parameters are unchanged. So I consider the risk pretty low.

Maybe you want to integrate this, seems like the v4l2 Adapter is not the most popular anyway. If not maybe this serves as a solution for others to find my branch.

_(Looking into other drivers it seems like mm does handle RGBA32 output the best – had figure this out in a trial an error way and convert the input. Is this documented somewhere? I could not find it here [wiki/Building_Micro-Manager_Device_Adapters](https://micro-manager.org/wiki/Building_Micro-Manager_Device_Adapters), might save people writing adapters some time.)_

Thank you, Ben