### PR TITLE
Fix variLC crashes

### DIFF
--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -283,11 +283,16 @@ int VariLC::Initialize()
 		return ret;
 
 	// Wavelength
+	std:string ans;
+	ret = sendCmd("V?", ans);	//The serial number response also contains the tuning range of the device
+	std::vector<double> nums = getNumbersFromMessage(ans, briefModeQ_);
+	if (ret != DEVICE_OK)
+		return ret;
 	pAct = new CPropertyAction(this, &VariLC::OnWavelength);
 	ret = CreateProperty("Wavelength", DoubleToString(wavelength_).c_str(), MM::Float, false, pAct);
 	if (ret != DEVICE_OK)
 		return ret;
-	SetPropertyLimits("Wavelength", 400., 800.);
+	SetPropertyLimits("Wavelength", nums.at(1), nums.at(2));
 
 	// Delay
 	pAct = new CPropertyAction(this, &VariLC::OnDelay);
@@ -338,8 +343,6 @@ int VariLC::Initialize()
 	if (ret != DEVICE_OK) {
 		return ret;
 	}
-	// Needed for Busy flag
-	// changedTime_ = GetCurrentMMTime();
 	SetErrorText(99, "Device set busy for ");
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -36,11 +36,6 @@
 // 4. wavelength default 546
 
 
-#ifdef WIN32
-//   #include <windows.h>
-   #define snprintf _snprintf 
-#endif
-
 #include "VariLC.h"
 #include <cstdio>
 #include <cctype>
@@ -747,7 +742,6 @@ int VariLC::OnSendToVariLC(MM::PropertyBase* pProp, MM::ActionType eAct)
 			 if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
 		 GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);
 		 GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);
-		 removeSpaces(getFromVariLC_);
 		 return DEVICE_OK;
 	  }
 	  else if (sendToVariLC_=="B ?" || sendToVariLC_=="B?") {
@@ -845,14 +839,4 @@ std::vector<double> VariLC::getNumbersFromMessage(std::string variLCmessage, boo
 	 }
 
 	return values;
-}
-
-static inline bool IsSpace(char ch)
-{
-   return std::isspace(ch);
-}
-
-void VariLC::removeSpaces(std::string input)
-{
-   input.erase(std::remove_if(input.begin(), input.end(), IsSpace), input.end());
 }

--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -285,7 +285,7 @@ int VariLC::Initialize()
 	// Wavelength
 	std:string ans;
 	ret = sendCmd("V?", ans);	//The serial number response also contains the tuning range of the device
-	std::vector<double> nums = getNumbersFromMessage(ans, briefModeQ_);
+	std::vector<double> nums = getNumbersFromMessage(ans, briefModeQ_);	//This will be in the format (revision level, shortest wavelength, longest wavelength, serial number).
 	if (ret != DEVICE_OK)
 		return ret;
 	pAct = new CPropertyAction(this, &VariLC::OnWavelength);

--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -64,37 +64,37 @@ using namespace std;
 ///////////////////////////////////////////////////////////////////////////////
 MODULE_API void InitializeModuleData()
 {
-   RegisterDevice(g_ControllerName, MM::GenericDevice, "VariLC");
-}                                                                            
+	RegisterDevice(g_ControllerName, MM::GenericDevice, "VariLC");
+}
 
-MODULE_API MM::Device* CreateDevice(const char* deviceName)                  
+MODULE_API MM::Device* CreateDevice(const char* deviceName)
 {
-   if (deviceName == 0) return 0;
-   if (strcmp(deviceName, g_ControllerName)    == 0) return new VariLC();                           
-   return 0;
+	if (deviceName == 0) return 0;
+	if (strcmp(deviceName, g_ControllerName) == 0) return new VariLC();
+	return 0;
 }
 
 MODULE_API void DeleteDevice(MM::Device* pDevice)
 {
-   delete pDevice;
+	delete pDevice;
 }
 
 
 // General utility function:
 int ClearPort(MM::Device& device, MM::Core& core, std::string port)
 {
-   // Clear contents of serial port 
-   const int bufSize = 2048;
-   unsigned char clear[bufSize];                                                        
-   unsigned long read = bufSize;                                               
-   int ret;                                                                    
-   while ((int) read == bufSize)                                                     
-   {                                                                           
-      ret = core.ReadFromSerial(&device, port.c_str(), clear, bufSize, read); 
-      if (ret != DEVICE_OK)                                                    
-         return ret;                                                           
-   }                                                                           
-   return DEVICE_OK;                                                           
+	// Clear contents of serial port 
+	const int bufSize = 2048;
+	unsigned char clear[bufSize];
+	unsigned long read = bufSize;
+	int ret;
+	while ((int)read == bufSize)
+	{
+		ret = core.ReadFromSerial(&device, port.c_str(), clear, bufSize, read);
+		if (ret != DEVICE_OK)
+			return ret;
+	}
+	return DEVICE_OK;
 }
 
 
@@ -106,270 +106,271 @@ int ClearPort(MM::Device& device, MM::Core& core, std::string port)
 ///////////////////////////////////////////////////////////////////////////////
 
 VariLC::VariLC() :
-  baud_(g_Baud9600),
-  initialized_(false),
-  initializedDelay_(false),
-  answerTimeoutMs_(1000),
-  wavelength_(546),
-  numTotalLCs_(2),
-  numActiveLCs_(2),
-  numPalEls_(5)
+	baud_(g_Baud9600),
+	initialized_(false),
+	initializedDelay_(false),
+	answerTimeoutMs_(1000),
+	wavelength_(546),
+	numTotalLCs_(2),
+	numActiveLCs_(2),
+	numPalEls_(5)
 {
-   InitializeDefaultErrorMessages();
-   
-   // pre-initialization properties
+	InitializeDefaultErrorMessages();
+
+	// pre-initialization properties
 
 
-   // Port:
-   CPropertyAction* pAct = new CPropertyAction(this, &VariLC::OnPort);
-   CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
-   SetProperty(MM::g_Keyword_Port, port_.c_str());
+	// Port:
+	CPropertyAction* pAct = new CPropertyAction(this, &VariLC::OnPort);
+	CreateProperty(MM::g_Keyword_Port, "Undefined", MM::String, false, pAct, true);
+	SetProperty(MM::g_Keyword_Port, port_.c_str());
 
-   pAct = new CPropertyAction (this, &VariLC::OnNumActiveLCs);
-   CreateProperty("Number of Active LCs", "2", MM::Integer, false, pAct, true); 
-   
-   pAct = new CPropertyAction (this, &VariLC::OnNumTotalLCs);
-   CreateProperty("Total Number of LCs", "2", MM::Integer, false, pAct, true); 
-   
-   pAct = new CPropertyAction (this, &VariLC::OnNumPalEls);
-   CreateProperty("Total Number of Palette Elements", "5", MM::Integer, false, pAct, true); 
-   
-   pAct = new CPropertyAction(this, &VariLC::OnBaud);
-   CreateProperty(g_BaudRate_key, "Undefined", MM::String, false, pAct, true);  
-   
-   AddAllowedValue(g_BaudRate_key, g_Baud115200, (long) 115200);
-   AddAllowedValue(g_BaudRate_key, g_Baud9600, (long) 9600);
+	pAct = new CPropertyAction(this, &VariLC::OnNumActiveLCs);
+	CreateProperty("Number of Active LCs", "2", MM::Integer, false, pAct, true);
 
-   EnableDelay();
+	pAct = new CPropertyAction(this, &VariLC::OnNumTotalLCs);
+	CreateProperty("Total Number of LCs", "2", MM::Integer, false, pAct, true);
+
+	pAct = new CPropertyAction(this, &VariLC::OnNumPalEls);
+	CreateProperty("Total Number of Palette Elements", "5", MM::Integer, false, pAct, true);
+
+	pAct = new CPropertyAction(this, &VariLC::OnBaud);
+	CreateProperty(g_BaudRate_key, "Undefined", MM::String, false, pAct, true);
+
+	AddAllowedValue(g_BaudRate_key, g_Baud115200, (long)115200);
+	AddAllowedValue(g_BaudRate_key, g_Baud9600, (long)9600);
+
+	EnableDelay();
 }
 
 
 VariLC::~VariLC()
 {
-   Shutdown();
+	Shutdown();
 }
 
 void VariLC::GetName(char* name) const
 {
-   CDeviceUtils::CopyLimitedString(name, g_ControllerName);
+	CDeviceUtils::CopyLimitedString(name, g_ControllerName);
 }
 
 
 bool VariLC::SupportsDeviceDetection(void)
 {
-   return true;
+	return true;
 }
 
 MM::DeviceDetectionStatus VariLC::DetectDevice(void)
 {
-   // all conditions must be satisfied...
-   MM::DeviceDetectionStatus result = MM::Misconfigured;
+	// all conditions must be satisfied...
+	MM::DeviceDetectionStatus result = MM::Misconfigured;
 
-   try
-   {	   
-	   long baud;
-	   GetProperty(g_BaudRate_key, baud);
+	try
+	{
+		long baud;
+		GetProperty(g_BaudRate_key, baud);
 
-      std::string transformed = port_;
-      for( std::string::iterator its = transformed.begin(); its != transformed.end(); ++its)
-      {
-         *its = (char)tolower(*its);
-      }	  	     
+		std::string transformed = port_;
+		for (std::string::iterator its = transformed.begin(); its != transformed.end(); ++its)
+		{
+			*its = (char)tolower(*its);
+		}
 
-      if( 0< transformed.length() &&  0 != transformed.compare("undefined")  && 0 != transformed.compare("unknown") )
-      {
-		int ret = 0;	  
-		MM::Device* pS;
+		if (0 < transformed.length() && 0 != transformed.compare("undefined") && 0 != transformed.compare("unknown"))
+		{
+			int ret = 0;
+			MM::Device* pS;
 
-		
-			 // the port property seems correct, so give it a try
-			 result = MM::CanNotCommunicate;
-			 // device specific default communication parameters
-			 GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_AnswerTimeout, "2000.0");			 
-			 GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_BaudRate, baud_.c_str() );
-			 GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_DelayBetweenCharsMs, "0.0");
-			 GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_Handshaking, "Off");
-			 GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_Parity, "None");
-			 GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_StopBits, "1");
-			 GetCoreCallback()->SetDeviceProperty(port_.c_str(), "Verbose", "1");
-			 pS = GetCoreCallback()->GetDevice(this, port_.c_str());
-			 pS->Initialize();
-	         
-			 ClearPort(*this, *GetCoreCallback(), port_);
-			 ret = SendSerialCommand(port_.c_str(), "V?", "\r");     
-			 GetSerialAnswer (port_.c_str(), "\r", serialnum_);
-			 GetSerialAnswer (port_.c_str(), "\r", serialnum_);
-				 if (ret!=DEVICE_OK || serialnum_.length() < 5)
-				 {
-					LogMessageCode(ret,true);
-					LogMessage(std::string("VariLC not found on ")+port_.c_str(), true);
-					LogMessage(std::string("VariLC serial no:")+serialnum_, true);
-					ret = 1;
-					serialnum_ = "0";
-					pS->Shutdown();	
-				 } else
-				 {
-					// to succeed must reach here....
-					LogMessage(std::string("VariLC found on ")+port_.c_str(), true);
-					LogMessage(std::string("VariLC serial no:")+serialnum_, true);
-					result = MM::CanCommunicate;	
-					GetCoreCallback()->SetSerialProperties(port_.c_str(),
-											  "600.0",
-											  baud_.c_str(),
-											  "0.0",
-											  "Off",
-											  "None",
-											  "1");
-					serialnum_ = "0";
-					pS->Initialize();
-					ret = SendSerialCommand(port_.c_str(), "R 1", "\r");
-					ret = SendSerialCommand(port_.c_str(), "C 0", "\r");
-					pS->Shutdown();					
-				}
-      }
-   }
-   catch(...)
-   {
-      LogMessage("Exception in DetectDevice!",false);
-   }
-   return result;
+
+			// the port property seems correct, so give it a try
+			result = MM::CanNotCommunicate;
+			// device specific default communication parameters
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_AnswerTimeout, "2000.0");
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_BaudRate, baud_.c_str());
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_DelayBetweenCharsMs, "0.0");
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_Handshaking, "Off");
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_Parity, "None");
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), MM::g_Keyword_StopBits, "1");
+			GetCoreCallback()->SetDeviceProperty(port_.c_str(), "Verbose", "1");
+			pS = GetCoreCallback()->GetDevice(this, port_.c_str());
+			pS->Initialize();
+
+			ClearPort(*this, *GetCoreCallback(), port_);
+			ret = SendSerialCommand(port_.c_str(), "V?", "\r");
+			GetSerialAnswer(port_.c_str(), "\r", serialnum_);
+			GetSerialAnswer(port_.c_str(), "\r", serialnum_);
+			if (ret != DEVICE_OK || serialnum_.length() < 5)
+			{
+				LogMessageCode(ret, true);
+				LogMessage(std::string("VariLC not found on ") + port_.c_str(), true);
+				LogMessage(std::string("VariLC serial no:") + serialnum_, true);
+				ret = 1;
+				serialnum_ = "0";
+				pS->Shutdown();
+			}
+			else
+			{
+				// to succeed must reach here....
+				LogMessage(std::string("VariLC found on ") + port_.c_str(), true);
+				LogMessage(std::string("VariLC serial no:") + serialnum_, true);
+				result = MM::CanCommunicate;
+				GetCoreCallback()->SetSerialProperties(port_.c_str(),
+					"600.0",
+					baud_.c_str(),
+					"0.0",
+					"Off",
+					"None",
+					"1");
+				serialnum_ = "0";
+				pS->Initialize();
+				ret = SendSerialCommand(port_.c_str(), "R 1", "\r");
+				ret = SendSerialCommand(port_.c_str(), "C 0", "\r");
+				pS->Shutdown();
+			}
+		}
+	}
+	catch (...)
+	{
+		LogMessage("Exception in DetectDevice!", false);
+	}
+	return result;
 }
 
 int VariLC::Initialize()
 {
-	for (long i=0;i<numTotalLCs_;++i) {
+	for (long i = 0; i < numTotalLCs_; ++i) {
 		retardance_[i] = 0.5;
 	}
 
-	for (long i=0;i<numPalEls_;i++) {
+	for (long i = 0; i < numPalEls_; i++) {
 		palEl_[i] = "";
 	}
- 
-// empty the Rx serial buffer before sending command
-   int ret = ClearPort(*this, *GetCoreCallback(), port_);
-   if (ret != DEVICE_OK)
-      return ret;
 
-   // Name
-   ret = CreateProperty(MM::g_Keyword_Name, g_ControllerName, MM::String, true);
-   if (DEVICE_OK != ret)
-      return ret;
-    
-    // Version number
-   CPropertyAction* pAct = new CPropertyAction (this, &VariLC::OnSerialNumber);
-   ret = CreateProperty("Version Number", "Version Number Not Found", MM::String, true, pAct);
-   if (ret != DEVICE_OK)
-      return ret;
+	// empty the Rx serial buffer before sending command
+	int ret = ClearPort(*this, *GetCoreCallback(), port_);
+	if (ret != DEVICE_OK)
+		return ret;
 
-   // Active LC number
-   pAct = new CPropertyAction (this, &VariLC::OnNumActiveLCs);
-   ret = CreateProperty("Active LCs", "0", MM::Integer, true, pAct);
-   if (ret != DEVICE_OK)
-      return ret;
+	// Name
+	ret = CreateProperty(MM::g_Keyword_Name, g_ControllerName, MM::String, true);
+	if (DEVICE_OK != ret)
+		return ret;
 
-   // Total LC number
-   pAct = new CPropertyAction (this, &VariLC::OnNumTotalLCs);
-   ret = CreateProperty("Total LCs", "0", MM::Integer, true, pAct);
-   if (ret != DEVICE_OK)
-      return ret;
+	// Version number
+	CPropertyAction* pAct = new CPropertyAction(this, &VariLC::OnSerialNumber);
+	ret = CreateProperty("Version Number", "Version Number Not Found", MM::String, true, pAct);
+	if (ret != DEVICE_OK)
+		return ret;
 
-   pAct = new CPropertyAction (this, &VariLC::OnBriefMode);
-   ret = CreateProperty("Mode; 1=Brief; 0=Standard", "", MM::String, true, pAct); 
-   if (ret != DEVICE_OK)
-	   return ret;
+	// Active LC number
+	pAct = new CPropertyAction(this, &VariLC::OnNumActiveLCs);
+	ret = CreateProperty("Active LCs", "0", MM::Integer, true, pAct);
+	if (ret != DEVICE_OK)
+		return ret;
 
-   //Set VariLC to Standard mode
-   briefModeQ_ = false;
-   ret = SendSerialCommand(port_.c_str(), "B 0", "\r");
-   if (ret!=DEVICE_OK)
-	   return DEVICE_SERIAL_COMMAND_FAILED;
-   ret = GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);  //add the following error check each time GetSerialAnswer is called
-   if (ret!=DEVICE_OK) {
-	   SetErrorText(99, "The VariLC did not respond.");
-   	   return 99;
-   }
-   if (getFromVariLC_.length() == 0)
-	   return DEVICE_NOT_CONNECTED;
+	// Total LC number
+	pAct = new CPropertyAction(this, &VariLC::OnNumTotalLCs);
+	ret = CreateProperty("Total LCs", "0", MM::Integer, true, pAct);
+	if (ret != DEVICE_OK)
+		return ret;
 
-   // Wavelength
-   pAct = new CPropertyAction (this, &VariLC::OnWavelength);
-   ret = CreateProperty("Wavelength", DoubleToString(wavelength_).c_str(), MM::Float, false, pAct); 
-   if (ret != DEVICE_OK)
-      return ret;
-   SetPropertyLimits("Wavelength", 400., 800.);
+	pAct = new CPropertyAction(this, &VariLC::OnBriefMode);
+	ret = CreateProperty("Mode; 1=Brief; 0=Standard", "", MM::String, true, pAct);
+	if (ret != DEVICE_OK)
+		return ret;
 
-   // Delay
-   pAct = new CPropertyAction (this, &VariLC::OnDelay);
-   ret = CreateProperty("Device Delay (ms.)", "200.0", MM::Float, false, pAct); 
-   if (ret != DEVICE_OK)
-      return ret;
-   SetPropertyLimits("Device Delay (ms.)", 0.0, 200.0);
-   
-   CPropertyActionEx *pActX = 0;
-//	 create an extended (i.e. array) properties 0 through 1
-	
-   for (long i=0;i<numActiveLCs_;++i) {
-	   ostringstream s;
-	   s << "Retardance LC-" << char(65+i);
-	   pActX = new CPropertyActionEx(this, &VariLC::OnRetardance, i);
-	   CreateProperty(s.str().c_str(), "0.5", MM::Float, false, pActX);
-	   SetPropertyLimits(s.str().c_str(), 0.0001, 3);
-   }
+	//Set VariLC to Standard mode
+	briefModeQ_ = false;
+	ret = SendSerialCommand(port_.c_str(), "B 0", "\r");
+	if (ret != DEVICE_OK)
+		return DEVICE_SERIAL_COMMAND_FAILED;
+	ret = GetSerialAnswer(port_.c_str(), "\r", getFromVariLC_);  //add the following error check each time GetSerialAnswer is called
+	if (ret != DEVICE_OK) {
+		SetErrorText(99, "The VariLC did not respond.");
+		return 99;
+	}
+	if (getFromVariLC_.length() == 0)
+		return DEVICE_NOT_CONNECTED;
 
-   // Absolute Retardance controls -- after Voltage controls
-   for (long i=0;i<numActiveLCs_;++i) {
-	   ostringstream s;
-	   s << "Retardance LC-" << char(65+i) << " [in nm.]";
-	   pActX = new CPropertyActionEx(this, &VariLC::OnAbsRetardance, i);
-	   CreateProperty(s.str().c_str(), "100", MM::Float, true, pActX);
-   }
- 
-//   for (long i=0;i<numPalEls_;++i) {
-//	   ostringstream s;
-//	   s << "Pal. elem. " << char(48+i) << ", enter 0 to define, 1 to activate";
-//	   pActX = new CPropertyActionEx(this, &VariLC::OnPalEl, i);
-//	   CreateProperty(s.str().c_str(), "", MM::String, false, pActX);
-//   }
+	// Wavelength
+	pAct = new CPropertyAction(this, &VariLC::OnWavelength);
+	ret = CreateProperty("Wavelength", DoubleToString(wavelength_).c_str(), MM::Float, false, pAct);
+	if (ret != DEVICE_OK)
+		return ret;
+	SetPropertyLimits("Wavelength", 400., 800.);
 
-   for (long i=0;i<numPalEls_;++i) {
-	   ostringstream s;
-	   std::string number;
+	// Delay
+	pAct = new CPropertyAction(this, &VariLC::OnDelay);
+	ret = CreateProperty("Device Delay (ms.)", "200.0", MM::Float, false, pAct);
+	if (ret != DEVICE_OK)
+		return ret;
+	SetPropertyLimits("Device Delay (ms.)", 0.0, 200.0);
 
-	   std::stringstream strstream;
-	   strstream << i;
-	   strstream >> number;
-	   if (i < 10) {
-			number = "0"+number;
+	CPropertyActionEx *pActX = 0;
+	//	 create an extended (i.e. array) properties 0 through 1
+
+	for (long i = 0; i < numActiveLCs_; ++i) {
+		ostringstream s;
+		s << "Retardance LC-" << char(65 + i);
+		pActX = new CPropertyActionEx(this, &VariLC::OnRetardance, i);
+		CreateProperty(s.str().c_str(), "0.5", MM::Float, false, pActX);
+		SetPropertyLimits(s.str().c_str(), 0.0001, 3);
+	}
+
+	// Absolute Retardance controls -- after Voltage controls
+	for (long i = 0; i < numActiveLCs_; ++i) {
+		ostringstream s;
+		s << "Retardance LC-" << char(65 + i) << " [in nm.]";
+		pActX = new CPropertyActionEx(this, &VariLC::OnAbsRetardance, i);
+		CreateProperty(s.str().c_str(), "100", MM::Float, true, pActX);
+	}
+
+	//   for (long i=0;i<numPalEls_;++i) {
+	//	   ostringstream s;
+	//	   s << "Pal. elem. " << char(48+i) << ", enter 0 to define, 1 to activate";
+	//	   pActX = new CPropertyActionEx(this, &VariLC::OnPalEl, i);
+	//	   CreateProperty(s.str().c_str(), "", MM::String, false, pActX);
+	//   }
+
+	for (long i = 0; i < numPalEls_; ++i) {
+		ostringstream s;
+		std::string number;
+
+		std::stringstream strstream;
+		strstream << i;
+		strstream >> number;
+		if (i < 10) {
+			number = "0" + number;
 		}
-	   
 
-	   s << "Pal. elem. " << number << "; enter 0 to define; 1 to activate";
-	   pActX = new CPropertyActionEx(this, &VariLC::OnPalEl, i);
-	   CreateProperty(s.str().c_str(), "", MM::String, false, pActX);
-   }
 
-   pAct = new CPropertyAction (this, &VariLC::OnSendToVariLC);
-   ret = CreateProperty("String send to VariLC", "", MM::String, false, pAct); 
-   if (ret != DEVICE_OK)
-      return ret;
- 
-   pAct = new CPropertyAction (this, &VariLC::OnGetFromVariLC);
-   ret = CreateProperty("String from VariLC", "", MM::String, true, pAct); 
-   if (ret != DEVICE_OK)
-      return ret;
+		s << "Pal. elem. " << number << "; enter 0 to define; 1 to activate";
+		pActX = new CPropertyActionEx(this, &VariLC::OnPalEl, i);
+		CreateProperty(s.str().c_str(), "", MM::String, false, pActX);
+	}
 
-   // Needed for Busy flag
-   // changedTime_ = GetCurrentMMTime();
-   SetErrorText(99, "Device set busy for ");
+	pAct = new CPropertyAction(this, &VariLC::OnSendToVariLC);
+	ret = CreateProperty("String send to VariLC", "", MM::String, false, pAct);
+	if (ret != DEVICE_OK)
+		return ret;
 
-   return DEVICE_OK;
+	pAct = new CPropertyAction(this, &VariLC::OnGetFromVariLC);
+	ret = CreateProperty("String from VariLC", "", MM::String, true, pAct);
+	if (ret != DEVICE_OK)
+		return ret;
+
+	// Needed for Busy flag
+	// changedTime_ = GetCurrentMMTime();
+	SetErrorText(99, "Device set busy for ");
+
+	return DEVICE_OK;
 }
 
 
 int VariLC::Shutdown()
-{ 
-  initialized_ = false;
-  return DEVICE_OK;
+{
+	initialized_ = false;
+	return DEVICE_OK;
 }
 
 
@@ -378,211 +379,215 @@ int VariLC::Shutdown()
 
 int VariLC::OnPort(MM::PropertyBase* pProp, MM::ActionType pAct)
 {
-   if (pAct == MM::BeforeGet)
-   {
-      pProp->Set(port_.c_str());
-   }
-   else if (pAct == MM::AfterSet)
-   {
-      if (initialized_)
-      {
-         pProp->Set(port_.c_str());
-         return DEVICE_INVALID_INPUT_PARAM;
-      }
-      pProp->Get(port_);
-   }   
-      
-   return DEVICE_OK;
+	if (pAct == MM::BeforeGet)
+	{
+		pProp->Set(port_.c_str());
+	}
+	else if (pAct == MM::AfterSet)
+	{
+		if (initialized_)
+		{
+			pProp->Set(port_.c_str());
+			return DEVICE_INVALID_INPUT_PARAM;
+		}
+		pProp->Get(port_);
+	}
+
+	return DEVICE_OK;
 }
 
 int VariLC::OnBaud(MM::PropertyBase* pProp, MM::ActionType eAct)
-{	
-   if (eAct == MM::BeforeGet)
-   {
-      pProp->Set(baud_.c_str());
-   }
-   else if (eAct == MM::AfterSet)
-   {
-      if (initialized_)
-      {
-         pProp->Set(baud_.c_str());
-         return DEVICE_INVALID_INPUT_PARAM;
-      }
-      pProp->Get(baud_);
-   }
+{
+	if (eAct == MM::BeforeGet)
+	{
+		pProp->Set(baud_.c_str());
+	}
+	else if (eAct == MM::AfterSet)
+	{
+		if (initialized_)
+		{
+			pProp->Set(baud_.c_str());
+			return DEVICE_INVALID_INPUT_PARAM;
+		}
+		pProp->Get(baud_);
+	}
 
-   return DEVICE_OK;
+	return DEVICE_OK;
 }
 
 
- int VariLC::OnBriefMode(MM::PropertyBase* pProp, MM::ActionType eAct)
+int VariLC::OnBriefMode(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
-   if (eAct == MM::BeforeGet){
-     int ret = SendSerialCommand(port_.c_str(), "B?", "\r");
-         if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-     std::string ans;
-     GetSerialAnswer (port_.c_str(), "\r", ans);
-	 GetSerialAnswer (port_.c_str(), "\r", ans);	 
-     
-	 if (ans == "1") {
-		 briefModeQ_ = true;
-	 } else {
-		 briefModeQ_ = false;
-	 }
-	 if (briefModeQ_) {
-	     pProp->Set(" 1");
-	 } else {
-	     pProp->Set(" 0");
-	 }
-   }
-   else if (eAct == MM::AfterSet)
-   {
+	if (eAct == MM::BeforeGet) {
+		int ret = SendSerialCommand(port_.c_str(), "B?", "\r");
+		if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+		std::string ans;
+		GetSerialAnswer(port_.c_str(), "\r", ans);
+		GetSerialAnswer(port_.c_str(), "\r", ans);
 
-   }
-   return DEVICE_OK;
+		if (ans == "1") {
+			briefModeQ_ = true;
+		}
+		else {
+			briefModeQ_ = false;
+		}
+		if (briefModeQ_) {
+			pProp->Set(" 1");
+		}
+		else {
+			pProp->Set(" 0");
+		}
+	}
+	else if (eAct == MM::AfterSet)
+	{
+
+	}
+	return DEVICE_OK;
 }
 
  int VariLC::OnNumTotalLCs(MM::PropertyBase* pProp, MM::ActionType eAct)
-{
-   if (eAct == MM::BeforeGet)
-   {
-     pProp->Set(numTotalLCs_);
-    }
-   else if (eAct == MM::AfterSet)
-   {
-	  pProp->Get(numTotalLCs_);
-   }
-   return DEVICE_OK;
-}
+ {
+	 if (eAct == MM::BeforeGet)
+	 {
+		 pProp->Set(numTotalLCs_);
+	 }
+	 else if (eAct == MM::AfterSet)
+	 {
+		 pProp->Get(numTotalLCs_);
+	 }
+	 return DEVICE_OK;
+ }
 
  int VariLC::OnNumActiveLCs(MM::PropertyBase* pProp, MM::ActionType eAct)
-{
-   if (eAct == MM::BeforeGet)
-   {
-     pProp->Set(numActiveLCs_);
-    }
-   else if (eAct == MM::AfterSet)
-   {		
-	  pProp->Get(numActiveLCs_);
-   }
-   return DEVICE_OK;
-}
+ {
+	 if (eAct == MM::BeforeGet)
+	 {
+		 pProp->Set(numActiveLCs_);
+	 }
+	 else if (eAct == MM::AfterSet)
+	 {
+		 pProp->Get(numActiveLCs_);
+	 }
+	 return DEVICE_OK;
+ }
 
 
  int VariLC::OnNumPalEls(MM::PropertyBase* pProp, MM::ActionType eAct)
-{
-   if (eAct == MM::BeforeGet)
-   {
-     pProp->Set(numPalEls_);
-    }
-   else if (eAct == MM::AfterSet)
-   {
-	  pProp->Get(numPalEls_);
-   }
-   return DEVICE_OK;
-}
-
- int VariLC::OnSerialNumber (MM::PropertyBase* pProp, MM::ActionType eAct)
  {
-   if (eAct == MM::BeforeGet)
-  {
-     int ret = SendSerialCommand(port_.c_str(), "V?", "\r");
-         if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-	 GetSerialAnswer (port_.c_str(), "\r", serialnum_);
-	 GetSerialAnswer (port_.c_str(), "\r", serialnum_);
-	 
-	 pProp->Set(serialnum_.c_str());
-   }
-   return DEVICE_OK;
+	 if (eAct == MM::BeforeGet)
+	 {
+		 pProp->Set(numPalEls_);
+	 }
+	 else if (eAct == MM::AfterSet)
+	 {
+		 pProp->Get(numPalEls_);
+	 }
+	 return DEVICE_OK;
  }
 
-int VariLC::OnWavelength (MM::PropertyBase* pProp, MM::ActionType eAct)
+ int VariLC::OnSerialNumber(MM::PropertyBase* pProp, MM::ActionType eAct)
  {
-   if (eAct == MM::BeforeGet)
-   {
-     int ret = SendSerialCommand(port_.c_str(), "W?", "\r");
-         if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-     std::string ans;
-	 GetSerialAnswer (port_.c_str(), "\r", ans);
-	 GetSerialAnswer (port_.c_str(), "\r", ans);
+	 if (eAct == MM::BeforeGet)
+	 {
+		 int ret = SendSerialCommand(port_.c_str(), "V?", "\r");
+		 if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+		 GetSerialAnswer(port_.c_str(), "\r", serialnum_);
+		 GetSerialAnswer(port_.c_str(), "\r", serialnum_);
 
-     vector<double> numbers = getNumbersFromMessage(ans,briefModeQ_);
-     pProp->Set(numbers[0]);
-   }
-   else if (eAct == MM::AfterSet)
-   {
-	  double wavelength;
-      // read value from property
-      pProp->Get(wavelength);
-      // write wavelength out to device....
-	  ostringstream cmd;
-	  cmd.precision(5);
-	  cmd << "W " << wavelength;
-     int ret = SendSerialCommand(port_.c_str(), cmd.str().c_str(), "\r");
-     if (ret!=DEVICE_OK)
-	     return DEVICE_SERIAL_COMMAND_FAILED;
-     std::string ans;
-     GetSerialAnswer (port_.c_str(), "\r", ans);
-	 
-     wavelength_ = wavelength;
-// Clear palette elements after change of wavelength
-   }
-   return DEVICE_OK;
+		 pProp->Set(serialnum_.c_str());
+	 }
+	 return DEVICE_OK;
+ }
+
+ int VariLC::OnWavelength(MM::PropertyBase* pProp, MM::ActionType eAct)
+ {
+	 if (eAct == MM::BeforeGet)
+	 {
+		 int ret = SendSerialCommand(port_.c_str(), "W?", "\r");
+		 if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+		 std::string ans;
+		 GetSerialAnswer(port_.c_str(), "\r", ans);
+		 GetSerialAnswer(port_.c_str(), "\r", ans);
+
+		 vector<double> numbers = getNumbersFromMessage(ans, briefModeQ_);
+		 pProp->Set(numbers[0]);
+	 }
+	 else if (eAct == MM::AfterSet)
+	 {
+		 double wavelength;
+		 // read value from property
+		 pProp->Get(wavelength);
+		 // write wavelength out to device....
+		 ostringstream cmd;
+		 cmd.precision(5);
+		 cmd << "W " << wavelength;
+		 int ret = SendSerialCommand(port_.c_str(), cmd.str().c_str(), "\r");
+		 if (ret != DEVICE_OK)
+			 return DEVICE_SERIAL_COMMAND_FAILED;
+		 std::string ans;
+		 GetSerialAnswer(port_.c_str(), "\r", ans);
+
+		 wavelength_ = wavelength;
+		 // Clear palette elements after change of wavelength
+	 }
+	 return DEVICE_OK;
  }
 
 int VariLC::OnRetardance(MM::PropertyBase* pProp, MM::ActionType eAct, long index)
 {
-   if (eAct == MM::BeforeGet)
-   {
-     int ret = SendSerialCommand(port_.c_str(), "L?", "\r");
-         if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-     std::string ans;
-	 GetSerialAnswer (port_.c_str(), "\r", ans);
-     GetSerialAnswer (port_.c_str(), "\r", ans);
+	if (eAct == MM::BeforeGet)
+	{
+		int ret = SendSerialCommand(port_.c_str(), "L?", "\r");
+		if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+		std::string ans;
+		GetSerialAnswer(port_.c_str(), "\r", ans);
+		GetSerialAnswer(port_.c_str(), "\r", ans);
 
-     vector<double> numbers = getNumbersFromMessage(ans,briefModeQ_);
-	 if (index < (int) numbers.size()) {
-	   retardance_[index] = numbers[index];
-	   pProp->Set(retardance_[index]);
+		vector<double> numbers = getNumbersFromMessage(ans, briefModeQ_);
+		if (index < (int)numbers.size()) {
+			retardance_[index] = numbers[index];
+			pProp->Set(retardance_[index]);
 
-	   ostringstream s;
-	   s << "Retardance LC-" << char(65+index) << " [in nm.]";
-	   std::string s2 = DoubleToString(retardance_[index]*wavelength_);
-	   SetProperty(s.str().c_str(), s2.c_str());
+			ostringstream s;
+			s << "Retardance LC-" << char(65 + index) << " [in nm.]";
+			std::string s2 = DoubleToString(retardance_[index] * wavelength_);
+			SetProperty(s.str().c_str(), s2.c_str());
 
-	 } else {
-		 return DEVICE_INVALID_PROPERTY_VALUE;
-	 }
-   }
-   else if (eAct == MM::AfterSet)
-   {
-	   double retardance;
+		}
+		else {
+			return DEVICE_INVALID_PROPERTY_VALUE;
+		}
+	}
+	else if (eAct == MM::AfterSet)
+	{
+		double retardance;
 
-      // read value from property
-      pProp->Get(retardance);
-      // write retardance out to device....
-	   ostringstream cmd;
-	   cmd.precision(4);
-      cmd << "L" ;
-      for (int i=0; i<numTotalLCs_; i++) {
-         if (i==index) {
-            cmd << " " << retardance;
-		 } else {
-			cmd << " " << retardance_[i];
-		 }
-      }
-      int ret = SendSerialCommand(port_.c_str(), cmd.str().c_str(), "\r");
-      if (ret!=DEVICE_OK)
-   		return DEVICE_SERIAL_COMMAND_FAILED;
-      
-      std::string ans;
-	  GetSerialAnswer (port_.c_str(), "\r", ans);	  
+		// read value from property
+		pProp->Get(retardance);
+		// write retardance out to device....
+		ostringstream cmd;
+		cmd.precision(4);
+		cmd << "L";
+		for (int i = 0; i < numTotalLCs_; i++) {
+			if (i == index) {
+				cmd << " " << retardance;
+			}
+			else {
+				cmd << " " << retardance_[i];
+			}
+		}
+		int ret = SendSerialCommand(port_.c_str(), cmd.str().c_str(), "\r");
+		if (ret != DEVICE_OK)
+			return DEVICE_SERIAL_COMMAND_FAILED;
 
-      retardance_[index] = retardance;
+		std::string ans;
+		GetSerialAnswer(port_.c_str(), "\r", ans);
 
-	  changedTime_ = GetCurrentMMTime();
-   }
-   return DEVICE_OK;
+		retardance_[index] = retardance;
+
+		changedTime_ = GetCurrentMMTime();
+	}
+	return DEVICE_OK;
 }
 
 int VariLC::OnAbsRetardance(MM::PropertyBase* pProp, MM::ActionType eAct, long index)
@@ -604,41 +609,42 @@ int VariLC::OnAbsRetardance(MM::PropertyBase* pProp, MM::ActionType eAct, long i
 
  int VariLC::OnPalEl(MM::PropertyBase* pProp, MM::ActionType eAct, long index)
 {
-   if (eAct == MM::BeforeGet)
-   {
-	 //PurgeComPort(port_.c_str());
-     int ret = SendSerialCommand(port_.c_str(), "D?", "\r");
-         if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-     std::string ans;
-//	 GetSerialAnswer (port_.c_str(), "\r", ans);
-	 while (ans!="D?") GetSerialAnswer (port_.c_str(), "\r", ans);
-//the while statement was needed to overcome an empty string that appears in ans while reading the 5th pallette element 
-//however, we should avoid infinite loop; bow out with report of comm error?
-    GetSerialAnswer (port_.c_str(), "\r", ans);
-     vector<double> numbers = getNumbersFromMessage(ans,briefModeQ_);
-     int elemNr = (int) numbers[0];
-    if (elemNr == 0) {
-		for (int i=0;i<numPalEls_+1;i++) {
-			palEl_[i] = "";
-		}
-	 } else {
-        for (int i=1;i<=elemNr;i++) {  //i is one based
-          ret = GetSerialAnswer (port_.c_str(), "\r", ans);
-              if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-          if ((i-1)==index) {
-             numbers = getNumbersFromMessage(ans,briefModeQ_);
-         	 ostringstream palElStr;
-         	 palElStr.precision(4);
-			 palElStr << "  " << (numbers[0]);
-		     for (long i=0;i<numActiveLCs_;++i) {
-        	   palElStr << "  " << (numbers[i+1]);
-		     }
-			 palEl_[index] = palElStr.str();
-          }
-        }
+	 if (eAct == MM::BeforeGet)
+	 {
+		 //PurgeComPort(port_.c_str());
+		 int ret = SendSerialCommand(port_.c_str(), "D?", "\r");
+		 if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+		 std::string ans;
+		 //	 GetSerialAnswer (port_.c_str(), "\r", ans);
+		 while (ans != "D?") GetSerialAnswer(port_.c_str(), "\r", ans);
+		 //the while statement was needed to overcome an empty string that appears in ans while reading the 5th pallette element 
+		 //however, we should avoid infinite loop; bow out with report of comm error?
+		 GetSerialAnswer(port_.c_str(), "\r", ans);
+		 vector<double> numbers = getNumbersFromMessage(ans, briefModeQ_);
+		 int elemNr = (int)numbers[0];
+		 if (elemNr == 0) {
+			 for (int i = 0; i < numPalEls_ + 1; i++) {
+				 palEl_[i] = "";
+			 }
+		 }
+		 else {
+			 for (int i = 1; i <= elemNr; i++) {  //i is one based
+				 ret = GetSerialAnswer(port_.c_str(), "\r", ans);
+				 if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+				 if ((i - 1) == index) {
+					 numbers = getNumbersFromMessage(ans, briefModeQ_);
+					 ostringstream palElStr;
+					 palElStr.precision(4);
+					 palElStr << "  " << (numbers[0]);
+					 for (long i = 0; i < numActiveLCs_; ++i) {
+						 palElStr << "  " << (numbers[i + 1]);
+					 }
+					 palEl_[index] = palElStr.str();
+				 }
+			 }
+		 }
+		 pProp->Set(palEl_[index].c_str());
 	 }
-	 pProp->Set(palEl_[index].c_str());
-   }
    else if (eAct == MM::AfterSet)
    {
 	   long setPalEl = 0;
@@ -664,107 +670,98 @@ int VariLC::OnAbsRetardance(MM::PropertyBase* pProp, MM::ActionType eAct, long i
 }
 
 
-int VariLC::OnSendToVariLC(MM::PropertyBase* pProp, MM::ActionType eAct)
-{
-   if (eAct == MM::BeforeGet)
-   {
-//      pProp->Set(sendToVariLC_.c_str());
-   }
-   else if (eAct == MM::AfterSet)
-   {
-      // read value from property
-      pProp->Get(sendToVariLC_);
-      // write retardance out to device....
-	  
-	  size_t len = strlen(sendToVariLC_.c_str());
-	  char state[6];
+ int VariLC::OnSendToVariLC(MM::PropertyBase* pProp, MM::ActionType eAct)
+ {
+	 if (eAct == MM::AfterSet) {
+		 // read value from property
+		 pProp->Get(sendToVariLC_);
+		 // write retardance out to device....
 
-	  if (len > 5) {		  
-		  strncpy(state, sendToVariLC_.c_str(), 5);
-		  state[5] = '\0';
-	  }
+		 size_t len = strlen(sendToVariLC_.c_str());
+		 char state[6];
+		 if (len > 5) {
+			 strncpy(state, sendToVariLC_.c_str(), 5);
+			 state[5] = '\0';
+		 }
+		 if (sendToVariLC_ == "Escape") {
+			 char command[2];
+			 command[0] = 27;
+			 command[1] = 0;
+			 int ret = SendSerialCommand(port_.c_str(), command, "\r");
+			 if (ret != DEVICE_OK)
+				 return DEVICE_SERIAL_COMMAND_FAILED;
+		 }
+		 else if (sendToVariLC_ == "@") {
+			 int ret = SendSerialCommand(port_.c_str(), sendToVariLC_.c_str(), "\r");
+			 if (ret != DEVICE_OK)
+				 return DEVICE_SERIAL_COMMAND_FAILED;
+		 }
+		 else if (sendToVariLC_ == "!") {
+			 int ret = SendSerialCommand(port_.c_str(), sendToVariLC_.c_str(), "\r");
+			 if (ret != DEVICE_OK)
+				 return DEVICE_SERIAL_COMMAND_FAILED;
+		 }
+		 else if ((std::string)state == "State") {
+			 std::vector<char> val(len - 5);
+			 for (size_t i = 5; i < len; i++) {
+				 val[5 - i] = sendToVariLC_[i];
+			 }
+			 val[len] = '\0';
 
-      if (sendToVariLC_=="Escape") {
-         char command[2];
-         command[0]=27;
-         command[1]=0;
-         int ret = SendSerialCommand(port_.c_str(), command, "\r");
-         if (ret!=DEVICE_OK)
-		   return DEVICE_SERIAL_COMMAND_FAILED;		 
-      } 
-	  else if (sendToVariLC_=="@") {         
-		 int ret = SendSerialCommand(port_.c_str(), sendToVariLC_.c_str(), "\r");
-         if (ret!=DEVICE_OK)
-		      return DEVICE_SERIAL_COMMAND_FAILED;
-      }
-	  else if (sendToVariLC_=="!") {                  
-		 int ret = SendSerialCommand(port_.c_str(), sendToVariLC_.c_str(), "\r");		 
-         if (ret!=DEVICE_OK)
-		      return DEVICE_SERIAL_COMMAND_FAILED;		
-      }
-	  else if ((std::string)state=="State") {   
-		  	  
-			  std::vector<char> val(len-5);
-			  for (size_t i=5; i < len; i++) {
-					val[5-i] = sendToVariLC_[i];
-			  }
-			  val[len] = '\0';
-
-			  std::stringstream ss;
-				for(size_t i = 0; i < val.size(); ++i)
-				{
-				  if(i != 0)
-					ss << ",";
-				  ss << val[i];
-				}
+			 std::stringstream ss;
+			 for (size_t i = 0; i < val.size(); ++i)
+			 {
+				 if (i != 0)
+					 ss << ",";
+				 ss << val[i];
+			 }
 			 std::string s = ss.str();
 
 			 sendToVariLC_ = "P" + s;
 
 			 changedTime_ = GetCurrentMMTime();
 			 int ret = SendSerialCommand(port_.c_str(), sendToVariLC_.c_str(), "\r");
-				 if (ret!=DEVICE_OK) {
-				   return DEVICE_SERIAL_COMMAND_FAILED;
-				 }
-      }
-	  else if (sendToVariLC_=="W ?" || sendToVariLC_=="W?") {
-		  int ret = SendSerialCommand(port_.c_str(), "W?", "\r");
-			 if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-		 GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);		 
-	  }
-	  else if (sendToVariLC_=="V ?" || sendToVariLC_=="V?") {
-		  int ret = SendSerialCommand(port_.c_str(), "V?", "\r");
-			 if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-		 GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);		 
-	  }
-	  else if (sendToVariLC_=="R ?" || sendToVariLC_=="R?") {
-		  int ret = SendSerialCommand(port_.c_str(), "R?", "\r");
-			 if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-		 GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);
-		 GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);
-		 return DEVICE_OK;
-	  }
-	  else if (sendToVariLC_=="B ?" || sendToVariLC_=="B?") {
-		  int ret = SendSerialCommand(port_.c_str(), "B?", "\r");
-			 if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-		 GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);		 
-	  }
-	  else if (sendToVariLC_=="L ?" || sendToVariLC_=="L?") {
-		  int ret = SendSerialCommand(port_.c_str(), "L?", "\r");
-			 if (ret!=DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
-		 GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);		 
-	  }
-	  else {
-         int ret = SendSerialCommand(port_.c_str(), sendToVariLC_.c_str(), "\r");
-         if (ret!=DEVICE_OK)
-		      return DEVICE_SERIAL_COMMAND_FAILED;		 
-      }
-	  
-		GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);  
-	  
-   }
-   return DEVICE_OK;
-}
+			 if (ret != DEVICE_OK) {
+				 return DEVICE_SERIAL_COMMAND_FAILED;
+			 }
+		 }
+		 else if (sendToVariLC_ == "W ?" || sendToVariLC_ == "W?") {
+			 int ret = SendSerialCommand(port_.c_str(), "W?", "\r");
+			 if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+			 GetSerialAnswer(port_.c_str(), "\r", getFromVariLC_);
+		 }
+		 else if (sendToVariLC_ == "V ?" || sendToVariLC_ == "V?") {
+			 int ret = SendSerialCommand(port_.c_str(), "V?", "\r");
+			 if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+			 GetSerialAnswer(port_.c_str(), "\r", getFromVariLC_);
+		 }
+		 else if (sendToVariLC_ == "R ?" || sendToVariLC_ == "R?") {
+			 int ret = SendSerialCommand(port_.c_str(), "R?", "\r");
+			 if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
+			 GetSerialAnswer(port_.c_str(), "\r", getFromVariLC_);
+			 GetSerialAnswer(port_.c_str(), "\r", getFromVariLC_);
+			 return DEVICE_OK;
+		 }
+		 else if (sendToVariLC_ == "B ?" || sendToVariLC_ == "B?") {
+			 int ret = SendSerialCommand(port_.c_str(), "B?", "\r");
+			 if (ret != DEVICE_OK) { return DEVICE_SERIAL_COMMAND_FAILED; }
+			 GetSerialAnswer(port_.c_str(), "\r", getFromVariLC_);
+		 }
+		 else if (sendToVariLC_ == "L ?" || sendToVariLC_ == "L?") {
+			 int ret = SendSerialCommand(port_.c_str(), "L?", "\r");
+			 if (ret != DEVICE_OK) { return DEVICE_SERIAL_COMMAND_FAILED; }
+			 GetSerialAnswer(port_.c_str(), "\r", getFromVariLC_);
+		 }
+		 else {
+			 int ret = SendSerialCommand(port_.c_str(), sendToVariLC_.c_str(), "\r");
+			 if (ret != DEVICE_OK) {
+				 return DEVICE_SERIAL_COMMAND_FAILED;
+			 }
+		 }
+		 GetSerialAnswer(port_.c_str(), "\r", getFromVariLC_);
+	 }
+	 return DEVICE_OK;
+ }
 
 int VariLC::OnGetFromVariLC(MM::PropertyBase* pProp, MM::ActionType eAct)
 {
@@ -772,10 +769,6 @@ int VariLC::OnGetFromVariLC(MM::PropertyBase* pProp, MM::ActionType eAct)
    {
 	//   GetSerialAnswer (port_.c_str(), "\r", getFromVariLC_);
       pProp->Set(getFromVariLC_.c_str());
-   }
-   else if (eAct == MM::AfterSet)
-   {
-
    }
    return DEVICE_OK;
 }
@@ -797,7 +790,6 @@ int VariLC::OnGetFromVariLC(MM::PropertyBase* pProp, MM::ActionType eAct)
 	  }
 	  delay = delayT*1000;
    }
-   
    return DEVICE_OK;
 }
 
@@ -809,7 +801,6 @@ bool VariLC::Busy()
          return true;
       }
    }
-   
    return false;
 }
 
@@ -839,4 +830,8 @@ std::vector<double> VariLC::getNumbersFromMessage(std::string variLCmessage, boo
 	 }
 
 	return values;
+}
+
+std::string VariLC::sendCmd(std::string cmd) {
+
 }

--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -281,8 +281,6 @@ int VariLC::Initialize()
 	ret = sendCmd("B0",getFromVariLC_);
 	if (ret != DEVICE_OK)
 		return ret;
-	if (getFromVariLC_.length() == 0)
-		return DEVICE_NOT_CONNECTED;
 
 	// Wavelength
 	pAct = new CPropertyAction(this, &VariLC::OnWavelength);
@@ -704,7 +702,13 @@ std::vector<double> VariLC::getNumbersFromMessage(std::string variLCmessage, boo
 	return values;
 }
 
-int VariLC::sendCmd(std::string cmd, std::string out) {
+int VariLC::sendCmd(std::string cmd, std::string& out) {
+	int ret = sendCmd(cmd);
+	GetSerialAnswer(port_.c_str(), "\r", out); //Try returning any extra response from the device.
+	return DEVICE_OK;
+}
+
+int VariLC::sendCmd(std::string cmd) {
 	int ret = SendSerialCommand(port_.c_str(), cmd.c_str(), "\r");
 	if (ret != DEVICE_OK) {
 		return DEVICE_SERIAL_COMMAND_FAILED;
@@ -715,6 +719,5 @@ int VariLC::sendCmd(std::string cmd, std::string out) {
 		SetErrorText(99, "The VariLC did not respond.");
 		return 99;
 	}
-	GetSerialAnswer(port_.c_str(), "\r", out); //Try returning any extra response from the device.
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -324,8 +324,6 @@ int VariLC::Initialize()
 		if (i < 10) {
 			number = "0" + number;
 		}
-
-
 		s << "Pal. elem. " << number << "; enter 0 to define; 1 to activate";
 		pActX = new CPropertyActionEx(this, &VariLC::OnPalEl, i);
 		CreateProperty(s.str().c_str(), "", MM::String, false, pActX);
@@ -343,18 +341,13 @@ int VariLC::Initialize()
 	// Needed for Busy flag
 	// changedTime_ = GetCurrentMMTime();
 	SetErrorText(99, "Device set busy for ");
-
 	return DEVICE_OK;
 }
 
-
-int VariLC::Shutdown()
-{
+int VariLC::Shutdown() {
 	initialized_ = false;
 	return DEVICE_OK;
 }
-
-
 
 //////////////// Action Handlers (VariLC) /////////////////
 
@@ -482,6 +475,10 @@ int VariLC::OnBriefMode(MM::PropertyBase* pProp, MM::ActionType eAct)
 		 int ret = sendCmd("W?", ans);
 		 if (ret != DEVICE_OK)return DEVICE_SERIAL_COMMAND_FAILED;
 		 vector<double> numbers = getNumbersFromMessage(ans, briefModeQ_);
+		 if (numbers.size() == 0) { //The device must have returned "W*" meaning that an invalid wavelength was sent
+			 SetErrorText(99, "The Varispec device was commanded to tune to an out of range wavelength.");
+			 return 99;
+		 }
 		 pProp->Set(numbers[0]);
 	 }
 	 else if (eAct == MM::AfterSet)

--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -7,7 +7,11 @@
 //
 // AUTHOR:        Rudolf Oldenbourg, MBL, w/ Arthur Edelstein and Karl Hoover, UCSF, Sept, Oct 2010
 // COPYRIGHT:     
-// LICENSE:       
+// LICENSE:  
+
+// Change Log - Nick Anthony - Sept 11, 2018
+// 1. Wavelength upper and lower limits are now queried from the device rather than being assumed to be 400-800 nm.
+// 2. In the event that an out of range wavelength is set the adapter will now log an error and continue running. Previously this would result in a sudden crash without any log.
 
 // Change Log - Amitabh Verma - Jan. 26, 2015
 // 1. Error response retrieval using 'R?' fixed

--- a/DeviceAdapters/VariLC/VariLC.h
+++ b/DeviceAdapters/VariLC/VariLC.h
@@ -95,7 +95,8 @@ class VariLC : public CGenericBase<VariLC>
 	  MM::MMTime delay;
       std::vector<double> getNumbersFromMessage(std::string variLCmessage, bool prefixQ);
 	  std::string DoubleToString(double N);
-	  int sendCmd(std::string cmd, std::string out = "");
+	  int sendCmd(std::string cmd, std::string& out);
+	  int sendCmd(std::string cmd);
 };
 
 

--- a/DeviceAdapters/VariLC/VariLC.h
+++ b/DeviceAdapters/VariLC/VariLC.h
@@ -95,8 +95,8 @@ class VariLC : public CGenericBase<VariLC>
 	  MM::MMTime delay;
       std::vector<double> getNumbersFromMessage(std::string variLCmessage, bool prefixQ);
 	  std::string DoubleToString(double N);
-	  int sendCmd(std::string cmd, std::string& out);
-	  int sendCmd(std::string cmd);
+	  int sendCmd(std::string cmd, std::string& out);	//Send a command and save the response in `out`.
+	  int sendCmd(std::string cmd);	//Send a command that does not repond with any extra information.
 };
 
 

--- a/DeviceAdapters/VariLC/VariLC.h
+++ b/DeviceAdapters/VariLC/VariLC.h
@@ -95,6 +95,7 @@ class VariLC : public CGenericBase<VariLC>
 	  MM::MMTime delay;
       std::vector<double> getNumbersFromMessage(std::string variLCmessage, bool prefixQ);
 	  std::string DoubleToString(double N);
+	  std::string sendCmd(std::string cmd);
 };
 
 

--- a/DeviceAdapters/VariLC/VariLC.h
+++ b/DeviceAdapters/VariLC/VariLC.h
@@ -95,7 +95,6 @@ class VariLC : public CGenericBase<VariLC>
 	  MM::MMTime delay;
       std::vector<double> getNumbersFromMessage(std::string variLCmessage, bool prefixQ);
 	  std::string DoubleToString(double N);
-	  void removeSpaces(std::string input);
 };
 
 

--- a/DeviceAdapters/VariLC/VariLC.h
+++ b/DeviceAdapters/VariLC/VariLC.h
@@ -95,7 +95,7 @@ class VariLC : public CGenericBase<VariLC>
 	  MM::MMTime delay;
       std::vector<double> getNumbersFromMessage(std::string variLCmessage, bool prefixQ);
 	  std::string DoubleToString(double N);
-	  std::string sendCmd(std::string cmd);
+	  int sendCmd(std::string cmd, std::string out = "");
 };
 
 


### PR DESCRIPTION
This pull request improves the stability and versatility of the variLC.

Previously the adapter would cause a sudden crash of MM if a wavelength outside of its tunable range was specified. Now it will log an error and prevent the crash from occuring.

Rather than assuming that the tunable range of the device is 400-800 nm the adapter will now query this information from the device during initialization. Different models have different tunable ranges.