### PR TITLE
Opencvgrabber device enumeration camera choice by name

### DIFF
--- a/DeviceAdapters/OpenCVgrabber/DeviceEnumerator.cpp
+++ b/DeviceAdapters/OpenCVgrabber/DeviceEnumerator.cpp
@@ -1,0 +1,121 @@
+#include "DeviceEnumerator.h"
+
+std::map<int, OpenCVDevice> DeviceEnumerator::getVideoDevicesMap() {
+	return getDevicesMap(CLSID_VideoInputDeviceCategory);
+}
+
+std::map<int, OpenCVDevice> DeviceEnumerator::getAudioDevicesMap() {
+	return getDevicesMap(CLSID_AudioInputDeviceCategory);
+}
+
+// Returns a map of id and devices that can be used
+std::map<int, OpenCVDevice> DeviceEnumerator::getDevicesMap(const GUID deviceClass)
+{
+	std::map<int, OpenCVDevice> deviceMap;
+
+	HRESULT hr = CoInitialize(nullptr);
+	if (FAILED(hr)) {
+		return deviceMap; // Empty deviceMap as an error
+	}
+
+	// Create the System Device Enumerator
+	ICreateDevEnum *pDevEnum;
+	hr = CoCreateInstance(CLSID_SystemDeviceEnum, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pDevEnum));
+
+	// If succeeded, create an enumerator for the category
+	IEnumMoniker *pEnum = NULL;
+	if (SUCCEEDED(hr)) {
+		hr = pDevEnum->CreateClassEnumerator(deviceClass, &pEnum, 0);
+		if (hr == S_FALSE) {
+			hr = VFW_E_NOT_FOUND;
+		}
+		pDevEnum->Release();
+	}
+
+	// Now we check if the enumerator creation succeeded
+	int deviceId = -1;
+	if (SUCCEEDED(hr)) {
+		// Fill the map with id and friendly device name
+		IMoniker *pMoniker = NULL;
+		while (pEnum->Next(1, &pMoniker, NULL) == S_OK) {
+
+			IPropertyBag *pPropBag;
+			HRESULT hr = pMoniker->BindToStorage(0, 0, IID_PPV_ARGS(&pPropBag));
+			if (FAILED(hr)) {
+				pMoniker->Release();
+				continue;
+			}
+
+			// Create variant to hold data
+			VARIANT var;
+			VariantInit(&var);
+
+			std::string deviceName;
+			std::string devicePath;
+
+			// Read FriendlyName or Description
+			hr = pPropBag->Read(L"Description", &var, 0); // Read description
+			if (FAILED(hr)) {
+				// If description fails, try with the friendly name
+				hr = pPropBag->Read(L"FriendlyName", &var, 0);
+			}
+			// If still fails, continue with next device
+			if (FAILED(hr)) {
+				VariantClear(&var);
+				continue;
+			}
+			// Convert to string
+			else {
+				deviceName = ConvertBSTRToMBS(var.bstrVal);
+			}
+
+			VariantClear(&var); // We clean the variable in order to read the next value
+
+								// We try to read the DevicePath
+			hr = pPropBag->Read(L"DevicePath", &var, 0);
+			if (FAILED(hr)) {
+				VariantClear(&var);
+				continue; // If it fails we continue with next device
+			}
+			else {
+				devicePath = ConvertBSTRToMBS(var.bstrVal);
+			}
+
+			// We populate the map
+			deviceId++;
+			OpenCVDevice currentDevice;
+			currentDevice.id = deviceId;
+			currentDevice.deviceName = deviceName;
+			currentDevice.devicePath = devicePath;
+			deviceMap[deviceId] = currentDevice;
+
+		}
+		pEnum->Release();
+	}
+	CoUninitialize();
+	return deviceMap;
+}
+
+/*
+This two methods were taken from
+https://stackoverflow.com/questions/6284524/bstr-to-stdstring-stdwstring-and-vice-versa
+*/
+
+std::string DeviceEnumerator::ConvertBSTRToMBS(BSTR bstr)
+{
+	int wslen = ::SysStringLen(bstr);
+	return ConvertWCSToMBS((wchar_t*)bstr, wslen);
+}
+
+std::string DeviceEnumerator::ConvertWCSToMBS(const wchar_t* pstr, long wslen)
+{
+	int len = ::WideCharToMultiByte(CP_ACP, 0, pstr, wslen, NULL, 0, NULL, NULL);
+
+	std::string dblstr(len, '\0');
+	len = ::WideCharToMultiByte(CP_ACP, 0 /* no flags */,
+		pstr, wslen /* not necessary NULL-terminated */,
+		&dblstr[0], len,
+		NULL, NULL /* no default char */);
+
+	return dblstr;
+}

--- a/DeviceAdapters/OpenCVgrabber/DeviceEnumerator.h
+++ b/DeviceAdapters/OpenCVgrabber/DeviceEnumerator.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Windows.h>
+#include <dshow.h>
+
+#pragma comment(lib, "strmiids")
+
+#include <map>
+#include <string>
+
+struct OpenCVDevice {
+	int id; // This can be used to open the device in OpenCV
+	std::string devicePath;
+	std::string deviceName; // This can be used to show the devices to the user
+};
+
+class DeviceEnumerator {
+
+public:
+
+	DeviceEnumerator() = default;
+	std::map<int, OpenCVDevice> getDevicesMap(const GUID deviceClass);
+	std::map<int, OpenCVDevice> getVideoDevicesMap();
+	std::map<int, OpenCVDevice> getAudioDevicesMap();
+
+private:
+
+	std::string ConvertBSTRToMBS(BSTR bstr);
+	std::string ConvertWCSToMBS(const wchar_t* pstr, long wslen);
+
+};

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
@@ -223,6 +223,8 @@ int COpenCVgrabber::Initialize()
    {
      return DEVICE_NOT_CONNECTED;
    }
+   // ignore first frame to make it work with more cameras
+   cvQueryFrame(capture_);
    frame_ = cvQueryFrame(capture_);
    if (!frame_)
    {

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
@@ -48,6 +48,7 @@ const double COpenCVgrabber::nominalPixelSizeUm_ = 1.0;
 // External names used used by the rest of the system
 // to load particular device from the "DemoCamera.dll" library
 const char* g_CameraDeviceName = "OpenCVgrabber";
+const char* cIDName = "Camera";
 
 // constants for naming pixel types (allowed values of the "PixelType" property)
 const char* g_PixelType_8bit = "8bit";
@@ -161,12 +162,16 @@ COpenCVgrabber::COpenCVgrabber() :
    SetErrorText(CAMERA_NOT_INITIALIZED, "Camera was not initialized");
 
    CPropertyAction* pAct = new CPropertyAction(this, &COpenCVgrabber::OnCameraID);
-   String cIDName = "Camera Number";
-   CreateProperty(cIDName.c_str(), "0", MM::Integer, false, pAct, true);
-   AddAllowedValue(cIDName.c_str(), "0");
-   AddAllowedValue(cIDName.c_str(), "1");
-   AddAllowedValue(cIDName.c_str(), "2");
-   AddAllowedValue(cIDName.c_str(), "3");
+   CreateProperty(cIDName, "Undefined", MM::String, false, pAct, true);
+
+   DeviceEnumerator de;
+   // Video Devices
+   map<int, OpenCVDevice> devices = de.getVideoDevicesMap();
+
+   for (auto const &device : devices)
+   {
+       AddAllowedValue(cIDName, device.second.deviceName.c_str(), long(device.first));
+   }
 
    readoutStartTime_ = GetCurrentMMTime();
    thd_ = new MySequenceThread(this);
@@ -218,7 +223,7 @@ int COpenCVgrabber::Initialize()
 
    // start opencv capture_ from first device, 
    // we need to initialise hardware early on to discover properties
-   capture_ = cvCaptureFromCAM(CV_CAP_ANY);
+   capture_ = cvCaptureFromCAM(cameraID_);
    if (!capture_) // do we have a capture_ device?
    {
      return DEVICE_NOT_CONNECTED;
@@ -1053,10 +1058,9 @@ int COpenCVgrabber::OnCameraID(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
    if (eAct == MM::AfterSet)
    {
-      pProp->Get(cameraID_);
-   } else if (eAct == MM::BeforeGet)
-   {
-      pProp->Set(cameraID_);
+      string srcName;
+      pProp->Get(srcName);
+      GetPropertyData(cIDName, srcName.c_str(), cameraID_);
    }
 
    return DEVICE_OK;

--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.h
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.h
@@ -34,6 +34,7 @@
 #include "../../MMDevice/DeviceBase.h"
 #include "../../MMDevice/ImgBuffer.h"
 #include "../../MMDevice/DeviceThreads.h"
+#include "DeviceEnumerator.h"
 #include <string>
 #include <map>
 #include <algorithm>


### PR DESCRIPTION
Although there seemed to be a camera number property after reviewing the code it did nothing as CV_CAP_ANY was hardcoded, and the camera number property ignored.
The following changes enumerate the detected cameras by name and initialise the correct camera.
Tested with China USB Camera x500 recognized as Lenovo EasyCamera on Windows 10.
