### PR TITLE
Reduction in use of deprecated code and other undesired things

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -107,7 +107,7 @@ public final class MMAcquisition extends DataViewerListener {
       eng_ = eng;
       show_ = show;
       // TODO: get rid of MMStudo cast
-      store_ = new DefaultDatastore((MMStudio) studio);
+      store_ = new DefaultDatastore(studio);
       pipeline_ = studio_.data().copyApplicationPipeline(store_, false);
       try {
          if (summaryMetadata.has("Directory") && summaryMetadata.get("Directory").toString().length() > 0) {

--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
@@ -67,8 +67,8 @@ public final class AlertsWindow extends MMFrame {
 
       Font defaultFont = new Font("Arial", Font.PLAIN, 10);
 
-      shouldShowOnMessage_ = studio_.profile().getBoolean(AlertsWindow.class,
-            SHOULD_SHOW_WINDOW, true);
+      shouldShowOnMessage_ = studio_.profile().getSettings(AlertsWindow.class).
+              getBoolean(SHOULD_SHOW_WINDOW, true);
       final JCheckBox showWindowCheckBox = new JCheckBox(
             "Open this window when messages arrive", shouldShowOnMessage_);
       showWindowCheckBox.setFont(defaultFont);
@@ -76,8 +76,8 @@ public final class AlertsWindow extends MMFrame {
          @Override
          public void actionPerformed(ActionEvent e) {
             shouldShowOnMessage_ = showWindowCheckBox.isSelected();
-            studio_.profile().setBoolean(AlertsWindow.class,
-               SHOULD_SHOW_WINDOW, shouldShowOnMessage_);
+            studio_.profile().getSettings(AlertsWindow.class).putBoolean(
+                    SHOULD_SHOW_WINDOW, shouldShowOnMessage_);
          }
       });
       super.add(showWindowCheckBox, "split, span");

--- a/mmstudio/src/main/java/org/micromanager/data/internal/CommentsHelper.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/CommentsHelper.java
@@ -63,7 +63,7 @@ public final class CommentsHelper {
       if (prop == null) {
          prop = PropertyMaps.builder().build();
       }
-      prop = prop.copy().putString(COMMENTS_KEY, comment).build();
+      prop = prop.copyBuilder().putString(COMMENTS_KEY, comment).build();
       annotation.setGeneralAnnotation(prop);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
@@ -125,6 +125,7 @@ public final class DefaultAnnotation implements Annotation {
    }
 
    @Override
+   @Deprecated
    public String getFilename() {
       return filename_;
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -73,11 +73,13 @@ public final class DefaultDataManager implements DataManager {
    }
 
    @Override
+   @Deprecated
    public Coords.Builder getCoordsBuilder() {
       return new DefaultCoords.Builder();
    }
 
    @Override
+   @Deprecated
    public Coords createCoords(String def) throws IllegalArgumentException {
       return DefaultCoords.fromNormalizedString(def);
    }
@@ -311,11 +313,13 @@ public final class DefaultDataManager implements DataManager {
    }
 
    @Override
+   @Deprecated
    public PropertyMap.Builder getPropertyMapBuilder() {
       return PropertyMaps.builder();
    }
 
    @Override
+   @Deprecated
    public PropertyMap loadPropertyMap(String path) throws IOException {
       return PropertyMaps.loadJSON(new File(path));
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import javax.swing.SwingWorker;
+
+import org.micromanager.Studio;
 import org.micromanager.data.Coords;
 import org.micromanager.data.Datastore;
 import org.micromanager.data.Storage;
@@ -23,23 +25,23 @@ import org.micromanager.internal.MMStudio;
  * @author nico
  */
 public class DefaultDataSaver extends SwingWorker<Void, Void> {
-      private final MMStudio mmStudio_;
+      private final Studio studio;
       private final DefaultDatastore store_;
       private final Datastore.SaveMode mode_;
       private final String path_;
       private final DefaultDatastore duplicate_;
       private final Storage saver_;
       
-   public DefaultDataSaver(MMStudio mmStudio, 
-           DefaultDatastore store, 
-           Datastore.SaveMode mode, 
-           String path) throws IOException {
-      mmStudio_ = mmStudio;
+   public DefaultDataSaver(Studio studio,
+                           DefaultDatastore store,
+                           Datastore.SaveMode mode,
+                           String path) throws IOException {
+      this.studio = studio;
       store_ = store;
       mode_ = mode;
       path_ = path;
       
-      duplicate_ = new DefaultDatastore(mmStudio_);
+      duplicate_ = new DefaultDatastore(this.studio);
 
       if (mode_ == Datastore.SaveMode.MULTIPAGE_TIFF) {
          saver_ = new StorageMultipageTiff(MMStudio.getFrame(),
@@ -167,10 +169,10 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
       try {
          get();
       } catch (ExecutionException | InterruptedException e) {
-          mmStudio_.logs().showError(e, "Failed to save to " + path_);
+          studio.logs().showError(e, "Failed to save to " + path_);
       }
       
-      mmStudio_.alerts().postAlert("Finished saving", this.getClass(), path_);
+      studio.alerts().postAlert("Finished saving", this.getClass(), path_);
    }
 
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -39,7 +39,6 @@ import org.micromanager.data.DatastoreRewriteException;
 import org.micromanager.data.Image;
 import org.micromanager.data.Storage;
 import org.micromanager.data.SummaryMetadata;
-import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.UserCancelledException;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.PrioritizedEventBus;
@@ -82,13 +81,13 @@ public class DefaultDatastore implements Datastore {
    protected Map<String, DefaultAnnotation> annotations_ = new HashMap<>();
    protected PrioritizedEventBus bus_;
    protected boolean isFrozen_ = false;
-   protected final MMStudio mmStudio_;
+   protected final Studio studio;
    
    private String savePath_ = null;
    private boolean haveSetSummary_ = false;
 
-   public DefaultDatastore(MMStudio mmStudio) {
-      mmStudio_ = mmStudio;
+   public DefaultDatastore(Studio mmStudio) {
+      studio = mmStudio;
       bus_ = new PrioritizedEventBus(true);
    }
 
@@ -348,7 +347,7 @@ public class DefaultDatastore implements Datastore {
    @Override
    public void close() throws IOException {
       freeze();
-      mmStudio_.events().post(
+      studio.events().post(
             new DefaultDatastoreClosingEvent(this));
       if (storage_ != null) {
          storage_.close();
@@ -381,7 +380,7 @@ public class DefaultDatastore implements Datastore {
       chooser.setAcceptAllFileFilterUsed(false);
       chooser.addChoosableFileFilter(SINGLEPLANEFILTER);
       chooser.addChoosableFileFilter(MULTIPAGEFILTER);
-      if (getPreferredSaveMode(mmStudio_).equals(Datastore.SaveMode.MULTIPAGE_TIFF)) {
+      if (getPreferredSaveMode(studio).equals(Datastore.SaveMode.MULTIPAGE_TIFF)) {
          chooser.setFileFilter(MULTIPAGEFILTER);
       }
       else {
@@ -409,11 +408,11 @@ public class DefaultDatastore implements Datastore {
                filter.getDescription());
          return null;
       }
-      setPreferredSaveMode(mmStudio_, mode);
+      setPreferredSaveMode(studio, mode);
       // the DefaultDataSave constructor creates the directory
       // so that displaysettings can be saved there even before we finish
       // saving all the data
-      DefaultDataSaver ds = new DefaultDataSaver(mmStudio_, this, mode,
+      DefaultDataSaver ds = new DefaultDataSaver(studio, this, mode,
               file.getAbsolutePath());
       if (!blocking) {
          final ProgressBar pb = new ProgressBar(parent, "Saving..", 0, 100);
@@ -444,7 +443,7 @@ public class DefaultDatastore implements Datastore {
    // if our current Storage is a file-based Storage).
    @Override
    public void save(Datastore.SaveMode mode, String path, boolean blocking) throws IOException {
-      DefaultDataSaver ds = new DefaultDataSaver(mmStudio_, this, mode, path);
+      DefaultDataSaver ds = new DefaultDataSaver(studio, this, mode, path);
       if (blocking) {
          ds.doInBackground();
       } else {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
@@ -436,6 +436,7 @@ public final class DefaultImage implements Image {
    }
 
    @Override
+   @Deprecated
    public int getImageJPixelType() {
       return pixelType_.imageJConstant();
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultMetadata.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultMetadata.java
@@ -57,6 +57,7 @@ public final class DefaultMetadata implements Metadata {
       }
 
       @Override
+      @Deprecated
       public Builder uuid() {
          return generateUUID();
       }
@@ -267,6 +268,7 @@ public final class DefaultMetadata implements Metadata {
    }
       
    @Override
+   @Deprecated
    public Double getElapsedTimeMs() {
       return pmap_.containsKey(ELAPSED_TIME_MS.key()) ?
             pmap_.getDouble(ELAPSED_TIME_MS.key(), Double.NaN) : null;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultSummaryMetadata.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultSummaryMetadata.java
@@ -426,6 +426,7 @@ public final class DefaultSummaryMetadata implements SummaryMetadata {
    }
 
    @Override
+   @Deprecated
    public Builder copy() {
       return copyBuilder();
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
@@ -132,7 +132,7 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
       // a PositionName property in its metadata.
       if (isDatasetWritable_ && image.getCoords().getStagePosition() > 0 &&
             (image.getMetadata() == null ||
-             image.getMetadata().getPositionName() == null)) {
+             image.getMetadata().getPositionName("").equals(""))) {
          throw new IllegalArgumentException("Image " + image + " does not have a valid positionName metadata value");
       }
       // If we're in the middle of loading a file, then the code that writes
@@ -140,9 +140,9 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
       // records.
       String positionPrefix = "";
       if (isMultiPosition_ && image.getMetadata() != null &&
-            image.getMetadata().getPositionName() != null) {
+            !image.getMetadata().getPositionName("").equals("")) {
          // File is in a subdirectory.
-         positionPrefix = image.getMetadata().getPositionName() + "/";
+         positionPrefix = image.getMetadata().getPositionName("") + "/";
       }
       String fileName = positionPrefix + createFileName(image.getCoords());
       if (amLoading_ && !(new File(dir_ + "/" + fileName).exists())) {
@@ -163,7 +163,7 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
                ReportingUtils.logError(ex);
             }
          }
-         String posName = image.getMetadata().getPositionName();
+         String posName = image.getMetadata().getPositionName("");
          if (posName != null && posName.length() > 0 &&
                !posName.contentEquals("null")) {
             // Create a directory to hold images for this stage position.
@@ -369,7 +369,7 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
          channel = orderedChannelNames_.get(coords.getChannel());
       }
       return String.format("img_%09d_%s_%03d.tif",
-            coords.getTime(), channel, coords.getZ());
+            coords.getT(), channel, coords.getZ());
    }
 
    private static final Pattern FILENAME_PATTERN_14 = Pattern.compile(
@@ -523,11 +523,7 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
    }
 
    private void openNewDataSet(Image image) throws IOException, Exception {
-      String posName = image.getMetadata().getPositionName();
-      if (posName == null || posName.contentEquals("null")) {
-         posName = "";
-      }
-
+      String posName = image.getMetadata().getPositionName("");
       int pos = image.getCoords().getStagePosition();
       if (pos == -1) {
          // No stage position axis.

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/FileSet.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/FileSet.java
@@ -250,12 +250,12 @@ class FileSet {
       }
 
       if (splitByXYPosition_) {
-         String posName = firstImage.getMetadata().getPositionName();
+         String posName = firstImage.getMetadata().getPositionName("");
          int posIndex = firstImage.getCoords().getStagePosition();
          if (posIndex == -1) {
             posIndex = 0;
          }
-         if (posName != null) {
+         if (posName != null && !posName.isEmpty()) {
             baseFilename += "_" + posName;
          }
          else {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -359,7 +359,7 @@ public final class MultipageTiffReader {
          DefaultCoords.Builder builder = new DefaultCoords.Builder();
          builder.channel(channel)
                  .z(slice)
-                 .time(frame)
+                 .t(frame)
                  .stagePosition(position);
          coordsToOffset_.put(builder.build(), imageOffset);
       }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/OMEMetadata.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/OMEMetadata.java
@@ -167,8 +167,8 @@ public final class OMEMetadata {
       }
 
       String positionName = "pos" + repImage.getCoords().getStagePosition();
-      if (repMetadata.getPositionName() != null) {
-         positionName = repMetadata.getPositionName();
+      if (!repMetadata.getPositionName("").equals("")) {
+         positionName = repMetadata.getPositionName("");
       }
       metadata_.setStageLabelName(positionName, seriesIndex);
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -881,13 +881,13 @@ public final class StorageMultipageTiff implements Storage {
       HashSet<Image> result = new HashSet<>();
       synchronized(coordsToPendingImage_) {
          for (Coords imageCoords : coordsToPendingImage_.keySet()) {
-            if (imageCoords.matches(coords)) {
+            if (imageCoords.isSubspaceCoordsOf(coords)) {
                result.add(coordsToPendingImage_.get(imageCoords));
             }
          }
       }
       for (Coords imageCoords : coordsToReader_.keySet()) {
-         if (imageCoords.matches(coords)) {
+         if (imageCoords.isSubspaceCoordsOf(coords)) {
             try {
                result.add(coordsToReader_.get(imageCoords).readImage(imageCoords));
             }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/comments/CommentsInspectorPanelPlugin.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/comments/CommentsInspectorPanelPlugin.java
@@ -18,7 +18,7 @@ import org.scijava.plugin.Plugin;
  * @author mark
  */
 @Plugin(type = InspectorPanelPlugin.class,
-      priority = Priority.HIGH_PRIORITY,
+      priority = Priority.HIGH,
       name = "Comments",
       description = "View and edit image comments")
 public final class CommentsInspectorPanelPlugin implements InspectorPanelPlugin {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/metadata/PlaneMetadataInspectorPanelPlugin.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/metadata/PlaneMetadataInspectorPanelPlugin.java
@@ -17,7 +17,7 @@ import org.micromanager.display.inspector.InspectorPanelPlugin;
  * @author mark
  */
 @Plugin(type = InspectorPanelPlugin.class,
-      priority = Priority.HIGH_PRIORITY + 100,
+      priority = Priority.HIGH + 100,
       name = "Plane Metadata",
       description = "View image plane metadata")
 public final class PlaneMetadataInspectorPanelPlugin implements InspectorPanelPlugin {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/metadata/SummaryMetadataInspectorPanelPlugin.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/metadata/SummaryMetadataInspectorPanelPlugin.java
@@ -25,7 +25,7 @@ import org.micromanager.display.inspector.InspectorPanelPlugin;
  * @author Mark A. Tsuchida
  */
 @Plugin(type = InspectorPanelPlugin.class,
-      priority = Priority.HIGH_PRIORITY + 200,
+      priority = Priority.HIGH + 200,
       name = "Summary Metadata",
       description = "View dataset metadata")
 public class SummaryMetadataInspectorPanelPlugin implements InspectorPanelPlugin {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -171,11 +171,13 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    }
 
    @Override
+   @Deprecated
    public DisplaySettings.DisplaySettingsBuilder getDisplaySettingsBuilder() {
       return new DefaultDisplaySettings.LegacyBuilder();
    }
    
-   @Override 
+   @Override
+   @Deprecated
    public DisplaySettings.Builder displaySettingsBuilder() {
       return DefaultDisplaySettings.builder();
    }
@@ -191,6 +193,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    }
 
    @Override
+   @Deprecated
    public DisplaySettings.ContrastSettings getContrastSettings(
          Integer contrastMin, Integer contrastMax, Double gamma,
          Boolean isVisible) {
@@ -199,6 +202,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    }
 
    @Override
+   @Deprecated
    public DisplaySettings.ContrastSettings getContrastSettings(
          Integer[] contrastMins, Integer[] contrastMaxes, Double[] gammas,
          Boolean isVisible) {
@@ -244,6 +248,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    */
 
    @Override
+   @Deprecated
    public PropertyMap.Builder getPropertyMapBuilder() {
       return PropertyMaps.builder();
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -293,6 +293,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
     */
    public static DefaultDisplaySettings getStandardSettings(String key) {
       UserProfile profile = MMStudio.getInstance().profile();
+      MutablePropertyMapView settings = profile.getSettings(DefaultDisplaySettings.class);
       LegacyBuilder builder = new LegacyBuilder();
       // We have to convert colors to/from int arrays.
       // Note we assume RGB tuples in the colors array.
@@ -305,29 +306,17 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       key += "_";
       // This value used to be an int, then got changed to a double, hence the
       // name change.
-      builder.animationFPS(profile.getDouble(
-               DefaultDisplaySettings.class,
+      builder.animationFPS(settings.getDouble(
                key + ANIMATION_FPS_DOUBLE, 10.0));
       builder.channelColorMode(
-            DisplaySettings.ColorMode.fromInt(profile.getInt(
-            DefaultDisplaySettings.class,
+            DisplaySettings.ColorMode.fromInt(settings.getInteger(
                key + CHANNEL_COLOR_MODE,
                DisplaySettings.ColorMode.COMPOSITE.getIndex())));
-      builder.zoom(profile.getDouble(
-            DefaultDisplaySettings.class,
-               key + ZOOM_RATIO, 1.0));
-      builder.shouldSyncChannels(profile.getBoolean(
-            DefaultDisplaySettings.class,
-               key + SHOULD_SYNC_CHANNELS, false));
-      builder.shouldAutostretch(profile.getBoolean(
-            DefaultDisplaySettings.class,
-               key + SHOULD_AUTOSTRETCH, true));
-      builder.shouldScaleWithROI(profile.getBoolean(
-            DefaultDisplaySettings.class,
-               key + SHOULD_SCALE_WITH_ROI, true));
-      builder.extremaPercentage(profile.getDouble(
-            DefaultDisplaySettings.class,
-               key + EXTREMA_PERCENTAGE, 0.0));
+      builder.zoom(settings.getDouble(key + ZOOM_RATIO, 1.0));
+      builder.shouldSyncChannels(settings.getBoolean(key + SHOULD_SYNC_CHANNELS, false));
+      builder.shouldAutostretch(settings.getBoolean(key + SHOULD_AUTOSTRETCH, true));
+      builder.shouldScaleWithROI(settings.getBoolean(key + SHOULD_SCALE_WITH_ROI, true));
+      builder.extremaPercentage(settings.getDouble(key + EXTREMA_PERCENTAGE, 0.0));
       // Note we don't store user data in the prefs explicitly; let third-party
       // code manually access the prefs if they want.
       return builder.build();
@@ -376,9 +365,9 @@ public final class DefaultDisplaySettings implements DisplaySettings {
          DisplaySettings.ColorMode defaultVal) {
       UserProfile profile = MMStudio.getInstance().profile();
       key = key + "_";
-      Integer mode = profile.getInt(DefaultDisplaySettings.class,
-            CHANNEL_COLOR_MODE, null);
-      if (mode == null) {
+      Integer mode = profile.getSettings(DefaultDisplaySettings.class).
+              getInteger(CHANNEL_COLOR_MODE, -1);
+      if (mode == -1) {
          return defaultVal;
       }
       return DisplaySettings.ColorMode.fromInt(mode);
@@ -415,6 +404,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       return result;
    }
 
+   @Deprecated
    public static class DefaultContrastSettings implements DisplaySettings.ContrastSettings {
       Integer[] contrastMins_;
       Integer[] contrastMaxes_;
@@ -445,11 +435,13 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       }
 
       @Override
+      @Deprecated
       public Integer[] getContrastMins() {
          return contrastMins_;
       }
 
       @Override
+      @Deprecated
       public Integer getSafeContrastMin(int component, Integer defaultVal) {
          if (component < 0 || contrastMins_ == null ||
                contrastMins_.length <= component) {
@@ -459,11 +451,13 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       }
 
       @Override
+      @Deprecated
       public Integer[] getContrastMaxes() {
          return contrastMaxes_;
       }
 
       @Override
+      @Deprecated
       public Integer getSafeContrastMax(int component, Integer defaultVal) {
          if (component < 0 || contrastMaxes_ == null ||
                contrastMaxes_.length <= component) {
@@ -473,6 +467,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       }
 
       @Override
+      @Deprecated
       public Double[] getContrastGammas() {
          return gammas_;
       }
@@ -487,6 +482,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       }
 
       @Override
+      @Deprecated
       public int getNumComponents() {
          int result = 0;
          if (contrastMins_ != null) {
@@ -502,11 +498,13 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       }
 
       @Override
+      @Deprecated
       public Boolean getIsVisible() {
          return isVisible();
       }
 
       @Override
+      @Deprecated
       public Boolean isVisible() {
          return isVisible_;
       }
@@ -697,6 +695,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    @Override
+   @Deprecated
    public ContrastSettings[] getChannelContrastSettings() {
       ContrastSettings[] ret = new ContrastSettings[getNumberOfChannels()];
       for (int i = 0; i < getNumberOfChannels(); ++i) {
@@ -706,6 +705,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    @Override
+   @Deprecated
    public ContrastSettings getSafeContrastSettings(int index,
          ContrastSettings defaultVal) {
       if (index < 0 || index >= getNumberOfChannels()) {
@@ -730,6 +730,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    @Override
+   @Deprecated
    public Integer getSafeContrastMin(int index, int component,
          Integer defaultVal) {
       if (index < 0 || index >= getNumberOfChannels()) {
@@ -744,6 +745,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    @Override
+   @Deprecated
    public Integer getSafeContrastMax(int index, int component,
          Integer defaultVal) {
       if (index < 0 || index >= getNumberOfChannels()) {
@@ -758,6 +760,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    @Override
+   @Deprecated
    public Double getSafeContrastGamma(int index, int component,
          Double defaultVal) {
       if (index < 0 || index >= getNumberOfChannels()) {
@@ -771,6 +774,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    @Override
+   @Deprecated
    public Boolean getSafeIsVisible(int index, Boolean defaultVal) {
       if (index < 0 || index >= getNumberOfChannels()) {
          return defaultVal;
@@ -779,11 +783,13 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    @Override
+   @Deprecated
    public DisplaySettings.ColorMode getChannelColorMode() {
       return getColorMode();
    }
 
    @Override
+   @Deprecated
    public Boolean getShouldSyncChannels() {
       return null;
    }
@@ -872,7 +878,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             }
          }
          if (minsArr != null) {
-            ArrayList<ContrastSettings> contrastSettings = new ArrayList<ContrastSettings>();
+            ArrayList<ContrastSettings> contrastSettings = new ArrayList<>();
             for (int i = 0; i < minsArr.length; ++i) {
                Integer min = minsArr[i];
                Integer max = maxesArr[i];

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/AxisLinker.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/AxisLinker.java
@@ -52,7 +52,7 @@ class AxisLinker {
             if (oldPos.getIndex(axis_) == value) {
                return true;
             }
-            newPos = oldPos.copy().index(axis_, value).build();
+            newPos = oldPos.copyBuilder().index(axis_, value).build();
             if (!viewer_.getDataProvider().hasImage(newPos)) {
                return false;
             }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
@@ -967,6 +967,7 @@ public final class DisplayController extends DisplayWindowAPIAdapter
    }
 
    @Override
+   @Deprecated
    public ImagePlus getImagePlus() {
       if (!SwingUtilities.isEventDispatchThread()) {
          RunnableFuture<ImagePlus> edtFuture = new FutureTask(
@@ -1081,6 +1082,7 @@ public final class DisplayController extends DisplayWindowAPIAdapter
    }
 
    @Override
+   @Deprecated
    public void toggleFullScreen() {
       throw new UnsupportedOperationException();
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
@@ -343,7 +343,7 @@ public final class ImageJBridge {
       // set the TZC coordinates, we need this:
       int channel = coords.hasAxis(Coords.CHANNEL) ? coords.getChannel() : 0;
       int slice = coords.hasAxis(Coords.Z) ? coords.getZ() : 0;
-      int timepoint = coords.hasAxis(Coords.TIME) ? coords.getTime() : 0;
+      int timepoint = coords.hasAxis(Coords.T) ? coords.getT() : 0;
       imagePlus_.updatePosition(channel + 1, slice + 1, timepoint + 1);
 
       // The way to get ImagePlus to repaint even when the position hasn't
@@ -499,14 +499,14 @@ public final class ImageJBridge {
          return new DefaultCoords.Builder().build();
       }
 
-      Coords.CoordsBuilder cb = position.copy();
+      Coords.CoordsBuilder cb = position.copyBuilder();
       if (uiController_.isAxisDisplayed(Coords.CHANNEL)) {
          cb.channel(channel);
       }
       if (uiController_.isAxisDisplayed(Coords.Z)) {
          cb.z(zSlice);
       }
-      if (uiController_.isAxisDisplayed(Coords.TIME)) {
+      if (uiController_.isAxisDisplayed(Coords.T)) {
          cb.time(timePoint);
       }
       return cb.build();
@@ -515,7 +515,7 @@ public final class ImageJBridge {
    int getIJFlatIndexForMMCoords(Coords coords) {
       int channel = Math.max(0, coords.getChannel());
       int zSlice = Math.max(0, coords.getZ());
-      int timePoint = Math.max(0, coords.getTime());
+      int timePoint = Math.max(0, coords.getT());
       int nChannels = getMMNumberOfChannels();
       int nZSlices = getMMNumberOfZSlices();
       int nTimePoints = getMMNumberOfTimePoints();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/DefaultImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/DefaultImageExporter.java
@@ -110,7 +110,7 @@ public final class DefaultImageExporter implements ImageExporter {
       public void selectImageCoords(Coords baseCoords,
             ArrayList<Coords> result) {
          for (int i = startIndex_; i <= stopIndex_; ++i) {
-            Coords newCoords = baseCoords.copy().index(axis_, i).build();
+            Coords newCoords = baseCoords.copyBuilder().index(axis_, i).build();
             if (child_ == null) {
                // Add the corresponding image, if any.
                if (store_.hasImage(newCoords)) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
@@ -52,6 +52,7 @@ import org.micromanager.Studio;
 import org.micromanager.data.Coords;
 import org.micromanager.data.DataProvider;
 import org.micromanager.data.Datastore;
+import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.ImageExporter;
 import org.micromanager.internal.utils.FileDialogs;
@@ -488,11 +489,8 @@ public final class ExportMovieDlg extends MMDialog {
     * Returns true if the display mode is composite.
     */
    private boolean getIsComposite() {
-      ImagePlus displayPlus = display_.getImagePlus();
-      if (displayPlus instanceof CompositeImage) {
-         return ((CompositeImage) displayPlus).getMode() == CompositeImage.COMPOSITE;
-      }
-      return false;
+      return display_.getDisplaySettings().getColorMode() ==
+              DisplaySettings.ColorMode.COMPOSITE;
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultAlbum.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultAlbum.java
@@ -186,7 +186,7 @@ public final class DefaultAlbum implements Album {
             curTime_++;
          }
       }
-      return image.getCoords().copyBuilder().time(curTime_).build();
+      return image.getCoords().copyBuilder().t(curTime_).build();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
@@ -93,8 +93,8 @@ public final class GroupEditor extends ConfigDialog {
          }
       }
       // Warn user about including shutter state in config groups.
-      if (shutters.size() > 0 && studio_.profile().getBoolean(
-               GroupEditor.class, DISPLAY_SHUTTER_WARNING, true)) {
+      if (shutters.size() > 0 && studio_.profile().getSettings(GroupEditor.class).
+              getBoolean(DISPLAY_SHUTTER_WARNING, true)) {
          JPanel contents = new JPanel(new MigLayout("fill, flowy"));
          // NB I would prefer to use a JTextArea here, and use its automatic
          // line wrapping, but that causes a NullPointerException when laying
@@ -119,8 +119,8 @@ public final class GroupEditor extends ConfigDialog {
                contents, "Shutter State in Config Group",
                JOptionPane.WARNING_MESSAGE, 0, null,
                buttons, buttons[0]);
-         studio_.profile().setBoolean(GroupEditor.class, DISPLAY_SHUTTER_WARNING,
-               !neverAgain.isSelected());
+         studio_.profile().getSettings(GroupEditor.class).putBoolean(
+                 DISPLAY_SHUTTER_WARNING, !neverAgain.isSelected());
          if (selection == 2) {
             // User cancelled.
             return;

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -213,7 +213,7 @@ public final class OptionsDlg extends MMDialog {
          changeBackground();
       });
 
-      startupScriptFile_ = new JTextField(ScriptPanel.getStartupScript());
+      startupScriptFile_ = new JTextField(ScriptPanel.getStartupScript(mmStudio_));
 
       final JCheckBox closeOnExitCheckBox = new JCheckBox();
       closeOnExitCheckBox.setText("Close app when quitting MM");
@@ -356,28 +356,28 @@ public final class OptionsDlg extends MMDialog {
       mmStudio_.setCircularBufferSize(seqBufSize);
       mmStudio_.setCoreLogLifetimeDays(deleteLogDays);
 
-      ScriptPanel.setStartupScript(startupScriptFile_.getText());
+      ScriptPanel.setStartupScript(mmStudio_, startupScriptFile_.getText());
       mmStudio_.app().makeActive();
       dispose();
    }
 
    public static boolean getIsDebugLogEnabled(Studio studio) {
-      return studio.profile().getBoolean(OptionsDlg.class,
+      return studio.profile().getSettings(OptionsDlg.class).getBoolean(
             IS_DEBUG_LOG_ENABLED, false);
    }
 
    public static void setIsDebugLogEnabled(Studio studio, boolean isEnabled) {
-      studio.profile().setBoolean(OptionsDlg.class,
+      studio.profile().getSettings(OptionsDlg.class).putBoolean(
             IS_DEBUG_LOG_ENABLED, isEnabled);
    }
 
    public static boolean getShouldCloseOnExit(Studio studio) {
-      return studio.profile().getBoolean(OptionsDlg.class,
+      return studio.profile().getSettings(OptionsDlg.class).getBoolean(
             SHOULD_CLOSE_ON_EXIT, true);
    }
 
    public static void setShouldCloseOnExit(Studio studio, boolean shouldClose) {
-      studio.profile().setBoolean(OptionsDlg.class,
+      studio.profile().getSettings(OptionsDlg.class).putBoolean(
             SHOULD_CLOSE_ON_EXIT, shouldClose);
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/RegistrationDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/RegistrationDlg.java
@@ -49,6 +49,7 @@ import org.micromanager.Studio;
 import org.micromanager.UserProfile;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.profile.internal.LegacyMM1Preferences;
+import org.micromanager.propertymap.MutablePropertyMapView;
 
 // TODO: the change to the Profile system (away from Preferences) has caused
 // registration state to be lost.
@@ -158,11 +159,9 @@ public final class RegistrationDlg extends JDialog {
                InputStream is;
                BufferedReader br;
                // save registration information to profile
-               UserProfile profile = studio_.profile();
-               profile.setString(RegistrationDlg.class, REGISTRATION_NAME,
-                       name_.getText());
-               profile.setString(RegistrationDlg.class, REGISTRATION_INST,
-                       inst_.getText());
+               MutablePropertyMapView settings = studio_.profile().getSettings(RegistrationDlg.class);
+               settings.putString(REGISTRATION_NAME, name_.getText());
+               settings.putString(REGISTRATION_INST, inst_.getText());
                // replace special characters to properly format the command string
                String name1 = name_.getText().replaceAll("[ \t]", "%20");
                name1 = name1.replaceAll("[&]", "%20and%20");
@@ -236,18 +235,18 @@ public final class RegistrationDlg extends JDialog {
    }
 
    private int incrementRegistrationAttempts() {
-      UserProfile profile = studio_.profile();
+      MutablePropertyMapView settings = studio_.profile().
+              getSettings(RegistrationDlg.class);
       int attempts = getNumRegistrationAttempts(studio_) + 1;
-      profile.setInt(RegistrationDlg.class, REGISTRATION_ATTEMPTS, attempts);
+      settings.putInteger(REGISTRATION_ATTEMPTS, attempts);
       return attempts;
    }
 
    public static boolean getHaveRegistered(Studio studio) {
       // HACK: if there's no entry, we also check the 1.4 Preferences.
-      Boolean result = studio.profile().getBoolean(
-            RegistrationDlg.class, HAVE_REGISTERED, null);
-      if (result != null) {
-         return result;
+      MutablePropertyMapView settings = studio.profile().getSettings(RegistrationDlg.class);
+      if (settings.containsBoolean(HAVE_REGISTERED)) {
+         return settings.getBoolean(HAVE_REGISTERED, false);
       }
       Preferences user = LegacyMM1Preferences.getUserRoot();
       Preferences system = LegacyMM1Preferences.getSystemRoot();

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigWizard.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigWizard.java
@@ -143,8 +143,8 @@ public final class ConfigWizard extends MMDialog {
 
       // Create microscope model used by pages.
       microModel_ = new MicroscopeModel();
-      microModel_.setSendConfiguration(studio_.profile().getBoolean(
-              ConfigWizard.class, CFG_OKAY_TO_SEND, true));
+      microModel_.setSendConfiguration(studio_.profile().
+              getSettings(ConfigWizard.class).getBoolean(CFG_OKAY_TO_SEND, true));
       microModel_.loadAvailableDeviceList(core_);
       microModel_.setFileName(defaultPath_);
 
@@ -381,9 +381,8 @@ public final class ConfigWizard extends MMDialog {
          }
       }
 
-      studio_.profile().setBoolean(
-           ConfigWizard.class, CFG_OKAY_TO_SEND,
-           microModel_.getSendConfiguration());
+      studio_.profile().getSettings(ConfigWizard.class).putBoolean(
+           CFG_OKAY_TO_SEND, microModel_.getSendConfiguration());
 
       org.micromanager.internal.utils.HotKeys.active_ = true;
       dispose();

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/FileMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/FileMenu.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
@@ -14,6 +15,7 @@ import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 
 import com.google.common.eventbus.Subscribe;
+import org.micromanager.Studio;
 import org.micromanager.data.Datastore;
 import org.micromanager.data.internal.SciFIODataProvider;
 import org.micromanager.display.DisplayWindow;
@@ -23,7 +25,7 @@ import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.ReportingUtils;
-
+import org.micromanager.propertymap.MutablePropertyMapView;
 
 
 /**
@@ -32,12 +34,14 @@ import org.micromanager.internal.utils.ReportingUtils;
 public final class FileMenu {
    private static final String FILE_HISTORY = "list of recently-viewed files";
    private static final int MAX_HISTORY_SIZE = 15;
-   private final MMStudio studio_;
+   private final Studio studio_;
+   private final MutablePropertyMapView settings_;
    private boolean enableCloseAll_ = false;
 
-   public FileMenu(MMStudio studio, JMenuBar menuBar) {
+   public FileMenu(Studio studio, JMenuBar menuBar) {
       studio_ = studio;
       studio_.displays().registerForEvents(this);
+      settings_ = studio_.profile().getSettings(FileMenu.class);
 
       // We generate the menu contents on the fly, as the "open recent"
       // menu items are dynamically-generated.
@@ -108,7 +112,7 @@ public final class FileMenu {
          new Runnable() {
             @Override
             public void run() {
-               studio_.closeSequence(false);
+               ((MMStudio) studio_).closeSequence(false);
             }
          }
       );
@@ -174,8 +178,7 @@ public final class FileMenu {
       JMenu result = new JMenu(String.format("Open Recent (%s)",
                isVirtual ? "Virtual" : "RAM"));
 
-      String[] history = getRecentFiles();
-      ArrayList<String> files = new ArrayList<String>(Arrays.asList(history));
+      List<String> files = getRecentFiles();
       // History is from oldest to newest; we want newest to oldest so new
       // files are on top.
       Collections.reverse(files);
@@ -223,8 +226,7 @@ public final class FileMenu {
     * @param newFile file to be added to history
     */
    public void updateFileHistory(String newFile) {
-      String[] fileHistory = getRecentFiles();
-      ArrayList<String> files = new ArrayList<String>(Arrays.asList(fileHistory));
+      List<String> files = getRecentFiles();
       if (files.contains(newFile)) {
          // It needs to go on the end; remove it from the middle.
          files.remove(newFile);
@@ -234,17 +236,15 @@ public final class FileMenu {
          files.remove(files.get(0));
       }
       files.add(newFile);
-      setRecentFiles(files.toArray(fileHistory));
+      setRecentFiles(files);
    }
 
-   private static String[] getRecentFiles() {
-      return MMStudio.getInstance().profile().getStringArray(
-            FileMenu.class, FILE_HISTORY, new String[] {});
+   private List<String> getRecentFiles() {
+      return settings_.getStringList(FILE_HISTORY, new String[] {});
    }
 
-   private static void setRecentFiles(String[] files) {
-      MMStudio.getInstance().profile().setStringArray(
-            FileMenu.class, FILE_HISTORY, files);
+   private void setRecentFiles(List<String> files) {
+      settings_.putStringList(FILE_HISTORY, files);
    }
 
    @Subscribe

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -39,6 +39,7 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.data.ProcessorConfigurator;
 import org.micromanager.data.ProcessorFactory;
@@ -264,7 +265,7 @@ final public class PipelineFrame extends MMFrame
       ArrayList<String> names = new ArrayList<String>(nameToPath.keySet());
       Collections.sort(names);
       addProcessorPopup_.removeAll();
-      final PropertyMap blankSettings = studio_.data().getPropertyMapBuilder().build();
+      final PropertyMap blankSettings = PropertyMaps.builder().build();
       for (final String name : names) {
          Action addAction = new AbstractAction() {
             @Override
@@ -305,7 +306,7 @@ final public class PipelineFrame extends MMFrame
    public void addAndConfigureProcessor(ProcessorPlugin plugin) {
       // Create it with a blank set of settings.
       ProcessorConfigurator configurator = plugin.createConfigurator(
-            studio_.data().getPropertyMapBuilder().build());
+            PropertyMaps.builder().build());
       getTableModel().addConfigurator(new ConfiguratorWrapper(plugin,
             configurator, plugin.getName()));
       setVisible(true);

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
@@ -216,8 +216,8 @@ public final class PipelineTableModel extends AbstractTableModel {
       for (ConfiguratorWrapper config : pipelineConfigs_) {
          serializedConfigs.add(config.toJSON());
       }
-      studio.profile().setStringArray(PipelineTableModel.class,
-            SAVED_PIPELINE, serializedConfigs.toArray(new String[] {}));
+      studio.profile().getSettings(PipelineTableModel.class).putStringList(
+            SAVED_PIPELINE, serializedConfigs);
    }
 
    /**
@@ -225,9 +225,9 @@ public final class PipelineTableModel extends AbstractTableModel {
     * updated the model.
     */
    public boolean restorePipelineFromProfile(Studio studio) {
-      String[] serializedConfigs = studio.profile().getStringArray(
-            PipelineTableModel.class, SAVED_PIPELINE,
-            new String[] {});
+      List<String> serializedConfigs = studio.profile().
+              getSettings(PipelineTableModel.class).
+              getStringList(SAVED_PIPELINE, new String[] {});
       boolean didUpdate = false;
       for (String configString : serializedConfigs) {
          ConfiguratorWrapper config = ConfiguratorWrapper.fromString(

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/AxisList.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/AxisList.java
@@ -7,6 +7,7 @@ import mmcorej.StrVector;
 import org.micromanager.UserProfile;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.propertymap.MutablePropertyMapView;
 
 /**
  * List with Axis data.  Currently, we use only a single global instance 
@@ -15,30 +16,31 @@ import org.micromanager.internal.utils.ReportingUtils;
 class AxisList {
    private ArrayList<AxisData> axisList_ = new ArrayList<AxisData>();
    private CMMCore core_;
-   
+
    public AxisList(CMMCore core) {
-      core_ = core;
-      // Initialize the axisList.
-      UserProfile profile = MMStudio.getInstance().profile();
-      try {
-         // add 1D stages
-         StrVector stages = core_.getLoadedDevicesOfType(DeviceType.StageDevice);
-         for (int i=0; i<stages.size(); i++) {
-            axisList_.add(new AxisData(profile.getBoolean(
-                        AxisList.class, stages.get(i), true), 
-                    stages.get(i), AxisData.AxisType.oneD));
-         }
-         // read 2-axis stages
-         StrVector stages2D = core_.getLoadedDevicesOfType(DeviceType.XYStageDevice);
-         for (int i=0; i<stages2D.size(); i++) {
-            axisList_.add(new AxisData(profile.getBoolean(
-                        AxisList.class, stages2D.get(i), true), 
-                    stages2D.get(i), AxisData.AxisType.twoD));
-         }
-      } catch (Exception e) {
-         ReportingUtils.showError(e);
-      }
+       core_ = core;
+       // Initialize the axisList.
+       // TODO settings are only read, never written ???
+       UserProfile profile = MMStudio.getInstance().profile();
+       MutablePropertyMapView settings = profile.getSettings(AxisList.class);
+       try {
+          // add 1D stages
+          StrVector stages = core_.getLoadedDevicesOfType(DeviceType.StageDevice);
+          for (int i=0; i<stages.size(); i++) {
+             axisList_.add(new AxisData(settings.getBoolean(stages.get(i), true),
+                     stages.get(i), AxisData.AxisType.oneD));
+          }
+          // read 2-axis stages
+          StrVector stages2D = core_.getLoadedDevicesOfType(DeviceType.XYStageDevice);
+          for (int i=0; i<stages2D.size(); i++) {
+             axisList_.add(new AxisData(settings.getBoolean(stages2D.get(i), true),
+                     stages2D.get(i), AxisData.AxisType.twoD));
+          }
+       } catch (Exception e) {
+          ReportingUtils.showError(e);
+       }
    }
+
    public AxisData get(int i) {
       if (i >=0 && i < axisList_.size()) {
          return axisList_.get(i);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/AxisTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/AxisTableModel.java
@@ -44,8 +44,9 @@ class AxisTableModel extends AbstractTableModel {
       bus_ = bus;
       // restore the usage settings from our previous session
       for (int i = 0; i < axisList_.getNumberOfPositions(); i++) {
-         axisList_.get(i).setUse(MMStudio.getInstance().profile().getBoolean(
-               AxisTableModel.class, axisList_.get(i).getAxisName(), true ) );
+         axisList_.get(i).setUse(MMStudio.getInstance().profile().
+                 getSettings(AxisTableModel.class).
+                 getBoolean(axisList_.get(i).getAxisName(), true ) );
       }
    }
 
@@ -96,9 +97,9 @@ class AxisTableModel extends AbstractTableModel {
       if (columnIndex == 0) { // i.e. action was in the column with checkboxes
          axisList_.get(rowIndex).setUse((Boolean) value);
          // store new choice to profile
-         MMStudio.getInstance().profile().setBoolean(
-               AxisTableModel.class, axisList_.get(rowIndex).getAxisName(), 
-               (Boolean) value); 
+         MMStudio.getInstance().profile().getSettings(AxisTableModel.class).
+                 putBoolean(axisList_.get(rowIndex).getAxisName(),
+                            (Boolean) value);
          bus_.post(new MoversChangedEvent());
       }
       fireTableCellUpdated(rowIndex, columnIndex);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
@@ -58,8 +58,13 @@ class OffsetPositionsDialog extends MMDialog {
       parent_ = parent;
       core_ = core;
       axisInputs_ = new ArrayList<JTextField>();
+
+      // center dialog on the parent dialog
+      int parentCenterX = (int) (parent.getX() + 0.5 * parent.getWidth());
+      int parentCenterY = (int) (parent.getY() + 0.5 * parent.getHeight());
       
-      this.loadAndRestorePosition(100,100, 320, 300);
+      this.loadAndRestorePosition(parentCenterX - 160,parentCenterY - 150,
+              320, 300);
       
       setTitle("Add offset to stage positions");
       setResizable(false);
@@ -102,7 +107,7 @@ class OffsetPositionsDialog extends MMDialog {
       okButton.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent event) {
-            ArrayList<Float> offsets = new ArrayList<Float>();
+            ArrayList<Float> offsets = new ArrayList<>();
             for (JTextField input : axisInputs_) {
                try {
                   Float value = Float.parseFloat(input.getText());

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -182,7 +182,7 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
       posTable_.setDefaultEditor(Object.class, cellEditor_);
       posTable_.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
       // set column divider location
-      int posCol0Width = profile.getInt(PositionListDlg.class,
+      int posCol0Width = profile.getSettings(PositionListDlg.class).getInteger(
             POS_COL0_WIDTH, 75);
       posTable_.getColumnModel().getColumn(0).setWidth(posCol0Width);
       posTable_.getColumnModel().getColumn(0).setPreferredWidth(posCol0Width);
@@ -199,7 +199,7 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
       axisPane.setMaximumSize(new Dimension(32767, 30 + tableHeight));
       axisPane.setMinimumSize(new Dimension(50, 30 + tableHeight));
       // set divider location
-      int axisCol0Width = profile.getInt(PositionListDlg.class,
+      int axisCol0Width = profile.getSettings(PositionListDlg.class).getInteger(
             AXIS_COL0_WIDTH, 75);
       axisTable_.getColumnModel().getColumn(0).setWidth(axisCol0Width);
       axisTable_.getColumnModel().getColumn(0).setPreferredWidth(axisCol0Width);
@@ -681,7 +681,7 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
       // Find the current position for that device in curMsp_
       for (int posIndex = 0; posIndex < curMsp_.size(); ++posIndex) {
          StagePosition subPos = curMsp_.get(posIndex);
-         if (!subPos.stageName.equals(deviceName)) {
+         if (subPos.stageName.equals(deviceName)) {
             continue;
          }
          x = subPos.x;
@@ -1196,10 +1196,10 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
 
    private void saveDims() {
       int posCol0Width = posTable_.getColumnModel().getColumn(0).getWidth();
-      studio_.profile().setInt(PositionListDlg.class, POS_COL0_WIDTH,
+      studio_.profile().getSettings(PositionListDlg.class).putInteger(POS_COL0_WIDTH,
             posCol0Width);
       int axisCol0Width = axisTable_.getColumnModel().getColumn(0).getWidth();
-      studio_.profile().setInt(PositionListDlg.class, AXIS_COL0_WIDTH,
+      studio_.profile().getSettings(PositionListDlg.class).putInteger(AXIS_COL0_WIDTH,
             axisCol0Width);
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -681,12 +681,15 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
       // Find the current position for that device in curMsp_
       for (int posIndex = 0; posIndex < curMsp_.size(); ++posIndex) {
          StagePosition subPos = curMsp_.get(posIndex);
-         if (!subPos.stageName.equals(deviceName)) {
-            continue;
+         if (subPos.getStageDeviceLabel().equals(deviceName)) {
+            if (subPos.is1DStagePosition()) {
+               z = subPos.get1DPosition();
+            }
+            else if (subPos.is2DStagePosition()) {
+               x = subPos.get2DPositionX();
+               y = subPos.get2DPositionY();
+            }
          }
-         x = subPos.x;
-         y = subPos.y;
-         z = subPos.z;
       }
       for (int row : selectedRows) {
          // Find the appropriate StagePosition in this MultiStagePosition and
@@ -695,18 +698,19 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
          boolean foundPos = false;
          for (int posIndex = 0; posIndex < listPos.size(); ++posIndex) {
             StagePosition subPos = listPos.get(posIndex);
-            if (!subPos.stageName.equals(deviceName)) {
-               continue;
+            if (subPos.getStageDeviceLabel().equals(deviceName)) {
+               if (subPos.is1DStagePosition()) {
+                  subPos.set1DPosition(subPos.getStageDeviceLabel(), z);
+               } else if (subPos.is2DStagePosition()) {
+                  subPos.set2DPosition(subPos.getStageDeviceLabel(), x, y);
+               }
+               foundPos = true;
             }
-            subPos.x = x;
-            subPos.y = y;
-            subPos.z = z;
-            foundPos = true;
          }
          if (!foundPos) {
             // No existing StagePosition for this location; add a new one.
-            StagePosition subPos = new StagePosition();
-            subPos.stageName = deviceName;
+            StagePosition subPos;
+            //subPos.stageName = deviceName;
             DeviceType type;
             try {
                type = core_.getDeviceType(deviceName);
@@ -716,13 +720,10 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
                continue;
             }
             if (type == DeviceType.StageDevice) {
-               subPos.x = x;
-               subPos.numAxes = 1;
+               subPos = StagePosition.create1D(deviceName, z);
             }
             else if (type == DeviceType.XYStageDevice) {
-               subPos.x = x;
-               subPos.y = y;
-               subPos.numAxes = 2;
+               subPos = StagePosition.create2D(deviceName, x, y);
             }
             else {
                throw new IllegalArgumentException("Unrecognized stage device type " + type + " for stage " + deviceName);
@@ -772,10 +773,8 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
          StrVector stages = core_.getLoadedDevicesOfType(DeviceType.StageDevice);
          for (int i=0; i<stages.size(); i++) {
             if (axisList_.use(stages.get(i))) {
-               StagePosition sp = new StagePosition();
-               sp.stageName = stages.get(i);
-               sp.numAxes = 1;
-               sp.x = core_.getPosition(stages.get(i));
+               StagePosition sp = StagePosition.create1D(stages.get(i),
+                       core_.getPosition(stages.get(i)));
                msp.add(sp);
                sb.append(sp.getVerbose()).append("\n");
             }
@@ -785,11 +784,10 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
          StrVector stages2D = core_.getLoadedDevicesOfType(DeviceType.XYStageDevice);
          for (int i=0; i<stages2D.size(); i++) {
             if (axisList_.use(stages2D.get(i))) {
-               StagePosition sp = new StagePosition();
-               sp.stageName = stages2D.get(i);
-               sp.numAxes = 2;
-               sp.x = core_.getXPosition(stages2D.get(i));
-               sp.y = core_.getYPosition(stages2D.get(i));
+               String stageName = stages2D.get(i);
+               StagePosition sp = StagePosition.create2D(stageName,
+                       core_.getXPosition(stageName),
+                       core_.getYPosition(stageName));
                msp.add(sp);
                sb.append(sp.getVerbose()).append("\n");
             }
@@ -1165,20 +1163,15 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
          MultiStagePosition multiPos = positions.getPosition(rowIndex - 1);
          for (int posIndex = 0; posIndex < multiPos.size(); ++posIndex) {
             StagePosition subPos = multiPos.get(posIndex);
-            if (subPos.stageName.equals(deviceName)) {
-               // This is the one to modify.
-               if (subPos.numAxes >= 3) {
-                  // With the current definition of StagePosition axis fields,
-                  // I don't think this can ever happen, but hey, future-
-                  // proofing.
-                  subPos.z += offsets.get(2);
+            if (subPos.getStageDeviceLabel().equals(deviceName)) {
+               if (subPos.is1DStagePosition()) {
+                  subPos.set1DPosition(subPos.getStageDeviceLabel(),
+                          subPos.get1DPosition() + offsets.get(0));
+               } else if (subPos.is2DStagePosition()) {
+                  subPos.set2DPosition(subPos.getStageDeviceLabel(),
+                          subPos.get2DPositionX() + offsets.get(0),
+                          subPos.get2DPositionY() + offsets.get(1));
                }
-               if (subPos.numAxes >= 2) {
-                  subPos.y += offsets.get(1);
-               }
-               // Assume every stage device has at least one axis, because
-               // if they don't, then oh dear...
-               subPos.x += offsets.get(0);
             }
          }
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -681,7 +681,7 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
       // Find the current position for that device in curMsp_
       for (int posIndex = 0; posIndex < curMsp_.size(); ++posIndex) {
          StagePosition subPos = curMsp_.get(posIndex);
-         if (subPos.stageName.equals(deviceName)) {
+         if (!subPos.stageName.equals(deviceName)) {
             continue;
          }
          x = subPos.x;

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
@@ -46,6 +46,7 @@ import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.internal.positionlist.utils.TileCreator;
 import org.micromanager.internal.positionlist.utils.ZGenerator;
+import org.micromanager.propertymap.MutablePropertyMapView;
 
 public final class TileCreatorDlg extends MMDialog {
    private static final long serialVersionUID = 1L;
@@ -93,6 +94,9 @@ public final class TileCreatorDlg extends MMDialog {
       positionListDlg_.activateAxisTable(false);
       endPosition_ = new MultiStagePosition[4];
       endPositionSet_ = new boolean[4];
+
+      MutablePropertyMapView settings = studio.profile().getSettings(
+              TileCreatorDlg.class);
 
       super.setTitle("Tile Creator");
 
@@ -292,13 +296,11 @@ public final class TileCreatorDlg extends MMDialog {
       overlapField_ = new JTextField();
       overlapField_.setBounds(70, 186, 50, 20);
       overlapField_.setFont(new Font("", Font.PLAIN, 10));
-      overlapField_.setText(studio.profile().getString(TileCreatorDlg.class, 
-              OVERLAP_PREF, "0"));
+      overlapField_.setText(settings.getString(OVERLAP_PREF, "0"));
       overlapField_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent arg0) {
-            studio.profile().setString(TileCreatorDlg.class, 
-               OVERLAP_PREF,overlapField_.getText() );
+            settings.putString(OVERLAP_PREF, overlapField_.getText() );
             updateCenteredSizeLabel();
          }
       });
@@ -343,8 +345,7 @@ public final class TileCreatorDlg extends MMDialog {
       okButton.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent arg0) {
-            studio.profile().setString(TileCreatorDlg.class, 
-               OVERLAP_PREF,overlapField_.getText() );
+            settings.putString(OVERLAP_PREF, overlapField_.getText() );
             addToPositionList();
          }
       });
@@ -381,16 +382,16 @@ public final class TileCreatorDlg extends MMDialog {
 
    @Override
    public void dispose(){
-        studio_.profile().setString(TileCreatorDlg.class, 
-        OVERLAP_PREF,overlapField_.getText() );
+        studio_.profile().getSettings(TileCreatorDlg.class).putString(
+                  OVERLAP_PREF,overlapField_.getText() );
         positionListDlg_.activateAxisTable(true);
         super.dispose();
    }
    
    @Subscribe
    public void shuttingDown(ShutdownCommencingEvent se) {
-      studio_.profile().setString(TileCreatorDlg.class,
-              OVERLAP_PREF, overlapField_.getText());
+      studio_.profile().getSettings(TileCreatorDlg.class).putString(
+                 OVERLAP_PREF, overlapField_.getText());
       dispose();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
@@ -527,16 +527,24 @@ public final class TileCreatorDlg extends MMDialog {
 
                switch (location) {
                   case 0: // top
-                     sp.y += offsetYUm;
+                     sp.set2DPosition(xyStage,
+                             core_.getXPosition(xyStage),
+                             core_.getYPosition(xyStage) + offsetYUm);
                      break;
                   case 1: // right
-                     sp.x += offsetXUm;
+                     sp.set2DPosition(xyStage,
+                             core_.getXPosition(xyStage) + offsetXUm,
+                             core_.getYPosition(xyStage));
                      break;
                   case 2: // bottom
-                     sp.y -= offsetYUm;
+                     sp.set2DPosition(xyStage,
+                             core_.getXPosition(xyStage),
+                             core_.getYPosition(xyStage) - offsetYUm);
                      break;
                   case 3: // left
-                     sp.x -= offsetXUm;
+                     sp.set2DPosition(xyStage,
+                             core_.getXPosition(xyStage) - offsetXUm,
+                             core_.getYPosition(xyStage));
                      break;
                }
                msp.add(sp);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/utils/TileCreator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/utils/TileCreator.java
@@ -84,10 +84,10 @@ public final class TileCreator {
          // Calculate a bounding rectangle around the defaultXYStage positions
          // TODO: develop method to deal with multiple axis
          StagePosition[] coords = boundingBox(endPoints, xyStage);
-         double maxX = coords[1].x;
-         double minX = coords[0].x;
-         double maxY = coords[1].y;
-         double minY = coords[0].y;
+         double maxX = coords[1].get2DPositionX();
+         double minX = coords[0].get2DPositionX();
+         double maxY = coords[1].get2DPositionY();
+         double minY = coords[0].get2DPositionY();
 
          double[] ans = getImageSize(pixelSizeUm);
          double imageSizeXUm = ans[0];
@@ -249,17 +249,17 @@ public final class TileCreator {
         StagePosition sp;
         for (int i = 0; i < endPoints.length; i++) {
            sp = endPoints[i].get(xyStage);
-           if (sp.x < minX) {
-              minX = sp.x;
+           if (sp.get2DPositionX() < minX) {
+              minX = sp.get2DPositionX();
            }
-           if (sp.x > maxX) {
-              maxX = sp.x;
+           if (sp.get2DPositionX() > maxX) {
+              maxX = sp.get2DPositionX();
            }
-           if (sp.y < minY) {
-              minY = sp.y;
+           if (sp.get2DPositionY() < minY) {
+              minY = sp.get2DPositionY();
            }
-           if (sp.y > maxY) {
-              maxY = sp.y;
+           if (sp.get2DPositionY() > maxY) {
+              maxY = sp.get2DPositionY();
            }
         }
         StagePosition minCoords = StagePosition.create2D(xyStage, minX, minY);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/utils/ZGeneratorAverage.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/utils/ZGeneratorAverage.java
@@ -46,10 +46,10 @@ class ZGeneratorAverage implements ZGenerator {
        for (int a=0; a<msp0.size(); a++){
            sp = msp0.get(a);
            if (sp.is1DStagePosition()){
-              c = sp.x;
+              c = sp.get1DPosition();
               //Calculate sum of positions for current axis
               for (int p=1; p<positionList.getNumberOfPositions(); p++){
-                  c = c + positionList.getPosition(p).get(a).x;                
+                  c = c + positionList.getPosition(p).get(a).get1DPosition();
               }
 
               Double z = c / positionList.getNumberOfPositions(); //average

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/utils/ZGeneratorShepard.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/utils/ZGeneratorShepard.java
@@ -74,7 +74,7 @@ class ZGeneratorShepard implements ZGenerator {
            sp = msp.get(a); //get an axis
            if (sp.is1DStagePosition()){
               for (int p=0; p<nPositions; p++){
-                  z[p] = positionList.getPosition(p).get(a).x;                
+                  z[p] = positionList.getPosition(p).get(a).get1DPosition();
               }              
               interpolators_.put(sp.getStageDeviceLabel(), 
                       new ShepardInterpolator(x, y, z, exp)); //store the interpolator for this axis

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -838,7 +838,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
          File curFile = FileDialogs.openFile(this, "Select a Beanshell script", BSH_FILE);
 
          if (curFile != null) {
-               studio_.profile().setString(ScriptPanel.class,
+               studio_.profile().getSettings(ScriptPanel.class).putString(
                      SCRIPT_FILE, curFile.getAbsolutePath());
                // only creates a new file when a file with this name does not exist
                addScriptToModel(curFile);
@@ -1376,13 +1376,13 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       return interp_.stopRequestPending();
    }
 
-   public static String getStartupScript() {
-      return MMStudio.getInstance().profile().getString(ScriptPanel.class,
-            STARTUP_SCRIPT, "MMStartup.bsh");
+   public static String getStartupScript(Studio studio) {
+      return studio.profile().getSettings(ScriptPanel.class).
+              getString(STARTUP_SCRIPT, "MMStartup.bsh");
    }
 
-   public static void setStartupScript(String path) {
-      MMStudio.getInstance().profile().setString(ScriptPanel.class,
+   public static void setStartupScript(Studio studio, String path) {
+      studio.profile().getSettings(ScriptPanel.class).putString(
             STARTUP_SCRIPT, path);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusBase.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusBase.java
@@ -127,7 +127,7 @@ public abstract class AutofocusBase implements AutofocusPlugin {
    public void saveSettings() {
       UserProfile profile = MMStudio.getInstance().profile();
       for (int i=0; i<properties_.size(); i++) {
-         profile.setString(this.getClass(),
+         profile.getSettings(this.getClass()).putString(
                properties_.get(i).name, properties_.get(i).value);
       }      
    }
@@ -135,8 +135,8 @@ public abstract class AutofocusBase implements AutofocusPlugin {
    public void loadSettings() {
       UserProfile profile = MMStudio.getInstance().profile();
       for (int i=0; i<properties_.size(); i++) {
-         properties_.get(i).value = profile.getString(this.getClass(),
-               properties_.get(i).name, properties_.get(i).value);
+         properties_.get(i).value = profile.getSettings(this.getClass()).
+                 getString(properties_.get(i).name, properties_.get(i).value);
       }      
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -61,6 +61,7 @@ import org.micromanager.internal.MMStudio;
  * device - property - value
  */
 public final class AutofocusPropertyEditor extends MMDialog {
+   private final Studio studio_;
    private final SpringLayout springLayout;
    private static final long serialVersionUID = 1507097881635431043L;
    
@@ -77,6 +78,7 @@ public final class AutofocusPropertyEditor extends MMDialog {
    
    public AutofocusPropertyEditor(Studio studio, DefaultAutofocusManager afmgr) {
       super("autofocus property editor");
+      studio_ = studio;
       afMgr_ = afmgr;
       setModal(false);
       data_ = new PropertyTableData();
@@ -106,7 +108,7 @@ public final class AutofocusPropertyEditor extends MMDialog {
          public void windowOpened(WindowEvent e) {
             // restore values from the previous session
             showReadonlyCheckBox_.setSelected(
-               profile.getBoolean(AutofocusPropertyEditor.class,
+               profile.getSettings(AutofocusPropertyEditor.class).getBoolean(
                   PREF_SHOW_READONLY, true));
             data_.updateStatus();
             data_.fireTableStructureChanged();
@@ -166,8 +168,8 @@ public final class AutofocusPropertyEditor extends MMDialog {
       getContentPane().add(showReadonlyCheckBox_);
       
       // restore values from the previous session
-      showReadonlyCheckBox_.setSelected(profile.getBoolean(
-               AutofocusPropertyEditor.class, PREF_SHOW_READONLY, true));
+      showReadonlyCheckBox_.setSelected(profile.getSettings(
+               AutofocusPropertyEditor.class).getBoolean(PREF_SHOW_READONLY, true));
       {
          btnClose = new JButton("Close");
          btnClose.addActionListener(new ActionListener() {
@@ -260,9 +262,8 @@ public final class AutofocusPropertyEditor extends MMDialog {
          
 
    public void cleanup() {
-      MMStudio.getInstance().profile().setBoolean(
-            AutofocusPropertyEditor.class, PREF_SHOW_READONLY, 
-              showReadonlyCheckBox_.isSelected());
+      studio_.profile().getSettings(AutofocusPropertyEditor.class).
+              putBoolean(PREF_SHOW_READONLY, showReadonlyCheckBox_.isSelected());
       if (afMgr_ != null)
          if (afMgr_.getAutofocusMethod() != null) {
             afMgr_.getAutofocusMethod().applySettings();

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/DefaultQuickAccessManager.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/DefaultQuickAccessManager.java
@@ -84,8 +84,8 @@ public final class DefaultQuickAccessManager implements QuickAccessManager {
    @Subscribe
    public void onStartupComplete(StartupCompleteEvent event) {
       try {
-         String configStr = studio_.profile().getString(
-               QuickAccessManager.class, SAVED_CONFIG, null);
+         String configStr = studio_.profile().
+                 getSettings(QuickAccessManager.class).getString( SAVED_CONFIG, null);
          if (configStr == null) {
             // Nothing saved.
             return;
@@ -120,8 +120,8 @@ public final class DefaultQuickAccessManager implements QuickAccessManager {
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
       String config = getConfig(false);
-      studio_.profile().setString(QuickAccessManager.class, SAVED_CONFIG,
-            config);
+      studio_.profile().getSettings(QuickAccessManager.class).
+              putString(SAVED_CONFIG, config);
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/DraggableIcon.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/DraggableIcon.java
@@ -313,7 +313,7 @@ public final class DraggableIcon extends JLabel {
                   DefaultQuickAccessManager.CUSTOM_FILE);
             iconJson.put(DefaultQuickAccessManager.ICON_PATH,
                   imageFile.getAbsolutePath());
-            config = config.copy()
+            config = config.copyBuilder()
                .putString(WidgetPlugin.CUSTOM_ICON_STRING, iconJson.toString())
                .build();
             frame_.removeControl(parentCell_, false);
@@ -340,7 +340,7 @@ public final class DraggableIcon extends JLabel {
             iconJson.put(DefaultQuickAccessManager.ICON_TYPE,
                   DefaultQuickAccessManager.COLOR_SWATCH);
             iconJson.put(DefaultQuickAccessManager.ICON_COLOR, color.getRGB());
-            config = config.copy()
+            config = config.copyBuilder()
                .putString(WidgetPlugin.CUSTOM_ICON_STRING, iconJson.toString())
                .build();
             frame_.removeControl(parentCell_, false);
@@ -364,7 +364,7 @@ public final class DraggableIcon extends JLabel {
             iconJson.put(DefaultQuickAccessManager.ICON_TYPE,
                   DefaultQuickAccessManager.JAR_ICON);
             iconJson.put(DefaultQuickAccessManager.ICON_PATH, name);
-            config = config.copy()
+            config = config.copyBuilder()
                .putString(WidgetPlugin.CUSTOM_ICON_STRING, iconJson.toString())
                .build();
             frame_.removeControl(parentCell_, false);

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/AutofocusButtons.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/AutofocusButtons.java
@@ -31,6 +31,7 @@ import javax.swing.JComponent;
 import javax.swing.JPanel;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.GUIUtils;
@@ -128,6 +129,6 @@ public final class AutofocusButtons extends WidgetPlugin implements SciJavaPlugi
 
    @Override
    public PropertyMap configureControl(Frame parent) {
-      return studio_.data().getPropertyMapBuilder().build();
+      return PropertyMaps.builder().build();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/ExposureTime.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/ExposureTime.java
@@ -31,6 +31,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.events.ExposureChangedEvent;
 import org.micromanager.events.GUIRefreshEvent;
@@ -117,7 +118,7 @@ public final class ExposureTime extends WidgetPlugin implements SciJavaPlugin {
 
    @Override
    public PropertyMap configureControl(Frame parent) {
-      return studio_.data().getPropertyMapBuilder().build();
+      return PropertyMaps.builder().build();
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/LiveButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/LiveButton.java
@@ -32,6 +32,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.events.LiveModeEvent;
 import org.micromanager.internal.utils.GUIUtils;
@@ -147,7 +148,6 @@ public final class LiveButton extends WidgetPlugin implements SciJavaPlugin {
    public PropertyMap configureControl(Frame parent) {
       // When used in the Quick-Access window, we use a bigger size than when
       // used in other contexts.
-      return studio_.data().getPropertyMapBuilder()
-         .putBoolean("isBig", true).build();
+      return PropertyMaps.builder().putBoolean("isBig", true).build();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/MDAButtons.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/MDAButtons.java
@@ -32,6 +32,7 @@ import javax.swing.JComponent;
 import javax.swing.JPanel;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.events.AcquisitionEndedEvent;
 import org.micromanager.events.AcquisitionStartedEvent;
@@ -170,6 +171,6 @@ public final class MDAButtons extends WidgetPlugin implements SciJavaPlugin {
 
    @Override
    public PropertyMap configureControl(Frame parent) {
-      return studio_.data().getPropertyMapBuilder().build();
+      return PropertyMaps.builder().build();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/SavedMDAButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/SavedMDAButton.java
@@ -31,6 +31,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.internal.dialogs.AcqControlDlg;
 import org.micromanager.internal.utils.FileDialogs;
@@ -145,7 +146,7 @@ public final class SavedMDAButton extends WidgetPlugin implements SciJavaPlugin 
       if (file == null) {
          return null;
       }
-      return studio_.data().getPropertyMapBuilder()
-         .putString("settingsPath", file.getAbsolutePath()).build();
+      return PropertyMaps.builder().putString("settingsPath",
+              file.getAbsolutePath()).build();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/ScriptButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/ScriptButton.java
@@ -31,6 +31,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.internal.script.ScriptPanel;
 import org.micromanager.internal.utils.FileDialogs;
@@ -122,7 +123,7 @@ public final class ScriptButton extends WidgetPlugin implements SciJavaPlugin {
       if (file == null) {
          return null;
       }
-      return studio_.data().getPropertyMapBuilder()
-         .putString("scriptPath", file.getAbsolutePath()).build();
+      return PropertyMaps.builder().putString("scriptPath",
+              file.getAbsolutePath()).build();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/ShutterControl.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/ShutterControl.java
@@ -34,6 +34,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.events.AutoShutterEvent;
 import org.micromanager.events.GUIRefreshEvent;
@@ -197,7 +198,7 @@ public final class ShutterControl extends WidgetPlugin implements SciJavaPlugin 
 
    @Override
    public PropertyMap configureControl(Frame parent) {
-      return studio_.data().getPropertyMapBuilder().build();
+      return PropertyMaps.builder().build();
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/SnapButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/SnapButton.java
@@ -32,6 +32,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.events.LiveModeEvent;
 import org.micromanager.internal.utils.GUIUtils;
@@ -139,7 +140,6 @@ public final class SnapButton extends WidgetPlugin implements SciJavaPlugin {
    public PropertyMap configureControl(Frame parent) {
       // When used in the Quick-Access window, we use a bigger size than when
       // used in other contexts.
-      return studio_.data().getPropertyMapBuilder()
-         .putBoolean("isBig", true).build();
+      return PropertyMaps.builder().putBoolean("isBig", true).build();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/TextLabel.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/TextLabel.java
@@ -25,6 +25,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.quickaccess.WidgetPlugin;
 import org.scijava.plugin.Plugin;
@@ -80,7 +81,6 @@ public final class TextLabel extends WidgetPlugin implements SciJavaPlugin {
          // Not a valid text label.
          return null;
       }
-      return studio_.data().getPropertyMapBuilder()
-         .putString("labelText", text).build();
+      return PropertyMaps.builder().putString("labelText", text).build();
    }
 }


### PR DESCRIPTION
Focused on reducing compiler warnings.  Most were due to the use of deprecated code within out code base for which alternatives are available.  This PR should not result in any change in behavior, but it is always possible that errors sneeked in, or that I misunderstood the API. Remaining use of deprecated code is mainly due to MDUtils and DisplaySettings, which are still used to stay compatible with data saved by older MM versions.  Is there an annotation that describes this better (i.e., do not use in new code, but this needs to stay here)?

Also reduced the use of MMStudio where Studio suffices, as well as the use of MMStudio.getInstance() wherever possible. Still quite a few more to go.

