### PR TITLE
Provides mechanism to avoid state value-index collisions in EMU

### DIFF
--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/ConfigurablePanel.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/ConfigurablePanel.java
@@ -264,6 +264,68 @@ public abstract class ConfigurablePanel extends JPanel{
 			t.start();
 		}
 	}
+	/**
+	 * Sets the UIProperty {@code propertyName}'s value to value of the {@code stateIndex}th state. This method calls the 
+	 * UIProperty's method to set the value, which will in turn call the corresponding MMProperty's
+	 * method. Since the change will be notified to all the UIProperties listening to the MMProperty 
+	 * (through {@link #triggerPropertyHasChanged(String, String)}), this method runs on an independent
+	 * thread (that is, not on the EDT).
+	 *  
+	 * @param propertyName UIProperty's name
+	 * @param stateIndex New state's index
+	 */
+	public void setUIPropertyValueByStateIndex(String propertyName, int stateIndex){
+		
+		// this should be a protected method, but in order to call it in SwingUIListeners it was set to public...
+		// passing it as lambdas could be a solution
+		
+		if(propertyName == null) {
+			throw new NullPointerException("The UIProperty's label cannot be null.");
+		}
+		
+		if(isComponentTriggeringEnabled()) {
+			// makes sure the call does NOT run on EDT
+			Thread t = new Thread("Property change: " + propertyName) {
+				public void run() {
+					if (properties_.containsKey(propertyName)) {
+						properties_.get(propertyName).setPropertyValueByStateIndex(stateIndex);
+					}
+				}
+			};
+			t.start();
+		}
+	}
+	/**
+	 * Sets the UIProperty {@code propertyName}'s value to value of the state labeled {@code stateIndex}. This method calls the 
+	 * UIProperty's method to set the value, which will in turn call the corresponding MMProperty's
+	 * method. Since the change will be notified to all the UIProperties listening to the MMProperty 
+	 * (through {@link #triggerPropertyHasChanged(String, String)}), this method runs on an independent
+	 * thread (that is, not on the EDT).
+	 *  
+	 * @param propertyName UIProperty's name
+	 * @param stateName New state's name
+	 */
+	public void setUIPropertyValueByState(String propertyName, String stateName){
+		
+		// this should be a protected method, but in order to call it in SwingUIListeners it was set to public...
+		// passing it as lambdas could be a solution
+		
+		if(propertyName == null) {
+			throw new NullPointerException("The UIProperty's label cannot be null.");
+		}
+		
+		if(isComponentTriggeringEnabled()) {
+			// makes sure the call does NOT run on EDT
+			Thread t = new Thread("Property change: " + propertyName) {
+				public void run() {
+					if (properties_.containsKey(propertyName)) {
+						properties_.get(propertyName).setPropertyValueByState(stateName);
+					}
+				}
+			};
+			t.start();
+		}
+	}
 	
 	/**
 	 * Sets the value of the IntegerInternalProperty called {@code propertyName} to {@code newValue}.

--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/swinglisteners/SwingUIListeners.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/swinglisteners/SwingUIListeners.java
@@ -112,8 +112,8 @@ public class SwingUIListeners {
 		
 		cbx.addActionListener(new ActionListener(){
 	    	public void actionPerformed(ActionEvent e){
-	    		String val = String.valueOf(cbx.getSelectedIndex());
-	    		cp.setUIPropertyValue(propertyKey,val);
+	    		int val = cbx.getSelectedIndex();
+	    		cp.setUIPropertyValueByStateIndex(propertyKey,val);
 	    	}
         });
 	}
@@ -145,7 +145,7 @@ public class SwingUIListeners {
 			AbstractButton btn = enm.nextElement();		
 			btn.addActionListener(new ActionListener(){
 		    	public void actionPerformed(ActionEvent e){
-		    		cp.setUIPropertyValue(propertyKey,String.valueOf(pos));
+		    		cp.setUIPropertyValueByStateIndex(propertyKey,pos);
 		    	}
 	        });
 			
@@ -189,7 +189,7 @@ public class SwingUIListeners {
 			AbstractButton btn = enm.nextElement();		
 			btn.addActionListener(new ActionListener(){
 		    	public void actionPerformed(ActionEvent e){
-		    		cp.setUIPropertyValue(propertyKey,values[pos]);
+		    		cp.setUIPropertyValueByState(propertyKey,values[pos]);
 		    	}
 	        });
 			
@@ -230,7 +230,7 @@ public class SwingUIListeners {
 	    		int ind = cbx.getSelectedIndex();
 	    		if(ind < values.length && ind >= 0) {
 	    			String val = values[ind];
-	    			cp.setUIPropertyValue(propertyKey,val);
+	    			cp.setUIPropertyValueByState(propertyKey,val);
 	    		}
 	    	}
         });

--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/uiproperties/MultiStateUIProperty.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/uiproperties/MultiStateUIProperty.java
@@ -97,8 +97,9 @@ public class MultiStateUIProperty extends UIProperty{
 	
 	/**
 	 * Gives names to the states. If stateNames has less entries than the number of states, then only
-	 * the corresponding states will be updated. If it has more entries, then the supernumerary entries
-	 * will be ignored.
+	 * the corresponding states will be updated. If it has more entries, then supernumerary entries
+	 * will be ignored. The method does not check for duplicated names, in such a case, only the first 
+	 * occurrence will be set.
 	 * 
 	 * @param stateNames State names
 	 * @return True if some names were set, false otherwise.
@@ -207,7 +208,9 @@ public class MultiStateUIProperty extends UIProperty{
 	
 	/**
 	 * Sets the value of the MMProperty to {@code val} if {@code val}
-	 * equals either one of the state values or one of the state names.
+	 * equals either one of the state values, state names or state indices 
+	 * (in that order). To avoid collisions, you can use setPropertyValueByState
+	 * or setPropertyValueByStateIndex.
 	 * 
 	 */
 	@Override
@@ -232,6 +235,45 @@ public class MultiStateUIProperty extends UIProperty{
 					return getMMProperty().setValue(states_[v], this);
 				}
 
+			}
+		}
+		return false;
+	}
+	
+	/**
+	 * Sets the value of the assigned MMProperty to the value in the state labeled {@code newState}. 
+	 * If newState is not a valid state name, then the regular setPropertyValue method is called.
+	 * 
+	 * @param stateName New state's name 
+	 * @return True if the value was set, false otherwise.
+	 */
+	@Override
+	public boolean setPropertyValueByState(String stateName) {
+		if (isAssigned()) {
+			// if it corresponds to a valid state name 
+			for (int i = 0; i < statenames_.length; i++) {
+				if (statenames_[i].equals(stateName)) {
+					return getMMProperty().setValue(states_[i], this);
+				}
+			}
+			
+			// otherwise, call the regular method
+			return setPropertyValue(stateName);
+		}
+		return false;
+	}
+
+	/**
+	 * Sets the value of the assigned MMProperty to the {@code stateIntex}th state.
+	 * 
+	 * @param stateIndex New state's index
+	 * @return True if the value was set, false otherwise.
+	 */
+	@Override
+	public boolean setPropertyValueByStateIndex(int stateIndex) {
+		if (isAssigned()) {
+			if (stateIndex >= 0 && stateIndex < states_.length) {
+				return getMMProperty().setValue(states_[stateIndex], this);
 			}
 		}
 		return false;

--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/uiproperties/SingleStateUIProperty.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/uiproperties/SingleStateUIProperty.java
@@ -70,11 +70,49 @@ public class SingleStateUIProperty extends UIProperty{
 	 */
 	@Override
 	public boolean setPropertyValue(String val) {
-		if (val != null && isAssigned() && (val.equals(state_) || val.equals(SingleStateUIProperty.getStateLabel()))) {
+		if (val != null && isAssigned() && (val.equals(state_) || val.equals(getStateLabel()))) {
 			return getMMProperty().setValue(state_, this);
 		}
 		return false;
 	}
+	
+
+	/**
+	 * Sets the value of the assigned MMProperty to the value in the state labeled {@code newState}. 
+	 * If newState is not a valid state name, then the regular setPropertyValue method is called.
+	 * 
+	 * @param stateName New state's name 
+	 * @return True if the value was set, false otherwise.
+	 */
+	@Override
+	public boolean setPropertyValueByState(String stateName) {
+		if (isAssigned()) {
+			// if it corresponds to a valid state name 
+			if (getStateLabel().equals(stateName)) {
+				return getMMProperty().setValue(state_, this);
+			}
+			
+			// otherwise, call the regular method
+			return setPropertyValue(stateName);
+		}
+		return false;
+	}
+
+	/**
+	 * Sets the value of the assigned MMProperty to the property state if stateIndex equals 0. 
+	 * 
+	 * @param stateIndex New state's index
+	 * @return True if the value was set, false otherwise.
+	 */
+	@Override
+	public boolean setPropertyValueByStateIndex(int stateIndex) {
+		if (isAssigned()) {
+			if (stateIndex == 0) {
+				return getMMProperty().setValue(state_, this);
+			}
+		}
+		return false;
+	}	
 	
 	/**
 	 * Returns the name of the state.

--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/uiproperties/TwoStateUIProperty.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/uiproperties/TwoStateUIProperty.java
@@ -111,7 +111,8 @@ public class TwoStateUIProperty extends UIProperty{
 	
 	/**
 	 * Sets the value of the UIproperty to {@code newValue} if {@code newValue}
-	 * is either equal to the ON state or to the OFF state, or their respective value.
+	 * is either equal to the ON state or to the OFF state, or their respective value. The 
+	 * method also accepts 1/0 or true/false as state labels.
 	 */
 	@Override
 	public boolean setPropertyValue(String newValue) {
@@ -131,7 +132,47 @@ public class TwoStateUIProperty extends UIProperty{
 		return false;
 	}	
 	
+	/**
+	 * Sets the value of the assigned MMProperty to the value in the state labeled {@code newState}. 
+	 * If newState is not a valid state name, then the regular setPropertyValue method is called.
+	 * 
+	 * @param stateName New state's name 
+	 * @return True if the value was set, false otherwise.
+	 */
+	@Override
+	public boolean setPropertyValueByState(String stateName) {
+		if (isAssigned()) {
+			// if it corresponds to a valid state name 
+			if (getOnStateLabel().equals(stateName)) {
+				return getMMProperty().setValue(getOnStateValue(), this);
+			} else if(getOffStateLabel().equals(stateName)) {
+				return getMMProperty().setValue(getOffStateValue(), this);
+			}
+			
+			// otherwise, call the regular method
+			return setPropertyValue(stateName);
+		}
+		return false;
+	}
 
+	/**
+	 * Sets the value of the assigned MMProperty to the On/Off state if stateIndex equals to 1/0 respectively. 
+	 * 
+	 * @param stateIndex New state's index
+	 * @return True if the value was set, false otherwise.
+	 */
+	@Override
+	public boolean setPropertyValueByStateIndex(int stateIndex) {
+		if (isAssigned()) {
+			if (stateIndex == 0) {
+				return getMMProperty().setValue(getOffStateValue(), this);
+			} else if(stateIndex == 1) {
+				return getMMProperty().setValue(getOnStateValue(), this);
+			}
+		}
+		return false;
+	}
+	
 	/**
 	 * {@inheritDoc}
 	 */

--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/uiproperties/UIProperty.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/uiproperties/UIProperty.java
@@ -199,6 +199,28 @@ public class UIProperty {
 		}  
 		return false;
 	}
+
+	/**
+	 * Sets the value of the assigned MMProperty to {@code newState}. For a pure UIProperty, this method is equivalent
+	 * to setPropertyValue (subclasses might have a different implementation).
+	 * 
+	 * @param newState New state 
+	 * @return True if the value was set, false otherwise.
+	 */
+	public boolean setPropertyValueByState(String newState) {
+		return mmproperty_.setValue(newState, this);
+	}
+	
+	/**
+	 * Sets the value of the assigned MMProperty to {@code newState}. For a pure UIProperty, this method is equivalent
+	 * to setPropertyValue (subclasses might have a different implementation).
+	 * 
+	 * @param stateIndex New state 
+	 * @return True if the value was set, false otherwise.
+	 */
+	public boolean setPropertyValueByStateIndex(int stateIndex) {
+		return mmproperty_.setValue(String.valueOf(stateIndex), this);
+	}
 	
 	/**
 	 * Returns the assigned MMProperty.

--- a/plugins/Emu/src/test/java/de/embl/rieslab/emu/micromanager/mmproperties/MultiStateUIPropertyTest.java
+++ b/plugins/Emu/src/test/java/de/embl/rieslab/emu/micromanager/mmproperties/MultiStateUIPropertyTest.java
@@ -382,6 +382,12 @@ public class MultiStateUIPropertyTest {
 			assertTrue(b);
 			assertEquals(vals[i], cp.property.getPropertyValue());
 		}
+		
+		for(int i=0;i<vals.length;i++) {
+			boolean b = cp.property.setPropertyValueByState(names[i]);
+			assertTrue(b);
+			assertEquals(vals[i], cp.property.getPropertyValue());
+		}
 	}
 
 	@Test
@@ -413,6 +419,12 @@ public class MultiStateUIPropertyTest {
 		
 		for(int i=0;i<vals.length;i++) {
 			boolean b = cp.property.setPropertyValue(String.valueOf(i));
+			assertTrue(b);
+			assertEquals(vals[i], cp.property.getPropertyValue());
+		}
+		
+		for(int i=0;i<vals.length;i++) {
+			boolean b = cp.property.setPropertyValueByStateIndex(i);
 			assertTrue(b);
 			assertEquals(vals[i], cp.property.getPropertyValue());
 		}
@@ -500,6 +512,59 @@ public class MultiStateUIPropertyTest {
 		b = cp.property.setPropertyValue("2");
 		assertTrue(b);
 		assertEquals(vals[2], cp.property.getPropertyValue());
+	}	
+	
+	@Test
+	public void testSetValuesByStatePriorityWithAmbiguity() throws AlreadyAssignedUIPropertyException, IncompatibleMMProperty {
+		MultiStateUIPropertyTestPanel cp = new MultiStateUIPropertyTestPanel("MyPanel");
+
+		final IntegerMMProperty mmprop = new IntegerMMProperty(null, new Logger(), "", "", false) {
+			@Override
+			public Integer getValue() { // avoids NullPointerException
+				return 0;
+			}
+			
+			@Override
+			public String getStringValue() {
+				return convertToString(value);
+			}
+			
+			@Override
+			public boolean setValue(String stringval, UIProperty source){
+				value = convertToValue(stringval);
+				return true;
+			}
+		};
+		
+		PropertyPair.pair(cp.property, mmprop);
+
+		final String[] vals = {"1", "3", "2", "0"};
+		final String[] names = {"3", "1", "0", "2"};
+		cp.property.setStateValues(vals);
+		cp.property.setStateNames(names);
+
+		boolean b;
+		
+		// by state value
+		for(int i=0;i<vals.length;i++) {
+			b = cp.property.setPropertyValue(vals[i]);
+			assertTrue(b);
+			assertEquals(vals[i], cp.property.getPropertyValue());
+		}
+		
+		// by state index
+		for(int i=0;i<vals.length;i++) {
+			b = cp.property.setPropertyValueByStateIndex(i);
+			assertTrue(b);
+			assertEquals(vals[i], cp.property.getPropertyValue());
+		}
+		
+		// by state name
+		for(int i=0;i<vals.length;i++) {
+			b = cp.property.setPropertyValueByState(names[i]);
+			assertTrue(b);
+			assertEquals(vals[i], cp.property.getPropertyValue());
+		}
 	}
 
 	@Test
@@ -559,6 +624,25 @@ public class MultiStateUIPropertyTest {
 		
 		b = cp.property.setPropertyValue(names[3]);
 		assertTrue(b);
+		assertEquals(vals[3], cp.property.getPropertyValue());
+
+		// by state indices
+		b = cp.property.setPropertyValueByStateIndex(5);
+		assertFalse(b);
+		assertEquals(vals[3], cp.property.getPropertyValue());
+		b = cp.property.setPropertyValueByStateIndex(-1);
+		assertFalse(b);
+		assertEquals(vals[3], cp.property.getPropertyValue());
+		
+		// by state names
+		b = cp.property.setPropertyValueByState(null);
+		assertFalse(b);
+		assertEquals(vals[3], cp.property.getPropertyValue());
+		b = cp.property.setPropertyValueByState("");
+		assertFalse(b);
+		assertEquals(vals[3], cp.property.getPropertyValue());
+		b = cp.property.setPropertyValueByState("dsfs");
+		assertFalse(b);
 		assertEquals(vals[3], cp.property.getPropertyValue());
 	}
 	

--- a/plugins/Emu/src/test/java/de/embl/rieslab/emu/micromanager/mmproperties/SingleStateUIPropertyTest.java
+++ b/plugins/Emu/src/test/java/de/embl/rieslab/emu/micromanager/mmproperties/SingleStateUIPropertyTest.java
@@ -120,6 +120,25 @@ public class SingleStateUIPropertyTest {
 		b = cp.property.setPropertyValue("5");
 		assertFalse(b);
 		assertEquals(val, cp.property.getPropertyValue());
+		
+		// using state index
+		b = cp.property.setPropertyValueByStateIndex(1);
+		assertFalse(b);
+		assertEquals(val, cp.property.getPropertyValue());
+		b = cp.property.setPropertyValueByStateIndex(-1);
+		assertFalse(b);
+		assertEquals(val, cp.property.getPropertyValue());
+		
+		// using state name
+		b = cp.property.setPropertyValueByState(null);
+		assertFalse(b);
+		assertEquals(val, cp.property.getPropertyValue());
+		b = cp.property.setPropertyValueByState("");
+		assertFalse(b);
+		assertEquals(val, cp.property.getPropertyValue());
+		b = cp.property.setPropertyValueByState("fdsdf");
+		assertFalse(b);
+		assertEquals(val, cp.property.getPropertyValue());
 	}
 
 	@Test

--- a/plugins/Emu/src/test/java/de/embl/rieslab/emu/micromanager/mmproperties/TwoStateUIPropertyTest.java
+++ b/plugins/Emu/src/test/java/de/embl/rieslab/emu/micromanager/mmproperties/TwoStateUIPropertyTest.java
@@ -167,6 +167,25 @@ public class TwoStateUIPropertyTest {
 		b = cp.property.setPropertyValue("2.48");
 		assertFalse(b);
 		assertEquals(offval, cp.property.getPropertyValue());	
+
+		// using state index
+		b = cp.property.setPropertyValueByStateIndex(-1);
+		assertFalse(b);
+		assertEquals(offval, cp.property.getPropertyValue());	
+		b = cp.property.setPropertyValueByStateIndex(3);
+		assertFalse(b);
+		assertEquals(offval, cp.property.getPropertyValue());
+		
+		// using state name
+		b = cp.property.setPropertyValueByState(null);
+		assertFalse(b);
+		assertEquals(offval, cp.property.getPropertyValue());	
+		b = cp.property.setPropertyValueByState("");
+		assertFalse(b);
+		assertEquals(offval, cp.property.getPropertyValue());	
+		b = cp.property.setPropertyValueByState("dsfs");
+		assertFalse(b);
+		assertEquals(offval, cp.property.getPropertyValue());	
 	}	
 	
 	@Test
@@ -366,6 +385,32 @@ public class TwoStateUIPropertyTest {
 
 		b = cp.property.setPropertyValue("0");
 		assertTrue(b);
+		assertEquals(offval, cp.property.getPropertyValue());
+		
+		// using state indices
+		b = cp.property.setPropertyValueByStateIndex(1);
+		assertTrue(b);
+		assertEquals(onval, cp.property.getPropertyValue());
+
+		b = cp.property.setPropertyValueByStateIndex(0);
+		assertTrue(b);
+		assertEquals(offval, cp.property.getPropertyValue());
+
+		b = cp.property.setPropertyValueByStateIndex(3);
+		assertFalse(b);
+		assertEquals(offval, cp.property.getPropertyValue());
+		
+		// using state names
+		b = cp.property.setPropertyValueByState(TwoStateUIProperty.getOnStateLabel());
+		assertTrue(b);
+		assertEquals(onval, cp.property.getPropertyValue());
+
+		b = cp.property.setPropertyValueByState(TwoStateUIProperty.getOffStateLabel());
+		assertTrue(b);
+		assertEquals(offval, cp.property.getPropertyValue());
+
+		b = cp.property.setPropertyValueByState("Somethign else");
+		assertFalse(b);
 		assertEquals(offval, cp.property.getPropertyValue());
 	}
 		

--- a/plugins/Emu/src/test/java/de/embl/rieslab/emu/micromanager/mmproperties/UIPropertyTest.java
+++ b/plugins/Emu/src/test/java/de/embl/rieslab/emu/micromanager/mmproperties/UIPropertyTest.java
@@ -79,6 +79,16 @@ public class UIPropertyTest {
 		boolean b = cp.property.setPropertyValue(String.valueOf(val));
 		assertTrue(b);
 		assertEquals(val, cp.property.getPropertyValue());
+		
+		val = "21";
+		b = cp.property.setPropertyValueByState(String.valueOf(val));
+		assertTrue(b);
+		assertEquals(val, cp.property.getPropertyValue());
+		
+		int intval = 10;
+		b = cp.property.setPropertyValueByStateIndex(intval);
+		assertTrue(b);
+		assertEquals(String.valueOf(intval), cp.property.getPropertyValue());
 	}
 
 	@Test


### PR DESCRIPTION
* Update EMU to 8e527f
* New methods in ConfigurablePanel and UIProperty subclasses
* These methods avoid state value-index collisions
* These methods are called in SwingUIListeners