### PR TITLE
ASIStage: Allow clearing of buffer values

### DIFF
--- a/DeviceAdapters/ASIStage/ASIStage.cpp
+++ b/DeviceAdapters/ASIStage/ASIStage.cpp
@@ -2664,10 +2664,6 @@ int ZStage::SendStageSequence()
 
 int ZStage::ClearStageSequence()
 {
-   if (runningFastSequence_)
-   {
-      return DEVICE_OK;
-   }
 
    sequence_.clear();
 


### PR DESCRIPTION
Remove the check on runningFastSequence_ in ZStage::ClearStageSequence().  loadStageSequence would append new sequence positions instead of replacing them.