### PR TITLE
Studio-ScriptPanel: Correctly stores scripts in profile.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -328,9 +328,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       posList_ = new PositionList();
       acqEngine_.setPositionList(posList_);
 
-      // Load (but do no show) the scriptPanel
-      createScriptPanel();
-      scriptPanel_.getScriptsFromPrefs();
       
       // Tell Core to start logging
       initializeLogging(core_);
@@ -461,8 +458,10 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
             IJ.getInstance().setLocation(150, 150);
          }
       }
-
-
+      
+      // Load (but do no show) the scriptPanel
+      createScriptPanel();
+      
       // Now create and show the main window
       mmMenuBar_ = MMMenuBar.createMenuBar(studio_);
       frame_ = new MainFrame(this, core_);
@@ -1155,6 +1154,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
   
       if (scriptPanel_ != null) {
          scriptPanel_.closePanel();
+         scriptPanel_ = null;
       }
 
       if (pipelineFrame_ != null) {

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -1219,10 +1219,9 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       int j = 0;
       String script;
       boolean isFile = false;
-      UserProfile profile = studio_.profile();
       model_.RemoveAllScripts();
       do {
-         script = profile.getString(ScriptPanel.class, SCRIPT_FILE + j, null);
+         script = settings_.getString(SCRIPT_FILE + j, null);
          if ( (script != null) && (!script.equals("") ) )
          {
             File file = new File(script);
@@ -1243,9 +1242,15 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
 
    public void saveScriptsToPrefs ()
    { 
+      // first clear existing entries
+      int i = 0;
+      while (settings_.containsString(SCRIPT_FILE + i)) {
+         settings_.remove(SCRIPT_FILE + i);
+         i++;
+      }
       File file;
       ArrayList<File> scriptFileArray = model_.getFileArray();
-      for (int i = 0; i < scriptFileArray.size(); i ++) 
+            for (i = 0; i < scriptFileArray.size(); i ++) 
       {
          file = scriptFileArray.get(i);
          if (file != null) {


### PR DESCRIPTION
Previously, because the profile was used before the UserProfile was activated,
and after it was shutdown, settings were read and written to the default
profile most (but not all) of the time. This commit mainly changes the
order during startup, and ensures that settings will not be saved
twice during shutdown (which apparently often runs twice).