### PR TITLE
add single axis stage to Utilities device adapter

### DIFF
--- a/DeviceAdapters/Utilities/Utilities.h
+++ b/DeviceAdapters/Utilities/Utilities.h
@@ -301,6 +301,57 @@ private:
 };
 
 
+class SingleAxisStage : public CStageBase<SingleAxisStage>
+{
+public:
+   SingleAxisStage();
+   virtual ~SingleAxisStage();
+
+public:
+   virtual void GetName(char* name) const;
+
+   virtual int Initialize();
+   virtual int Shutdown();
+
+   virtual bool Busy();
+
+   virtual int Move(double) { return DEVICE_UNSUPPORTED_COMMAND; }
+   virtual int Stop();
+   virtual int Home() { return DEVICE_UNSUPPORTED_COMMAND; }
+
+   virtual int SetPositionUm(double pos);
+   virtual int GetPositionUm(double& pos);
+   virtual int SetRelativePositionUm(double pos);
+   virtual int SetPositionSteps(long steps);
+   virtual int GetPositionSteps(long& steps);
+
+   virtual int SetOrigin() { return DEVICE_UNSUPPORTED_COMMAND; }
+
+   virtual int GetLimits(double& lower, double& upper);
+   virtual bool IsContinuousFocusDrive() const;
+
+   virtual int IsStageSequenceable(bool& isSequenceable) const;
+   virtual int GetStageSequenceMaxLength(long& nrEvents) const;
+   virtual int StartStageSequence();
+   virtual int StopStageSequence();
+   virtual int ClearStageSequence();
+   virtual int AddToStageSequence(double position);
+   virtual int SendStageSequence();
+
+private:
+   int OnAxisUsed(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnStepSize(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnPhysicalStage(MM::PropertyBase* pProp, MM::ActionType eAct);
+
+private:
+   bool useXaxis_;
+   double simulatedStepSizeUm_;
+   bool initialized_;
+   std::string usedStage_;
+   MM::XYStage* physicalStage_;
+};
+
+
 /**
  * DAMonochromator: Use DA device as monochromator
  * Also acts as a shutter (using a particular wavelength as "closed")


### PR DESCRIPTION
Allows either the X axis or Y axis of an XY stage to be used as a (1D) stage device.  The logical inverse of the ComboXYStage device.

My motivation was using one axis of an XY stage as part of a ComboStage device.  This required treating one axis of the XY stage as a single-axis stage, which is what this PR adds.  With this addition to the adapter I can do so and successfully created a ComboStage out of a linear stage and one axis of an XY stage.