### PR TITLE
MMCoreJ throws specific exceptions instead of `java.lang.Exception`

### DIFF
--- a/MMCoreJ_wrap/CMMError.java
+++ b/MMCoreJ_wrap/CMMError.java
@@ -1,0 +1,8 @@
+package mmcorej;
+
+public class CMMError extends java.lang.Exception {
+	public CMMError() { super(); }
+	public CMMError(String message) { super(message); }
+	public CMMError(String message, Throwable cause) { super(message, cause); }
+	public CMMError(Throwable cause) { super(cause); }
+}

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -599,24 +599,24 @@
 %rename(eql) operator=;
 
 // CMMError used by MMCore
-%typemap(throws, throws="java.lang.Exception") CMMError {
-   jclass excep = jenv->FindClass("java/lang/Exception");
+%typemap(throws, throws="mmcorej.CMMError") CMMError {
+   jclass excep = jenv->FindClass("mmcorej/CMMError");
    if (excep)
      jenv->ThrowNew(excep, $1.getFullMsg().c_str());
    return $null;
 }
 
 // MetadataKeyError used by Metadata class
-%typemap(throws, throws="java.lang.Exception") MetadataKeyError {
-   jclass excep = jenv->FindClass("java/lang/Exception");
+%typemap(throws, throws="mmcorej.MetadataKeyError") MetadataKeyError {
+   jclass excep = jenv->FindClass("mmcorej.MetadataKeyError");
    if (excep)
      jenv->ThrowNew(excep, $1.getMsg().c_str());
    return $null;
 }
 
 // MetadataIndexError used by Metadata class
-%typemap(throws, throws="java.lang.Exception") MetadataIndexError {
-   jclass excep = jenv->FindClass("java/lang/Exception");
+%typemap(throws, throws="mmcorej.MetadataIndexError") MetadataIndexError {
+   jclass excep = jenv->FindClass("mmcorej/MetadataIndexError");
    if (excep)
      jenv->ThrowNew(excep, $1.getMsg().c_str());
    return $null;

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -622,7 +622,7 @@
    return $null;
 }
 
-// We've translated exceptions to java.lang.Exception, so don't wrap the unused
+// We've translated exceptions to java versions that extend java.lang.Exception, so don't automatically wrap the unused
 // C++ exception classes.
 %ignore CMMError;
 %ignore MetadataKeyError;

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -608,7 +608,7 @@
 
 // MetadataKeyError used by Metadata class
 %typemap(throws, throws="mmcorej.MetadataKeyError") MetadataKeyError {
-   jclass excep = jenv->FindClass("mmcorej.MetadataKeyError");
+   jclass excep = jenv->FindClass("mmcorej/MetadataKeyError");
    if (excep)
      jenv->ThrowNew(excep, $1.getMsg().c_str());
    return $null;

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -850,7 +850,7 @@
    }
 
    /**
-    * Convenience function.  Retuns affine transform as a String
+    * Convenience function.  Returns affine transform as a String
     * Used in this class and by the acquisition engine 
     * (rather than duplicating this code there
     */

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -698,7 +698,7 @@
 
    }
 
-   private TaggedImage createTaggedImage(Object pixels, Metadata md, int cameraChannelIndex) throws java.lang.Exception {
+   private TaggedImage createTaggedImage(Object pixels, Metadata md, int cameraChannelIndex) throws mmcorej.CMMError, mmcorej.org.json.JSONException {
       TaggedImage image = createTaggedImage(pixels, md);
       JSONObject tags = image.tags;
       
@@ -716,7 +716,7 @@
       return image;
    }
 
-   private TaggedImage createTaggedImage(Object pixels, Metadata md) throws java.lang.Exception {
+   private TaggedImage createTaggedImage(Object pixels, Metadata md) throws mmcorej.CMMError, mmcorej.org.json.JSONException  {
       JSONObject tags = metadataToMap(md);
       PropertySetting setting;
       Configuration config = getSystemStateCache();
@@ -754,39 +754,39 @@
       return new TaggedImage(pixels, tags);	
    }
 
-   public TaggedImage getTaggedImage(int cameraChannelIndex) throws java.lang.Exception {
+   public TaggedImage getTaggedImage(int cameraChannelIndex) throws mmcorej.CMMError, mmcorej.org.json.JSONException {
       Metadata md = new Metadata();
       Object pixels = getImage(cameraChannelIndex);
       return createTaggedImage(pixels, md, cameraChannelIndex);
    }
 
-   public TaggedImage getTaggedImage() throws java.lang.Exception {
+   public TaggedImage getTaggedImage() throws mmcorej.CMMError, mmcorej.org.json.JSONException {
       return getTaggedImage(0);
    }
 
-   public TaggedImage getLastTaggedImage(int cameraChannelIndex) throws java.lang.Exception {
+   public TaggedImage getLastTaggedImage(int cameraChannelIndex) throws mmcorej.CMMError, mmcorej.org.json.JSONException {
       Metadata md = new Metadata();
       Object pixels = getLastImageMD(cameraChannelIndex, 0, md);
       return createTaggedImage(pixels, md, cameraChannelIndex);
    }
    
-   public TaggedImage getLastTaggedImage() throws java.lang.Exception {
+   public TaggedImage getLastTaggedImage() throws mmcorej.CMMError, mmcorej.org.json.JSONException {
       return getLastTaggedImage(0);
    }
 
-   public TaggedImage getNBeforeLastTaggedImage(long n) throws java.lang.Exception {
+   public TaggedImage getNBeforeLastTaggedImage(long n) throws mmcorej.CMMError, mmcorej.org.json.JSONException {
       Metadata md = new Metadata();
       Object pixels = getNBeforeLastImageMD(n, md);
       return createTaggedImage(pixels, md);
    }
 
-   public TaggedImage popNextTaggedImage(int cameraChannelIndex) throws java.lang.Exception {
+   public TaggedImage popNextTaggedImage(int cameraChannelIndex) throws mmcorej.CMMError, mmcorej.org.json.JSONException {
       Metadata md = new Metadata();
       Object pixels = popNextImageMD(cameraChannelIndex, 0, md);
       return createTaggedImage(pixels, md, cameraChannelIndex);
    }
 
-   public TaggedImage popNextTaggedImage() throws java.lang.Exception {
+   public TaggedImage popNextTaggedImage() throws mmcorej.CMMError, mmcorej.org.json.JSONException {
       return popNextTaggedImage(0);
    }
 
@@ -816,7 +816,7 @@
     * Convenience function: returns multiple ROIs of the current camera as a
     * list of java.awt.Rectangles.
     */
-   public List<Rectangle> getMultiROI() throws java.lang.Exception {
+   public List<Rectangle> getMultiROI() throws mmcorej.CMMError {
       UnsignedVector xs = new UnsignedVector();
       UnsignedVector ys = new UnsignedVector();
       UnsignedVector widths = new UnsignedVector();
@@ -835,7 +835,7 @@
     * Convenience function: convert incoming list of Rectangles into vectors
     * of ints to set multiple ROIs.
     */
-   public void setMultiROI(List<Rectangle> rects) throws java.lang.Exception {
+   public void setMultiROI(List<Rectangle> rects) throws mmcorej.CMMError {
       UnsignedVector xs = new UnsignedVector();
       UnsignedVector ys = new UnsignedVector();
       UnsignedVector widths = new UnsignedVector();
@@ -854,7 +854,7 @@
     * Used in this class and by the acquisition engine 
     * (rather than duplicating this code there
     */
-   public String getPixelSizeAffineAsString() throws java.lang.Exception {
+   public String getPixelSizeAffineAsString() throws mmcorej.CMMError {
       String pa = "";
       DoubleVector aff = getPixelSizeAffine(true);
       if (aff.size() == 6)  {
@@ -869,7 +869,7 @@
    /* 
     * Convenience function. Returns the current x,y position of the stage in a Point2D.Double.
     */
-   public Point2D.Double getXYStagePosition(String stage) throws java.lang.Exception {
+   public Point2D.Double getXYStagePosition(String stage) throws mmcorej.CMMError {
       // stage position is given as x,y in individual one-member arrays (pointers in C++):
       double p[][] = new double[2][1];
       getXYPosition(stage, p[0], p[1]);
@@ -880,7 +880,7 @@
     * Convenience function: returns the current XY position of the current
     * XY stage device as a Point2D.Double.
     */
-   public Point2D.Double getXYStagePosition() throws java.lang.Exception {
+   public Point2D.Double getXYStagePosition() throws mmcorej.CMMError {
       double x[] = new double[1];
       double y[] = new double[1];
       getXYPosition(x, y);
@@ -890,7 +890,7 @@
    /* 
     * Convenience function. Returns the current x,y position of the galvo in a Point2D.Double.
     */
-   public Point2D.Double getGalvoPosition(String galvoDevice) throws java.lang.Exception {
+   public Point2D.Double getGalvoPosition(String galvoDevice) throws mmcorej.CMMError {
       // stage position is given as x,y in individual one-member arrays (pointers in C++):
       double p[][] = new double[2][1];
       getGalvoPosition(galvoDevice, p[0], p[1]);

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -648,7 +648,7 @@
       return tags;
    }
 
-   private String getROITag() throws java.lang.Exception {
+   private String getROITag() throws mmcorej.CMMError {
       String roi = "";
       int [] x = new int[1];
       int [] y = new int[1];
@@ -795,7 +795,7 @@
    /*
     * Convenience function. Returns the ROI of the current camera in a java.awt.Rectangle.
     */
-   public Rectangle getROI() throws java.lang.Exception {
+   public Rectangle getROI() throws mmcorej.CMMError  {
       // ROI values are given as x,y,w,h in individual one-member arrays (pointers in C++):
       int[][] a = new int[4][1];
       getROI(a[0], a[1], a[2], a[3]);
@@ -805,7 +805,7 @@
     /*
     * Convenience function. Returns the ROI of specified camera in a java.awt.Rectangle.
     */
-   public Rectangle getROI(String label) throws java.lang.Exception {
+   public Rectangle getROI(String label) throws mmcorej.CMMError  {
       // ROI values are given as x,y,w,h in individual one-member arrays (pointers in C++):
       int[][] a = new int[4][1];
       getROI(label, a[0], a[1], a[2], a[3]);

--- a/MMCoreJ_wrap/MetadataIndexError.java
+++ b/MMCoreJ_wrap/MetadataIndexError.java
@@ -1,0 +1,8 @@
+package mmcorej;
+
+public class MetadataIndexError extends java.lang.Exception {
+	public MetadataIndexError() { super(); }
+	public MetadataIndexError(String message) { super(message); }
+	public MetadataIndexError(String message, Throwable cause) { super(message, cause); }
+	public MetadataIndexError(Throwable cause) { super(cause); }
+}

--- a/MMCoreJ_wrap/MetadataKeyError.java
+++ b/MMCoreJ_wrap/MetadataKeyError.java
@@ -1,0 +1,8 @@
+package mmcorej;
+
+public class MetadataKeyError extends java.lang.Exception {
+	public MetadataKeyError() { super(); }
+	public MetadataKeyError(String message) { super(message); }
+	public MetadataKeyError(String message, Throwable cause) { super(message, cause); }
+	public MetadataKeyError(Throwable cause) { super(cause); }
+}

--- a/MMCoreJ_wrap/build.xml
+++ b/MMCoreJ_wrap/build.xml
@@ -11,6 +11,10 @@
 		<mkdir dir="${intdir}"/>
 
 		<copy todir="${srcdir}/${package}" file="TaggedImage.java"/>
+		<copy todir="${srcdir}/${package}" file="CMMError.java"/>
+		<copy todir="${srcdir}/${package}" file="MetadataIndexError.java"/>
+		<copy todir="${srcdir}/${package}" file="MetadataKeyError.java"/>
+
 
 		<mm-javac destdir="${intdir}">
 			<src path="${json.srcdir}"/>


### PR DESCRIPTION
This PR resolves #766.

Three generic subclasses of `java.lang.Exception` have been created which mirror the C++ exceptions in MMCore. Methods in MMCoreJ will now throw these specific exceptions instead of throwing `java.lang.Exception`. This will give code that calls methods from MMCoreJ more flexibility in exception handling and will discourage the bad practice of broad catch statements:

    try {
        someCode()
    } catch (Exception e) {
        logError()
    }

which can result in improper handling of other unexpected errors such as `InterruptedException`.