### PR TITLE
Fixes SnapLiveManager.snap returning wrong image when live but suspended

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -611,7 +611,7 @@ public final class SnapLiveManager implements org.micromanager.SnapLiveManager {
     */
    @Override
    public List<Image> snap(boolean shouldDisplay) {
-      if (isLiveOn_) {
+      if (isLiveOn_ && suspendCount_ == 0) {
          // Just return the most recent images.
          ArrayList<Image> result = new ArrayList<Image>();
          ArrayList<Integer> keys = new ArrayList<Integer>(channelToLastImage_.keySet());


### PR DESCRIPTION
This fixes a potential issue I have noticed with the implementation of the `SnapLiveManager.snap(boolean)` method. Currently, the returned images are not "live" in certain cases:

Live mode | Suspended | Returns current image?
------------|-------------|-----------------
❌ | ❌ | ✔
❌ | ✔ | ✔
✔ | ❌ | ✔
✔ | ✔ | ❌

The reason for this is the `if (isLiveOn_)` check in `SnapLiveManager.snap(boolean)`:

https://github.com/micro-manager/micro-manager/blob/a6d52ce51bafcf30ae3a95f9b7e9929da45fb838/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java#L609-L625

This PR adds a `suspendCount_ == 0` check to ensure that images are only taken from the live view when it is actually live.
