### PR TITLE
Make Serial port communication faster for USB based serial ports

### DIFF
--- a/DeviceAdapters/SerialManager/SerialManager.cpp
+++ b/DeviceAdapters/SerialManager/SerialManager.cpp
@@ -641,7 +641,10 @@ int SerialPort::OpenWin32SerialPort(const std::string& portName,
 
    COMMTIMEOUTS timeouts;
    memset(&timeouts, 0, sizeof(timeouts));
-   timeouts.ReadIntervalTimeout = 1;
+   timeouts.ReadIntervalTimeout = MAXDWORD;
+   timeouts.ReadTotalTimeoutMultiplier = MAXDWORD;
+   timeouts.ReadTotalTimeoutConstant = 1;
+
    if (!SetCommTimeouts(portHandle, &timeouts))
    {
       DWORD err = GetLastError();


### PR DESCRIPTION
This PR changes the timing settings for serial ports under Windows. Essentially, this speeds up USB based serial ports significantly - I have observed an improvement of up to **10x** (from ~70ms to ~7ms per command) compared to the previous implementation. This makes navigating using serial port based stages significantly smoother.

The new timing settings effectively tell Windows to complete the read calls to the serial port immediately instead of waiting for a while. For a more detailed explanation see [this post on StackOverflow](https://stackoverflow.com/a/48977270/3032376).

Since I do not have access to a computer with a true serial port, I could not quantify the impact on this type of port. However, my understanding is that it should not negatively affect performance.