### PR TITLE
Fix corrupt metadata acquire multiple

### DIFF
--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
@@ -238,7 +238,9 @@ public class AcquireMultipleRegionsForm extends javax.swing.JFrame {
                 gui_.positions().setPositionList(currRegion.tileGrid(getXFieldSize(), getYFieldSize(), axisList_, zGenType_));               
                 gui_.app().refreshGUI();
                 Datastore store = gui_.acquisitions().runAcquisition(currRegion.filename, currRegion.directory);
+                store.freeze();
                 gui_.displays().closeDisplaysFor(store);
+                store.close();
             } catch (Exception ex) {
                 handleError(ex);
             }

--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/Region.java
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/Region.java
@@ -174,6 +174,7 @@ class Region {
                         MSP.add(newSP);
                     }
                 }
+                MSP.setLabel("Pos_" + String.format("%03d", xidx) + "_" + String.format("%03d", yidx));
 		PL.addPosition(MSP);
             }
             //Update Y coordinate


### PR DESCRIPTION
This pull request fixes an issue where datastores created by the acquire multiple regions plugin were not frozen prior to being closed. This would leave them in a state where their metadata was not complete.

I have also changed the plugin so that it will name it's positions in the position list with a grid location.

This opens up two possibilities for using ImageJ to stitch together the images (by metadata and by filename) that were not available before.