### PR TITLE
ZProjector: work around bug in Multi-Page Tiff saving code.

### DIFF
--- a/plugins/ZProjector/src/main/java/org/micromanager/zprojector/CoordsComparator.java
+++ b/plugins/ZProjector/src/main/java/org/micromanager/zprojector/CoordsComparator.java
@@ -14,12 +14,12 @@ public class CoordsComparator implements Comparator<String> {
 
    
    public CoordsComparator() {
-      cAxesNumeric.put(Coords.C, 1);
-      cAxesNumeric.put(Coords.CHANNEL, 1);
+      cAxesNumeric.put(Coords.T, 1);
+      cAxesNumeric.put(Coords.TIME_POINT, 1);
+      cAxesNumeric.put(Coords.C,3);
+      cAxesNumeric.put(Coords.CHANNEL, 3);
       cAxesNumeric.put(Coords.Z, 2);
       cAxesNumeric.put(Coords.Z_SLICE, 2);
-      cAxesNumeric.put(Coords.T, 3);
-      cAxesNumeric.put(Coords.TIME_POINT, 3);
       cAxesNumeric.put(Coords.P, 4);
       cAxesNumeric.put(Coords.STAGE_POSITION, 4);
    }


### PR DESCRIPTION
Projecting a large data set that misses data in the last time point.
This caused the problem descibed in issue #716.  By changing the order
of Coords, such that the time axis is worked on last, results in
saving the data correctly.  I am not absolutely sure that other
orders do not work (will test), and clearly, the current solution
only works when missing data at the end of the time axis, not of
other axes.