### PR TITLE
Studio: Album can be used again after Close All was chosen.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -300,6 +300,8 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       events().registerForEvents(snapLiveManager_);
 
       shutterManager_ = new DefaultShutterManager(studio_);
+      // DisplayManager needs to be created before Pipelineframe and albumInstance
+      displayManager_ = new DefaultDisplayManager(this);
       albumInstance_ = new DefaultAlbum(studio_);
 
       // The tools menu depends on the Quick-Access Manager.
@@ -309,9 +311,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       acqEngine_.setParentGUI(this);
       acqEngine_.setZStageDevice(core_.getFocusDevice());
 
-      
-      // DisplayManager needs to be created before Pipelineframe
-      displayManager_ = new DefaultDisplayManager(this);
+
       
       // Load, but do not show, image pipeline panel.
       // Note: pipelineFrame is used in the dataManager, however, pipelineFrame 


### PR DESCRIPTION
Fixes bug reported in issue #425:
    Snap to Album
    Close All, choose no prompts
    Snap to Album again (nothing appears)
DefaultAlbum now listens to display events.  When its display
closes, it now sets its reference to the Datastore to null,
prompting additions to the Album re-open a new datastore and
display.