### PR TITLE
Studio: Bug fix for key-press movements not moving stage as expected.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
@@ -157,8 +157,13 @@ public class XYNavigator {
 		if (xyStage == null || xyStage.equals("")) {
 			return;
 		}
-		Point2D stagePos = toStageSpace(pixSizeUm, tmpXUm, tmpYUm);
-		moveXYStageUm(studio_.core().getXYStageDevice(), stagePos.getX(), stagePos.getY());
+		// It is a bit funny to calculate back to pixels and then receive
+		// a stagposition in microns, but that is likely more exact than
+		// lying about pixelSize here (by setting it to 1)
+		Point2D stagePos = toStageSpace(pixSizeUm, tmpXUm / pixSizeUm,
+				tmpYUm / pixSizeUm);
+		moveXYStageUm(studio_.core().getXYStageDevice(), stagePos.getX(),
+				stagePos.getY());
 	}
 
 


### PR DESCRIPTION
Code doing orientation correction wants input in pixels rather than
microns, resulting in movement multiplied by pixel size rather than the
amount enetered in the StageControl Plugin.  Orientation correction is
still carried out, but now input x and y movements are first expressed
as pixels, resulting in correct values.

Addresses issue #760.