### PR TITLE
Make _snprintf macro for VS2010 conditional

### DIFF
--- a/DeviceAdapters/AAAOTF/AAAOTF.cpp
+++ b/DeviceAdapters/AAAOTF/AAAOTF.cpp
@@ -10,8 +10,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "AAAOTF.h"
 #include <string>

--- a/DeviceAdapters/ABS/ABSCamera.h
+++ b/DeviceAdapters/ABS/ABSCamera.h
@@ -4,9 +4,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>   
-   #define snprintf _snprintf 
    #pragma warning(disable : 4996) // disable warning for deperecated CRT functions on Windows 
 #endif
+#include "FixSnprintf.h"
 
 #include "MMDevice.h"
 #include "MMDeviceConstants.h"

--- a/DeviceAdapters/ABS/CcmFileStd.cpp
+++ b/DeviceAdapters/ABS/CcmFileStd.cpp
@@ -24,9 +24,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>   
-   #define snprintf _snprintf 
    #pragma warning(disable : 4996) // disable warning for deperecated CRT functions on Windows 
 #endif
+#include "FixSnprintf.h"
 
 #include "ccmfilestd.h"
 #include "memoryinifile.h"

--- a/DeviceAdapters/ABS/TimeSpanPC.h
+++ b/DeviceAdapters/ABS/TimeSpanPC.h
@@ -3,9 +3,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>   
-   #define snprintf _snprintf 
    #pragma warning(disable : 4996) // disable warning for deperecated CRT functions on Windows 
 #endif
+#include "FixSnprintf.h"
 
 class CTimeSpanPC
 {

--- a/DeviceAdapters/ABS/absdelayloaddll.cpp
+++ b/DeviceAdapters/ABS/absdelayloaddll.cpp
@@ -1,9 +1,9 @@
 #ifdef WIN32
   #define WIN32_LEAN_AND_MEAN
   #include <windows.h>   
-  #define snprintf _snprintf 
   #pragma warning(disable : 4996) // disable warning for deperecated CRT functions on Windows 
 #endif
+#include "FixSnprintf.h"
 #include <stdio.h>
 #include "delayimp.h"
 #include "ABSDelayLoadDll.h"

--- a/DeviceAdapters/AOTF/AOTF.cpp
+++ b/DeviceAdapters/AOTF/AOTF.cpp
@@ -28,8 +28,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "AOTF.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/ASIWPTR/wptr.cpp
+++ b/DeviceAdapters/ASIWPTR/wptr.cpp
@@ -23,11 +23,7 @@
 // AUTHOR:        Vikram Kopuri, based on Code by Nenad Amodaj Nico Stuurman and Jizhen Zhao
 //
 
-
-#ifdef WIN32
-   //#include <windows.h>
-   #define snprintf _snprintf 
-#endif
+#include "FixSnprintf.h"
 
 #include "wptr.h"
 #include <string>

--- a/DeviceAdapters/AgilentLaserCombiner/AgilentLaserCombiner.cpp
+++ b/DeviceAdapters/AgilentLaserCombiner/AgilentLaserCombiner.cpp
@@ -13,8 +13,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "AgilentLaserCombiner.h"
 #include "LaserCombinerSDK.h"

--- a/DeviceAdapters/Aladdin/Aladdin.cpp
+++ b/DeviceAdapters/Aladdin/Aladdin.cpp
@@ -26,8 +26,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/AndorLaserCombiner/AndorLaserCombiner.cpp
+++ b/DeviceAdapters/AndorLaserCombiner/AndorLaserCombiner.cpp
@@ -29,8 +29,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 // Declarations for the ALC library.

--- a/DeviceAdapters/Apogee/Apogee.cpp
+++ b/DeviceAdapters/Apogee/Apogee.cpp
@@ -32,8 +32,8 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Apogee.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/Arduino/Arduino.cpp
+++ b/DeviceAdapters/Arduino/Arduino.cpp
@@ -20,8 +20,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 const char* g_DeviceNameArduinoHub = "Arduino-Hub";
 const char* g_DeviceNameArduinoSwitch = "Arduino-Switch";

--- a/DeviceAdapters/Arduino32bitBoards/Arduino32bitBoards.cpp
+++ b/DeviceAdapters/Arduino32bitBoards/Arduino32bitBoards.cpp
@@ -31,8 +31,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 const char* g_DeviceNameArduino32Hub = "Arduino32-Hub";
 const char* g_DeviceNameArduino32Switch = "Arduino32-Switch";

--- a/DeviceAdapters/BlueboxOptics_niji/niji.cpp
+++ b/DeviceAdapters/BlueboxOptics_niji/niji.cpp
@@ -28,8 +28,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/CARVII/CARVII.cpp
+++ b/DeviceAdapters/CARVII/CARVII.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "CARVII.h"
 #include "CARVIIHub.h"

--- a/DeviceAdapters/CNCMicroscope/ArduinoNeoPixelShutter/ArduinoNeoPixelShutter.cpp
+++ b/DeviceAdapters/CNCMicroscope/ArduinoNeoPixelShutter/ArduinoNeoPixelShutter.cpp
@@ -24,8 +24,8 @@ limitations under the License.
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 const char* g_DeviceNameArduinoNeoPixelHub = "ArduinoNeoPixel-Hub";
 const char* g_DeviceNameArduinoNeoPixelShutter = "ArduinoNeoPixel-Shutter";

--- a/DeviceAdapters/CSUW1/CSUW1.cpp
+++ b/DeviceAdapters/CSUW1/CSUW1.cpp
@@ -33,8 +33,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "CSUW1.h"
 #include "CSUW1Hub.h"

--- a/DeviceAdapters/ChuoSeiki_MD5000/ChuoSeiki_MD_XYZ.cpp
+++ b/DeviceAdapters/ChuoSeiki_MD5000/ChuoSeiki_MD_XYZ.cpp
@@ -29,8 +29,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "ChuoSeiki_MD_XYZ.h"
 

--- a/DeviceAdapters/ChuoSeiki_QT/ChuoSeiki_QT_XYZ.cpp
+++ b/DeviceAdapters/ChuoSeiki_QT/ChuoSeiki_QT_XYZ.cpp
@@ -33,8 +33,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "ChuoSeiki_QT_XYZ.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/CoherentCube/CoherentCube.cpp
+++ b/DeviceAdapters/CoherentCube/CoherentCube.cpp
@@ -26,8 +26,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
+++ b/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
@@ -24,8 +24,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "CoherentOBIS.h"
 

--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.cpp
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.cpp
@@ -25,8 +25,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "CoherentScientificRemote.h"
 

--- a/DeviceAdapters/Conix/Conix.cpp
+++ b/DeviceAdapters/Conix/Conix.cpp
@@ -14,8 +14,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "Conix.h"
 #include <cstdio>

--- a/DeviceAdapters/CoolLEDpE300/pE300.cpp
+++ b/DeviceAdapters/CoolLEDpE300/pE300.cpp
@@ -20,8 +20,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/CoolLEDpE4000/pE4000.cpp
+++ b/DeviceAdapters/CoolLEDpE4000/pE4000.cpp
@@ -20,8 +20,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/Corvus/Corvus.cpp
+++ b/DeviceAdapters/Corvus/Corvus.cpp
@@ -37,11 +37,7 @@
 
 // "st" gives 8bit value. bit 0 tells if ready to execute; busy if "1"
 
-
-#ifdef WIN32
-//   #include <windows.h>
-   #define snprintf _snprintf 
-#endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/DTOpenLayer/DTOpenLayer.cpp
+++ b/DeviceAdapters/DTOpenLayer/DTOpenLayer.cpp
@@ -23,8 +23,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "DTOpenLayer.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/Diskovery/Diskovery.cpp
+++ b/DeviceAdapters/Diskovery/Diskovery.cpp
@@ -24,8 +24,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Diskovery.h"
 #include <string>

--- a/DeviceAdapters/Diskovery/DiskoveryModel.cpp
+++ b/DeviceAdapters/Diskovery/DiskoveryModel.cpp
@@ -24,8 +24,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 #include "DiskoveryModel.h"

--- a/DeviceAdapters/FLICamera/FLICamera.cpp
+++ b/DeviceAdapters/FLICamera/FLICamera.cpp
@@ -25,7 +25,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
+#include "FixSnprintf.h"
 
 extern "C" {
 	long __stdcall FLILibAttach(void);

--- a/DeviceAdapters/FreeSerialPort/FreeSerialPort.cpp
+++ b/DeviceAdapters/FreeSerialPort/FreeSerialPort.cpp
@@ -24,8 +24,8 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "FreeSerialPort.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/HamiltonMVP/MVPCommands.h
+++ b/DeviceAdapters/HamiltonMVP/MVPCommands.h
@@ -41,9 +41,7 @@
 #include <string>
 #include <vector>
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
+#include "FixSnprintf.h"
 
 
 const char* const MVP_TERM = "\r";

--- a/DeviceAdapters/HydraLMT200/ITKHydra.cpp
+++ b/DeviceAdapters/HydraLMT200/ITKHydra.cpp
@@ -35,10 +35,7 @@
 
 //TODO: NEED TO MAKE SURE COMMENDS SEND IN CR + LFKE SURE COMMENDS SEND IN CR + LF
 
-#ifdef WIN32
-//   #include <windows.h>
-   #define snprintf _snprintf
-#endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/ITC18/MMITC18.cpp
+++ b/DeviceAdapters/ITC18/MMITC18.cpp
@@ -12,10 +12,10 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf
 #else
     #include <dlfcn.h> 
 #endif
+#include "FixSnprintf.h"
 
 #include "MMITC18.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/IlluminateLEDArray/LEDArray.cpp
+++ b/DeviceAdapters/IlluminateLEDArray/LEDArray.cpp
@@ -30,8 +30,8 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 int LedArray::Initialize()

--- a/DeviceAdapters/IsmatecMCP/MCPCommands.h
+++ b/DeviceAdapters/IsmatecMCP/MCPCommands.h
@@ -39,10 +39,8 @@
 #include <cstdlib>
 #include <string>
 
+#include "FixSnprintf.h"
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
 
 const char* const MCP_CMD_TERM = "\r";
 const char* const MCP_RESP_TERM = "\r\n";

--- a/DeviceAdapters/K8055/K8055.cpp
+++ b/DeviceAdapters/K8055/K8055.cpp
@@ -17,8 +17,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 using namespace std;
 

--- a/DeviceAdapters/K8061/K8061.cpp
+++ b/DeviceAdapters/K8061/K8061.cpp
@@ -18,8 +18,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 using namespace std;
 

--- a/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
@@ -28,10 +28,10 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #else
 #include <netinet/in.h>
 #endif
+#include "FixSnprintf.h"
 
 #include "LeicaDMI.h"
 #include "LeicaDMIModel.h"

--- a/DeviceAdapters/LeicaDMI/LeicaDMIModel.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIModel.cpp
@@ -28,10 +28,10 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #else
 #include <netinet/in.h>
 #endif
+#include "FixSnprintf.h"
 
 #include "LeicaDMIModel.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.cpp
@@ -28,10 +28,10 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #else
 #include <netinet/in.h>
 #endif
+#include "FixSnprintf.h"
 
 #include "LeicaDMIScopeInterface.h"
 #include "LeicaDMIModel.h"

--- a/DeviceAdapters/LeicaDMR/LeicaDMR.cpp
+++ b/DeviceAdapters/LeicaDMR/LeicaDMR.cpp
@@ -26,10 +26,7 @@
 // AUTHOR:        Nico Stuurman (based on code by Nenad Amodaj), nico@cmp.ucsf.edu, April 2007
 //
 
-#ifdef WIN32
-   //#include <windows.h>
-   #define snprintf _snprintf 
-#endif
+#include "FixSnprintf.h"
 
 #include "LeicaDMR.h"
 #include "LeicaDMRHub.h"

--- a/DeviceAdapters/LeicaDMSTC/LeicaDMSTC.cpp
+++ b/DeviceAdapters/LeicaDMSTC/LeicaDMSTC.cpp
@@ -22,10 +22,7 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
 
-#ifdef WIN32
-   //#include <windows.h>
-   #define snprintf _snprintf 
-#endif
+#include "FixSnprintf.h"
 
 #include "LeicaDMSTC.h"
 #include "LeicaDMSTCHub.h"

--- a/DeviceAdapters/Ludl/Ludl.cpp
+++ b/DeviceAdapters/Ludl/Ludl.cpp
@@ -29,8 +29,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "Ludl.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/LudlLow/Ludl.cpp
+++ b/DeviceAdapters/LudlLow/Ludl.cpp
@@ -28,8 +28,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "Ludl.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/LumencorCIA/CIA.cpp
+++ b/DeviceAdapters/LumencorCIA/CIA.cpp
@@ -22,9 +22,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
    #include <iostream>
 #endif
+#include "FixSnprintf.h"
 
 #define DEBUG
 

--- a/DeviceAdapters/LumencorCIA/LECtrl.cpp
+++ b/DeviceAdapters/LumencorCIA/LECtrl.cpp
@@ -22,10 +22,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
    #include <iostream>
-
 #endif
+#include "FixSnprintf.h"
 
 #include <string>
 #include <math.h>

--- a/DeviceAdapters/MP285/MP285.cpp
+++ b/DeviceAdapters/MP285/MP285.cpp
@@ -32,8 +32,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/MP285/MP285Ctrl.cpp
+++ b/DeviceAdapters/MP285/MP285Ctrl.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/MP285/MP285Error.cpp
+++ b/DeviceAdapters/MP285/MP285Error.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/MP285/MP285XYStage.cpp
+++ b/DeviceAdapters/MP285/MP285XYStage.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/MP285/MP285ZStage.cpp
+++ b/DeviceAdapters/MP285/MP285ZStage.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/MT20/MT20.cpp
+++ b/DeviceAdapters/MT20/MT20.cpp
@@ -35,9 +35,7 @@ const char* g_MT20Shutter = "MT20-Shutter";
 const char* g_MT20Filterwheel = "MT20-Filterwheel";
 const char* g_MT20Attenuator = "MT20-Attenuator";
 
-#ifdef WIN32
-	#define snprintf _snprintf
-#endif
+#include "FixSnprintf.h"
 
 // instantiate MT20hub object, which will handle communication with device
 MT20hub mt20;

--- a/DeviceAdapters/MT20/MT20hub.cpp
+++ b/DeviceAdapters/MT20/MT20hub.cpp
@@ -28,12 +28,12 @@
 
 #ifdef WIN32
 	#define close closesocket
-	#define snprintf _snprintf
 	//#define errno WSAGetLastError()
 	#define strerror stringerror	// defined internally to use FormatMessage() instead of strerror
 #else
 	#include <errno.h>
 #endif
+#include "FixSnprintf.h"
 
 MT20hub::MT20hub() :
 	connected_(false),

--- a/DeviceAdapters/MaestroServo/MaestroServo.cpp
+++ b/DeviceAdapters/MaestroServo/MaestroServo.cpp
@@ -19,8 +19,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "MaestroServo.h"
 #include <string>

--- a/DeviceAdapters/Marzhauser-LStep/LStep.cpp
+++ b/DeviceAdapters/Marzhauser-LStep/LStep.cpp
@@ -31,10 +31,9 @@
 //
 
 #ifdef WIN32
-//   #include <windows.h>
-   #define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "LStep.h"
 #include <string>

--- a/DeviceAdapters/Marzhauser/Marzhauser.cpp
+++ b/DeviceAdapters/Marzhauser/Marzhauser.cpp
@@ -32,10 +32,9 @@
 //
 
 #ifdef WIN32
-//   #include <windows.h>
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "Marzhauser.h"
 #include <string>

--- a/DeviceAdapters/MarzhauserLStepOld/LStepOld.cpp
+++ b/DeviceAdapters/MarzhauserLStepOld/LStepOld.cpp
@@ -19,8 +19,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "LStepOld.h"
 #include <string>

--- a/DeviceAdapters/MicroPoint/MicroPoint.cpp
+++ b/DeviceAdapters/MicroPoint/MicroPoint.cpp
@@ -27,9 +27,9 @@
 //                Thanks to Sophie Dumont, Mary Elting, and Michael Mohammadi
 
 #ifdef WIN32
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "MicroPoint.h"
 #include <cstdio>

--- a/DeviceAdapters/NI100X/NI100X.cpp
+++ b/DeviceAdapters/NI100X/NI100X.cpp
@@ -13,8 +13,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/replace.hpp>

--- a/DeviceAdapters/NIDAQ/NIDAQ.cpp
+++ b/DeviceAdapters/NIDAQ/NIDAQ.cpp
@@ -20,8 +20,8 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 const char* g_DeviceNameNIDAQDO = "NI-DAQ-DO";
 const char* g_DeviceNameNIDAQAO = "NI-DAQ-AO";

--- a/DeviceAdapters/NKTSuperK/SuperKModule.cpp
+++ b/DeviceAdapters/NKTSuperK/SuperKModule.cpp
@@ -31,8 +31,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "SuperK.h"
 

--- a/DeviceAdapters/NeoPixel/NeoPixel.cpp
+++ b/DeviceAdapters/NeoPixel/NeoPixel.cpp
@@ -19,8 +19,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 const char* g_DeviceNameShutter = "NeoPixel-Shutter";
 

--- a/DeviceAdapters/Neos/Neos.cpp
+++ b/DeviceAdapters/Neos/Neos.cpp
@@ -19,8 +19,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Neos.h"
 #include <string>

--- a/DeviceAdapters/NewportSMC/Newport.cpp
+++ b/DeviceAdapters/NewportSMC/Newport.cpp
@@ -25,8 +25,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "Newport.h"
 #include <string>

--- a/DeviceAdapters/NiMotionStageController/NiMotionControl.cpp
+++ b/DeviceAdapters/NiMotionStageController/NiMotionControl.cpp
@@ -27,8 +27,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "NIMotionControl.h"
 #include <string>

--- a/DeviceAdapters/NiMotionStageController/ZStage.cpp
+++ b/DeviceAdapters/NiMotionStageController/ZStage.cpp
@@ -26,8 +26,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "ZStage.h"
 #include <string>

--- a/DeviceAdapters/Nikon/Nikon.cpp
+++ b/DeviceAdapters/Nikon/Nikon.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Nikon.h"
 #include <string>

--- a/DeviceAdapters/OVP_ECS2/OVP_ECS2.cpp
+++ b/DeviceAdapters/OVP_ECS2/OVP_ECS2.cpp
@@ -21,9 +21,7 @@
 //
 
 
-#ifdef WIN32
-#define snprintf _snprintf 
-#endif
+#include "FixSnprintf.h"
 
 #include "OVP_ECS2.h"
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/ObjectiveImaging/OasisControl.cpp
+++ b/DeviceAdapters/ObjectiveImaging/OasisControl.cpp
@@ -31,8 +31,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 // The main Oasis controller API
 #include "oasis4i.h"

--- a/DeviceAdapters/PI/PI.cpp
+++ b/DeviceAdapters/PI/PI.cpp
@@ -25,8 +25,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "PI.h"
 #include <string>

--- a/DeviceAdapters/PICAM/PICAMUniversal.cpp
+++ b/DeviceAdapters/PICAM/PICAMUniversal.cpp
@@ -70,9 +70,7 @@ using namespace std;
 #define START_ONPROPERTY(name,action)
 #endif
 
-#if WIN64
-#define snprintf _snprintf
-#endif
+#include "FixSnprintf.h"
 
 // Number of references to this class
 int  Universal::refCount_ = 0;

--- a/DeviceAdapters/PIMotionController/PiMotionControl.cpp
+++ b/DeviceAdapters/PIMotionController/PiMotionControl.cpp
@@ -27,8 +27,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "PIMotionControl.h"
 #include <string>

--- a/DeviceAdapters/PI_GCS/PI_GCS.cpp
+++ b/DeviceAdapters/PI_GCS/PI_GCS.cpp
@@ -24,8 +24,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "PI_GCS.h"
 #include <string>

--- a/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
@@ -69,9 +69,7 @@ using namespace std;
 #define START_ONPROPERTY(name,action)   
 #endif
 
-#if WIN32
-#define snprintf _snprintf
-#endif
+#include "FixSnprintf.h"
 
 // Number of references to this class
 int  Universal::refCount_ = 0;

--- a/DeviceAdapters/ParallelPort/ParallelPort.cpp
+++ b/DeviceAdapters/ParallelPort/ParallelPort.cpp
@@ -31,8 +31,8 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "ParallelPort.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/Pecon/Pecon.cpp
+++ b/DeviceAdapters/Pecon/Pecon.cpp
@@ -10,8 +10,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Pecon.h"
 #include <cstdio>

--- a/DeviceAdapters/Piezosystem_30DV50/Piezosystem_30DV50.cpp
+++ b/DeviceAdapters/Piezosystem_30DV50/Piezosystem_30DV50.cpp
@@ -34,8 +34,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Piezosystem_30DV50.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/Piezosystem_NV120_1/Piezosystem_NV120_1.cpp
+++ b/DeviceAdapters/Piezosystem_NV120_1/Piezosystem_NV120_1.cpp
@@ -33,8 +33,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Piezosystem_NV120_1.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/Piezosystem_NV40_1/Piezosystem_NV40_1.cpp
+++ b/DeviceAdapters/Piezosystem_NV40_1/Piezosystem_NV40_1.cpp
@@ -34,8 +34,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Piezosystem_NV40_1.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/Piezosystem_NV40_3/Piezosystem_NV40_3.cpp
+++ b/DeviceAdapters/Piezosystem_NV40_3/Piezosystem_NV40_3.cpp
@@ -34,8 +34,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Piezosystem_NV40_3.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/Piezosystem_dDrive/Piezosystem_dDrive.cpp
+++ b/DeviceAdapters/Piezosystem_dDrive/Piezosystem_dDrive.cpp
@@ -36,8 +36,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Piezosystem_dDrive.h"
 #include "devicelist.h"

--- a/DeviceAdapters/Piper/stdafx.h
+++ b/DeviceAdapters/Piper/stdafx.h
@@ -28,7 +28,7 @@
 
 #include <Windows.h>
 
-#define snprintf _snprintf
+#include "FixSnprintf.h"
 
 #define __PIPER_API_EXPORT __declspec(dllimport)
 

--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -26,8 +26,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PrincetonInstruments/PVCAMUniversal.cpp
@@ -58,15 +58,14 @@
 #include <iomanip>
 #include <stdint.h>
 
+#include "FixSnprintf.h"
+
 using namespace std;
 unsigned Universal::refCount_ = 0;
 bool Universal::PVCAM_initialized_ = false;
 MMThreadLock g_pvcamLock;
 
 const int BUFSIZE = 60;
-#if WIN32
-#define snprintf _snprintf
-#endif
 
 // global constants
 extern const char* g_PixelType_8bit;

--- a/DeviceAdapters/Prior/Prior.cpp
+++ b/DeviceAdapters/Prior/Prior.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "prior.h"
 #include <cstdio>

--- a/DeviceAdapters/PriorLegacy/PriorLegacy.cpp
+++ b/DeviceAdapters/PriorLegacy/PriorLegacy.cpp
@@ -29,8 +29,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "PriorLegacy.h"
 #include <cstdio>

--- a/DeviceAdapters/Rapp/Rapp.cpp
+++ b/DeviceAdapters/Rapp/Rapp.cpp
@@ -27,9 +27,9 @@
 //                Special thanks to Andre Ratz
 
 #ifdef WIN32
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "Rapp.h"
 #include <cstdio>

--- a/DeviceAdapters/Sapphire/Sapphire.cpp
+++ b/DeviceAdapters/Sapphire/Sapphire.cpp
@@ -26,8 +26,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/Scientifica/Scientifica.cpp
+++ b/DeviceAdapters/Scientifica/Scientifica.cpp
@@ -24,8 +24,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Scientifica.h"
 #include <cstdio>

--- a/DeviceAdapters/ScionCam/ScionCamera.cpp
+++ b/DeviceAdapters/ScionCam/ScionCamera.cpp
@@ -41,8 +41,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "ScionCamera.h"
 #include <string>

--- a/DeviceAdapters/ScionCam/capture.cpp
+++ b/DeviceAdapters/ScionCam/capture.cpp
@@ -40,8 +40,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include	"ScionCamera.h"
 #include	<math.h>

--- a/DeviceAdapters/ScionCam/utilities.cpp
+++ b/DeviceAdapters/ScionCam/utilities.cpp
@@ -40,8 +40,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include	"ScionCamera.h"
 

--- a/DeviceAdapters/Sensicam/Sensicam.cpp
+++ b/DeviceAdapters/Sensicam/Sensicam.cpp
@@ -45,15 +45,13 @@
 // temp
 #include "stdio.h"
 
+#include "FixSnprintf.h"
+
 using namespace std;
 
 CSensicam* CSensicam::m_pInstance = 0;
 const char* g_PixelType_8bit = "8bit";
 const char* g_PixelType_16bit = "16bit";
-
-#ifdef WIN32
-   #define snprintf _snprintf
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // Exported MMDevice API

--- a/DeviceAdapters/ServoZDrive/ServoZ.cpp
+++ b/DeviceAdapters/ServoZDrive/ServoZ.cpp
@@ -24,8 +24,8 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/DeviceAdapters/SimpleAutofocus/FocusMonitor.cpp
+++ b/DeviceAdapters/SimpleAutofocus/FocusMonitor.cpp
@@ -29,8 +29,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "SimpleAutofocus.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/SimpleAutofocus/SimpleAutofocus.cpp
+++ b/DeviceAdapters/SimpleAutofocus/SimpleAutofocus.cpp
@@ -26,8 +26,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 
 #include "SimpleAutofocus.h"

--- a/DeviceAdapters/Skeleton/Skeleton.cpp
+++ b/DeviceAdapters/Skeleton/Skeleton.cpp
@@ -12,8 +12,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Skeleton.h"
 #include <string>

--- a/DeviceAdapters/SmarActHCU-3D/SmarActHCU-3D.cpp
+++ b/DeviceAdapters/SmarActHCU-3D/SmarActHCU-3D.cpp
@@ -13,8 +13,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "SmarActHCU-3D.h"
 #include <string>

--- a/DeviceAdapters/Spot(Windows)/SpotCamera.cpp
+++ b/DeviceAdapters/Spot(Windows)/SpotCamera.cpp
@@ -25,8 +25,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <string>
 #include <math.h>

--- a/DeviceAdapters/Spot/SpotCamera.cpp
+++ b/DeviceAdapters/Spot/SpotCamera.cpp
@@ -25,8 +25,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <string>
 #include <math.h>

--- a/DeviceAdapters/Standa/Standa.cpp
+++ b/DeviceAdapters/Standa/Standa.cpp
@@ -22,8 +22,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Standa.h"
 

--- a/DeviceAdapters/SutterLambda/SutterLambda.cpp
+++ b/DeviceAdapters/SutterLambda/SutterLambda.cpp
@@ -21,8 +21,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "SutterLambda.h"
 #include <vector>

--- a/DeviceAdapters/SutterLambda2/SutterLambda2.cpp
+++ b/DeviceAdapters/SutterLambda2/SutterLambda2.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "SutterHub.h"
 #include "SutterWheel.h"

--- a/DeviceAdapters/SutterStage/SutterStage.cpp
+++ b/DeviceAdapters/SutterStage/SutterStage.cpp
@@ -29,8 +29,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "SutterStage.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/TeesnySLM/TeensySLM.cpp
+++ b/DeviceAdapters/TeesnySLM/TeensySLM.cpp
@@ -20,8 +20,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 
 const char* g_DeviceNameTeensySLM = "Teensy-SLM";

--- a/DeviceAdapters/TetheredCam/LibRaw/internal/defines.h
+++ b/DeviceAdapters/TetheredCam/LibRaw/internal/defines.h
@@ -77,7 +77,6 @@ it under the terms of the one of three licenses as you choose:
 #include <sys/utime.h>
 #include <winsock2.h>
 #pragma comment(lib, "ws2_32.lib")
-#define snprintf _snprintf
 #define strcasecmp _stricmp
 #define strncasecmp strnicmp
 #else
@@ -85,6 +84,7 @@ it under the terms of the one of three licenses as you choose:
 #include <utime.h>
 #include <netinet/in.h>
 #endif
+#include "FixSnprintf.h"
 
 #ifdef LJPEG_DECODE
 #error Please compile dcraw.c by itself.

--- a/DeviceAdapters/Thorlabs/IntegratedFilterWheel.cpp
+++ b/DeviceAdapters/Thorlabs/IntegratedFilterWheel.cpp
@@ -24,8 +24,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 // Prevent "unused variable" warnings.
 #ifdef __GNUC__

--- a/DeviceAdapters/Thorlabs/MotorZStage.cpp
+++ b/DeviceAdapters/Thorlabs/MotorZStage.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "MotorZStage.h"
 #include "Thorlabs.h"

--- a/DeviceAdapters/Thorlabs/PiezoZStage.cpp
+++ b/DeviceAdapters/Thorlabs/PiezoZStage.cpp
@@ -24,8 +24,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "PiezoZStage.h"
 #include "Thorlabs.h"

--- a/DeviceAdapters/Thorlabs/Thorlabs.cpp
+++ b/DeviceAdapters/Thorlabs/Thorlabs.cpp
@@ -22,8 +22,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Thorlabs.h"
 #include "XYStage.h"

--- a/DeviceAdapters/ThorlabsAPTStage/ThorlabsAPTStage.cpp
+++ b/DeviceAdapters/ThorlabsAPTStage/ThorlabsAPTStage.cpp
@@ -41,8 +41,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "ThorlabsAPTStage.h"
 #include "APTAPI.h"

--- a/DeviceAdapters/ThorlabsDCStage/ThorlabsDCStage.cpp
+++ b/DeviceAdapters/ThorlabsDCStage/ThorlabsDCStage.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "ThorlabsDCStage.h"
 #include "APTAPI.h"

--- a/DeviceAdapters/ThorlabsDCxxxx/DCxxxx_Plugin.cpp
+++ b/DeviceAdapters/ThorlabsDCxxxx/DCxxxx_Plugin.cpp
@@ -24,8 +24,8 @@
 
 #ifdef WIN32
 	#include <windows.h>
-	#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 #include <string>
 #include <math.h>
 #include "DCxxxx_Plugin.h"

--- a/DeviceAdapters/ThorlabsFilterWheel/FilterWheel.cpp
+++ b/DeviceAdapters/ThorlabsFilterWheel/FilterWheel.cpp
@@ -27,8 +27,8 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "FilterWheel.h"
 #include <cstdio>

--- a/DeviceAdapters/ThorlabsSC10/SC10.cpp
+++ b/DeviceAdapters/ThorlabsSC10/SC10.cpp
@@ -12,8 +12,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "SC10.h"
 #include <string>

--- a/DeviceAdapters/Tofra/Tofra.cpp
+++ b/DeviceAdapters/Tofra/Tofra.cpp
@@ -24,8 +24,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Tofra.h"
 #include <boost/lexical_cast.hpp>

--- a/DeviceAdapters/Vincent/Vincent.cpp
+++ b/DeviceAdapters/Vincent/Vincent.cpp
@@ -22,8 +22,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Vincent.h"
 #include <string>

--- a/DeviceAdapters/Vortran/Stradus.cpp
+++ b/DeviceAdapters/Vortran/Stradus.cpp
@@ -23,8 +23,8 @@
 #include "Stradus.h"
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "../../MMDevice/MMDevice.h"
 #include <cstdio>

--- a/DeviceAdapters/Vortran/VersaLase.cpp
+++ b/DeviceAdapters/Vortran/VersaLase.cpp
@@ -50,8 +50,8 @@
 #include "VersaLase.h"
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "../../MMDevice/MMDevice.h"
 #include "../../MMDevice/DeviceBase.h"

--- a/DeviceAdapters/WieneckeSinske/CAN29.cpp
+++ b/DeviceAdapters/WieneckeSinske/CAN29.cpp
@@ -28,10 +28,10 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #else
 #include <arpa/inet.h>
 #endif
+#include "FixSnprintf.h"
 
 #include "CAN29.h"
 #include <string>

--- a/DeviceAdapters/WieneckeSinske/WieneckeSinske.cpp
+++ b/DeviceAdapters/WieneckeSinske/WieneckeSinske.cpp
@@ -29,10 +29,10 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #else
 #include <arpa/inet.h>
 #endif
+#include "FixSnprintf.h"
 
 #include "WieneckeSinske.h"
 #include <string>

--- a/DeviceAdapters/XCite120PC_Exacte/XCite.cpp
+++ b/DeviceAdapters/XCite120PC_Exacte/XCite.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "XCite120PC.h"
 #include "XCiteExacte.h"

--- a/DeviceAdapters/XCite120PC_Exacte/XCite120PC.cpp
+++ b/DeviceAdapters/XCite120PC_Exacte/XCite120PC.cpp
@@ -27,8 +27,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "XCite120PC.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/XCite120PC_Exacte/XCiteExacte.cpp
+++ b/DeviceAdapters/XCite120PC_Exacte/XCiteExacte.cpp
@@ -28,8 +28,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "XCiteExacte.h"
 #include "../../MMDevice/ModuleInterface.h"

--- a/DeviceAdapters/XCiteLed/XLed.cpp
+++ b/DeviceAdapters/XCiteLed/XLed.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/XCiteLed/XLedCtrl.cpp
+++ b/DeviceAdapters/XCiteLed/XLedCtrl.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/XCiteLed/XLedDev.cpp
+++ b/DeviceAdapters/XCiteLed/XLedDev.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/XCiteXT600/XT600.cpp
+++ b/DeviceAdapters/XCiteXT600/XT600.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/XCiteXT600/XT600Ctrl.cpp
+++ b/DeviceAdapters/XCiteXT600/XT600Ctrl.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/XCiteXT600/XT600Dev.cpp
+++ b/DeviceAdapters/XCiteXT600/XT600Dev.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/XLight/XLight.cpp
+++ b/DeviceAdapters/XLight/XLight.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "XLight.h"
 #include "XLIGHTHub.h"

--- a/DeviceAdapters/Xcite/Xcite.cpp
+++ b/DeviceAdapters/Xcite/Xcite.cpp
@@ -23,8 +23,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "Xcite.h"
 #include <string>

--- a/DeviceAdapters/Yokogawa/CSU22.cpp
+++ b/DeviceAdapters/Yokogawa/CSU22.cpp
@@ -33,8 +33,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "CSU22.h"
 #include "CSU22Hub.h"

--- a/DeviceAdapters/Yokogawa/CSUX.cpp
+++ b/DeviceAdapters/Yokogawa/CSUX.cpp
@@ -33,8 +33,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "CSUX.h"
 #include "CSUXHub.h"

--- a/DeviceAdapters/Zaber/FilterCubeTurret.cpp
+++ b/DeviceAdapters/Zaber/FilterCubeTurret.cpp
@@ -22,9 +22,9 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 
 #ifdef WIN32
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "FilterCubeTurret.h"
 

--- a/DeviceAdapters/Zaber/FilterWheel.cpp
+++ b/DeviceAdapters/Zaber/FilterWheel.cpp
@@ -21,9 +21,9 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 
 #ifdef WIN32
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "FilterWheel.h"
 

--- a/DeviceAdapters/Zaber/Illuminator.cpp
+++ b/DeviceAdapters/Zaber/Illuminator.cpp
@@ -21,9 +21,9 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 
 #ifdef WIN32
-#define snprintf _snprintf
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "Illuminator.h"
 

--- a/DeviceAdapters/Zaber/Stage.cpp
+++ b/DeviceAdapters/Zaber/Stage.cpp
@@ -21,9 +21,9 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 
 #ifdef WIN32
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "Stage.h"
 

--- a/DeviceAdapters/Zaber/XYStage.cpp
+++ b/DeviceAdapters/Zaber/XYStage.cpp
@@ -22,9 +22,9 @@
 //
 
 #ifdef WIN32
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "XYStage.h"
 

--- a/DeviceAdapters/Zaber/Zaber.cpp
+++ b/DeviceAdapters/Zaber/Zaber.cpp
@@ -22,9 +22,9 @@
 //
 
 #ifdef WIN32
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "Zaber.h"
 #include "XYStage.h"

--- a/DeviceAdapters/ZeissAxioZoom/ZeissAxioZoom.h
+++ b/DeviceAdapters/ZeissAxioZoom/ZeissAxioZoom.h
@@ -51,10 +51,10 @@
 #ifdef WIN32
 #include <windows.h>
 #include <winsock.h>
-#define snprintf _snprintf 
 #else
 #include <netinet/in.h>
 #endif
+#include "FixSnprintf.h"
 
 #include "../../MMDevice/MMDevice.h"
 #include "../../MMDevice/DeviceBase.h"

--- a/DeviceAdapters/ZeissCAN/PhotoModule.cpp
+++ b/DeviceAdapters/ZeissCAN/PhotoModule.cpp
@@ -1,8 +1,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "ZeissCAN.h"
 using namespace std;

--- a/DeviceAdapters/ZeissCAN/ZStage.cpp
+++ b/DeviceAdapters/ZeissCAN/ZStage.cpp
@@ -10,8 +10,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "ZeissCAN.h"
 using namespace std;

--- a/DeviceAdapters/ZeissCAN/ZeissCAN.cpp
+++ b/DeviceAdapters/ZeissCAN/ZeissCAN.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "ZeissCAN.h"
 #include <cstdio>

--- a/DeviceAdapters/ZeissCAN/mcu28.cpp
+++ b/DeviceAdapters/ZeissCAN/mcu28.cpp
@@ -31,8 +31,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include "ZeissCAN.h"
 #include <cstdio>

--- a/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
+++ b/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
@@ -45,10 +45,10 @@
 #ifdef WIN32
 #include <windows.h>
 #include <winsock.h>
-#define snprintf _snprintf 
 #else
 #include <netinet/in.h>
 #endif
+#include "FixSnprintf.h"
 
 #include "../../MMDevice/MMDevice.h"
 #include "../../MMDevice/DeviceBase.h"

--- a/DeviceAdapters/kdv/KDV.cpp
+++ b/DeviceAdapters/kdv/KDV.cpp
@@ -31,8 +31,8 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
 #endif
+#include "FixSnprintf.h"
 
 #include "KDV.h"
 #include <string>

--- a/DeviceAdapters/nPoint/nPC400.cpp
+++ b/DeviceAdapters/nPoint/nPC400.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/nPoint/nPC400Channel.cpp
+++ b/DeviceAdapters/nPoint/nPC400Channel.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/nPoint/nPC400Ctrl.cpp
+++ b/DeviceAdapters/nPoint/nPC400Ctrl.cpp
@@ -30,8 +30,8 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
 #endif
+#include "FixSnprintf.h"
 
 #include <stdio.h>
 #include <string>

--- a/DeviceAdapters/pgFocus/pgFocus.cpp
+++ b/DeviceAdapters/pgFocus/pgFocus.cpp
@@ -16,9 +16,9 @@
 //
 
 #ifdef WIN32
-#define snprintf _snprintf 
 #pragma warning(disable: 4355)
 #endif
+#include "FixSnprintf.h"
 
 #include "pgFocus.h"
 #include <cstdio>

--- a/DeviceAdapters/pgFocus/pgFocus.h
+++ b/DeviceAdapters/pgFocus/pgFocus.h
@@ -20,10 +20,10 @@
 #ifdef WIN32
 #include <windows.h>
 #include <winsock.h>
-#define snprintf _snprintf
 #else
 #include <netinet/in.h>
 #endif
+#include "FixSnprintf.h"
 
 
 #include "../../MMDevice/MMDevice.h"

--- a/MMCore/Host.cpp
+++ b/MMCore/Host.cpp
@@ -27,9 +27,9 @@
 #include <winsock2.h>
 #include "Iphlpapi.h"
 #include <stdio.h>
-#define snprintf _snprintf 
-
 #endif //_WINDOWS
+
+#include "../MMDevice/FixSnprintf.h"
 
 #ifdef __APPLE__
 

--- a/MMCore/Makefile.am
+++ b/MMCore/Makefile.am
@@ -11,6 +11,7 @@ noinst_LTLIBRARIES = libMMCore.la
 libMMCore_la_LIBADD = $(BOOST_SYSTEM_LIB) $(BOOST_DATE_TIME_LIB) $(BOOST_THREAD_LIB) ../MMDevice/libMMDevice.la
 
 libMMCore_la_SOURCES = \
+	../MMDevice/FixSnprintf.h \
 	../MMDevice/MMDevice.h \
 	../MMDevice/MMDeviceConstants.h \
 	../MMDevice/ModuleInterface.h \

--- a/MMCoreJ_wrap/Makefile.am
+++ b/MMCoreJ_wrap/Makefile.am
@@ -33,6 +33,7 @@ swig_sources = MMCoreJ.i \
 	../MMCore/MMCore.h  \
 	../MMCore/MMEventCallback.h \
 	../MMCore/PluginManager.h \
+	../MMDevice/FixSnprintf.h \
 	../MMDevice/ImageMetadata.h \
 	../MMDevice/MMDevice.h \
 	../MMDevice/MMDeviceConstants.h

--- a/MMCorePy_wrap/Makefile.am
+++ b/MMCorePy_wrap/Makefile.am
@@ -17,6 +17,7 @@ swig_sources = MMCorePy.i \
 	../MMCore/MMCore.h  \
 	../MMCore/MMEventCallback.h \
 	../MMCore/PluginManager.h \
+	../MMDevice/FixSnprintf.h \
 	../MMDevice/ImageMetadata.h \
 	../MMDevice/MMDevice.h \
 	../MMDevice/MMDeviceConstants.h

--- a/MMDevice/DeviceUtils.cpp
+++ b/MMDevice/DeviceUtils.cpp
@@ -27,10 +27,11 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
 #else
    #include <unistd.h>
 #endif
+
+#include "FixSnprintf.h"
 
 char CDeviceUtils::m_pszBuffer[MM::MaxStrLength]={""};
 

--- a/MMDevice/FixSnprintf.h
+++ b/MMDevice/FixSnprintf.h
@@ -1,0 +1,54 @@
+/*
+ * Provide snprintf() for MSVC prior to VS2015
+ * This file is part of MMDevice
+ *
+ * Author: Mark Tsuchida
+ *
+ * (C)2020 Board of Regents of the University of Wisconsin System
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// VC++ added a proper snprintf() in VS2015. Prior to that, both _snprintf()
+// and _snprintf_s() were incompatible with the C standard snprintf().
+// This file serves as a single location where this issue is dealt with.
+//
+// This file can be included before or after stdio.h, but should be included
+// outside of any conditional compilation block.
+
+#if defined(_MSC_VER) && _MSC_VER < 1900 // VS2015
+
+// Unlike snprintf(), _snprintf() does not null-terminate the result if it is
+// longer than the buffer. However, Micro-Manager code has customarily defined
+// snprintf to be _snprintf. Since we will be moving to a newer compiler in the
+// near future (at which point this file can be removed), I'm just keeping that
+// method rather than trying to emulate correct behavior (it's trickier than it
+// initially appears).
+
+#define snprintf _snprintf
+
+#endif

--- a/MMDevice/MMDevice-SharedRuntime.vcxproj
+++ b/MMDevice/MMDevice-SharedRuntime.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="DeviceBase.h" />
     <ClInclude Include="DeviceThreads.h" />
     <ClInclude Include="DeviceUtils.h" />
+    <ClInclude Include="FixSnprintf.h" />
     <ClInclude Include="ImageMetadata.h" />
     <ClInclude Include="ImgBuffer.h" />
     <ClInclude Include="MMDevice.h" />

--- a/MMDevice/MMDevice-SharedRuntime.vcxproj.filters
+++ b/MMDevice/MMDevice-SharedRuntime.vcxproj.filters
@@ -43,6 +43,9 @@
     <ClInclude Include="DeviceUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FixSnprintf.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="ImageMetadata.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/MMDevice/MMDevice-StaticRuntime.vcxproj
+++ b/MMDevice/MMDevice-StaticRuntime.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="DeviceBase.h" />
     <ClInclude Include="DeviceThreads.h" />
     <ClInclude Include="DeviceUtils.h" />
+    <ClInclude Include="FixSnprintf.h" />
     <ClInclude Include="ImageMetadata.h" />
     <ClInclude Include="ImgBuffer.h" />
     <ClInclude Include="MMDevice.h" />

--- a/MMDevice/MMDevice-StaticRuntime.vcxproj.filters
+++ b/MMDevice/MMDevice-StaticRuntime.vcxproj.filters
@@ -43,6 +43,9 @@
     <ClInclude Include="DeviceUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FixSnprintf.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="ImageMetadata.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -72,12 +72,13 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf
 
    typedef HMODULE HDEVMODULE;
 #else
    typedef void* HDEVMODULE;
 #endif
+
+#include "FixSnprintf.h"
 
 
 class ImgBuffer;

--- a/MMDevice/Makefile.am
+++ b/MMDevice/Makefile.am
@@ -1,10 +1,26 @@
 noinst_LTLIBRARIES = libMMDevice.la
-noinst_HEADERS = DeviceBase.h MMDevice.h MMDeviceConstants.h \
-	ModuleInterface.h Property.h DeviceUtils.h ImgBuffer.h DeviceThreads.h \
-	ImageMetadata.h Debayer.h
-libMMDevice_la_SOURCES = $(noinst_HEADERS) ModuleInterface.cpp \
+
+noinst_HEADERS = \
+	Debayer.h \
+	DeviceBase.h \
+	DeviceThreads.h \
+	DeviceUtils.h \
+	FixSnprintf.h \
+	ImageMetadata.h \
+	ImgBuffer.h \
+	MMDevice.h \
+	MMDeviceConstants.h \
+	ModuleInterface.h \
+	Property.h
+
+libMMDevice_la_SOURCES = \
+	$(noinst_HEADERS) \
+	Debayer.cpp \
+	DeviceUtils.cpp \
+	ImgBuffer.cpp \
 	MMDevice.cpp \
-	Property.cpp DeviceUtils.cpp ImgBuffer.cpp Debayer.cpp
+	ModuleInterface.cpp \
+	Property.cpp
 
 EXTRA_DIST = license.txt
 

--- a/MMDevice/Property.cpp
+++ b/MMDevice/Property.cpp
@@ -26,9 +26,7 @@
 
 using namespace std;
 
-#if WIN32
-   #define snprintf _snprintf
-#endif
+#include "FixSnprintf.h"
 
 const int BUFSIZE = 60; // For number-to-string conversion
 


### PR DESCRIPTION
This should fix the most common error when building with Visual Studio 2015 or newer, while keeping 2010 compatibility for the time being.