### PR TITLE
Studio: unregister closing Inspector from eventbus.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
@@ -200,6 +200,7 @@ public final class InspectorController
 
    @Override
    public void close() {
+      studio_.events().unregisterForEvents(this);
       viewerCollection_.unregisterForEvents(this);
       if (frame_ != null) {
          detachFromDataViewer();


### PR DESCRIPTION
Otherwise, closing an Inspector will lead to an exception on application exit.