### PR TITLE
Opencvgrabber device enumeration master

### DIFF
--- a/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
+++ b/DeviceAdapters/OpenCVgrabber/OpenCVgrabber.cpp
@@ -168,10 +168,11 @@ COpenCVgrabber::COpenCVgrabber() :
    DeviceEnumerator de;
    // Video Devices
    map<int, OpenCVDevice> devices = de.getVideoDevicesMap();
+   map<int, OpenCVDevice>::iterator it;
 
-   for (int i = 0; i++; devices.size())
+   for ( it = devices.begin(); it != devices.end(); it++)
    {
-       AddAllowedValue(cIDName, devices.at(i).deviceName.c_str(), long(i));
+       AddAllowedValue(cIDName, it->second.deviceName.c_str(), long(it->first));
    }
 #else
    String cIDNameReally = "Camera Number";


### PR DESCRIPTION
Although there seemed to be a camera number property after reviewing the code it did nothing as CV_CAP_ANY was hardcoded, and the camera number property ignored.
The following changes enumerate the detected cameras by name and initialise the correct camera.
Tested with China USB Camera x500 recognized as Lenovo EasyCamera on Windows 10.

This version compiles against master with Windows SDK 7.1. 

PS: Could not test with downloaded version 1.4 of Micro-Manager because I get "incompatible device interface version required(required = 65; found = 68)"

Old version for 2.0beta was here https://github.com/micro-manager/micro-manager/pull/605