### PR TITLE
Studio: CoreEventcallback relays all StagePositionChanged events.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
@@ -160,35 +160,29 @@ public final class CoreEventCallback extends MMEventCallback {
 
    @Override
    public void onStagePositionChanged(String deviceName, double pos) {
-      // TODO: this check should be in the core, not the java layer!
-      if (deviceName.equals(core_.getFocusDevice())) {
-         // see OnPropertyChanged for reasons to run this on the EDT
-         if (!SwingUtilities.isEventDispatchThread()) {
-            SwingUtilities.invokeLater(() -> {
-               studio_.events().post(
-                       new StagePositionChangedEvent(deviceName, pos));
-            });
-         } else {
+      // see OnPropertyChanged for reasons to run this on the EDT
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
             studio_.events().post(
                     new StagePositionChangedEvent(deviceName, pos));
-         }
+         });
+      } else {
+         studio_.events().post(
+                 new StagePositionChangedEvent(deviceName, pos));
       }
    }
 
    @Override
    public void onXYStagePositionChanged(String deviceName, double xPos, double yPos) {
-      // TODO: this check should be in the core, not the java layer!
-      if (deviceName.equals(core_.getXYStageDevice())) {
-         // see OnPropertyChanged for reasons to run this on the EDT
-         if (!SwingUtilities.isEventDispatchThread()) {
-            SwingUtilities.invokeLater(() -> {
-               studio_.events().post(
-                       new XYStagePositionChangedEvent(deviceName, xPos, yPos));
-            });
-         } else {
+      // see OnPropertyChanged for reasons to run this on the EDT
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
             studio_.events().post(
                     new XYStagePositionChangedEvent(deviceName, xPos, yPos));
-         }
+         });
+      } else {
+         studio_.events().post(
+                 new XYStagePositionChangedEvent(deviceName, xPos, yPos));
       }
    }
 


### PR DESCRIPTION
Rather than selecting only the stagepositionchanged events for the core-focus drive, all such events are relayed on the Eventbus and listeners should select the drive they are interested in. Same change
was made for the XYStage callback.  Reasons for this restriction in the code were unclear as all listeners (StaticInfo and StageControlFrame) were already checking the drive name.