### PR TITLE
MMDevice: allow conditional disable for 'timezone'

### DIFF
--- a/MMDevice/DeviceUtils.cpp
+++ b/MMDevice/DeviceUtils.cpp
@@ -193,7 +193,7 @@ bool CDeviceUtils::CheckEnvironment(std::string env)
 
 
 
-#ifdef _WINDOWS
+#if defined(_WIN32) && !defined(MMDEVICE_NO_GETTIMEOFDAY)
  
 int gettimeofday(struct timeval *tv, struct timezone *tz)
 {

--- a/MMDevice/DeviceUtils.h
+++ b/MMDevice/DeviceUtils.h
@@ -26,7 +26,7 @@
 #include "../MMDevice/MMDeviceConstants.h"
 #include <vector>
 #include <string>
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <time.h>
 #include <windows.h>
 #endif
@@ -37,7 +37,10 @@
   #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
  
-#ifdef _WINDOWS
+// Definition of struct timezone and gettimeofday can be disabled in case
+// interfacing with some other system that also tries to define conflicting
+// symbols (e.g. Python <= 3.6).
+#if defined(_WIN32) && !defined(MMDEVICE_NO_GETTIMEOFDAY)
 struct timezone 
 {
   int  tz_minuteswest; /* minutes W of Greenwich */


### PR DESCRIPTION
Python 3.5 and 3.6 for Windows, in their pyconfig.h, define a macro
'timezone', which breaks DeviceUtils.h.

We cannot easily remove struct timezone and gettimeofday() (they are
used by multiple device adapters), so allow conditional disablement for
now.

This has no effect on device interface version (no ABI change).