### PR TITLE
Studio: Channel colors unified in RememberedSettings.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -58,6 +58,7 @@ import org.micromanager.display.DataViewer;
 import org.micromanager.display.DataViewerListener;
 import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.DisplayWindow;
+import org.micromanager.display.internal.RememberedSettings;
 import org.micromanager.events.AcquisitionEndedEvent;
 import org.micromanager.internal.utils.JavaUtils;
 import org.micromanager.internal.utils.MDUtils;
@@ -212,6 +213,10 @@ public final class MMAcquisition extends DataViewerListener {
                      displaySettingsBuilder.colorModeComposite();
                   }
                   for (int channelIndex = 0; channelIndex < nrChannels; channelIndex++) {
+                     displaySettingsBuilder.channel(channelIndex, RememberedSettings.loadChannel(studio_,
+                             store_.getSummaryMetadata().getChannelGroup(),
+                             store_.getSummaryMetadata().getChannelNameList().get(channelIndex)));
+                     /*
                      ChannelDisplaySettings channelSettings
                              = displaySettingsBuilder.getChannelSettings(channelIndex);
                      Color chColor = new Color(chColors.getInt(channelIndex));
@@ -227,6 +232,8 @@ public final class MMAcquisition extends DataViewerListener {
                         }
                      }
                      displaySettingsBuilder.channel(channelIndex,csb.build());
+
+                      */
                   }
                } while (!display_.compareAndSetDisplaySettings(
                        display_.getDisplaySettings(), displaySettingsBuilder.build()));

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
@@ -28,6 +28,7 @@ public interface ChannelDisplaySettings {
       Builder useCameraHistoRange(boolean use);
       
       Builder name(String name);
+      Builder groupName(String groupName);
       Builder visible(boolean visible);
       Builder show();
       Builder hide();
@@ -40,12 +41,44 @@ public interface ChannelDisplaySettings {
       ChannelDisplaySettings build();
    }
 
+   /**
+    * Color used to represent this channel, i.e., brightest color of the LUT
+    * used to display this channel
+    *
+    * @return Color for this channel
+    */
    Color getColor();
+
    boolean isUniformComponentScalingEnabled();
+
+   /**
+    * Range of this histogram displayed for this channel
+    * For now, histogram always starts at zero, so this represents
+    * the maximum value on the x-axis of the histogram.
+    *
+    * @return Maximum value on the x-axis of the histogram expressed as a factor of 2
+    */
    int getHistoRangeBits();
+
+   /**
+    * @return True when historangebits is equal to the maximum intensity coming from the camera
+    */
    boolean useCameraRange();
+
+   /**
+    * @return True when this channel is visible to the user, false otherwise
+    */
    boolean isVisible();
+
+   /**
+    * @return Name of the channel being displayed.
+    */
    String getName();
+
+   /**
+    * @return Name of the channelGroup this channel belongs to
+    */
+   String getGroupName();
 
    int getNumberOfComponents();
    ComponentDisplaySettings getComponentSettings(int component);
@@ -54,5 +87,4 @@ public interface ChannelDisplaySettings {
    Builder copyBuilder();
    Builder copyBuilderWithComponentSettings(int component, ComponentDisplaySettings settings);
 
-   // TODO Add static builder() in Java 8
 }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ColorModeCell.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ColorModeCell.java
@@ -15,6 +15,8 @@ import net.imglib2.display.ColorTable8;
 import org.micromanager.internal.utils.ColorMaps;
 
 /**
+ * Generates the items in the colorModeComboBox in the top of the
+ * Histograms and Intensity scaling panel
  *
  * @author mark
  */

--- a/mmstudio/src/main/java/org/micromanager/display/internal/RememberedChannelSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/RememberedChannelSettings.java
@@ -215,7 +215,7 @@ public final class RememberedChannelSettings {
          String name = summary.getSafeChannelName(ch);
          RememberedChannelSettings settings = loadSettings(channelGroup, name, 
                  Color.WHITE, null, null, true);
-         builder.channel(ch, settings.toChannelDisplaySetting(name));
+         builder.channel(ch, settings.toChannelDisplaySetting(channelGroup, name));
       }
       builder.autostretch(true);
       return builder.build();      
@@ -225,12 +225,13 @@ public final class RememberedChannelSettings {
         (SummaryMetadata summary, int chNr) {
       RememberedChannelSettings settings = loadSettings(summary.getChannelGroup(),
               summary.getChannelNameList().get(chNr), Color.WHITE, null, null, true);
-      return settings.toChannelDisplaySetting(summary.getChannelNameList().get(chNr));
+      return settings.toChannelDisplaySetting(summary.getChannelGroup(),
+              summary.getChannelNameList().get(chNr));
    }
    
-   public ChannelDisplaySettings toChannelDisplaySetting(String channelName) {
+   public ChannelDisplaySettings toChannelDisplaySetting(String channelGroup, String channelName) {
       ChannelDisplaySettings.Builder builder = DefaultChannelDisplaySettings.builder();
-      builder.color(color_).name(channelName);
+      builder.color(color_).groupName(channelGroup).name(channelName);
       // ugly, we rely on a null list to know if we should return defaults...
       if (histogramMins_ != null) {
          for (int comp = 0; comp < histogramMins_.size(); comp++) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/RememberedSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/RememberedSettings.java
@@ -90,7 +90,8 @@ public class RememberedSettings {
       MutablePropertyMapView settings = 
               studio.profile().getSettings(RememberedSettings.class);
       if (settings.containsPropertyMap(key)) {
-         return DefaultChannelDisplaySettings.fromPropertyMap(settings.getPropertyMap(key, null));
+          return DefaultChannelDisplaySettings.fromPropertyMap(
+                  settings.getPropertyMap(key, null), channelGroup, channelName);
       } else {
          // for backward compatibility
          String rKey = RememberedChannelSettings.genKey(channelGroup, channelName);
@@ -103,7 +104,7 @@ public class RememberedSettings {
                     null, 
                     null, 
                     true);
-            return rcs.toChannelDisplaySetting(channelName);
+            return rcs.toChannelDisplaySetting(channelGroup, channelName);
          }
       }
       

--- a/mmstudio/src/main/java/org/micromanager/display/internal/RememberedSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/RememberedSettings.java
@@ -59,10 +59,10 @@ public class RememberedSettings {
               studio.profile().getSettings(RememberedSettings.class);
       if (cds instanceof DefaultChannelDisplaySettings) {        
          DefaultChannelDisplaySettings dcds = (DefaultChannelDisplaySettings) cds;
-         // for safety, ensure that channelname is stored with ChannelDisplaySettings
+         // for safety, ensure channelgroup and channelname are stored with ChannelDisplaySettings
          if (!dcds.getName().equals(channelName)) {
             dcds = (DefaultChannelDisplaySettings) 
-                    dcds.copyBuilder().name(channelName).build();
+                    dcds.copyBuilder().groupName(channelGroup).name(channelName).build();
          }
          PropertyMap pMap = dcds.toPropertyMap();
          settings.putPropertyMap(key, pMap);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -72,6 +72,7 @@ import org.micromanager.data.internal.DefaultCoords;
 import org.micromanager.display.ChannelDisplaySettings;
 import org.micromanager.display.ComponentDisplaySettings;
 import org.micromanager.display.DisplaySettings;
+import org.micromanager.display.internal.RememberedSettings;
 import org.micromanager.display.internal.animate.AnimationController;
 import org.micromanager.display.internal.displaywindow.imagej.ImageJBridge;
 import org.micromanager.display.internal.event.DisplayKeyPressEvent;
@@ -946,8 +947,19 @@ public final class DisplayUIController implements Closeable, WindowListener,
          for (int i = 0; i < nChannels; ++i) {
             ChannelDisplaySettings channelSettings
                     = settings.getChannelSettings(i);
+            // Update RememberedSettings for this channel.
+            // We update color only, but unfortunately, we get called here
+            // also when other things change
+            // TODO: should all channeldisplaysetting changes be remembered?
+            ChannelDisplaySettings rememberedSettings =
+                    RememberedSettings.loadChannel(studio_,
+                            channelSettings.getGroupName(), channelSettings.getName());
+            RememberedSettings.storeChannel(studio_, channelSettings.getGroupName(), channelSettings.getName(),
+                    rememberedSettings.copyBuilder().color(channelSettings.getColor()).build());
+
             ComponentDisplaySettings componentSettings =
                   channelSettings.getComponentSettings(0);
+            // TODO: Remember changes in component display settings?
             ijBridge_.mm2ijSetChannelColor(i, channelSettings.getColor());
             if (!autostretch) {
                int max = Math.max(1, (int) Math.min(Integer.MAX_VALUE,

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -777,14 +777,22 @@ public final class SnapLiveManager extends DataViewerListener
 
    /**
     * Make a name up for the given channel/camera number combination.
+    * This tries to replicate the code in the acquisition engine
+    * Hopefully this can be refactors to get its info from one and the same
+    * place
     */
    private String makeChannelName(String channel, String cameraChannelName) {
-      String result = channel;
+      String result;
       if (numCameraChannels_ > 1) {
          if (channel.isEmpty()) {
             result = cameraChannelName;
          } else {
-            result = result + "-" + cameraChannelName;
+            result = channel + "-" + cameraChannelName;
+         }
+      } else {
+         result = channel;
+         if (result.isEmpty()) {
+            result = "Default";
          }
       }
       return result;

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -776,10 +776,9 @@ public final class SnapLiveManager extends DataViewerListener
    }
 
    /**
-    * Make a name up for the given channel/camera number combination.
-    * This tries to replicate the code in the acquisition engine
-    * Hopefully this can be refactors to get its info from one and the same
-    * place
+    * Make a name for the given channel/camera number combination.
+    * This tries to replicate the code in the acquisition engine.
+    * TODO: Combine code in acq engine and this function
     */
    private String makeChannelName(String channel, String cameraChannelName) {
       String result;


### PR DESCRIPTION
Addresses issue #752. Both MMAcquisition and the Snap/LiveManager now pull the channel colors
from the static methods in RememberedSettings.  This unifies the channel
colors except for the ones shown in the MDA.  We could either remove the
channel colors in the MDA dialog altogether, update them whenever the
colors of the Snap/Live window are updated, or leave things as they are now,
This laso created the opportunity to update more than just the colors.
However, I like to keep those separate between Snap/Live and acquisition,
since I can imagine many situation where you do not want one to influence
the other. Todo: evaluate how this affects displays created through the
 scripting api.