### PR TITLE
Studio: duplicates pixels before handing them to ImageJ.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/MMVirtualStack.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/MMVirtualStack.java
@@ -128,7 +128,7 @@ public final class MMVirtualStack extends VirtualStack {
    public ImageProcessor getProcessor(int flatIndex) {
       Coords coords = parent_.getMMCoordsForIJFlatIndex(flatIndex);
       Image image = parent_.getMMImage(coords);
-      return DefaultImageJConverter.createProcessor(image, false);
+      return DefaultImageJConverter.createProcessor(image, true);
    }
 
    @Override


### PR DESCRIPTION
As discussed in previous PR.  We can change this again in the future, but for now this will protect our images from accidental changes in ImageJ.