### PR TITLE
Manages colors associated with channels. Closes #769

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/ChannelSpec.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/ChannelSpec.java
@@ -177,7 +177,6 @@ public class ChannelSpec {
     */
    public static ChannelSpec fromJSONStream(String stream) {
       Gson gson = new Gson();
-      ChannelSpec cs = gson.fromJson(stream, ChannelSpec.class);
-      return cs;
+      return gson.fromJson(stream, ChannelSpec.class);
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/ChannelSpec.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/ChannelSpec.java
@@ -34,29 +34,135 @@ import java.awt.Color;
  */
 @SuppressWarnings("unused")
 public class ChannelSpec {
+   public static class Builder{
 
-   /** Whether this channel should be imaged in each Z slice of the stack */
-   public Boolean doZStack = true;
-   /** Channel group this channel config belongs to **/
+      /** Channel group this channel config belongs to **/
+      private String channelGroup_ = "";
+      /** Name of the channel */
+      private String config_ = "";
+      /** Exposure time, in milliseconds */
+      private double exposure_ = 10.0;
+      /** Z-offset, in microns */
+      private double zOffset_ = 0.0;
+      /** Whether this channel should be imaged in each Z slice of the stack */
+      private Boolean doZStack_ = true;
+      /** Color to use when displaying this channel */
+      private Color color_ = Color.gray;
+      /** Number of frames to skip between each time this channel is imaged. */
+      private int skipFactorFrame_ = 0;
+      /** Whether the channel is enabled for imaging at all. */
+      private boolean useChannel_ = true;
+      /** Name of the camera to use. */
+      private String camera_ = "";
+
+      public Builder() {}
+
+      public Builder channelGroup (String channelGroup) { channelGroup_ = channelGroup;
+         return this;
+      }
+      public Builder config (String config) { config_ = config; return this; }
+      public Builder exposure (double exposure) { exposure_ = exposure; return this; }
+      public Builder zOffset (double zOffset) { zOffset_ = zOffset; return this; }
+      public Builder doZStack (Boolean doZStack) { doZStack_ = doZStack; return this; }
+      public Builder color (Color color) { color_ = color; return this; }
+      public Builder skipFactorFrame (int skipFactorFrame) { skipFactorFrame_ = skipFactorFrame; return this; }
+      public Builder useChannel (boolean useChannel) { useChannel_ = useChannel; return this; }
+      public Builder camera (String camera) {camera_ = camera; return this; }
+
+      private Builder(String channelGroup, String config, double exposure,
+                      double zOffset, Boolean doZStack, Color color,
+                      int skipFactorFrame, boolean useChannel, String camera) {
+         channelGroup_ = channelGroup;
+         config_ = config;
+         exposure_ = exposure;
+         zOffset_ = zOffset;
+         doZStack_ = doZStack;
+         color_ = color;
+         skipFactorFrame_ = skipFactorFrame;
+         useChannel_ = useChannel;
+         camera_ = camera;
+      }
+
+      public ChannelSpec build() {
+         return new ChannelSpec(channelGroup_, config_, exposure_, zOffset_,
+                 doZStack_, color_, skipFactorFrame_, useChannel_,  camera_);
+      }
+   }
+
+
+   /** Channel group this channel config belongs to
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
    public String channelGroup = "";
-   /** Name of the channel */
+   /** Name of the channel
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
    public String config = "";
-   /** Exposure time, in milliseconds */
+   /** Exposure time, in milliseconds
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
    public double exposure = 10.0;
-   /** Z-offset, in microns */
+   /** Z-offset, in microns
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
    public double zOffset = 0.0;
-   /** Color to use when displaying this channel */
+   /** Whether this channel should be imaged in each Z slice of the stack
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
+   public Boolean doZStack = true;
+   /** Color to use when displaying this channel
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
    public Color color = Color.gray;
-   /** Number of frames to skip between each time this channel is imaged. */
+   /** Number of frames to skip between each time this channel is imaged.
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
    public int skipFactorFrame = 0;
-   /** Whether the channel is enabled for imaging at all. */
+   /** Whether the channel is enabled for imaging at all.
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
    public boolean useChannel = true;
-   /** Name of the camera to use. */
+   /** Name of the camera to use.
+    * @deprecated Use Builder and getters instead **/
+   @Deprecated
    public String camera = "";
 
+   /**
+    * @deprecated Use Builder.build() instead for a default ChannelSpec
+    */
+   @Deprecated
    public ChannelSpec(){
       color = Color.WHITE;
    }
+
+   private ChannelSpec(String mChannelGroup, String mConfig, double mExposure,
+                      double mZOffset, Boolean mDoZStack, Color mColor,
+                      int mSkipFactorFrame, boolean mUseChannel, String mCamera) {
+      channelGroup = mChannelGroup;
+      config = mConfig;
+      exposure = mExposure;
+      zOffset = mZOffset;
+      doZStack = mDoZStack;
+      color = mColor;
+      skipFactorFrame = mSkipFactorFrame;
+      useChannel = mUseChannel;
+      camera = mCamera;
+   }
+
+   public Builder copyBuilder() {
+      return new Builder(channelGroup, config, exposure, zOffset, doZStack,
+              color, skipFactorFrame, useChannel, camera);
+   }
+
+   public String channelGroup () { return channelGroup; }
+   public String config() { return config; }
+   public double exposure() { return exposure; }
+   public double zOffset() { return zOffset; }
+   public boolean doZStack() { return doZStack; }
+   public Color color() { return color; }
+   public int skipFactorFrame() { return skipFactorFrame; }
+   public boolean useChannel() { return useChannel; }
+   public String camera() { return camera; }
 
    /**
     * Serialize to JSON encoded string
@@ -75,4 +181,3 @@ public class ChannelSpec {
       return cs;
    }
 }
-

--- a/mmstudio/src/main/java/org/micromanager/acquisition/ChannelSpec.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/ChannelSpec.java
@@ -37,6 +37,8 @@ public class ChannelSpec {
 
    /** Whether this channel should be imaged in each Z slice of the stack */
    public Boolean doZStack = true;
+   /** Channel group this channel config belongs to **/
+   public String channelGroup = "";
    /** Name of the channel */
    public String config = "";
    /** Exposure time, in milliseconds */

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -770,8 +770,9 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
    public boolean addChannel(String config, double exp, Boolean doZStack, double zOffset, int skip, Color c, boolean use) {
       if (isConfigAvailable(config)) {
          ChannelSpec.Builder cb = new ChannelSpec.Builder();
-         cb.channelGroup(this.getChannelGroup()).config(config).useChannel(use);
-         cb.exposure(exp).doZStack(doZStack).zOffset(zOffset).color(c).skipFactorFrame(skip);
+         cb.channelGroup(this.getChannelGroup()).config(config).useChannel(use).
+                 exposure(exp).doZStack(doZStack).zOffset(zOffset).color(c).
+                 skipFactorFrame(skip);
          channels_.add(cb.build());
          return true;
       } else {

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -174,6 +174,9 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
    private int getNumChannels() {
       int numChannels = 0;
       if (useChannels_) {
+         if (channels_ == null) {
+            return 0;
+         }
          for (ChannelSpec channel : channels_) {
             if (channel.useChannel) {
                ++numChannels;
@@ -765,6 +768,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
    public boolean addChannel(String config, double exp, Boolean doZStack, double zOffset, int skip, Color c, boolean use) {
       if (isConfigAvailable(config)) {
          ChannelSpec channel = new ChannelSpec();
+         channel.channelGroup = this.getChannelGroup();
          channel.config = config;
          channel.useChannel = use;
          channel.exposure = exp;

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -178,7 +178,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
             return 0;
          }
          for (ChannelSpec channel : channels_) {
-            if (channel.useChannel) {
+            if (channel.useChannel()) {
                ++numChannels;
             }
          }
@@ -228,8 +228,10 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
    }
 
    private void updateChannelCameras() {
-      for (ChannelSpec channel : channels_) {
-         channel.camera = getSource(channel);
+      for (int row = 0; row < channels_.size(); row++) {
+         ChannelSpec channel = channels_.get(row);
+         channels_.add(row,
+                 channel.copyBuilder().camera(getSource(channel)).build());
       }
    }
 
@@ -254,7 +256,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
 
    private String getSource(ChannelSpec channel) {
       try {
-         Configuration state = core_.getConfigState(core_.getChannelGroup(), channel.config);
+         Configuration state = core_.getConfigState(core_.getChannelGroup(), channel.config());
          if (state.isPropertyIncluded("Core", "Camera")) {
             return state.getSetting("Core", "Camera").getPropertyValue();
          } else {
@@ -314,7 +316,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
 
       if (this.useChannels_) {
          for (ChannelSpec channel : channels_) {
-            if (channel.useChannel) {
+            if (channel.useChannel()) {
                acquisitionSettings.channels.add(channel);
             }
          }
@@ -767,16 +769,10 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
    @Override
    public boolean addChannel(String config, double exp, Boolean doZStack, double zOffset, int skip, Color c, boolean use) {
       if (isConfigAvailable(config)) {
-         ChannelSpec channel = new ChannelSpec();
-         channel.channelGroup = this.getChannelGroup();
-         channel.config = config;
-         channel.useChannel = use;
-         channel.exposure = exp;
-         channel.doZStack = doZStack;
-         channel.zOffset = zOffset;
-         channel.color = c;
-         channel.skipFactorFrame = skip;
-         channels_.add(channel);
+         ChannelSpec.Builder cb = new ChannelSpec.Builder();
+         cb.channelGroup(this.getChannelGroup()).config(config).useChannel(use);
+         cb.exposure(exp).doZStack(doZStack).zOffset(zOffset).color(c).skipFactorFrame(skip);
+         channels_.add(cb.build());
          return true;
       } else {
          ReportingUtils.logError("\"" + config + "\" is not found in the current Channel group.");

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -215,7 +215,8 @@ public final class MMAcquisition extends DataViewerListener {
                   for (int channelIndex = 0; channelIndex < nrChannels; channelIndex++) {
                      displaySettingsBuilder.channel(channelIndex, RememberedSettings.loadChannel(studio_,
                              store_.getSummaryMetadata().getChannelGroup(),
-                             store_.getSummaryMetadata().getChannelNameList().get(channelIndex)));
+                             store_.getSummaryMetadata().getChannelNameList().get(channelIndex),
+                             null));  // TODO: use chColors as default Color?
                      /*
                      ChannelDisplaySettings channelSettings
                              = displaySettingsBuilder.getChannelSettings(channelIndex);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
@@ -808,7 +808,7 @@ public final class MultipageTiffWriter {
          for (int ch = 0; ch < numChannels; ch++) {
             String name = summary.getSafeChannelName(ch);
             ChannelDisplaySettings cds = RememberedSettings.loadChannel(
-                    MMStudio.getInstance(), channelGroup, name);
+                    MMStudio.getInstance(), channelGroup, name, null);
             // Display Ranges: For each channel, write min then max
             // TODO: doesn't handle multi-component images.
             mdBuffer.putDouble(bufferPosition, (double) 
@@ -836,7 +836,7 @@ public final class MultipageTiffWriter {
          if (ds == null) {
             String name = summary.getSafeChannelName(ch);
             color = RememberedSettings.loadChannel(
-                    MMStudio.getInstance(), channelGroup, name).getColor();
+                    MMStudio.getInstance(), channelGroup, name, null).getColor();
          } else {
             color = ds.getChannelColor(ch);
          }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/RememberedSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/RememberedSettings.java
@@ -81,34 +81,40 @@ public class RememberedSettings {
     * @param studio        Object used to get access to profile
     * @param channelGroup  Group to which the channel belongs
     * @param channelName   Channel name
+    * @param defaultColor  If nothing was found, use this color as the default color
+    *                      will be ignored when null
     * @return Stored or Default ChannelDisplaySetting
     */
    public static ChannelDisplaySettings loadChannel(Studio studio, 
-           String channelGroup, 
-           String channelName) {
+           String channelGroup, String channelName, Color defaultColor) {
       String key = genKey(channelGroup, channelName);
-      MutablePropertyMapView settings = 
+      MutablePropertyMapView settings =
               studio.profile().getSettings(RememberedSettings.class);
       if (settings.containsPropertyMap(key)) {
-          return DefaultChannelDisplaySettings.fromPropertyMap(
-                  settings.getPropertyMap(key, null), channelGroup, channelName);
-      } else {
+         return DefaultChannelDisplaySettings.fromPropertyMap(
+                 settings.getPropertyMap(key, null), channelGroup, channelName);
+      }
+      else {
          // for backward compatibility
          String rKey = RememberedChannelSettings.genKey(channelGroup, channelName);
          settings = studio.profile().getSettings(RememberedChannelSettings.class);
          if (settings.containsInteger(rKey + ":" + COLOR)) {
             RememberedChannelSettings rcs = RememberedChannelSettings.loadSettings(
-                    channelGroup, 
-                    channelName, 
-                    Color.WHITE, 
-                    null, 
-                    null, 
+                    channelGroup,
+                    channelName,
+                    Color.WHITE,
+                    null,
+                    null,
                     true);
             return rcs.toChannelDisplaySetting(channelGroup, channelName);
          }
       }
-      
-      return DefaultChannelDisplaySettings.builder().name(channelName).component(1).build();
+      ChannelDisplaySettings.Builder cdsBuilder =
+              DefaultChannelDisplaySettings.builder().name(channelName).component(1);
+      if (defaultColor != null) {
+         cdsBuilder.color(defaultColor);
+      }
+      return cdsBuilder.build();
    }
    
    /**
@@ -127,7 +133,7 @@ public class RememberedSettings {
       List<String> channelNames = summary.getChannelNameList();
       for (int ch = 0; ch < channelNames.size(); ch++) {
          String channelName = summary.getSafeChannelName(ch);
-         ChannelDisplaySettings cds = loadChannel(studio, channelGroup, channelName);
+         ChannelDisplaySettings cds = loadChannel(studio, channelGroup, channelName, null);
          builder.channel(ch, cds);
       }
       if (channelNames.size() > 1) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -88,6 +88,7 @@ import org.micromanager.display.internal.event.DisplayMouseWheelEvent;
 import org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEvent;
 import org.micromanager.display.internal.gearmenu.GearButton;
 import org.micromanager.display.overlay.Overlay;
+import org.micromanager.events.internal.ChannelColorEvent;
 import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.Geometry;
 import org.micromanager.internal.utils.MMFrame;
@@ -187,6 +188,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
    private ImagesAndStats displayedImages_;
    private Double cachedPixelSize_ = -1.0;
    private boolean isPreview_ = false;
+   private ChannelColorEvent channelColorEvent_;
 
    private BoundsRectAndMask lastSeenSelection_;
 
@@ -953,7 +955,20 @@ public final class DisplayUIController implements Closeable, WindowListener,
             // TODO: should all channeldisplaysetting changes be remembered?
             ChannelDisplaySettings rememberedSettings =
                     RememberedSettings.loadChannel(studio_,
-                            channelSettings.getGroupName(), channelSettings.getName());
+                            channelSettings.getGroupName(), channelSettings.getName(), null);
+            if (!rememberedSettings.getColor().equals(channelSettings.getColor())) {
+               // To ensure that we do not respond to the event posted by us
+               // (which will result in a continuous loop), remember our event
+               // so that it can be ignored in the event handler.
+               // This requires that the event bus is synchronous (which it is now),
+               // and that this code always runs on the same thread (it should
+               // always run on the EDT)
+               channelColorEvent_ = new ChannelColorEvent(
+                       channelSettings.getGroupName(),
+                       channelSettings.getName(),
+                       channelSettings.getColor());
+               studio_.events().post(channelColorEvent_);
+            }
             RememberedSettings.storeChannel(studio_, channelSettings.getGroupName(), channelSettings.getName(),
                     rememberedSettings.copyBuilder().color(channelSettings.getColor()).build());
 
@@ -2011,6 +2026,41 @@ public final class DisplayUIController implements Closeable, WindowListener,
       if (liveModeEvent.getIsOn()) {
          nrLiveFramesReceived_ = 0;
          lastImageNumber_ = 0;
+      }
+   }
+
+   @Subscribe
+   public void onChannelColorEvent(ChannelColorEvent channelColorEvent) {
+      // make sure we do not respond to the event we generated ourselves
+      if (!channelColorEvent.equals(channelColorEvent_)) {
+         if (channelColorEvent.getColor() != null) {
+            DisplaySettings oldDisplaySettings, newDisplaySettings;
+            do {
+               oldDisplaySettings = displayController_.getDisplaySettings();
+               int index = 0;
+               boolean found = false;
+               while (!found && index < oldDisplaySettings.getNumberOfChannels()) {
+                  ChannelDisplaySettings channelSettings = oldDisplaySettings.getChannelSettings(index);
+                  if (channelSettings.getGroupName().equals(channelColorEvent.getChannelGroup()) &&
+                          channelSettings.getName().equals(channelColorEvent.getChannel())) {
+                     found = true;
+                  }
+                  else {
+                     index++;
+                  }
+               }
+               if (!found) {
+                  return;
+               }
+               ChannelDisplaySettings channelSettings
+                       = oldDisplaySettings.getChannelSettings(index);
+               newDisplaySettings = oldDisplaySettings.
+                       copyBuilderWithChannelSettings(index,
+                               channelSettings.copyBuilder().color(
+                                       channelColorEvent.getColor()).build()).
+                       build();
+            } while (!displayController_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+         }
       }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/ChannelColorEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/ChannelColorEvent.java
@@ -1,0 +1,31 @@
+package org.micromanager.events.internal;
+
+import java.awt.Color;
+
+/**
+ * Signals that the user assigned a new color to a channel
+ * Used to synchronize the color used to display a channel in the UI
+ */
+public class ChannelColorEvent {
+   private final String channelGroup_;
+   private final String channel_;
+   private final Color color_;
+
+   public ChannelColorEvent(String channelGroup, String channel, Color color) {
+      channelGroup_ = channelGroup;
+      channel_ = channel;
+      color_ = color;
+   }
+
+   public String getChannelGroup() {
+      return channelGroup_;
+   }
+
+   public String getChannel() {
+      return channel_;
+   }
+
+   public Color getColor() {
+      return color_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -137,7 +137,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    private static final String CIRCULAR_BUFFER_SIZE = "size, in megabytes of the circular buffer used to temporarily store images before they are written to disk";
    private static final String AFFINE_TRANSFORM_LEGACY = "affine transform for mapping camera coordinates to stage coordinates for a specific pixel size config: ";
    private static final String AFFINE_TRANSFORM = "affine transform parameters for mapping camera coordinates to stage coordinates for a specific pixel size config: ";
-
+   private static final String EXPOSURE_KEY = "Exposure_";
    
    // GUI components
    private boolean wasStartedAsImageJPlugin_;
@@ -596,8 +596,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
          try {
             channelGroup = core_.getChannelGroup();
             channel = core_.getCurrentConfigFromCache(channelGroup);
-            AcqControlDlg.storeChannelExposure(
-                  channelGroup, channel, exposureTime);
+            storeChannelExposureTime(channelGroup, channel, exposureTime);
          }
          catch (Exception e) {
             studio_.logs().logError("Unable to determine channel group");
@@ -1510,8 +1509,14 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    @Override
    public double getChannelExposureTime(String channelGroup, String channel,
            double defaultExp) {
-      return AcqControlDlg.getChannelExposure(channelGroup, channel,
-            defaultExp);
+      return this.profile().getSettings(MMStudio.class).getDouble(
+              EXPOSURE_KEY + channelGroup + "_" + channel, defaultExp);
+   }
+
+   public void storeChannelExposureTime(String channelGroup, String channel,
+                                      double exposure) {
+      this.profile().getSettings(MMStudio.class).putDouble(
+              EXPOSURE_KEY + channelGroup + "_" + channel, exposure);
    }
 
    /**
@@ -1528,7 +1533,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    public void setChannelExposureTime(String channelGroup, String channel,
            double exposure) {
       try {
-         AcqControlDlg.storeChannelExposure(channelGroup, channel, exposure);
+         storeChannelExposureTime(channelGroup, channel, exposure);
          if (channelGroup != null && channelGroup.equals(core_.getChannelGroup())) {
             if (channel != null && !channel.equals("") && 
                     channel.equals(core_.getCurrentConfigFromCache(channelGroup))) {

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -487,7 +487,8 @@ public final class SnapLiveManager extends DataViewerListener
          ds = ds.copyBuilderWithChannelSettings(ch, 
                  RememberedSettings.loadChannel(mmStudio_, 
                          store_.getSummaryMetadata().getChannelGroup(), 
-                         store_.getSummaryMetadata().getChannelNameList().get(ch))).
+                         store_.getSummaryMetadata().getChannelNameList().get(ch),
+                         null)).
                  build();
       }
       display_.setDisplaySettings(ds);
@@ -620,7 +621,8 @@ public final class SnapLiveManager extends DataViewerListener
                   ChannelDisplaySettings newCD = RememberedSettings.loadChannel(
                           mmStudio_, 
                           core_.getChannelGroup(),
-                          name);
+                          name,
+                          null);
                   display_.setDisplaySettings(display_.getDisplaySettings().
                           copyBuilderWithChannelSettings(camCh, newCD).build());
                }               

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -190,7 +190,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       channelTable_.setAutoCreateColumnsFromModel(false);
       channelTable_.setModel(model_);
 
-      channelCellEditor_ = new ChannelCellEditor(acqEng_);
+      channelCellEditor_ = new ChannelCellEditor(mmStudio_, acqEng_);
       ChannelCellRenderer cellRenderer = new ChannelCellRenderer(acqEng_);
       channelTable_.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -511,7 +511,6 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
          String newGroup = (String) channelGroupCombo_.getSelectedItem();
          if (acqEng_.setChannelGroup(newGroup)) {
             channelCellEditor_.stopCellEditing();
-            model_.cleanUpConfigurationList();
             if (mmStudio_.getAutofocusManager() != null) {
                mmStudio_.getAutofocusManager().refresh();
             }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -38,7 +38,6 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.table.*;
 import mmcorej.CMMCore;
 import net.miginfocom.swing.MigLayout;
-import org.micromanager.Studio;
 import org.micromanager.UserProfile;
 import org.micromanager.acquisition.ChannelSpec;
 import org.micromanager.acquisition.SequenceSettings;
@@ -1107,11 +1106,6 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       acqEng_.setCustomTimeIntervals(intervals);
       acqEng_.enableCustomTimeIntervals(settings.getBoolean(
               ACQ_ENABLE_CUSTOM_INTERVALS, false));
-
-      int numChannels = settings.getInteger(ACQ_NUM_CHANNELS, 0);
-
-      ChannelSpec defaultChannel = new ChannelSpec();
-
       acqEng_.getChannels().clear();
       acqEng_.setShouldDisplayImages(!getShouldHideMDADisplay());
 
@@ -1339,14 +1333,14 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
          ArrayList<ChannelSpec> list = ((ChannelTableModel) channelTable_.getModel() ).getChannels();
          ArrayList<Integer> imagesPerChannel = new ArrayList<>();
          for (ChannelSpec list1 : list) {
-            if (!list1.useChannel) {
+            if (!list1.useChannel()) {
                continue;
             }
             int num = 1;
             if (frames) {
-               num *= Math.max(1, numFrames / (list1.skipFactorFrame + 1));
+               num *= Math.max(1, numFrames / (list1.skipFactorFrame() + 1));
             }
-            if (slices && list1.doZStack) {
+            if (slices && list1.doZStack()) {
                num *= numSlices;
             }
             if (positions) {
@@ -1461,8 +1455,8 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
          // Check for excessively long exposure times.
          ArrayList<String> badChannels = new ArrayList<>();
          for (ChannelSpec spec : model.getChannels()) {
-            if (spec.exposure > 30000) { // More than 30s
-               badChannels.add(spec.config);
+            if (spec.exposure() > 30000) { // More than 30s
+               badChannels.add(spec.config());
             }
          }
          if (badChannels.size() > 0 && getShouldCheckExposureSanity()) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -110,17 +110,12 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
    private File acqFile_;
    private String acqDir_;
    private int zVals_ = 0;
-   private JButton acquireButton_;
    private JButton setBottomButton_;
    private JButton setTopButton_;
    private final MMStudio mmStudio_;
    private final NumberFormat numberFormat_;
-   private JLabel namePrefixLabel_;
-   private JLabel saveTypeLabel_;
    private JRadioButton singleButton_;
    private JRadioButton multiButton_;
-   private JLabel rootLabel_;
-   private JButton browseRootButton_;
    private JCheckBox stackKeepShutterOpenCheckBox_;
    private JCheckBox chanKeepShutterOpenCheckBox_;
    private AcqOrderMode[] acqOrderModes_;
@@ -143,15 +138,6 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
    private static final String ACQ_NUM_CHANNELS = "acqNumchannels";
    private static final String ACQ_CHANNELS_KEEP_SHUTTER_OPEN = "acqChannelsKeepShutterOpen";
    private static final String ACQ_STACK_KEEP_SHUTTER_OPEN = "acqStackKeepShutterOpen";
-   private static final String CHANNEL_NAME_PREFIX = "acqChannelName";
-   private static final String CHANNEL_USE_PREFIX = "acqChannelUse";
-   private static final String CHANNEL_EXPOSURE_PREFIX = "acqChannelExp";
-   private static final String CHANNEL_ZOFFSET_PREFIX = "acqChannelZOffset";
-   private static final String CHANNEL_DOZSTACK_PREFIX = "acqChannelDoZStack";
-   private static final String CHANNEL_COLOR_R_PREFIX = "acqChannelColorR";
-   private static final String CHANNEL_COLOR_G_PREFIX = "acqChannelColorG";
-   private static final String CHANNEL_COLOR_B_PREFIX = "acqChannelColorB";
-   private static final String CHANNEL_SKIP_PREFIX = "acqSkip";
    private static final String ACQ_Z_VALUES = "acqZValues";
    private static final String ACQ_DIR_NAME = "acqDirName";
    private static final String ACQ_ROOT_NAME = "acqRootName";
@@ -166,8 +152,8 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
    public static final FileType ACQ_SETTINGS_FILE = new FileType("ACQ_SETTINGS_FILE", "Acquisition settings",
            System.getProperty("user.home") + "/AcqSettings.txt",
            true, "txt");
-   private int columnWidth_[];
-   private int columnOrder_[];
+   private int[] columnWidth_;
+   private int[] columnOrder_;
    private CheckBoxPanel framesPanel_;
    private JPanel defaultTimesPanel_;
    private JPanel customTimesPanel_;
@@ -176,9 +162,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
    protected CheckBoxPanel positionsPanel_;
    private JPanel acquisitionOrderPanel_;
    private CheckBoxPanel afPanel_;
-   private JPanel summaryPanel_;
    private CheckBoxPanel savePanel_;
-   private ComponentTitledPanel commentsPanel_;
    private boolean disableGUItoSettings_ = false;
 
    public final void createChannelTable() {
@@ -192,7 +176,6 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
             return new JTableHeader(columnModel) {
                @Override
                public String getToolTipText(MouseEvent e) {
-                  String tip = null;
                   java.awt.Point p = e.getPoint();
                   int index = columnModel.getColumnIndexAtX(p.x);
                   int realIndex = columnModel.getColumn(index).getModelIndex();
@@ -205,7 +188,6 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       channelTable_.setFont(new Font("Dialog", Font.PLAIN, 10));
       channelTable_.setAutoCreateColumnsFromModel(false);
       channelTable_.setModel(model_);
-      model_.setChannels(acqEng_.getChannels());
 
       ChannelCellEditor cellEditor = new ChannelCellEditor(acqEng_);
       ChannelCellRenderer cellRenderer = new ChannelCellRenderer(acqEng_);
@@ -286,9 +268,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       JTextField field = ((JSpinner.DefaultEditor) numFrames_.getEditor()).getTextField();
       field.setColumns(5);
       ((JSpinner.DefaultEditor) numFrames_.getEditor()).getTextField().setFont(DEFAULT_FONT);
-      numFrames_.addChangeListener((ChangeEvent e) -> {
-         applySettings();
-      });
+      numFrames_.addChangeListener((ChangeEvent e) -> applySettings());
 
       defaultTimesPanel_.add(numFrames_, "wrap");
 
@@ -336,9 +316,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       customTimesPanel_.add(overrideLabel, "alignx center, wrap");
       customTimesPanel_.add(disableCustomIntervalsButton, "alignx center");
 
-      framesPanel_.addActionListener((ActionEvent e) -> {
-         applySettings();
-      });
+      framesPanel_.addActionListener((ActionEvent e) -> applySettings());
       return framesPanel_;
    }
 
@@ -351,9 +329,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       listButton_.setIcon(IconLoader.getIcon(
             "/org/micromanager/icons/application_view_list.png"));
       listButton_.setFont(new Font("Dialog", Font.PLAIN, 10));
-      listButton_.addActionListener((ActionEvent e) -> {
-         mmStudio_.app().showPositionList();
-      });
+      listButton_.addActionListener((ActionEvent e) -> mmStudio_.app().showPositionList());
 
       // Not sure why 'span' is needed to prevent second column from appearing
       // (interaction with CheckBoxPanel layout??)
@@ -435,9 +411,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
       zValCombo_ = new JComboBox<>(new String[] {RELATIVE_Z, ABSOLUTE_Z});
       zValCombo_.setFont(DEFAULT_FONT);
-      zValCombo_.addActionListener((final ActionEvent e) -> {
-         zValCalcChanged();
-      });
+      zValCombo_.addActionListener((final ActionEvent e) -> zValCalcChanged());
       slicesPanel_.add(zValCombo_,
             "skip 1, spanx, gaptop 4, gapbottom 0, alignx left, wrap");
 
@@ -520,14 +494,14 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
    }
 
    private JPanel createSummary() {
-      summaryPanel_ = createLabelPanel("Summary");
-      summaryPanel_.setLayout(new MigLayout(PANEL_CONSTRAINT + ", filly, insets 4 8 4 8"));
+      JPanel summaryPanel = createLabelPanel("Summary");
+      summaryPanel.setLayout(new MigLayout(PANEL_CONSTRAINT + ", filly, insets 4 8 4 8"));
       summaryTextArea_ = new JTextArea(8, 25);
       summaryTextArea_.setFont(new Font("Arial", Font.PLAIN, 11));
       summaryTextArea_.setEditable(false);
       summaryTextArea_.setOpaque(false);
-      summaryPanel_.add(summaryTextArea_, "grow");
-      return summaryPanel_;
+      summaryPanel.add(summaryTextArea_, "grow");
+      return summaryPanel;
    }
 
    private JPanel createChannelsPanel() {
@@ -544,7 +518,6 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       updateGroupsCombo();
       channelGroupCombo_.addActionListener((ActionEvent arg0) -> {
          String newGroup = (String) channelGroupCombo_.getSelectedItem();
-         
          if (acqEng_.setChannelGroup(newGroup)) {
             model_.cleanUpConfigurationList();
             if (mmStudio_.getAutofocusManager() != null) {
@@ -655,17 +628,17 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
    private JPanel createRunButtons() {
       JPanel result = new JPanel(new MigLayout("flowy, insets 0, gapx 0, gapy 2"));
-      acquireButton_ = new JButton("Acquire!");
-      acquireButton_.setMargin(new Insets(-9, -9, -9, -9));
-      acquireButton_.setFont(new Font("Arial", Font.BOLD, 12));
-      acquireButton_.addActionListener((ActionEvent e) -> {
+      JButton acquireButton = new JButton("Acquire!");
+      acquireButton.setMargin(new Insets(-9, -9, -9, -9));
+      acquireButton.setFont(new Font("Arial", Font.BOLD, 12));
+      acquireButton.addActionListener((ActionEvent e) -> {
          AbstractCellEditor ae = (AbstractCellEditor) channelTable_.getCellEditor();
          if (ae != null) {
             ae.stopCellEditing();
          }
          runAcquisition();
       });
-      result.add(acquireButton_, BUTTON_SIZE);
+      result.add(acquireButton, BUTTON_SIZE);
 
       final JButton stopButton = new JButton("Stop");
       stopButton.addActionListener((final ActionEvent e) -> {
@@ -703,7 +676,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       savePanel_.setLayout(new MigLayout(PANEL_CONSTRAINT,
                "[][grow, fill][]", "[][][]"));
 
-      rootLabel_ = new JLabel("Directory root:");
+      JLabel rootLabel_ = new JLabel("Directory root:");
       rootLabel_.setFont(DEFAULT_FONT);
       savePanel_.add(rootLabel_, "alignx label");
 
@@ -711,26 +684,26 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       rootField_.setFont(DEFAULT_FONT);
       savePanel_.add(rootField_);
 
-      browseRootButton_ = new JButton("...");
-      browseRootButton_.setToolTipText("Browse");
-      browseRootButton_.setMargin(new Insets(2, 5, 2, 5));
-      browseRootButton_.setFont(new Font("Dialog", Font.PLAIN, 10));
-      browseRootButton_.addActionListener((final ActionEvent e) -> {
+      JButton browseRootButton = new JButton("...");
+      browseRootButton.setToolTipText("Browse");
+      browseRootButton.setMargin(new Insets(2, 5, 2, 5));
+      browseRootButton.setFont(new Font("Dialog", Font.PLAIN, 10));
+      browseRootButton.addActionListener((final ActionEvent e) -> {
          setRootDirectory();
       });
-      savePanel_.add(browseRootButton_, "wrap");
+      savePanel_.add(browseRootButton, "wrap");
 
-      namePrefixLabel_ = new JLabel("Name prefix:");
-      namePrefixLabel_.setFont(DEFAULT_FONT);
-      savePanel_.add(namePrefixLabel_, "alignx label");
+      JLabel namePrefixLabel = new JLabel("Name prefix:");
+      namePrefixLabel.setFont(DEFAULT_FONT);
+      savePanel_.add(namePrefixLabel, "alignx label");
 
       nameField_ = new JTextField();
       nameField_.setFont(DEFAULT_FONT);
       savePanel_.add(nameField_, "wrap");
 
-      saveTypeLabel_ = new JLabel("Saving format:");
-      saveTypeLabel_.setFont(DEFAULT_FONT);
-      savePanel_.add(saveTypeLabel_, "alignx label");
+      JLabel saveTypeLabel = new JLabel("Saving format:");
+      saveTypeLabel.setFont(DEFAULT_FONT);
+      savePanel_.add(saveTypeLabel, "alignx label");
 
       singleButton_ = new JRadioButton("Separate image files");
       singleButton_.setFont(DEFAULT_FONT);
@@ -760,8 +733,8 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
    }
 
    private JPanel createCommentsPanel() {
-      commentsPanel_ = createLabelPanel("Acquisition Comments");
-      commentsPanel_.setLayout(new MigLayout(PANEL_CONSTRAINT,
+      ComponentTitledPanel commentsPanel = createLabelPanel("Acquisition Comments");
+      commentsPanel.setLayout(new MigLayout(PANEL_CONSTRAINT,
                "[grow, fill]", "[]"));
 
       commentTextArea_ = new JTextArea();
@@ -777,8 +750,8 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
                BorderFactory.createEtchedBorder()));
       commentScrollPane.setViewportView(commentTextArea_);
 
-      commentsPanel_.add(commentScrollPane, "wmin 0, height pref!, span");
-      return commentsPanel_;
+      commentsPanel.add(commentScrollPane, "wmin 0, height pref!, span");
+      return commentsPanel;
    }
 
    private void createToolTips() {
@@ -988,7 +961,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
    @Subscribe
    public void onChannelGroupChanged(ChannelGroupChangedEvent event) {
-      updateGroupsCombo();
+      updateChannelAndGroupCombo();
    }
 
    /**
@@ -1154,29 +1127,11 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       acqEng_.enableCustomTimeIntervals(settings.getBoolean(
               ACQ_ENABLE_CUSTOM_INTERVALS, false));
 
-
       int numChannels = settings.getInteger(ACQ_NUM_CHANNELS, 0);
 
       ChannelSpec defaultChannel = new ChannelSpec();
 
       acqEng_.getChannels().clear();
-      for (int i = 0; i < numChannels; i++) {
-         String name = settings.getString(CHANNEL_NAME_PREFIX + i, "Undefined");
-         boolean use = settings.getBoolean(CHANNEL_USE_PREFIX + i, true);
-         double exp = settings.getDouble(CHANNEL_EXPOSURE_PREFIX + i, 0.0);
-         Boolean doZStack = settings.getBoolean(CHANNEL_DOZSTACK_PREFIX + i, true);
-         double zOffset = settings.getDouble(CHANNEL_ZOFFSET_PREFIX + i, 0.0);
-         int r = settings.getInteger(CHANNEL_COLOR_R_PREFIX + i, 
-                 defaultChannel.color.getRed());
-         int g = settings.getInteger(CHANNEL_COLOR_G_PREFIX + i, 
-                 defaultChannel.color.getGreen());
-         int b = settings.getInteger(CHANNEL_COLOR_B_PREFIX + i, 
-                 defaultChannel.color.getBlue());
-         int skip = settings.getInteger(CHANNEL_SKIP_PREFIX + i, 
-                 defaultChannel.skipFactorFrame);
-         Color c = new Color(r, g, b);
-         acqEng_.addChannel(name, exp, doZStack, zOffset, skip, c, use);
-      }
       acqEng_.setShouldDisplayImages(!getShouldHideMDADisplay());
 
       // Restore Column Width and Column order
@@ -1220,20 +1175,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       settings.putBoolean(ACQ_STACK_KEEP_SHUTTER_OPEN, acqEng_.isShutterOpenForStack());
 
       settings.putString(ACQ_CHANNEL_GROUP, acqEng_.getChannelGroup());
-      ArrayList<ChannelSpec> channels = acqEng_.getChannels();
-      settings.putInteger(ACQ_NUM_CHANNELS, channels.size());
-      for (int i = 0; i < channels.size(); i++) {
-         ChannelSpec channel = channels.get(i);
-         settings.putString(CHANNEL_NAME_PREFIX + i, channel.config);
-         settings.putBoolean(CHANNEL_USE_PREFIX + i, channel.useChannel);
-         settings.putDouble(CHANNEL_EXPOSURE_PREFIX + i, channel.exposure);
-         settings.putBoolean(CHANNEL_DOZSTACK_PREFIX + i, channel.doZStack);
-         settings.putDouble(CHANNEL_ZOFFSET_PREFIX + i, channel.zOffset);
-         settings.putInteger(CHANNEL_COLOR_R_PREFIX + i, channel.color.getRed());
-         settings.putInteger(CHANNEL_COLOR_G_PREFIX + i, channel.color.getGreen());
-         settings.putInteger(CHANNEL_COLOR_B_PREFIX + i, channel.color.getBlue());
-         settings.putInteger(CHANNEL_SKIP_PREFIX + i, channel.skipFactorFrame);
-      }
+      model_.storeChannels();
 
       //Save custom time intervals
       double[] customIntervals = acqEng_.getCustomTimeIntervals();
@@ -1611,12 +1553,8 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       if (disableGUItoSettings_) {
          return;
       }
+      // Disable updates to prevent action listener loops
       disableGUItoSettings_ = true;
-      // Disable update prevents action listener loops
-
-
-      // TODO: remove setChannels()
-      model_.setChannels(acqEng_.getChannels());
 
       double intervalMs = acqEng_.getFrameIntervalMs();
       interval_.setText(numberFormat_.format(convertMsToTime(intervalMs, timeUnitCombo_.getSelectedIndex())));
@@ -1708,23 +1646,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
       disableGUItoSettings_ = false;
    }
-       
-   private void updateDoubleValue(double value, JTextField field) {
-       try {
-           if (NumberUtils.displayStringToDouble(field.getText()) != value) {
-               field.setText(NumberUtils.doubleToDisplayString(value));
-           }
-       } catch (ParseException e) {
-           field.setText(NumberUtils.doubleToDisplayString(value));
-       }
-   }
-       
-   private void updateCheckBox(boolean setting,  CheckBoxPanel panel) {
-      if (panel.isSelected() != setting) {
-          panel.setSelected(setting);
-      }
-   }
-   
+
    @Override      
    public void settingsChanged() {
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -50,6 +50,7 @@ import org.micromanager.display.internal.RememberedSettings;
 import org.micromanager.events.ChannelExposureEvent;
 import org.micromanager.events.ChannelGroupChangedEvent;
 import org.micromanager.events.GUIRefreshEvent;
+import org.micromanager.events.internal.ChannelColorEvent;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.interfaces.AcqSettingsListener;
 import org.micromanager.internal.utils.AcqOrderMode;
@@ -909,6 +910,16 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
             setChannelExposureTime(channelGroup, channel, exposure);
          }
       }
+   }
+
+   @Subscribe
+   public void onChannelColorEvent(ChannelColorEvent event) {
+      model_.setChannelColor(event.getChannelGroup(), event.getChannel(), event.getColor());
+      ChannelDisplaySettings newCDS =
+              RememberedSettings.loadChannel(mmStudio_, event.getChannelGroup(),
+                      event.getChannel(), null ).copyBuilder().color(event.getColor()).
+                      build();
+      RememberedSettings.storeChannel(mmStudio_, event.getChannelGroup(), event.getChannel(), newCDS);
    }
 
    @Subscribe
@@ -1897,22 +1908,6 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       MMStudio.getInstance().profile().getSettings( 
               AcqControlDlg.class).putDouble(
             "Exposure_" + channelGroup + "_" + channel, exposure);
-   }
-
-   public static Integer getChannelColor(Studio studio, String channelGroup,
-         String channel, int defaultVal) {
-      return RememberedSettings.loadChannel(studio, channelGroup, channel).
-              getColor().getRGB();
-   }
-
-   public static void setChannelColor(Studio studio, 
-           String channelGroup, 
-           String channel,
-           int color) {
-      ChannelDisplaySettings newCDS = 
-              RememberedSettings.loadChannel(studio, channelGroup, channel).
-                      copyBuilder().color(new Color(color)).build();
-      RememberedSettings.storeChannel(studio, channelGroup, channel, newCDS);
    }
 
    public static boolean getShouldSyncExposure() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
@@ -134,15 +134,6 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
          if (editCol_ == 0) {
             return checkBox_.isSelected();
          } else if (editCol_ == 1) {
-            // As a side effect, change to the color and exposure of the new
-            // channel. If no color is available, use the "next" colorblind-
-            // friendly color, based on our row index.
-            channel_.color = new Color(AcqControlDlg.getChannelColor(
-                    studio_, acqEng_.getChannelGroup(),
-                     (String) channelSelect_.getSelectedItem(),
-                     ColorPalettes.getFromDefaultPalette(editRow_).getRGB()));
-            channel_.exposure = AcqControlDlg.getChannelExposure(
-                  acqEng_.getChannelGroup(), channel_.config, 10.0);
             return channelSelect_.getSelectedItem();
          } else if (editCol_ == 2 || editCol_ == 3) {
             return NumberUtils.displayStringToDouble(text_.getText());

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
@@ -1,6 +1,5 @@
 package org.micromanager.internal.dialogs;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.ActionListener;
 import java.text.ParseException;
@@ -19,7 +18,6 @@ import javax.swing.table.TableCellEditor;
 import org.micromanager.Studio;
 import org.micromanager.acquisition.ChannelSpec;
 import org.micromanager.acquisition.internal.AcquisitionEngine;
-import org.micromanager.internal.utils.ColorPalettes;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
@@ -104,11 +104,11 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
                channelSelect_.addItem(config);
             }
          }
-         channelSelect_.setSelectedItem(channel.config);
+         channelSelect_.setSelectedItem(channel.config());
          
          // end editing on selection change
          channelSelect_.addPropertyChangeListener(e -> {
-            if (!channelSelect_.getSelectedItem().equals(channel_.config)) {
+            if (!channelSelect_.getSelectedItem().equals(channel_.config())) {
                fireEditingStopped();
             }
          });

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
@@ -80,9 +80,6 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
          text_.setText(NumberUtils.intToDisplayString((Integer) value));
          return text_;
       } else if (colIndex == 1) {
-         // channel
-         channelSelect_.removeAllItems();
-
          // remove old listeners
          ActionListener[] listeners = channelSelect_.getActionListeners();
          for (ActionListener listener : listeners) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -146,9 +146,7 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
    @Override
    public boolean isCellEditable(int nRow, int nCol) {
       if (nCol == 4) {
-         if (!acqEng_.isZSliceSettingEnabled()) {
-            return false;
-         }
+         return acqEng_.isZSliceSettingEnabled();
       }
 
       return true;
@@ -226,8 +224,8 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
 
    /**
     * Used to change the order of the channels in the MDA window
-    * @param rowIdx
-    * @return 
+    * @param rowIdx Row nr (zero-based) of the row to be moved
+    * @return row nr where the selected row ended up
     */
    public int rowDown(int rowIdx) {
       if (rowIdx >= 0 && rowIdx < channels_.size() - 1) {
@@ -242,8 +240,8 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
 
    /**
     * Used to change the order of the channels in the Window
-    * @param rowIdx
-    * @return 
+    * @param rowIdx Row nr (0-based) of the row to move up
+    * @return Row nr where this row ended up
     */
    public int rowUp(int rowIdx) {
       if (rowIdx >= 1 && rowIdx < channels_.size()) {
@@ -299,7 +297,7 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
 
    /**
     * reports if the same channel name is used twice
-    * @return 
+    * @return true when the list of channels contains the same channel name twice
     */
    public boolean duplicateChannels() {
       for (int i = 0; i < channels_.size() - 1; i++) {
@@ -337,8 +335,7 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
    public void storeChannels() {
       String channelGroup = "";
       List<String> configNames = new ArrayList<>(channels_.size());
-      for (Iterator<ChannelSpec> it = channels_.iterator(); it.hasNext(); ) {
-         ChannelSpec cs = it.next();
+      for (ChannelSpec cs : channels_) {
          if (!cs.config.contentEquals("")) {
             channelGroup = cs.channelGroup;
             configNames.add(cs.config);
@@ -352,7 +349,6 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
    }
 
    private static String channelProfileKey(String channelGroup, String config) {
-      StringBuilder key = new StringBuilder(channelGroup);
-      return key.append("-").append(config).toString();
+      return channelGroup + "-" + config;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -120,8 +120,21 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
          channel.useChannel = ((Boolean) value);
       } else if (col == 1) {
          channel.config = value.toString();
-         channel.exposure = AcqControlDlg.getChannelExposure(
-               acqEng_.getChannelGroup(), channel.config, 10.0);
+         ChannelSpec cs = ChannelSpec.fromJSONStream(
+                 settings_.getString(channelProfileKey(acqEng_.getChannelGroup(),
+                         channel.config), ""));
+         if (cs == null) {
+            // Our fallback color is the colorblind-friendly color for our
+            // current row index.
+            channel.color = new Color(ColorPalettes.getFromDefaultPalette(row).getRGB());
+            channel.exposure = 10.0;
+         }
+         else {
+            channel.color = cs.color;
+            channel.exposure = cs.exposure;
+         }
+         this.fireTableCellUpdated(row, 2);
+         this.fireTableCellUpdated(row, 6);
       } else if (col == 2) {
          channel.exposure = ((Double) value);
          AcqControlDlg.storeChannelExposure(acqEng_.getChannelGroup(),
@@ -348,7 +361,7 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
       settings_.putStringList("CG:" + channelGroup, configNames);
    }
 
-   private static String channelProfileKey(String channelGroup, String config) {
+    private static String channelProfileKey(String channelGroup, String config) {
       return channelGroup + "-" + config;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -346,11 +346,13 @@ public final class ChannelTableModel extends AbstractTableModel implements Table
    }
 
    public void storeChannels() {
-      String channelGroup = "";
+      String channelGroup = acqEng_.getChannelGroup();
       List<String> configNames = new ArrayList<>(channels_.size());
       for (ChannelSpec cs : channels_) {
          if (!cs.config.contentEquals("")) {
-            channelGroup = cs.channelGroup;
+            if (cs.channelGroup.isEmpty()) {
+               cs.channelGroup = channelGroup;
+            };
             configNames.add(cs.config);
             // write this config to the profile
             settings_.putString(channelProfileKey(cs.channelGroup, cs.config),

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ColorEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ColorEditor.java
@@ -42,10 +42,11 @@ ActionListener {
    private static final long serialVersionUID = -5497293610937812813L;
    Color currentColor;
    JButton button;
-   JColorChooser colorChooser;
-   JDialog dialog;
+   private final JColorChooser colorChooser;
+   private final JDialog dialog;
    protected static final String EDIT = "edit";
-   int column_;
+   int row_;
+   private final int column_;
    AbstractTableModel model_;
 
    public ColorEditor(AbstractTableModel model, int column) {
@@ -82,14 +83,20 @@ ActionListener {
          button.setBackground(currentColor);
          colorChooser.setColor(currentColor);
          dialog.setVisible(true);
+         // program flow is funky.  The dialog creates another actionevent, that
+         // is picked up by this same function, goes through the "else" below,
+         // and then continues here
 
          // Make the renderer reappear.
          fireEditingStopped();
          // Fire an event to enable saving the new color in the colorprefs
          // Don't know how to fire just for this row:
+         model_.fireTableCellUpdated(row_, column_);
+         /*
          for (int row=0; row < model_.getRowCount(); row++) {
             model_.fireTableCellUpdated(row, column_);
          }
+         */
 
       } else { //User pressed dialog's "OK" button.
          currentColor = colorChooser.getColor();
@@ -109,7 +116,11 @@ ActionListener {
          boolean isSelected,
          int row,
          int column) {
+      row_ = row;
       currentColor = (Color)value;
+      button.setBackground(currentColor);
+      button.setForeground(currentColor);
+      button.setOpaque(true);
       return button;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/PresetButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/PresetButton.java
@@ -177,7 +177,8 @@ public final class PresetButton extends WidgetPlugin implements SciJavaPlugin {
             pickerLabel.setBackground(
                     RememberedSettings.loadChannel(studio_, 
                             (String) groupSelector.getSelectedItem(), 
-                            (String) presetSelector.getSelectedItem()).getColor());
+                            (String) presetSelector.getSelectedItem(),
+                            null).getColor());
          }
       });
 
@@ -189,8 +190,9 @@ public final class PresetButton extends WidgetPlugin implements SciJavaPlugin {
             // case the color will remain the same.
             pickerLabel.setBackground(
                RememberedSettings.loadChannel(studio_, 
-                            (String) groupSelector.getSelectedItem(), 
-                            (String) presetSelector.getSelectedItem()).getColor());
+                       (String) groupSelector.getSelectedItem(),
+                       (String) presetSelector.getSelectedItem(),
+                       null).getColor());
          }
       });
       // Default to the Channel group, if available.


### PR DESCRIPTION
Synchronizes channels colors in the application.  Changing the color of the live/snap window (if it shows the image of a channel) will update the corresponding color in the MDA dialog (and vice versa).  Adds channelgroup to ChannelSpec class (which is in the API, hence this is an API update).