### PR TITLE
Studio: Correctly reads grid column and row in stored positionlists.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/MultiStagePosition.java
+++ b/mmstudio/src/main/java/org/micromanager/MultiStagePosition.java
@@ -447,10 +447,10 @@ public final class MultiStagePosition {
             PropertyKey.MULTI_STAGE_POSITION__DEFAULT_XY_STAGE.key(), null);
       ret.defaultZStage_ = pmap.getString(
             PropertyKey.MULTI_STAGE_POSITION__DEFAULT_Z_STAGE.key(), null);
-      ret.gridRow_ = pmap.getAsNumber(
-            PropertyKey.MULTI_STAGE_POSITION__GRID_ROW.key(), 0).intValue();
-      ret.gridCol_ = pmap.getAsNumber(
-            PropertyKey.MULTI_STAGE_POSITION__GRID_COLUMN.key(), 0).intValue();
+      ret.gridRow_ = pmap.getInteger(
+            PropertyKey.MULTI_STAGE_POSITION__GRID_ROW.key(), 0);
+      ret.gridCol_ = pmap.getInteger(
+            PropertyKey.MULTI_STAGE_POSITION__GRID_COLUMN.key(), 0);
       for (String key : pmap.getPropertyMap(
             PropertyKey.MULTI_STAGE_POSITION__PROPERTIES.key(),
             PropertyMaps.emptyPropertyMap()).keySet()) {


### PR DESCRIPTION
Bug reported by Nick Anthony in issue #690.  Values were stored as Integers,
but read back as primitives which failed.  Reading them back in as Integers
fixes this bug and makes it possible to retrieve these data in old stored
positionlists.