### PR TITLE
Studio: Exports to ImageJ even when images are missing from a datastore

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImageJConverter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImageJConverter.java
@@ -75,6 +75,34 @@ public final class DefaultImageJConverter implements ImageJConverter {
       }
       return null;
    }
+   
+   /**
+    * Creates an Image ImageProcessor with the pixel type and dimensions
+    * of the input Image, but all pixel values set to 0
+    * @param image Input Image that serves as the template for the output ImageProcessor
+    * @return imageProcessor with the type and dimensions of the input Image
+    */
+   public static ImageProcessor createBlankProcessor(Image image) {
+      int width = image.getWidth();
+      int height = image.getHeight();
+      int bytesPerPixel = image.getBytesPerPixel();
+      int numComponents = image.getNumComponents();
+     
+      if (bytesPerPixel == 4 && numComponents == 3) {
+         return new ColorProcessor(width, height);
+      }
+      else if (bytesPerPixel == 1 && numComponents == 1) {
+         return new ByteProcessor(width, height);
+      }
+      else if (bytesPerPixel == 2 && numComponents == 1) {
+         return new ShortProcessor(width, height);
+      }
+      else if (bytesPerPixel == 4 && numComponents == 1) {
+         return new FloatProcessor(width, height);
+      }
+      return null;
+   }
+   
 
    @Override
    public ImageProcessor createProcessorFromComponent(Image image,

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/CopyToImageJItem.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/CopyToImageJItem.java
@@ -92,7 +92,15 @@ public final class CopyToImageJItem implements DisplayGearMenuPlugin, SciJavaPlu
                for (int z = 0; z <= dp.getMaxIndices().getZ(); z++) {
                   for (int c = 0; c <= dp.getMaxIndices().getC(); c++) {
                      image = dp.getImage(cb.c(c).t(t).z(z).build());
-                     ImageProcessor iProc = DefaultImageJConverter.createProcessor(image, copy);
+                     ImageProcessor iProc;
+                     if (image != null) {
+                        iProc = DefaultImageJConverter.createProcessor(                            
+                             image, copy);
+                     } else { // handle missing images - should be handled by MM
+                              // so remove this code once this is done nicely in MM
+                        iProc = DefaultImageJConverter.createBlankProcessor(
+                                dp.getAnyImage());
+                     }
                      imgStack.addSlice(iProc);
                   }
                }


### PR DESCRIPTION
Previously, a null pointer would be prevent export of datastores that
had missing images.  The new code will fill in these missing Images
with empty images of the same dimensions as type as the other
images in the datastore.