### PR TITLE
Allow specification of default User Profile to skip splashscreen

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -193,7 +193,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
     * @param args
     */
    public static void main(String args[]) {
-       //TODO this is not used when launching Micro-Manager from ImageJ or from Matlab, so when is it used?
       String profileNameAutoStart = null; //The name of the user profile that Micro-Manager should start up with. In the case that this is left as null then a splash screen will request that the user select a profile before startup.
       for (int i=0; i<args.length; i++) { // a library for the parsing of arguments such as apache commons - cli would make this more robust if needed.
           if (args[i].equals("-profile")) {

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -115,7 +115,6 @@ import org.micromanager.profile.internal.gui.HardwareConfigurationManager;
 import org.micromanager.quickaccess.QuickAccessManager;
 import org.micromanager.quickaccess.internal.DefaultQuickAccessManager;
 
-
 /*
  * Implements the Studio (i.e. primary API) and does various other
  * tasks that should probably be refactored out at some point.
@@ -194,9 +193,23 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
     * @param args
     */
    public static void main(String args[]) {
+       //TODO this is not used when launching Micro-Manager from ImageJ or from Matlab, so when is it used?
+      String profileNameAutoStart = null; //The name of the user profile that Micro-Manager should start up with. In the case that this is left as null then a splash screen will request that the user select a profile before startup.
+      for (int i=0; i<args.length; i++) { // a library for the parsing of arguments such as apache commons - cli would make this more robust if needed.
+          if (args[i].equals("-profile")) {
+              if (i < args.length-1) {
+                  i++;
+                  profileNameAutoStart = args[i];
+              } else {
+                  ReportingUtils.showError("Micro-Manager received no value for the `-profile` startup argument.");
+              }
+          } else {
+              ReportingUtils.showError("Micro-Manager received unknown startup argument: " + args[i]);
+          }
+      }
       try {
          UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-         MMStudio mmStudio = new MMStudio(false);
+         MMStudio mmStudio = new MMStudio(false, profileNameAutoStart);
       } catch (ClassNotFoundException e) {
          ReportingUtils.showError(e, "A java error has caused Micro-Manager to exit.");
          System.exit(1);


### PR DESCRIPTION
This PR extends the changes in: https://github.com/nicost/micro-manager/pull/48 so that they can be used when MMStudio is launched from ImageJ rather than only from Matlab.

This adds the ability for a user to pass arguments to micromanager at startup just like you would with any CLI program. 

In the case of launching MMStudio from ImageJ this would be done in an imageJ macro as `run("Micro-Manager Studio", "-profile MyProfileName");` A user could potentially modify the following line  to make this happen as soon as ImageJ is launched: https://github.com/micro-manager/micro-manager/blob/7a37a23f9134a16807a1f6662322d6301588bfd4/bindist/any-platform/macros/StartupMacros.txt#L45

Currently the only option supported is the `-profile {UserProfileName}` option which causes MicroManager to skip the splash screen and load directly into a user profile. Other options could easily be added to the code in this pull request.

Assuming that this feature is accepted I see two questions that should be resolved before merging:

  - The code to parse the arguments is currently implemented in three places in order to support multiple methods of running Micro-Manager (MMStudioPlugin, MMStudio::main, and the StartMMStudio.m matlab script). The convergence point of these three methods is the constructor of MMStudio. Should the string parsing be moved into the constructor of MMStudio so there is only one implementation?

  - MMStudio::main claims to be used for running MMStudio as "stand-alone". Is this still possible, I couldn't get it to work? If not, then maybe this would be a good time to remove the function altogether.