### PR TITLE
implement SetRelativePositionUm() for MultiStage

### DIFF
--- a/DeviceAdapters/Utilities/Utilities.cpp
+++ b/DeviceAdapters/Utilities/Utilities.cpp
@@ -1121,6 +1121,22 @@ int MultiStage::SetPositionUm(double pos)
 }
 
 
+int MultiStage::SetRelativePositionUm(double d)
+{
+   for (unsigned i = 0; i < nrPhysicalStages_; ++i)
+   {
+      if (!physicalStages_[i])
+         continue;
+
+      double physicalRelPos = stageScalings_[i] * d;
+      int err = physicalStages_[i]->SetRelativePositionUm(physicalRelPos);
+      if (err != DEVICE_OK)
+         return err;
+   }
+   return DEVICE_OK;
+}
+
+
 int MultiStage::GetPositionUm(double& pos)
 {
    // TODO We should allow user to select which stage to use for position


### PR DESCRIPTION
I was recently wanting to move 2 linear stages together with a scale factor and I discovered that there already is a MultiStage device for doing this.  Great!

However, this MultiStage device is missing the ability to do "native" relative moves which is important to me.  The default implementation utilizes absolute moves and only knows the current position of the 1st stage and assumes that the other stages haven't been moved otherwise (which for me isn't a valid assumption).  The fix is very straightforward, invoking relative moves on all the physical stages.  I wouldn't expect any trouble unless somebody is depending on the odd behavior of the existing adapter.  If that's the case then we could add a property to determine which behavior to use.