### PR TITLE
Support Zeiss Definite Focus 2  stabilizing position

### DIFF
--- a/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
+++ b/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
@@ -247,6 +247,8 @@ class DefiniteFocusModel
       int SetPeriod(ZeissULong period);
       int GetStatus(ZeissUShort& status);
       int SetStatus(ZeissUShort status);
+      int GetVersion(ZeissUShort& version);
+      int SetVersion(ZeissUShort version);
       int GetError(ZeissUShort& error);
       int SetError(ZeissUShort error);
       int GetDeviation(ZeissLong& deviation);
@@ -269,6 +271,7 @@ class DefiniteFocusModel
       ZeissByte controlOnOff_;
       ZeissULong period_;
       ZeissUShort status_;
+      ZeissUShort version_;
       ZeissUShort error_;
       ZeissLong deviation_;
       ZeissUByte dataLength_;
@@ -614,6 +617,7 @@ class ZeissScope : public CGenericBase<ZeissScope>
       // ----------------                                                       
       int OnPort(MM::PropertyBase* pProp, MM::ActionType eAct); 
       int OnAnswerTimeOut(MM::PropertyBase* pProp, MM::ActionType eAct); 
+      int OnVersionChange(MM::PropertyBase* pProp, MM::ActionType eAct); 
 
    private:
       bool initialized_;

--- a/DeviceAdapters/ZeissCAN29/ZeissModel.cpp
+++ b/DeviceAdapters/ZeissCAN29/ZeissModel.cpp
@@ -93,6 +93,20 @@ int DefiniteFocusModel::SetStatus(ZeissUShort status)
    return DEVICE_OK;
 } 
 
+int DefiniteFocusModel::GetVersion(ZeissUShort& version) 
+{
+   MMThreadGuard(this->dfLock_); 
+   version = version_; 
+   return DEVICE_OK;
+} 
+
+int DefiniteFocusModel::SetVersion(ZeissUShort version) 
+{
+   MMThreadGuard(this->dfLock_); 
+   version_ = version; 
+   return DEVICE_OK;
+} 
+
 int DefiniteFocusModel::GetError(ZeissUShort& error) 
 {
    MMThreadGuard(this->dfLock_); 


### PR DESCRIPTION
This commit changes the ZeissCAN29 device adapter by adding a property "DefiniteFocusVersion" (either 1 or 2) and using its value while fosussing (using the StabilizeThisPosition command) to determine the amount of data to read from the response.