### PR TITLE
Leica driver fixes

### DIFF
--- a/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
@@ -3048,9 +3048,17 @@ int AFC::GetCurrentFocusScore(double& score){
    return ret;
 }
 bool AFC::IsContinuousFocusLocked() {
+   int topColor, bottomColor;
    int ret;
-
-   double score;
+   ret = g_ScopeModel.afc_.GetLEDColors(topColor, bottomColor);
+   if (ret != DEVICE_OK)
+      return false;
+   if (bottomColor == 2 /* green */) {
+       return true;
+    } else {
+       return false;
+   }
+  /* double score;
    ret = GetCurrentFocusScore(score);
    if (ret != DEVICE_OK)
       return false;
@@ -3061,7 +3069,7 @@ bool AFC::IsContinuousFocusLocked() {
    else{
 	   return false;
    }
-
+*/
 }
 
 int AFC::FullFocus() {

--- a/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
@@ -2998,7 +2998,7 @@ int AFC::Initialize()
   
    pAct = new CPropertyAction(this, &AFC::OnLEDIntensity);
    ret = CreateProperty("LEDIntensity","200",MM::Integer,false,pAct);
-
+   SetPropertyLimits("LEDIntensity",0,255);
    initialized_ = true;
    return 0;
 }
@@ -3089,7 +3089,13 @@ int AFC::IncrementalFocus() {
    return FullFocus();
 }
 
-int AFC::GetLEDIntensity(int &intensity){
+int AFC::GetLEDIntensity(int &intensity){ 
+	int ret = g_ScopeInterface.GetAFCLEDIntensity(*this,*GetCoreCallback());
+    bool busy = true;
+    while (busy) {
+		g_ScopeModel.afc_.GetBusy(busy);
+		CDeviceUtils::SleepMs(10);
+    }
 	return g_ScopeModel.afc_.GetLEDIntensity(intensity);
 }
 
@@ -3167,7 +3173,7 @@ int AFC::OnLockThreshold(MM::PropertyBase* pProp, MM::ActionType eAct)
 
 int AFC::OnLEDIntensity(MM::PropertyBase* pProp,MM::ActionType eAct)
 {
-     if (eAct == MM::BeforeGet)
+   if (eAct == MM::BeforeGet)
    {
 	  int intensity;
 	  int ret = GetLEDIntensity(intensity);
@@ -3179,9 +3185,8 @@ int AFC::OnLEDIntensity(MM::PropertyBase* pProp,MM::ActionType eAct)
    else if (eAct == MM::AfterSet)
    {
       
-      pProp->Get(lockThreshold_);
-	 
-      return DEVICE_OK;
+      pProp->Get(LEDIntensity_);
+	  return SetLEDIntensity((int) LEDIntensity_);
    }
 
    return DEVICE_OK;

--- a/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
@@ -213,11 +213,6 @@ LeicaScope::~LeicaScope()
 }
 
 
-bool LeicaScope::SupportsDeviceDetection(void)
-{
-   return true;
-}
-
 MM::DeviceDetectionStatus LeicaScope::DetectDevice()
 {
    MM::Device* pS = GetCoreCallback()->GetDevice(this, g_ScopeInterface.port_.c_str());
@@ -1412,6 +1407,7 @@ ZDrive::~ZDrive()
 bool ZDrive::Busy()
 {
    bool busy;
+   //g_scopeInterface.
    int ret = g_ScopeModel.ZDrive_.GetBusy(busy);
    if (ret != DEVICE_OK)  // This is bad and should not happen
       return false;
@@ -2933,7 +2929,8 @@ AFC::AFC() :
    initialized_(false),    
    name_(g_LeicaAFC),
    timeOut_(5000),
-   fullFocusTime_(300)
+   fullFocusTime_(300),
+   lockThreshold_(3)
 {
 
    // create pre-initialization properties
@@ -2944,6 +2941,7 @@ AFC::AFC() :
    
    // Description                                                            
    CreateProperty(MM::g_Keyword_Description, "Leica Adaptive Focus Control (Hardware autofocus)", MM::String, true);
+ 
    
 }
 
@@ -2994,8 +2992,12 @@ int AFC::Initialize()
 
    pAct = new CPropertyAction(this, &AFC::OnOffset);
    ret = CreateProperty("Offset", "0.0", MM::Float, false, pAct);
-   if (ret != DEVICE_OK)
-      return ret;
+
+   pAct = new CPropertyAction(this, &AFC::OnLockThreshold);
+   ret = CreateProperty("LockThreshold","1.0",MM::Float,false,pAct);
+  
+   pAct = new CPropertyAction(this, &AFC::OnLEDIntensity);
+   ret = CreateProperty("LEDIntensity","200",MM::Integer,false,pAct);
 
    initialized_ = true;
    return 0;
@@ -3029,18 +3031,37 @@ int AFC::GetContinuousFocusing(bool& state) {
    return g_ScopeModel.afc_.GetMode(state);
 }
 
-bool AFC::IsContinuousFocusLocked() {
-   int topColor, bottomColor;
+int AFC::GetCurrentFocusScore(double& score){
+   //std::ostringstream command;
+   //std::string answer;
+   
    int ret;
-   ret = g_ScopeModel.afc_.GetLEDColors(topColor, bottomColor);
+   ret = g_ScopeInterface.GetAFCFocusScore(*this,*GetCoreCallback());
+   bool busy = true;
+   while (busy) {
+		g_ScopeModel.afc_.GetBusy(busy);
+		CDeviceUtils::SleepMs(10);
+   }
+   ret = g_ScopeModel.afc_.GetScore(score);
+   if (ret != DEVICE_OK)
+     return ret;
+   return ret;
+}
+bool AFC::IsContinuousFocusLocked() {
+   int ret;
+
+   double score;
+   ret = GetCurrentFocusScore(score);
    if (ret != DEVICE_OK)
       return false;
-   
-   if (bottomColor == 2 /* green */) {
-      return true;
-   } else {
-      return false;
+
+   if (abs(score)<lockThreshold_){
+	   return true;
    }
+   else{
+	   return false;
+   }
+
 }
 
 int AFC::FullFocus() {
@@ -3068,6 +3089,14 @@ int AFC::IncrementalFocus() {
    return FullFocus();
 }
 
+int AFC::GetLEDIntensity(int &intensity){
+	return g_ScopeModel.afc_.GetLEDIntensity(intensity);
+}
+
+int AFC::SetLEDIntensity(int intensity){
+	return g_ScopeInterface.SetAFCLEDIntensity(*this, *GetCoreCallback(),intensity);
+}
+
 int AFC::GetOffset(double &offset) {
    return g_ScopeModel.afc_.GetOffset(offset);
 }
@@ -3075,7 +3104,12 @@ int AFC::GetOffset(double &offset) {
 int AFC::SetOffset(double offset) {
    return g_ScopeInterface.SetAFCOffset(*this, *GetCoreCallback(), offset);;
 }
-
+//int AFC::GetLockThreshold(double &threshold){
+//	return g_ScopeModel.afc_.GetThreshold(threshold);
+//}
+//int AFC::SetLockThreshold(double threshold){
+//	return g_ScopeModel.afc_.SetThreshold(threshold);
+//}
 ///////////////////////////////////////////////////////////////////////////////
 // Action handlers
 ///////////////////////////////////////////////////////////////////////////////
@@ -3111,6 +3145,47 @@ int AFC::OnFullFocusTime(MM::PropertyBase* pProp, MM::ActionType eAct)
       return DEVICE_OK;
    }
    return DEVICE_OK;
+}
+
+int AFC::OnLockThreshold(MM::PropertyBase* pProp, MM::ActionType eAct)
+{
+   if (eAct == MM::BeforeGet)
+   {
+      pProp->Set(lockThreshold_);
+	
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      
+      pProp->Get(lockThreshold_);
+	 
+      return DEVICE_OK;
+   }
+
+   return DEVICE_OK;
+}
+
+int AFC::OnLEDIntensity(MM::PropertyBase* pProp,MM::ActionType eAct)
+{
+     if (eAct == MM::BeforeGet)
+   {
+	  int intensity;
+	  int ret = GetLEDIntensity(intensity);
+      if (ret != DEVICE_OK)
+         return ret;
+      pProp->Set((long) intensity);
+	
+   }
+   else if (eAct == MM::AfterSet)
+   {
+      
+      pProp->Get(lockThreshold_);
+	 
+      return DEVICE_OK;
+   }
+
+   return DEVICE_OK;
+
 }
 
 int AFC::OnOffset(MM::PropertyBase* pProp, MM::ActionType eAct)

--- a/DeviceAdapters/LeicaDMI/LeicaDMI.h
+++ b/DeviceAdapters/LeicaDMI/LeicaDMI.h
@@ -51,7 +51,6 @@ class LeicaScope : public HubBase<LeicaScope>
       int Shutdown();
       void GetName(char* pszName) const;
       bool Busy();
-      bool SupportsDeviceDetection(void);
       MM::DeviceDetectionStatus DetectDevice();
 
       // HUB interface
@@ -498,20 +497,25 @@ public:
    int FullFocus();
    int IncrementalFocus();
    int GetLastFocusScore(double& /*score*/) {return DEVICE_UNSUPPORTED_COMMAND;}
-   int GetCurrentFocusScore(double& score) {score = 0.0; return DEVICE_OK;}
+   int GetCurrentFocusScore(double& score);
    int GetOffset(double &offset);
    int SetOffset(double offset);
+   int GetLEDIntensity(int &intensity);
+   int SetLEDIntensity(int intensity);
 
    //Action Handlers
    int OnDichroicMirrorPosition(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnFullFocusTime(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnOffset(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnLockThreshold(MM::PropertyBase* pProp,  MM::ActionType eAct);
+   int OnLEDIntensity(MM::PropertyBase* pProp,  MM::ActionType eAct);
 
-private:
    bool initialized_;
    std::string name_;
    long timeOut_;
    long fullFocusTime_;
+   double lockThreshold_;
+   int LEDIntensity;
 };
 
 class AFCOffset : public CStageBase<AFCOffset>

--- a/DeviceAdapters/LeicaDMI/LeicaDMI.h
+++ b/DeviceAdapters/LeicaDMI/LeicaDMI.h
@@ -515,7 +515,7 @@ public:
    long timeOut_;
    long fullFocusTime_;
    double lockThreshold_;
-   int LEDIntensity;
+   long LEDIntensity_;
 };
 
 class AFCOffset : public CStageBase<AFCOffset>

--- a/DeviceAdapters/LeicaDMI/LeicaDMIModel.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIModel.cpp
@@ -311,6 +311,19 @@ LeicaAFCModel::LeicaAFCModel() :
    offset_(0.0)
 {
 }
+int LeicaAFCModel::GetEdgePosition(double& edgeposition)
+{
+   MMThreadGuard guard(mutex_);
+   edgeposition = edgeposition_;
+   return DEVICE_OK;
+}
+
+int LeicaAFCModel::SetEdgePosition(double edgeposition)
+{
+   MMThreadGuard guard(mutex_);
+   edgeposition_ = edgeposition;
+   return DEVICE_OK;
+}
 
 int LeicaAFCModel::GetOffset(double& offset)
 {
@@ -339,7 +352,18 @@ int LeicaAFCModel::SetMode(bool on)
    mode_ = on;
    return DEVICE_OK;
 }
-
+int LeicaAFCModel::GetScore(double &score)
+{
+   MMThreadGuard guard(mutex_);
+   score = score_;
+   return DEVICE_OK;
+}
+int LeicaAFCModel::SetScore(double score)
+{
+   MMThreadGuard guard(mutex_);
+   score_ = score;
+   return DEVICE_OK;
+}
 int LeicaAFCModel::GetLEDColors(int& topColor, int& bottomColor)
 {
    MMThreadGuard guard(mutex_);
@@ -355,7 +379,18 @@ int LeicaAFCModel::SetLEDColors(int topColor, int bottomColor)
    bottomLEDColor_ = bottomColor;
    return DEVICE_OK;
 }
-
+int LeicaAFCModel::GetLEDIntensity(int &LEDintensity)
+{
+	MMThreadGuard guard(mutex_);
+   LEDintensity = LEDintensity_;
+   return DEVICE_OK;
+}
+int LeicaAFCModel::SetLEDIntensity(int LEDintensity)
+{
+   MMThreadGuard guard(mutex_);
+   LEDintensity_ = LEDintensity;
+   return DEVICE_OK;
+}
 /*
  * Class that keeps a model of the state of the Leica DMI microscope
  */

--- a/DeviceAdapters/LeicaDMI/LeicaDMIModel.h
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIModel.h
@@ -259,17 +259,26 @@ class LeicaAFCModel : public LeicaDeviceModel
 public:
    LeicaAFCModel();
 
-   int GetOffset(double& mag); // Set point
-   int SetOffset(double mag);  // Measured value
+   int GetOffset(double& offset); // Set point
+   int SetOffset(double offset);  // Measured value
    int GetMode(bool& mode);
    int SetMode(bool mode);
+   int GetScore(double& score);
+   int SetScore(double score);
+   int GetEdgePosition(double& edgeposition);
+   int SetEdgePosition(double edgeposition);
    int GetLEDColors(int& topColor, int& bottomColor);
    int SetLEDColors(int topColor, int bottomColor);
+   int GetLEDIntensity(int& LEDintensity);
+   int SetLEDIntensity(int LEDintensity);
 private:
+   double edgeposition_;
    double offset_;
+   double score_;
    bool mode_;
    int topLEDColor_;
    int bottomLEDColor_;
+   int LEDintensity_;
 };
 
 

--- a/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.cpp
@@ -2081,11 +2081,22 @@ int LeicaScopeInterface::SetAFCMode(MM::Device &device, MM::Core &core, bool on)
 int LeicaScopeInterface::SetAFCOffset(MM::Device &device, MM::Core &core, double offset)
 {
    std::stringstream os;
+   if (offset==-1){
+	    scopeModel_->afc_.SetBusy(true);
+	    os << g_AFC << "022";
+	int ret = core.SetSerialCommand(&device, port_.c_str(), os.str().c_str(), "\r");
+	if(ret != DEVICE_OK)
+		return ret;	
+	return DEVICE_OK;
+   }
+   else{
+
    os << g_AFC << "024" << " " << offset;
 	int ret = core.SetSerialCommand(&device, port_.c_str(), os.str().c_str(), "\r");
 	if(ret != DEVICE_OK)
 		return ret;	
 	return DEVICE_OK;
+   }
 }
 
 /**
@@ -2786,6 +2797,9 @@ int LeicaMonitoringThread::svc()
                         scopeModel_->afc_.SetBusy(false);
                         break;
                      }
+					 case (22) :  //set AFC offset to here
+						scopeModel_->afc_.SetBusy(false);
+                        break;
                      case (23) : // Current edge position value
                      {
                         double edgeposition;

--- a/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.cpp
@@ -227,6 +227,16 @@ int LeicaScopeInterface::Initialize(MM::Device& device, MM::Core& core)
       command.str("");
    }
 
+   // Suppress event reporting for Fast Filter Wheel
+   if (scopeModel_->IsDeviceAvailable(g_Fast_Filter_Wheel)) {
+      command << g_Fast_Filter_Wheel << "003 0 0";
+      ret = GetAnswer(device, core, command.str().c_str(), answer);
+      if (ret != DEVICE_OK)
+         return ret;
+      command.str("");
+   }
+
+
    CDeviceUtils::SleepMs(100);
 
    if (scopeModel_->IsDeviceAvailable(g_Lamp)) {
@@ -460,6 +470,14 @@ int LeicaScopeInterface::Initialize(MM::Device& device, MM::Core& core)
       command.str("");
    }
 
+   // Start event reporting for Fast Filter Wheel
+   if (scopeModel_->IsDeviceAvailable(g_Fast_Filter_Wheel)) {
+      command << g_Fast_Filter_Wheel << "003 1 0";
+      ret = GetAnswer(device, core, command.str().c_str(), answer);
+      if (ret != DEVICE_OK)
+         return ret;
+      command.str("");
+   }
 
 
    // Start monitoring of all messages coming from the microscope
@@ -2383,18 +2401,22 @@ int LeicaMonitoringThread::svc()
                    break;
                case (g_Fast_Filter_Wheel) :
                   {
-                   int filterID_raw;
-                   os >> filterID_raw;
-                   int filterID = filterID_raw - 1;
+                   
                    switch (commandId) {
                       case (22) : // Position set response
-                         {
-                            int pos;
-                            os >> pos;
-                            scopeModel_->FastFilterWheel_[filterID].SetPosition(pos);
-                            scopeModel_->FastFilterWheel_[filterID].SetBusy(false);
-                         }
+						 scopeModel_->FastFilterWheel_[0].SetBusy(false);
                          break;
+					  case (23) : // Position get response
+						  {
+							  int filterID_raw;
+			                  os >> filterID_raw;
+						      int filterID = filterID_raw - 1;
+							  int pos;
+							  os >> pos;
+							  scopeModel_->FastFilterWheel_[filterID].SetBusy(false);
+                              scopeModel_->FastFilterWheel_[filterID].SetPosition(pos);
+						  }
+
                    }
                   }
                    break;

--- a/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.h
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.h
@@ -56,7 +56,10 @@ class LeicaScopeInterface
       // Utility function
       int GetAnswer(MM::Device& device, MM::Core& core, const char* command, std::string& answer);
       int GetStandInfo(MM::Device& device, MM::Core& core);
-	   int GetDevicesPresent(MM::Device& device, MM::Core& core);
+	  int GetAFCFocusScore(MM::Device& device, MM::Core& core);
+	  int GetAFCMode(MM::Device& device, MM::Core& core);
+	  int GetAFCLEDIntensity(MM::Device& device, MM::Core& core);
+	  int GetDevicesPresent(MM::Device& device, MM::Core& core);
       int GetILTurretInfo(MM::Device& device, MM::Core& core);
       int GetCondensorInfo(MM::Device& device, MM::Core& core);
       int GetRevolverInfo(MM::Device& device, MM::Core& core);
@@ -68,9 +71,9 @@ class LeicaScopeInterface
       int GetFastFilterWheelInfo(MM::Device& device, MM::Core& core);
       int GetMagChangerInfo(MM::Device& device, MM::Core& core);
       int GetDriveParameters(MM::Device& device, MM::Core& core, int deviceID);
-	   int GetTransmittedLightState(MM::Device& device, MM::Core& core, int & position);
+	  int GetTransmittedLightState(MM::Device& device, MM::Core& core, int & position);
       int GetTransmittedLightManual(MM::Device& device, MM::Core& core, int & position);
-	   int GetTransmittedLightShutterPosition(MM::Device& device, MM::Core& core, int & position);
+	  int GetTransmittedLightShutterPosition(MM::Device& device, MM::Core& core, int & position);
 
 		int GetSidePortInfo(MM::Device& device, MM::Core& core);
 
@@ -94,13 +97,14 @@ class LeicaScopeInterface
       int SetTLPolarizerPosition(MM::Device& device, MM::Core& core, int position);
       int SetDICPrismTurretPosition(MM::Device& device, MM::Core& core, int position);
       int SetDICPrismFinePosition(MM::Device& device, MM::Core& core, int position);
-	   int SetTransmittedLightState(MM::Device& device, MM::Core& core, int position);
+	  int SetTransmittedLightState(MM::Device& device, MM::Core& core, int position);
       int SetTransmittedLightManual(MM::Device& device, MM::Core& core, int position);
-	   int SetTransmittedLightShutterPosition(MM::Device& device, MM::Core& core, int position);
+	  int SetTransmittedLightShutterPosition(MM::Device& device, MM::Core& core, int position);
       int SetAFCMode(MM::Device& device, MM::Core& core, bool on);
       int SetAFCOffset(MM::Device &device, MM::Core &core, double offset);
       int SetAFCDichroicMirrorPosition(MM::Device &device, MM::Core &core, int position);
-		int SetSidePortPosition(MM::Device& device, MM::Core& core, int position);
+	  int SetAFCLEDIntensity(MM::Device &device, MM::Core &core, int intensity);
+	  int SetSidePortPosition(MM::Device& device, MM::Core& core, int position);
 
       bool portInitialized_;
       LeicaMonitoringThread* monitoringThread_;


### PR DESCRIPTION
This makes a number of changes to the Leica driver that fixes issue with the AFC, and the fast filter wheel which we are using at the Allen Institute with our DMI-8 systems.  This will make the fast filter wheel work if it in the only one installed on the system.  Command 22 the the fast filter wheel can't properly set the busy flag of the device to not busy because the response does not indicate which filter wheel was told to change position.  This is a flaw in the Leica API, I'm complaining to Leica, but this at least works for 1 filter wheel systems, where the old driver wouldn't work at all.