### PR TITLE
Allow multiple PositionListDlg

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -100,7 +100,7 @@ import org.micromanager.internal.menus.MMMenuBar;
 import org.micromanager.internal.navigation.UiMovesStageManager;
 import org.micromanager.internal.pipelineinterface.PipelineFrame;
 import org.micromanager.internal.pluginmanagement.DefaultPluginManager;
-import org.micromanager.internal.positionlist.PositionListDlg;
+import org.micromanager.internal.positionlist.MMPositionListDlg;
 import org.micromanager.internal.propertymap.DefaultPropertyMap;
 import org.micromanager.internal.script.ScriptPanel;
 import org.micromanager.internal.utils.DaytimeNighttime;
@@ -167,7 +167,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    private CMMCore core_;
    private AcquisitionWrapperEngine acqEngine_;
    private PositionList posList_;
-   private PositionListDlg posListDlg_;
+   private MMPositionListDlg posListDlg_;
    private boolean isProgramRunning_;
    private boolean configChanged_ = false;
    private boolean isClickToMoveEnabled_ = false;
@@ -1459,7 +1459,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    @Override
    public void showPositionList() {
       if (posListDlg_ == null) {
-         posListDlg_ = new PositionListDlg(studio_, posList_, 
+         posListDlg_ = new MMPositionListDlg(studio_, posList_, 
                  acqControlWin_);
       }
       posListDlg_.setVisible(true);

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1461,6 +1461,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       if (posListDlg_ == null) {
          posListDlg_ = new MMPositionListDlg(studio_, posList_, 
                  acqControlWin_);
+         posListDlg_.addListeners();
       }
       posListDlg_.setVisible(true);
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1461,7 +1461,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       if (posListDlg_ == null) {
          posListDlg_ = new PositionListDlg(core_, studio_, posList_, 
                  acqControlWin_);
-         posListDlg_.addListeners();
       }
       posListDlg_.setVisible(true);
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1459,7 +1459,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    @Override
    public void showPositionList() {
       if (posListDlg_ == null) {
-         posListDlg_ = new PositionListDlg(core_, studio_, posList_, 
+         posListDlg_ = new PositionListDlg(studio_, posList_, 
                  acqControlWin_);
       }
       posListDlg_.setVisible(true);

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -962,15 +962,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       return isClickToMoveEnabled_;
    }
    
-   // Ensure that the "XY list..." dialog exists.
-   private void checkPosListDlg() {
-      if (posListDlg_ == null) {
-         posListDlg_ = new PositionListDlg(core_, studio_, posList_, 
-                 acqControlWin_);
-         posListDlg_.addListeners();
-      }
-   }
-   
 
    // //////////////////////////////////////////////////////////////////////////
    // public interface available for scripting access
@@ -1483,7 +1474,11 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
     */
    @Override
    public void showPositionList() {
-      checkPosListDlg();
+      if (posListDlg_ == null) {
+         posListDlg_ = new PositionListDlg(core_, studio_, posList_, 
+                 acqControlWin_);
+         posListDlg_.addListeners();
+      }
       posListDlg_.setVisible(true);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -317,7 +317,9 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       // Note: pipelineFrame is used in the dataManager, however, pipelineFrame 
       // needs the dataManager.  Let's hope for the best....
       dataManager_ = new DefaultDataManager(studio_);
-      createPipelineFrame();
+      if (pipelineFrame_ == null) { //Create the pipelineframe if it hasn't already been done.
+         pipelineFrame_ = new PipelineFrame(studio_);
+      }
 
       alertManager_ = new DefaultAlertManager(studio_);
       
@@ -921,12 +923,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       }
    }
 
-   private void createPipelineFrame() {
-      if (pipelineFrame_ == null) {
-         pipelineFrame_ = new PipelineFrame(studio_);
-      }
-   }
-
    public PipelineFrame getPipelineFrame() {
       return pipelineFrame_;
    }
@@ -1014,18 +1010,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
          return false;
       }
       return true;
-   }
-
-   private boolean isCurrentImageFormatSupported() {
-      long channels = core_.getNumberOfComponents();
-      long bpp = core_.getBytesPerPixel();
-
-      if (channels > 1 && channels != 4 && bpp != 1) {
-         handleError("Unsupported image format.");
-      } else {
-         return true;
-      }
-      return false;
    }
 
    private void configureBinningCombo() throws Exception {

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
@@ -8,8 +8,6 @@ package org.micromanager.internal.positionlist;
 import com.google.common.eventbus.Subscribe;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import javax.swing.event.TableModelListener;
-import mmcorej.CMMCore;
 import org.micromanager.PositionList;
 import org.micromanager.Studio;
 import org.micromanager.events.internal.DefaultNewPositionListEvent;
@@ -17,13 +15,16 @@ import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.dialogs.AcqControlDlg;
 
 /**
- *
- * @author nick
+ * The MMPositionListDlg class extends PositionListDlg to be used as the singleton PositionListDlg used in the MMStudio API
+ * In addition to the normal behavior of a PositionListDlg, this object will:
+ *   1: Update an AcqControlDlg window each time the position list is modified.
+ *   2: Post a DefaultNewPositionListEvent to the MMStudio EventManager each time the position list is modified.
+ *   3: Save preferences to the MMStudio UserProfile.
  */
-public final class MMStudioPositionListDlg extends PositionListDlg {
+public final class MMPositionListDlg extends PositionListDlg {
     AcqControlDlg acd_;
     
-    public MMStudioPositionListDlg(Studio studio, PositionList posList, AcqControlDlg acd) {
+    public MMPositionListDlg(Studio studio, PositionList posList, AcqControlDlg acd) {
         super(studio, posList);
         acd_ = acd;
         

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
@@ -1,8 +1,18 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//AUTHOR:        Nick Anthony 2020
+//LICENSE:       This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//CVS:          $Id$
+//
 package org.micromanager.internal.positionlist;
 
 import com.google.common.eventbus.Subscribe;

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMStudioPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMStudioPositionListDlg.java
@@ -5,9 +5,13 @@
  */
 package org.micromanager.internal.positionlist;
 
+import com.google.common.eventbus.Subscribe;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import mmcorej.CMMCore;
 import org.micromanager.PositionList;
 import org.micromanager.Studio;
+import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.dialogs.AcqControlDlg;
 
 /**
@@ -20,6 +24,13 @@ public final class MMStudioPositionListDlg extends PositionListDlg {
     public MMStudioPositionListDlg(Studio studio, PositionList posList, AcqControlDlg acd) {
         super(studio, posList);
         acd_ = acd;
+        
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent arg0) {
+               saveDims();
+            }
+        });
     }
     
     @Override
@@ -27,4 +38,21 @@ public final class MMStudioPositionListDlg extends PositionListDlg {
         super.updatePositionData();
         acd_.updateGUIContents();
     }
+    
+    private void saveDims() {
+      int posCol0Width = posTable_.getColumnModel().getColumn(0).getWidth();
+      studio_.profile().getSettings(PositionListDlg.class).putInteger(POS_COL0_WIDTH,
+            posCol0Width);
+      int axisCol0Width = axisTable_.getColumnModel().getColumn(0).getWidth();
+      studio_.profile().getSettings(PositionListDlg.class).putInteger(AXIS_COL0_WIDTH,
+            axisCol0Width);
+   }
+    
+    @Subscribe
+   public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
+      if (!event.getIsCancelled()) {
+         saveDims();
+         dispose();
+      }
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMStudioPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMStudioPositionListDlg.java
@@ -1,0 +1,30 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.micromanager.internal.positionlist;
+
+import mmcorej.CMMCore;
+import org.micromanager.PositionList;
+import org.micromanager.Studio;
+import org.micromanager.internal.dialogs.AcqControlDlg;
+
+/**
+ *
+ * @author nick
+ */
+public final class MMStudioPositionListDlg extends PositionListDlg {
+    AcqControlDlg acd_;
+    
+    public MMStudioPositionListDlg(Studio studio, PositionList posList, AcqControlDlg acd) {
+        super(studio, posList);
+        acd_ = acd;
+    }
+    
+    @Override
+    protected void updatePositionData() {
+        super.updatePositionData();
+        acd_.updateGUIContents();
+    }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMStudioPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMStudioPositionListDlg.java
@@ -8,9 +8,11 @@ package org.micromanager.internal.positionlist;
 import com.google.common.eventbus.Subscribe;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import javax.swing.event.TableModelListener;
 import mmcorej.CMMCore;
 import org.micromanager.PositionList;
 import org.micromanager.Studio;
+import org.micromanager.events.internal.DefaultNewPositionListEvent;
 import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.dialogs.AcqControlDlg;
 
@@ -31,12 +33,14 @@ public final class MMStudioPositionListDlg extends PositionListDlg {
                saveDims();
             }
         });
+        
     }
     
     @Override
     protected void updatePositionData() {
         super.updatePositionData();
         acd_.updateGUIContents();
+        studio_.events().post(new DefaultNewPositionListEvent(getPositionList()));
     }
     
     private void saveDims() {
@@ -54,5 +58,5 @@ public final class MMStudioPositionListDlg extends PositionListDlg {
          saveDims();
          dispose();
       }
-   }
+   }   
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -70,31 +70,31 @@ import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.ReportingUtils;
 
 public class PositionListDlg extends MMFrame implements MouseListener, ChangeListener {
-   private static final long serialVersionUID = 1L;
-   private String posListDir_;
-   private File curFile_;
-   private static final String POS = "pos";
-   private static final String POS_COL0_WIDTH = "posCol0WIDTH";
-   private static final String AXIS_COL0_WIDTH = "axisCol0WIDTH";
-   private static final FileType POSITION_LIST_FILE =
+   static final long serialVersionUID = 1L;
+   String posListDir_;
+   File curFile_;
+   static final String POS = "pos";
+   static final String POS_COL0_WIDTH = "posCol0WIDTH";
+   static final String AXIS_COL0_WIDTH = "axisCol0WIDTH";
+   static final FileType POSITION_LIST_FILE =
            new FileType("POSITION_LIST_FILE","Position list file",
                         System.getProperty("user.home") + "/PositionList.pos",
                         true, POS);
 
-   private Font arialSmallFont_;
-   private JTable posTable_;
-   private final JTable axisTable_;
-   private final AxisTableModel axisModel_;
-   private CMMCore core_;
-   private Studio studio_;
-   private AxisList axisList_;
-   private final JButton tileButton_;
+   Font arialSmallFont_;
+   JTable posTable_;
+   final JTable axisTable_;
+   final AxisTableModel axisModel_;
+   CMMCore core_;
+   Studio studio_;
+   AxisList axisList_;
+   final JButton tileButton_;
 
-   private MultiStagePosition curMsp_;
-   public JButton markButton_;
-   private final PositionTableModel positionModel_;
+   MultiStagePosition curMsp_;
+   JButton markButton_;
+   final PositionTableModel positionModel_;
 
-   private EventBus bus_;
+   EventBus bus_;
 
    @Subscribe
    public void onTileUpdate(MoversChangedEvent event) {

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -122,7 +122,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
     * Create the dialog
     * @param studio - Studio
     * @param posList - Position list to be displayed in this dialog
-    * @param acd - MDA window
     */
    @SuppressWarnings("LeakingThisInConstructor")
    public PositionListDlg(Studio studio, PositionList posList) {
@@ -828,7 +827,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       tileCreatorDlg.setVisible(true);
    }
 
-   private PositionList getPositionList() {
+   protected PositionList getPositionList() {
       return positionModel_.getPositionList();
 
    }
@@ -1012,9 +1011,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
 
       @Override
       public void run() {
-
          try {
-
             core_.home(deviceName);
 
             // check if the device busy?

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -428,7 +428,8 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       return button;
    }
    
-   public void addListeners() {   
+   public void addListeners() { 
+       // This method should be called after the constructor finishes to fully register all needed listeners.
       axisTable_.addMouseListener(this);
       posTable_.addMouseListener(this);      
       getPositionList().addChangeListener(this);    

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -826,7 +826,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       tileCreatorDlg.setVisible(true);
    }
 
-   protected PositionList getPositionList() {
+   public PositionList getPositionList() {
       return positionModel_.getPositionList();
 
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -416,11 +416,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       // Register to be informed when the current stage position changes.
       studio_.events().registerForEvents(this);
       refreshCurrentPosition();
-      
-      //Add listeners
-      axisTable_.addMouseListener(this);
-      posTable_.addMouseListener(this);      
-      getPositionList().addChangeListener(this); 
    }
    
    private JButton posListButton(Dimension buttonSize, Font font) {
@@ -431,6 +426,12 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       button.setMargin(new Insets(0, 0, 0, 0));
       
       return button;
+   }
+   
+   public void addListeners() {   
+      axisTable_.addMouseListener(this);
+      posTable_.addMouseListener(this);      
+      getPositionList().addChangeListener(this);    
    }
    
    

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -87,7 +87,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    private final AxisTableModel axisModel_;
    private CMMCore core_;
    private Studio studio_;
-   private AcqControlDlg acqControlDlg_;
    private AxisList axisList_;
    private final JButton tileButton_;
 
@@ -126,8 +125,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
     * @param acd - MDA window
     */
    @SuppressWarnings("LeakingThisInConstructor")
-   public PositionListDlg(Studio studio,
-                     PositionList posList, AcqControlDlg acd) {
+   public PositionListDlg(Studio studio, PositionList posList) {
       super("position list");
       final UserProfile profile = studio.profile();
       addWindowListener(new WindowAdapter() {
@@ -140,7 +138,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       studio_ = studio;
       bus_ = new EventBus(EventBusExceptionLogger.getInstance());
       bus_.register(this);
-      acqControlDlg_ = acd;
 
       setTitle("Stage Position List");
       setLayout(new MigLayout("flowy, filly, insets 8", "[grow][]", 
@@ -522,7 +519,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       }
    }
 
-   private void updatePositionData() {
+   protected void updatePositionData() {
       positionModel_.fireTableDataChanged();
    }
    
@@ -557,7 +554,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    protected void clearAllPositions() {
       getPositionList().clearAllPositions();
       updatePositionData();
-      acqControlDlg_.updateGUIContents();
    }
 
    
@@ -609,7 +605,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
          getPositionList().removePosition(selectedRows[i] - 1);
       }
       updatePositionData();
-      acqControlDlg_.updateGUIContents();
    }
 
    /**
@@ -630,7 +625,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
          msp.setLabel(getPositionList().generateLabel());
          getPositionList().addPosition(msp);
          updatePositionData();
-         acqControlDlg_.updateGUIContents();
       }
       else { // replace instead of add
          msp.setLabel(getPositionList().getPosition(
@@ -718,7 +712,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
          }
       }
       updatePositionData();
-      acqControlDlg_.updateGUIContents();
    }
  
    // The stage position changed; update curMsp_.
@@ -1160,7 +1153,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
          }
       }
       updatePositionData();
-      acqControlDlg_.updateGUIContents();
    }
 
    @Subscribe

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -456,8 +456,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    }
 
    protected void updateMarkButtonText() {
-      PositionTableModel tm = (PositionTableModel) posTable_.getModel();
-      MultiStagePosition msp = tm.getPositionList().
+      MultiStagePosition msp = getPositionList().
               getPosition(posTable_.getSelectedRow() - 1);
       if (markButton_ != null) {
          if (msp == null) {
@@ -470,17 +469,15 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    
 
    public void addPosition(MultiStagePosition msp, String label) {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
       msp.setLabel(label);
-      ptm.getPositionList().addPosition(msp);
-      ptm.fireTableDataChanged();
+      getPositionList().addPosition(msp);
+      positionModel_.fireTableDataChanged();
    }
 
    public void addPosition(MultiStagePosition msp) {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
-      msp.setLabel(ptm.getPositionList().generateLabel());
-      ptm.getPositionList().addPosition(msp);
-      ptm.fireTableDataChanged();
+      msp.setLabel(getPositionList().generateLabel());
+      getPositionList().addPosition(msp);
+      positionModel_.fireTableDataChanged();
    }
 
    protected boolean savePositionListAs() {
@@ -526,14 +523,12 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    }
 
    public void updatePositionData() {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
-      ptm.fireTableDataChanged();
+      positionModel_.fireTableDataChanged();
    }
    
    public void rebuildAxisList() {
       axisList_ = new AxisList(core_);
-      AxisTableModel axm = (AxisTableModel)axisTable_.getModel();
-      axm.fireTableDataChanged();
+      axisModel_.fireTableDataChanged();
    }
 
    public void activateAxisTable(boolean state) {
@@ -542,14 +537,12 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    }
    
    public void setPositionList(PositionList pl) {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
-      ptm.setData(pl);
-      ptm.fireTableDataChanged();
+      positionModel_.setData(pl);
+      positionModel_.fireTableDataChanged();
    }
 
    protected void goToCurrentPosition() {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
-      MultiStagePosition msp = ptm.getPositionList().getPosition(posTable_.getSelectedRow() - 1);
+      MultiStagePosition msp = getPositionList().getPosition(posTable_.getSelectedRow() - 1);
       if (msp == null)
          return;
 
@@ -562,15 +555,13 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    }
 
    protected void clearAllPositions() {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
-      ptm.getPositionList().clearAllPositions();
-      ptm.fireTableDataChanged();
+      getPositionList().clearAllPositions();
+      positionModel_.fireTableDataChanged();
       acqControlDlg_.updateGUIContents();
    }
 
    
    protected void incrementOrderOfSelectedPosition(int direction) {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
       int currentRow = posTable_.getSelectedRow() - 1;
       int newEdittingRow = -1;
 
@@ -579,15 +570,15 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
          {
             if (0 <= destinationRow) {
                if (destinationRow < posTable_.getRowCount()) {
-                  PositionList pl = ptm.getPositionList();
+                  PositionList pl = getPositionList();
 
                   MultiStagePosition[] mspos = pl.getPositions();
 
                   MultiStagePosition tmp = mspos[currentRow];
                   pl.replacePosition(currentRow, mspos[destinationRow]);//
                   pl.replacePosition(destinationRow, tmp);
-                  ptm.setData(pl);
-                  if (destinationRow + 1 < ptm.getRowCount()) {
+                  positionModel_.setData(pl);
+                  if (destinationRow + 1 < positionModel_.getRowCount()) {
                      newEdittingRow = destinationRow + 1;
                   }
                } else {
@@ -598,7 +589,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
             }
          }
       }
-      ptm.fireTableDataChanged();
+      positionModel_.fireTableDataChanged();
 
       if (-1 < newEdittingRow) {
          posTable_.changeSelection(newEdittingRow, newEdittingRow, false, false);
@@ -610,15 +601,14 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    
    
    protected void removeSelectedPositions() {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
       int[] selectedRows = posTable_.getSelectedRows();
       // Reverse the rows so that we delete from the end; if we delete from
       // the front then the position list gets re-ordered as we go and we 
       // delete the wrong positions!
       for (int i = selectedRows.length - 1; i >= 0; --i) {
-         ptm.getPositionList().removePosition(selectedRows[i] - 1);
+         getPositionList().removePosition(selectedRows[i] - 1);
       }
-      ptm.fireTableDataChanged();
+      positionModel_.fireTableDataChanged();
       acqControlDlg_.updateGUIContents();
    }
 
@@ -631,25 +621,24 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       refreshCurrentPosition();
       MultiStagePosition msp = curMsp_;
 
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
       MultiStagePosition selMsp = null;
       if (shouldOverwrite) {
-         selMsp = ptm.getPositionList().getPosition(posTable_.getSelectedRow() -1);
+         selMsp = getPositionList().getPosition(posTable_.getSelectedRow() -1);
       }
 
       if (selMsp == null) {
-         msp.setLabel(ptm.getPositionList().generateLabel());
-         ptm.getPositionList().addPosition(msp);
-         ptm.fireTableDataChanged();
+         msp.setLabel(getPositionList().generateLabel());
+         getPositionList().addPosition(msp);
+         positionModel_.fireTableDataChanged();
          acqControlDlg_.updateGUIContents();
       }
       else { // replace instead of add
-         msp.setLabel(ptm.getPositionList().getPosition(
+         msp.setLabel(getPositionList().getPosition(
                  posTable_.getSelectedRow() - 1).getLabel() );
          int selectedRow = posTable_.getSelectedRow();
-         ptm.getPositionList().replacePosition(
+         getPositionList().replacePosition(
                  posTable_.getSelectedRow() -1, msp);
-         ptm.fireTableDataChanged();
+         positionModel_.fireTableDataChanged();
          // Not sure why this is here as we undo the selection after
          // this functions exits...
          posTable_.setRowSelectionInterval(selectedRow, selectedRow);
@@ -691,7 +680,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       for (int row : selectedRows) {
          // Find the appropriate StagePosition in this MultiStagePosition and
          // update its values.
-         MultiStagePosition listPos = positionModel_.getPositionList().getPosition(row - 1);
+         MultiStagePosition listPos = getPositionList().getPosition(row - 1);
          boolean foundPos = false;
          for (int posIndex = 0; posIndex < listPos.size(); ++posIndex) {
             StagePosition subPos = listPos.get(posIndex);
@@ -797,9 +786,8 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       curMsp_.setLabel("Current");
       positionModel_.setCurrentMSP(curMsp_);
 
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
-      ptm.fireTableCellUpdated(0, 1);
-      ptm.fireTableCellUpdated(0, 0);
+      positionModel_.fireTableCellUpdated(0, 1);
+      positionModel_.fireTableCellUpdated(0, 0);
       posTable_.revalidate();
       axisTable_.revalidate();
    }
@@ -853,8 +841,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    }
 
    private PositionList getPositionList() {
-      PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
-      return ptm.getPositionList();
+      return positionModel_.getPositionList();
 
    }
 
@@ -1155,7 +1142,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
     * @param offsets
     */
    public void offsetSelectedSites(String deviceName, ArrayList<Float> offsets) {
-      PositionList positions = positionModel_.getPositionList();
+      PositionList positions = getPositionList();
       for (int rowIndex : posTable_.getSelectedRows()) {
          MultiStagePosition multiPos = positions.getPosition(rowIndex - 1);
          for (int posIndex = 0; posIndex < multiPos.size(); ++posIndex) {

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -69,14 +69,13 @@ import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.ReportingUtils;
 
-public final class PositionListDlg extends MMFrame implements MouseListener, ChangeListener {
+public class PositionListDlg extends MMFrame implements MouseListener, ChangeListener {
    private static final long serialVersionUID = 1L;
    private String posListDir_;
    private File curFile_;
    private static final String POS = "pos";
    private static final String POS_COL0_WIDTH = "posCol0WIDTH";
    private static final String AXIS_COL0_WIDTH = "axisCol0WIDTH";
-   // @SuppressWarnings("unused")
    private static final FileType POSITION_LIST_FILE =
            new FileType("POSITION_LIST_FILE","Position list file",
                         System.getProperty("user.home") + "/PositionList.pos",
@@ -100,7 +99,7 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
 
    @Subscribe
    public void onTileUpdate(MoversChangedEvent event) {
-      setTileButtonEnabled();
+      setTileButtonEnabled(); //This handler is executed when the axis checkboxes are changed.
    }
 
    private void setTileButtonEnabled() {
@@ -128,7 +127,7 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
     * @param acd - MDA window
     */
    @SuppressWarnings("LeakingThisInConstructor")
-   public PositionListDlg(CMMCore core, Studio studio,
+   public PositionListDlg(Studio studio,
                      PositionList posList, AcqControlDlg acd) {
       super("position list");
       final UserProfile profile = studio.profile();
@@ -138,7 +137,7 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
             saveDims();
          }
       });
-      core_ = core;
+      core_ = studio.core();
       studio_ = studio;
       bus_ = new EventBus(EventBusExceptionLogger.getInstance());
       bus_.register(this);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -121,7 +121,6 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
 
    /**
     * Create the dialog
-    * @param core -  MMCore
     * @param studio - Studio
     * @param posList - Position list to be displayed in this dialog
     * @param acd - MDA window

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -69,31 +69,31 @@ import org.micromanager.internal.utils.ReportingUtils;
  * The PositionListDlg class provides a convenient UI to generate, edit, load, and save PositionList objects.
  */
 public class PositionListDlg extends MMFrame implements MouseListener, ChangeListener {
-   static final long serialVersionUID = 1L;
-   String posListDir_;
-   File curFile_;
-   static final String POS = "pos";
-   static final String POS_COL0_WIDTH = "posCol0WIDTH";
-   static final String AXIS_COL0_WIDTH = "axisCol0WIDTH";
-   static final FileType POSITION_LIST_FILE =
+   protected static final long serialVersionUID = 1L;
+   protected String posListDir_;
+   protected File curFile_;
+   protected static final String POS = "pos";
+   protected static final String POS_COL0_WIDTH = "posCol0WIDTH";
+   protected static final String AXIS_COL0_WIDTH = "axisCol0WIDTH";
+   protected static final FileType POSITION_LIST_FILE =
            new FileType("POSITION_LIST_FILE","Position list file",
                         System.getProperty("user.home") + "/PositionList.pos",
                         true, POS);
 
-   Font arialSmallFont_;
-   JTable posTable_;
-   final JTable axisTable_;
-   final AxisTableModel axisModel_;
-   CMMCore core_;
-   Studio studio_;
-   AxisList axisList_;
-   final JButton tileButton_;
+   protected Font arialSmallFont_;
+   protected JTable posTable_;
+   protected final JTable axisTable_;
+   private final AxisTableModel axisModel_;
+   protected CMMCore core_;
+   protected Studio studio_;
+   private AxisList axisList_;
+   protected final JButton tileButton_;
 
-   MultiStagePosition curMsp_;
-   JButton markButton_;
-   final PositionTableModel positionModel_;
+   protected MultiStagePosition curMsp_;
+   protected JButton markButton_;
+   private final PositionTableModel positionModel_;
 
-   EventBus bus_;
+   protected EventBus bus_;
 
    @Subscribe
    public void onTileUpdate(MoversChangedEvent event) {

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -471,13 +471,13 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    public void addPosition(MultiStagePosition msp, String label) {
       msp.setLabel(label);
       getPositionList().addPosition(msp);
-      positionModel_.fireTableDataChanged();
+      updatePositionData();
    }
 
    public void addPosition(MultiStagePosition msp) {
       msp.setLabel(getPositionList().generateLabel());
       getPositionList().addPosition(msp);
-      positionModel_.fireTableDataChanged();
+      updatePositionData();
    }
 
    protected boolean savePositionListAs() {
@@ -522,7 +522,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       }
    }
 
-   public void updatePositionData() {
+   private void updatePositionData() {
       positionModel_.fireTableDataChanged();
    }
    
@@ -538,7 +538,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    
    public void setPositionList(PositionList pl) {
       positionModel_.setData(pl);
-      positionModel_.fireTableDataChanged();
+      updatePositionData();
    }
 
    protected void goToCurrentPosition() {
@@ -556,7 +556,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
 
    protected void clearAllPositions() {
       getPositionList().clearAllPositions();
-      positionModel_.fireTableDataChanged();
+      updatePositionData();
       acqControlDlg_.updateGUIContents();
    }
 
@@ -589,7 +589,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
             }
          }
       }
-      positionModel_.fireTableDataChanged();
+      updatePositionData();
 
       if (-1 < newEdittingRow) {
          posTable_.changeSelection(newEdittingRow, newEdittingRow, false, false);
@@ -608,7 +608,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       for (int i = selectedRows.length - 1; i >= 0; --i) {
          getPositionList().removePosition(selectedRows[i] - 1);
       }
-      positionModel_.fireTableDataChanged();
+      updatePositionData();
       acqControlDlg_.updateGUIContents();
    }
 
@@ -629,7 +629,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       if (selMsp == null) {
          msp.setLabel(getPositionList().generateLabel());
          getPositionList().addPosition(msp);
-         positionModel_.fireTableDataChanged();
+         updatePositionData();
          acqControlDlg_.updateGUIContents();
       }
       else { // replace instead of add
@@ -638,7 +638,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
          int selectedRow = posTable_.getSelectedRow();
          getPositionList().replacePosition(
                  posTable_.getSelectedRow() -1, msp);
-         positionModel_.fireTableDataChanged();
+         updatePositionData();
          // Not sure why this is here as we undo the selection after
          // this functions exits...
          posTable_.setRowSelectionInterval(selectedRow, selectedRow);
@@ -717,7 +717,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
             listPos.add(subPos);
          }
       }
-      positionModel_.fireTableDataChanged();
+      updatePositionData();
       acqControlDlg_.updateGUIContents();
    }
  
@@ -1159,7 +1159,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
             }
          }
       }
-      positionModel_.fireTableDataChanged();
+      updatePositionData();
       acqControlDlg_.updateGUIContents();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -428,6 +428,11 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
       // Register to be informed when the current stage position changes.
       studio_.events().registerForEvents(this);
       refreshCurrentPosition();
+      
+      //Add listeners
+      axisTable_.addMouseListener(this);
+      posTable_.addMouseListener(this);      
+      getPositionList().addChangeListener(this); 
    }
    
    private JButton posListButton(Dimension buttonSize, Font font) {
@@ -438,12 +443,6 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
       button.setMargin(new Insets(0, 0, 0, 0));
       
       return button;
-   }
-   
-   public void addListeners() {   
-      axisTable_.addMouseListener(this);
-      posTable_.addMouseListener(this);      
-      getPositionList().addChangeListener(this);    
    }
    
    

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -128,12 +128,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    public PositionListDlg(Studio studio, PositionList posList) {
       super("position list");
       final UserProfile profile = studio.profile();
-      addWindowListener(new WindowAdapter() {
-         @Override
-         public void windowClosing(WindowEvent arg0) {
-            saveDims();
-         }
-      });
+
       core_ = studio.core();
       studio_ = studio;
       bus_ = new EventBus(EventBusExceptionLogger.getInstance());
@@ -1153,22 +1148,5 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
          }
       }
       updatePositionData();
-   }
-
-   @Subscribe
-   public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
-      if (!event.getIsCancelled()) {
-         saveDims();
-         dispose();
-      }
-   }
-
-   private void saveDims() {
-      int posCol0Width = posTable_.getColumnModel().getColumn(0).getWidth();
-      studio_.profile().getSettings(PositionListDlg.class).putInteger(POS_COL0_WIDTH,
-            posCol0Width);
-      int axisCol0Width = axisTable_.getColumnModel().getColumn(0).getWidth();
-      studio_.profile().getSettings(PositionListDlg.class).putInteger(AXIS_COL0_WIDTH,
-            axisCol0Width);
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -32,8 +32,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.io.File;
 import java.util.ArrayList;
 import javax.swing.ImageIcon;
@@ -58,9 +56,7 @@ import org.micromanager.Studio;
 import org.micromanager.UserProfile;
 import org.micromanager.events.StagePositionChangedEvent;
 import org.micromanager.events.XYStagePositionChangedEvent;
-import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.dialogs.AcqControlDlg;
 import org.micromanager.internal.utils.DaytimeNighttime;
 import org.micromanager.internal.utils.EventBusExceptionLogger;
 import org.micromanager.internal.utils.FileDialogs;
@@ -69,6 +65,9 @@ import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.ReportingUtils;
 
+/**
+ * The PositionListDlg class provides a convenient UI to generate, edit, load, and save PositionList objects.
+ */
 public class PositionListDlg extends MMFrame implements MouseListener, ChangeListener {
    static final long serialVersionUID = 1L;
    String posListDir_;

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionTableModel.java
@@ -113,6 +113,5 @@ class PositionTableModel extends AbstractTableModel {
    @Override
    public void fireTableDataChanged() {
       super.fireTableDataChanged();
-      studio_.events().post(new DefaultNewPositionListEvent(posList_));
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionTableModel.java
@@ -109,9 +109,4 @@ class PositionTableModel extends AbstractTableModel {
    public void setCurrentMSP(MultiStagePosition msp) {
       curMsp_ = msp;
    }
-
-   @Override
-   public void fireTableDataChanged() {
-      super.fireTableDataChanged();
-   }
 }


### PR DESCRIPTION
The current implementation of `PositionListDlg`  operates under the assumption that there will be only one instance of it. It fires `NewPositionListEvent`s to the MMStudio `EventManager` and it updates the `AcquisitionControlDlg` whenever a change is made to the `PositionList`.

However there are scenarios where someone may want to make use of one or multiple `PositionListDlg`s to generate or edit a `PositionList` without wanting to have any effect on the `EventManager` or the `AcquisitionControlDlg`

This PR removes the functionality that relies on only having one instance from the `PositionListDlg` and moves it to a new subclass called `MMPositionListDlg`

The end result is that the behavior of the base Micro-Manager program are completely unchanged while readability is improved. However developers wanting to extend Micro-Manager now have an easy-to-use UI for `PositionList`s that won't unexpectedly affect other aspects of the program.

It is worth noting that numerous other minor changes have been made just for the sake of code readability.