### PR TITLE
Enable by-passing the splash-screen again

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
@@ -70,6 +70,8 @@ public final class IntroDlg extends JDialog {
 
    private ProfileSelectionUIController profileController_;
    private ConfigSelectionUIController configController_;
+   private UserProfileAdmin admin_;
+   private boolean skipProfileSelection_ = false;
 
    public static String DISCLAIMER_TEXT =
       "This software is distributed free of charge in the hope that it will be useful, " +
@@ -77,15 +79,20 @@ public final class IntroDlg extends JDialog {
       "of merchantability or fitness for a particular purpose. In no event shall the copyright owner or contributors " +
       "be liable for any direct, indirect, incidental, special, examplary, or consequential damages.\n\n" +
       
-      "Copyright University of California San Francisco, 2007, 2008, 2009, 2010. All rights reserved.";
+      "Copyright University of California San Francisco, 2005-2020. All rights reserved.";
 
    public static String SUPPORT_TEXT =
-      "Micro-Manager was initially funded by grants from the Sandler Foundation and is now supported by a grant from the NIH.";
+      "Micro-Manager was funded by grants from the Sandler Foundation and NIH, and is now supported by the CZI.";
 
    public static String CITATION_TEXT =
       "If you have found this software useful, please cite Micro-Manager in your publications.";
 
 
+   /**
+    * Shows the Splash screen
+    * @param studio Instance of MMStudio.  Can not be null.
+    * @param versionStr 
+    */
    public IntroDlg(Studio studio, String versionStr) {
       // Select a plugin to use to customize the dialog.
       Map<String, IntroPlugin> plugins = studio == null ?
@@ -135,24 +142,23 @@ public final class IntroDlg extends JDialog {
       contentsPanel.add(versionLabel, new CC().gapLeft("5").wrap());
 
       try {
-         UserProfileAdmin admin = ((MMStudio) studio).profileAdmin();
-         profileController_ = ProfileSelectionUIController.create(admin);
+         admin_ = ((MMStudio) studio).profileAdmin();
+         profileController_ = ProfileSelectionUIController.create(admin_);
          StartupSettings startupSettings = StartupSettings.create(
-                 admin.getNonSavingProfile(admin.getUUIDOfCurrentProfile()));
-         if (!startupSettings.shouldSkipProfileSelectionAtStartup()) {
+                 admin_.getNonSavingProfile(admin_.getUUIDOfCurrentProfile()));
+         skipProfileSelection_ = (!startupSettings.shouldSkipProfileSelectionAtStartup());
+         if (!skipProfileSelection_) {
             JLabel userProfileLabel = new JLabel("User Profile:");
             userProfileLabel.setFont(DEFAULT_FONT);
             contentsPanel.add(userProfileLabel, new CC().gapTop("5").gapLeft("5").wrap());
             contentsPanel.add(profileController_.getUI(), new CC().growX().gapRight("5").wrap());
-         } else {
-            profileController_.
-         }
+         } 
          final JLabel loadConfigurationLabel = new JLabel();
          loadConfigurationLabel.setFont(DEFAULT_FONT);
          loadConfigurationLabel.setText("Hardware Configuration File:");
          contentsPanel.add(loadConfigurationLabel, new CC().gapLeft("5").wrap());
 
-         configController_ = ConfigSelectionUIController.create(admin);
+         configController_ = ConfigSelectionUIController.create(admin_);
          contentsPanel.add(configController_.getUI(), new CC().growX().gapRight("5").wrap());
       }
       catch (IOException e) {
@@ -225,6 +231,9 @@ public final class IntroDlg extends JDialog {
    }
 
    public UUID getSelectedProfileUUID() {
+      if (skipProfileSelection_) {
+         return admin_.getUUIDOfDefaultProfile();
+      }
       return profileController_.getSelectedProfileUUID();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
@@ -146,7 +146,7 @@ public final class IntroDlg extends JDialog {
          profileController_ = ProfileSelectionUIController.create(admin_);
          StartupSettings startupSettings = StartupSettings.create(
                  admin_.getNonSavingProfile(admin_.getUUIDOfCurrentProfile()));
-         skipProfileSelection_ = (!startupSettings.shouldSkipProfileSelectionAtStartup());
+         skipProfileSelection_ = startupSettings.shouldSkipProfileSelectionAtStartup();
          if (!skipProfileSelection_) {
             JLabel userProfileLabel = new JLabel("User Profile:");
             userProfileLabel.setFont(DEFAULT_FONT);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
@@ -136,15 +136,16 @@ public final class IntroDlg extends JDialog {
 
       try {
          UserProfileAdmin admin = ((MMStudio) studio).profileAdmin();
-         if (!StartupSettings.create(admin.getNonSavingProfile(
-               admin.getUUIDOfCurrentProfile())).
-               shouldSkipProfileSelectionAtStartup()) {
+         profileController_ = ProfileSelectionUIController.create(admin);
+         StartupSettings startupSettings = StartupSettings.create(
+                 admin.getNonSavingProfile(admin.getUUIDOfCurrentProfile()));
+         if (!startupSettings.shouldSkipProfileSelectionAtStartup()) {
             JLabel userProfileLabel = new JLabel("User Profile:");
             userProfileLabel.setFont(DEFAULT_FONT);
             contentsPanel.add(userProfileLabel, new CC().gapTop("5").gapLeft("5").wrap());
-
-            profileController_ = ProfileSelectionUIController.create(admin);
             contentsPanel.add(profileController_.getUI(), new CC().growX().gapRight("5").wrap());
+         } else {
+            profileController_.
          }
          final JLabel loadConfigurationLabel = new JLabel();
          loadConfigurationLabel.setFont(DEFAULT_FONT);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -22,7 +22,6 @@
 package org.micromanager.internal.dialogs;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.text.ParseException;
@@ -113,14 +112,12 @@ public final class OptionsDlg extends MMDialog {
               "Always use the default user profile; no prompt will be displayed to select a profile at startup.");
       alwaysUseDefaultProfileCheckBox.setSelected(
               startupSettings.shouldSkipProfileSelectionAtStartup());
-      alwaysUseDefaultProfileCheckBox.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            boolean checked = alwaysUseDefaultProfileCheckBox.isSelected();
-            startupSettings.setSkipProfileSelectionAtStartup(checked);
-            askForConfigFileCheckBox.setSelected(checked);
-            startupSettings.setSkipConfigSelectionAtStartup(checked);
-         }
+      alwaysUseDefaultProfileCheckBox.addActionListener((ActionEvent e) -> {
+         boolean checked = alwaysUseDefaultProfileCheckBox.isSelected();
+         startupSettings.setSkipProfileSelectionAtStartup(checked);
+         askForConfigFileCheckBox.setEnabled(checked);
+         startupSettings.setSkipConfigSelectionAtStartup(
+                 askForConfigFileCheckBox.isSelected());
       });
 
       // Slaving the "use default profile" setting.  
@@ -132,17 +129,15 @@ public final class OptionsDlg extends MMDialog {
          startupSettings.setSkipConfigSelectionAtStartup(
                  !askForConfigFileCheckBox.isSelected());
       });
-      askForConfigFileCheckBox.setSelected(alwaysUseDefaultProfileCheckBox.isSelected());
-      askForConfigFileCheckBox.setEnabled(false);
+      askForConfigFileCheckBox.setSelected(
+              startupSettings.shouldSkipConfigSelectionAtStartup());
+      askForConfigFileCheckBox.setEnabled(alwaysUseDefaultProfileCheckBox.isSelected());
 
       final JCheckBox deleteLogCheckBox = new JCheckBox();
       deleteLogCheckBox.setText("Delete log files after");
       deleteLogCheckBox.setSelected(mmStudio_.getShouldDeleteOldCoreLogs());
-      deleteLogCheckBox.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            mmStudio_.setShouldDeleteOldCoreLogs(deleteLogCheckBox.isSelected());
-         }
+      deleteLogCheckBox.addActionListener((ActionEvent e) -> {
+         mmStudio_.setShouldDeleteOldCoreLogs(deleteLogCheckBox.isSelected());
       });
 
       logDeleteDaysField_ =
@@ -152,58 +147,52 @@ public final class OptionsDlg extends MMDialog {
       deleteLogFilesButton.setText("Delete Log Files Now");
       deleteLogFilesButton.setToolTipText("Delete all CoreLog files except " +
             "for the current one");
-      deleteLogFilesButton.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(final ActionEvent e) {
-            String dir1 =
-               LogFileManager.getLogFileDirectory().getAbsolutePath();
-            String dir2 =
-               LogFileManager.getLegacyLogFileDirectory().getAbsolutePath();
-            String dirs;
-            if (dir1.equals(dir2)) {
-               dirs = dir1;
-            }
-            else {
-               dirs = dir1 + " and " + dir2;
-            }
-
-            int answer = JOptionPane.showConfirmDialog(OptionsDlg.this,
-               "<html><body><p style='width: 400px;'>" +
-               "Delete all CoreLog files in " + dirs + "?" +
-               "</p></body></html>",
-               "Delete Log Files",
-               JOptionPane.YES_NO_OPTION,
-               JOptionPane.QUESTION_MESSAGE);
-            if (answer == JOptionPane.YES_OPTION) {
-               LogFileManager.deleteLogFilesDaysOld(0,
-                  core_.getPrimaryLogFile());
-            }
+      deleteLogFilesButton.addActionListener((final ActionEvent e) -> {
+         String dir1 =
+                 LogFileManager.getLogFileDirectory().getAbsolutePath();
+         String dir2 =
+                 LogFileManager.getLegacyLogFileDirectory().getAbsolutePath();
+         String dirs;
+         if (dir1.equals(dir2)) {
+            dirs = dir1;
+         }
+         else {
+            dirs = dir1 + " and " + dir2;
+         }
+         
+         int answer = JOptionPane.showConfirmDialog(OptionsDlg.this,
+                 "<html><body><p style='width: 400px;'>" +
+                         "Delete all CoreLog files in " + dirs + "?" +
+                                 "</p></body></html>",
+                 "Delete Log Files",
+                 JOptionPane.YES_NO_OPTION,
+                 JOptionPane.QUESTION_MESSAGE);
+         if (answer == JOptionPane.YES_OPTION) {
+            LogFileManager.deleteLogFilesDaysOld(0,
+                    core_.getPrimaryLogFile());
          }
       });
 
       final JButton clearPreferencesButton = new JButton();
       clearPreferencesButton.setText("Reset Preferences");
       clearPreferencesButton.setToolTipText("Clear all preference settings and restore defaults");
-      clearPreferencesButton.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(final ActionEvent e) {
-            int answer = JOptionPane.showConfirmDialog(OptionsDlg.this,
-               "Reset all preference settings?",
-               "Reset Preferences",
-               JOptionPane.YES_NO_OPTION,
-               JOptionPane.QUESTION_MESSAGE);
-            if (answer != JOptionPane.YES_OPTION) {
-               return;
-            }
-            // Clear everything except whether or not this user has
-            // registered.
-            boolean haveRegistered = RegistrationDlg.getHaveRegistered(mmStudio_);
-            profile_.clearSettingsForAllClasses();
-            RegistrationDlg.setHaveRegistered(mmStudio_, haveRegistered);
-            // Rather than updating all the GUI elements, let's just close
-            // the dialog.
-            dispose();
+      clearPreferencesButton.addActionListener((final ActionEvent e) -> {
+         int answer = JOptionPane.showConfirmDialog(OptionsDlg.this,
+                 "Reset all preference settings?",
+                 "Reset Preferences",
+                 JOptionPane.YES_NO_OPTION,
+                 JOptionPane.QUESTION_MESSAGE);
+         if (answer != JOptionPane.YES_OPTION) {
+            return;
          }
+         // Clear everything except whether or not this user has
+         // registered.
+         boolean haveRegistered = RegistrationDlg.getHaveRegistered(mmStudio_);
+         profile_.clearSettingsForAllClasses();
+         RegistrationDlg.setHaveRegistered(mmStudio_, haveRegistered);
+         // Rather than updating all the GUI elements, let's just close
+         // the dialog.
+         dispose();
       });
 
       bufSizeField_ = new JTextField(
@@ -216,11 +205,8 @@ public final class OptionsDlg extends MMDialog {
       comboDisplayBackground_ = new JComboBox(options);
       comboDisplayBackground_.setMaximumRowCount(2);
       comboDisplayBackground_.setSelectedItem(mmStudio_.app().skin().getSkin().getDesc());
-      comboDisplayBackground_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            changeBackground();
-         }
+      comboDisplayBackground_.addActionListener((ActionEvent e) -> {
+         changeBackground();
       });
 
       startupScriptFile_ = new JTextField(ScriptPanel.getStartupScript());
@@ -228,64 +214,46 @@ public final class OptionsDlg extends MMDialog {
       final JCheckBox closeOnExitCheckBox = new JCheckBox();
       closeOnExitCheckBox.setText("Close app when quitting MM");
       closeOnExitCheckBox.setSelected(getShouldCloseOnExit(mmStudio_));
-      closeOnExitCheckBox.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            boolean shouldClose = closeOnExitCheckBox.isSelected();
-            setShouldCloseOnExit(mmStudio_, shouldClose);
-            MMStudio.getFrame().setExitStrategy(shouldClose);
-         }
+      closeOnExitCheckBox.addActionListener((ActionEvent arg0) -> {
+         boolean shouldClose = closeOnExitCheckBox.isSelected();
+         setShouldCloseOnExit(mmStudio_, shouldClose);
+         MMStudio.getFrame().setExitStrategy(shouldClose);
       });
 
       final JCheckBox metadataFileWithMultipageTiffCheckBox = new JCheckBox();
       metadataFileWithMultipageTiffCheckBox.setText("Create metadata.txt file with Image Stack Files");
       metadataFileWithMultipageTiffCheckBox.setSelected(
             StorageMultipageTiff.getShouldGenerateMetadataFile());
-      metadataFileWithMultipageTiffCheckBox.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            StorageMultipageTiff.setShouldGenerateMetadataFile(metadataFileWithMultipageTiffCheckBox.isSelected());
-         }
+      metadataFileWithMultipageTiffCheckBox.addActionListener((ActionEvent arg0) -> {
+         StorageMultipageTiff.setShouldGenerateMetadataFile(metadataFileWithMultipageTiffCheckBox.isSelected());
       });
       
       final JCheckBox separateFilesForPositionsMPTiffCheckBox = new JCheckBox();
       separateFilesForPositionsMPTiffCheckBox.setText("Save XY positions in separate Image Stack Files");
       separateFilesForPositionsMPTiffCheckBox.setSelected(
             StorageMultipageTiff.getShouldSplitPositions());
-      separateFilesForPositionsMPTiffCheckBox.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            StorageMultipageTiff.setShouldSplitPositions(separateFilesForPositionsMPTiffCheckBox.isSelected());
-         }
+      separateFilesForPositionsMPTiffCheckBox.addActionListener((ActionEvent arg0) -> {
+         StorageMultipageTiff.setShouldSplitPositions(separateFilesForPositionsMPTiffCheckBox.isSelected());
       });
   
       final JCheckBox syncExposureMainAndMDA = new JCheckBox();
       syncExposureMainAndMDA.setText("Sync exposure between Main and MDA windows");
       syncExposureMainAndMDA.setSelected(AcqControlDlg.getShouldSyncExposure());
-      syncExposureMainAndMDA.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            AcqControlDlg.setShouldSyncExposure(syncExposureMainAndMDA.isSelected());
-         }
+      syncExposureMainAndMDA.addActionListener((ActionEvent arg0) -> {
+         AcqControlDlg.setShouldSyncExposure(syncExposureMainAndMDA.isSelected());
       });
   
       final JCheckBox hideMDAdisplay = new JCheckBox();
       hideMDAdisplay.setText("Hide MDA display");
       hideMDAdisplay.setSelected(AcqControlDlg.getShouldHideMDADisplay());
-      hideMDAdisplay.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent arg0) {
-            AcqControlDlg.setShouldHideMDADisplay(hideMDAdisplay.isSelected());
-         }
+      hideMDAdisplay.addActionListener((ActionEvent arg0) -> {
+         AcqControlDlg.setShouldHideMDADisplay(hideMDAdisplay.isSelected());
       });
 
       final JButton closeButton = new JButton();
       closeButton.setText("Close");
-      closeButton.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(final ActionEvent ev) {
-            closeRequested();
-         }
+      closeButton.addActionListener((final ActionEvent ev) -> {
+         closeRequested();
       });
 
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -82,8 +82,8 @@ public final class OptionsDlg extends MMDialog {
       super.setModal(true);
       super.setAlwaysOnTop(true);
       super.setTitle("Micro-Manager Options");
-      
-      super.loadAndRestorePosition(100, 100);     
+
+      super.loadAndRestorePosition(100, 100);
 
       super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
       super.addWindowListener(new WindowAdapter() {
@@ -105,9 +105,8 @@ public final class OptionsDlg extends MMDialog {
       });
 
       final JCheckBox askForConfigFileCheckBox = new JCheckBox();
-      
       final JCheckBox alwaysUseDefaultProfileCheckBox = new JCheckBox(
-            "Always use the default user profile");
+              "Always use the default user profile");
       alwaysUseDefaultProfileCheckBox.setToolTipText(
               "Always use the default user profile; no prompt will be displayed to select a profile at startup.");
       alwaysUseDefaultProfileCheckBox.setSelected(
@@ -117,10 +116,10 @@ public final class OptionsDlg extends MMDialog {
          startupSettings.setSkipProfileSelectionAtStartup(checked);
          askForConfigFileCheckBox.setEnabled(checked);
          if (checked) {
-         startupSettings.setSkipConfigSelectionAtStartup(
-                 askForConfigFileCheckBox.isSelected());
+            startupSettings.setSkipConfigSelectionAtStartup(
+                    askForConfigFileCheckBox.isSelected());
          } else {
-             startupSettings.setSkipConfigSelectionAtStartup(false);
+            startupSettings.setSkipConfigSelectionAtStartup(false);
          }
       });
 
@@ -281,8 +280,11 @@ public final class OptionsDlg extends MMDialog {
 
       super.add(new JSeparator(), "wrap");
 
-      super.add(alwaysUseDefaultProfileCheckBox, "wrap");
-      super.add(askForConfigFileCheckBox, "wrap");
+      if (mmStudio_.profileAdmin().getUUIDOfCurrentProfile() ==
+              mmStudio_.profileAdmin().getUUIDOfDefaultProfile()) {
+         super.add(alwaysUseDefaultProfileCheckBox, "wrap");
+         super.add(askForConfigFileCheckBox, "wrap");
+      }
       
       super.add(new JSeparator(), "wrap");
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -116,8 +116,12 @@ public final class OptionsDlg extends MMDialog {
          boolean checked = alwaysUseDefaultProfileCheckBox.isSelected();
          startupSettings.setSkipProfileSelectionAtStartup(checked);
          askForConfigFileCheckBox.setEnabled(checked);
+         if (checked) {
          startupSettings.setSkipConfigSelectionAtStartup(
                  askForConfigFileCheckBox.isSelected());
+         } else {
+             startupSettings.setSkipConfigSelectionAtStartup(false);
+         }
       });
 
       // Slaving the "use default profile" setting.  
@@ -130,7 +134,7 @@ public final class OptionsDlg extends MMDialog {
                  !askForConfigFileCheckBox.isSelected());
       });
       askForConfigFileCheckBox.setSelected(
-              startupSettings.shouldSkipConfigSelectionAtStartup());
+              !startupSettings.shouldSkipConfigSelectionAtStartup());
       askForConfigFileCheckBox.setEnabled(alwaysUseDefaultProfileCheckBox.isSelected());
 
       final JCheckBox deleteLogCheckBox = new JCheckBox();

--- a/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
+++ b/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
@@ -75,8 +75,7 @@ public final class UserProfileAdmin {
    private boolean didMigrateLegacy_ = false;
 
    private Index virtualIndex_ = new Index();
-   private final Map<String, Profile> virtualProfiles_ =
-         new HashMap<String, Profile>();
+   private final Map<String, Profile> virtualProfiles_ = new HashMap<>();
 
    private UUID currentProfileUUID_ = DEFAULT_PROFILE_UUID;
 
@@ -209,7 +208,7 @@ public final class UserProfileAdmin {
     * migrating legacy profiles
     */
    public Map<UUID, String> getProfileUUIDsAndNames() throws IOException {
-      Map<UUID, String> ret = new LinkedHashMap<UUID, String>();
+      Map<UUID, String> ret = new LinkedHashMap<>();
       for (IndexEntry entry : getIndex().getEntries()) {
          UUID uuid = entry.getUUID();
          String name = entry.getName();
@@ -275,18 +274,14 @@ public final class UserProfileAdmin {
             }
             ret.setFallbackProfile(getNonSavingGlobalProfile());
             if (autosaving) {
-               ret.setSaver(ProfileSaver.create(ret, new Runnable() {
-                  @Override
-                  public void run() {
-                     Profile profile;
-                     profile = Profile.fromSettings(ret.toPropertyMap());
-                     try {
-                        writeFile(filename, profile, false);
-                     }
-                     catch (IOException e) {
-                        if (errorHandler != null) {
-                           errorHandler.exceptionThrown(e);
-                        }
+               ret.setSaver(ProfileSaver.create(ret, () -> {
+                  Profile profile1;
+                  profile1 = Profile.fromSettings(ret.toPropertyMap());
+                  try {
+                     writeFile(filename, profile1, false);
+                  }catch (IOException e) {
+                     if (errorHandler != null) {
+                        errorHandler.exceptionThrown(e);
                      }
                   }
                }, saverExecutor_));
@@ -540,7 +535,7 @@ public final class UserProfileAdmin {
          return false;
       }
 
-      List<IndexEntry> entries = new ArrayList<IndexEntry>();
+      List<IndexEntry> entries = new ArrayList<>();
       for (String legacyName : legacyIndex.keySet()) {
          UUID uuid;
          String newName = legacyName;
@@ -599,8 +594,7 @@ public final class UserProfileAdmin {
        * Modern format uses a nested property map for each owner.
        */
 
-      Map<String, PropertyMap.Builder> settings =
-            new LinkedHashMap<String, PropertyMap.Builder>();
+      Map<String, PropertyMap.Builder> settings = new LinkedHashMap<>();
       for (String legacyKey : legacy.keySet()) {
          List<String> split = Splitter.on(':').limit(2).splitToList(legacyKey);
          if (split.size() < 2) {
@@ -675,12 +669,8 @@ public final class UserProfileAdmin {
          System.out.println("Migrated = " + admin.migrateLegacyProfiles());
 
          UUID uuid = admin.getUUIDOfDefaultProfile();
-         UserProfile profile = admin.getAutosavingProfile(uuid,
-               new ExceptionListener() {
-            @Override
-            public void exceptionThrown(Exception e) {
-               System.err.println("Exception Listener:" + e);
-            }
+         UserProfile profile = admin.getAutosavingProfile(uuid, (Exception e) -> {
+            System.err.println("Exception Listener:" + e);
          });
 
          profile.getSettings(UserProfileAdmin.class).putColor("Test!", Color.RED);
@@ -688,10 +678,7 @@ public final class UserProfileAdmin {
 
          admin.shutdownAutosaves();
       }
-      catch (IOException e) {
-         System.err.println(e.getMessage());
-      }
-      catch (InterruptedException e) {
+      catch (IOException | InterruptedException e) {
          System.err.println(e.getMessage());
       }
    }


### PR DESCRIPTION
Options were still present but not functional.  This PR makes them functional again.  However, I can not makes these options work for the non-default-users.  In addition, it makes sense that only the default user can set these settings, so that is the approach I took.

In general, it would be nice to have a clearly documented mechanism for loading properties that need to be in effect before the profile is loaded/selected.