### PR TITLE
Mavenized distribution of MMCoreJ_wrap

### DIFF
--- a/MMCoreJ_wrap/mvnDeploy.bsh
+++ b/MMCoreJ_wrap/mvnDeploy.bsh
@@ -1,0 +1,2 @@
+mvn deploy:deploy-file -DpomFile=pom.xml -Dfile=../build/Java/MMCoreJ.jar -DrepositoryId=nico -Durl=file:///z:/public_html/maven
+

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -3,12 +3,42 @@
    <groupId>org.micromanager</groupId>
    <artifactId>MMCoreJ</artifactId>
    <packaging>jar</packaging>
-   <version>10.10.0-SNAPSHOT</version>
+   <version>10.1.0-SNAPSHOT</version>
 
    <properties>
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.compiler.target>1.8</maven.compiler.target>
+       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    </properties>
+
+	<!--
+	    Do not use maven to build MMCoreJ.jar.  
+		The code below tries to make a valid jar in case someone 
+		does this anyways.  In no way rely on this behavior
+	-->	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+                        <source>../build/intermediates/Swig</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>
 

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -3,7 +3,7 @@
    <groupId>org.micromanager</groupId>
    <artifactId>MMCoreJ</artifactId>
    <packaging>jar</packaging>
-   <version>10.1.0-SNAPSHOT</version>
+   <version>10.1.0.0</version>
 
    <properties>
       <maven.compiler.source>1.8</maven.compiler.source>

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -11,6 +11,25 @@
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    </properties>
 
+   <developers>
+      <developer>
+         <id>nenada</id>
+         <name>Nenad Amodaj</name>
+         <organization>Luminous Point</organization>
+      </developer>
+      <developer>
+         <id>marktsuchida</id>
+         <name>Mark Tsuchida</name>
+         <organization>University of Wisconsin, Madison</organization>
+      </developer>
+      <developer>
+         <id>nicost</id>
+         <name>Nico Stuurman</name>
+         <organization>UCSF/HHMI</organization>
+      </developer>
+   </developers>
+
+
 	<!--
 	    Do not use maven to build MMCoreJ.jar.  
 		The code below tries to make a valid jar in case someone 
@@ -37,6 +56,32 @@
 					</execution>
 				</executions>
 			</plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.2.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
 		</plugins>
 	</build>
 
@@ -45,7 +90,7 @@
            <snapshots>
                <enabled>false</enabled>
            </snapshots>
-           <id>bintray-micro-manager-mmcorej</id>
+           <id>bintray-micromanager-micro-manager</id>
            <name>bintray</name>
            <url>https://dl.bintray.com/micromanager/micro-manager</url>
        </repository>

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
-   <groupId>org.micromanager</groupId>
+   <groupId>org.micro-manager.mmcorej</groupId>
    <artifactId>MMCoreJ</artifactId>
    <packaging>jar</packaging>
    <version>10.1.0.0</version>
@@ -39,6 +39,25 @@
 			</plugin>
 		</plugins>
 	</build>
+
+   <repositories>
+       <repository>
+           <snapshots>
+               <enabled>false</enabled>
+           </snapshots>
+           <id>bintray-micro-manager-mmcorej</id>
+           <name>bintray</name>
+           <url>https://dl.bintray.com/micromanager/micro-manager</url>
+       </repository>
+   </repositories>
+
+   <distributionManagement>
+       <repository>
+          <id>bintray-micro-manager-mmcorej</id>
+          <name>micro-manager-mmcorej</name>
+          <url>https://api.bintray.com/maven/micromanager/micro-manager/MMCoreJ/;publish=1</url>
+       </repository>
+   </distributionManagement>
 
 </project>
 

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -90,17 +90,17 @@
            <snapshots>
                <enabled>false</enabled>
            </snapshots>
-           <id>bintray-micromanager-micro-manager</id>
+           <id>bintray-micro-manager</id>
            <name>bintray</name>
-           <url>https://dl.bintray.com/micromanager/micro-manager</url>
+           <url>https://dl.bintray.com/micro-manager/micro-manager</url>
        </repository>
    </repositories>
 
    <distributionManagement>
        <repository>
-          <id>bintray-micro-manager-mmcorej</id>
+          <id>bintray-micro-manager</id>
           <name>micro-manager-mmcorej</name>
-          <url>https://api.bintray.com/maven/micromanager/micro-manager/MMCoreJ/;publish=1</url>
+          <url>https://api.bintray.com/maven/micro-manager/micro-manager/MMCoreJ/;publish=1</url>
        </repository>
    </distributionManagement>
 

--- a/MMCoreJ_wrap/pom.xml
+++ b/MMCoreJ_wrap/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>org.micromanager</groupId>
+   <artifactId>MMCoreJ</artifactId>
+   <packaging>jar</packaging>
+   <version>10.10.0-SNAPSHOT</version>
+
+   <properties>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+   </properties>
+
+</project>
+

--- a/MMCoreJ_wrap/src/main/java/mmcorej/org/json/HTTP.java
+++ b/MMCoreJ_wrap/src/main/java/mmcorej/org/json/HTTP.java
@@ -53,12 +53,12 @@ public class HTTP {
      * In addition, the other parameters in the header will be captured, using
      * the HTTP field names as JSON names, so that <pre>
      *    Date: Sun, 26 May 2002 18:06:04 GMT
-     *    Cookie: Q=q2=PPEAsg--; B=677gi6ouf29bn&b=2&f=s
+     *    Cookie:{@code  Q=q2=PPEAsg--; B=677gi6ouf29bn&b=2&f=s}
      *    Cache-Control: no-cache</pre>
      * become
      * <pre>{...
      *    Date: "Sun, 26 May 2002 18:06:04 GMT",
-     *    Cookie: "Q=q2=PPEAsg--; B=677gi6ouf29bn&b=2&f=s",
+     *    Cookie: {@code "Q=q2=PPEAsg--; B=677gi6ouf29bn&b=2&f=s"},
      *    "Cache-Control": "no-cache",
      * ...}</pre>
      * It does no further checking or conversion. It does not parse dates.

--- a/MMCoreJ_wrap/src/main/java/mmcorej/org/json/JSONObject.java
+++ b/MMCoreJ_wrap/src/main/java/mmcorej/org/json/JSONObject.java
@@ -71,8 +71,8 @@ import java.util.Map;
  *     <code>{ } [ ] / \ : , = ; #</code> and if they do not look like numbers
  *     and if they are not the reserved words <code>true</code>,
  *     <code>false</code>, or <code>null</code>.</li>
- * <li>Keys can be followed by <code>=</code> or <code>=></code> as well as
- *     by <code>:</code>.</li>
+ * <li>Keys can be followed by {@code =} or {@code =>} as well as
+ *     by {@code :}.</li>
  * <li>Values can be followed by <code>;</code> <small>(semicolon)</small> as
  *     well as by <code>,</code> <small>(comma)</small>.</li>
  * <li>Numbers may have the <code>0-</code> <small>(octal)</small> or
@@ -795,7 +795,7 @@ public class JSONObject {
 
     /**
      * Produce a string in double quotes with backslash sequences in all the
-     * right places. A backslash will be inserted within </, allowing JSON
+     * right places. A backslash will be inserted within {@code </}, allowing JSON
      * text to be delivered in HTML. In JSON text, a string cannot contain a
      * control character or an unescaped quote or backslash.
      * @param string A String

--- a/MMCoreJ_wrap/src/main/java/mmcorej/org/json/XML.java
+++ b/MMCoreJ_wrap/src/main/java/mmcorej/org/json/XML.java
@@ -35,7 +35,7 @@ import java.util.Iterator;
  */
 public class XML {
 
-    /** The Character '&'. */
+    /** The Character '&amp;'. */
     public static final Character AMP   = new Character('&');
 
     /** The Character '''. */
@@ -47,10 +47,10 @@ public class XML {
     /** The Character '='. */
     public static final Character EQ    = new Character('=');
 
-    /** The Character '>'. */
+    /** The Character '&gt;'. */
     public static final Character GT    = new Character('>');
 
-    /** The Character '<'. */
+    /** The Character '&lt;'. */
     public static final Character LT    = new Character('<');
 
     /** The Character '?'. */
@@ -65,10 +65,10 @@ public class XML {
     /**
      * Replace special characters with XML escapes:
      * <pre>
-     * &amp; <small>(ampersand)</small> is replaced by &amp;amp;
-     * &lt; <small>(less than)</small> is replaced by &amp;lt;
-     * &gt; <small>(greater than)</small> is replaced by &amp;gt;
-     * &quot; <small>(double quote)</small> is replaced by &amp;quot;
+     * &amp; (ampersand) is replaced by &amp;amp;
+     * &lt; (less than) is replaced by &amp;lt;
+     * &gt; (greater than) is replaced by &amp;gt;
+     * &quot; (double quote) is replaced by &amp;quot;
      * </pre>
      * @param string The string to be escaped.
      * @return The escaped string.
@@ -267,7 +267,7 @@ public class XML {
      * does not like to distinguish between elements and attributes.
      * Sequences of similar elements are represented as JSONArrays. Content
      * text may be placed in a "content" member. Comments, prologs, DTDs, and
-     * <code>&lt;[ [ ]]></code> are ignored.
+     * {@code &lt;[ [ ]]>} are ignored.
      * @param string The source string.
      * @return A JSONObject containing the structured data from the XML string.
      * @throws JSONException

--- a/MMCoreJ_wrap/src/main/java/mmcorej/org/json/XMLTokener.java
+++ b/MMCoreJ_wrap/src/main/java/mmcorej/org/json/XMLTokener.java
@@ -82,10 +82,10 @@ public class XMLTokener extends JSONTokener {
 
     /**
      * Get the next XML outer token, trimming whitespace. There are two kinds
-     * of tokens: the '<' character which begins a markup tag, and the content
+     * of tokens: the '&lt;' character which begins a markup tag, and the content
      * text between markup tags.
      *
-     * @return  A string, or a '<' Character, or null if there is no more
+     * @return  A string, or a '&lt;' Character, or null if there is no more
      * source text.
      * @throws JSONException
      */
@@ -119,7 +119,7 @@ public class XMLTokener extends JSONTokener {
 
     /**
      * Return the next entity. These entities are translated to Characters:
-     *     <code>&amp;  &apos;  &gt;  &lt;  &quot;</code>.
+     *     {@code &amp;  &apos;  &gt;  &lt;  &quot;}.
      * @param a An ampersand character.
      * @return  A Character or an entity String if the entity is not recognized.
      * @throws JSONException If missing ';' in XML entity.
@@ -143,9 +143,9 @@ public class XMLTokener extends JSONTokener {
 
 
     /**
-     * Returns the next XML meta token. This is used for skipping over <!...>
-     * and <?...?> structures.
-     * @return Syntax characters (<code>< > / = ! ?</code>) are returned as
+     * Returns the next XML meta token. This is used for skipping over {@code <!...>}
+     * and {@code <?...?>} structures.
+     * @return Syntax characters ({@code < > / = ! ?}) are returned as
      *  Character, and strings and names are returned as Boolean. We don't care
      *  what the values actually are.
      * @throws JSONException If a string is not properly closed or if the XML
@@ -210,7 +210,7 @@ public class XMLTokener extends JSONTokener {
 
     /**
      * Get the next XML Token. These tokens are found inside of angle
-     * brackets. It may be one of these characters: <code>/ > = ! ?</code> or it
+     * brackets. It may be one of these characters: {@code / > = ! ?} or it
      * may be a string wrapped in single quotes or double quotes, or it may be a
      * name.
      * @return a String or a Character.

--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -4,7 +4,7 @@
 	<info organisation="org.micromanager" module="micromanager"/>
 
 	<configurations
-		defaultconfmapping="build->default;test->default;compile->default;optional->default;imagej->default;runtime->default">
+      defaultconfmapping="build->default;test->default;compile->default;optional->default;imagej->default;runtime->default">
 		<conf name="build" visibility="private" description="needed for building only"/>
 		<conf name="test" visibility="private" description="needed for testing only"/>
 		<conf name="compile" description="compile-time dependencies, except for ij.jar"/>
@@ -16,6 +16,7 @@
 	<dependencies defaultconf="compile">
 		<dependency conf="build->master" org="ant-contrib" name="ant-contrib" rev="1.0b3"/>
 		<dependency conf="test" org="junit" name="junit" rev="4.11"/>
+		<dependency conf="imagej" org="net.imagej" name="ij" rev="1.51s"/>
 		<dependency conf="test" org="org.msgpack" name="msgpack" rev="0.6.12"/>
 
 		<dependency org="com.fifesoft" name="rsyntaxtextarea" rev="2.6.1"/>
@@ -41,9 +42,15 @@
 		<!-- Magellan dependencies -->
 		<!-- https://mvnrepository.com/artifact/org.zeromq/jeromq -->
 		<dependency org="org.zeromq" name="jeromq" rev="0.5.1"/>
-		<dependency org="org.micro-manager.acqengj" name="AcqEngJ" rev="0.1.0"/>
-		<dependency org="org.micro-manager.ndviewer" name="NDViewer" rev="0.1.0"/>
-		<dependency org="org.micro-manager.ndtiffstorage" name="NDTiffStorage" rev="0.1.0"/>
+		<dependency org="org.micro-manager.acqengj" name="AcqEngJ" rev="0.1.0">
+         <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
+      </dependency>
+		<dependency org="org.micro-manager.ndviewer" name="NDViewer" rev="0.1.0">
+         <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
+      </dependency>
+		<dependency org="org.micro-manager.ndtiffstorage" name="NDTiffStorage" rev="0.1.0">
+         <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
+      </dependency>
 
 		<dependency org="io.scif" name="scifio" rev="0.37.3"/>
 
@@ -70,7 +77,6 @@
       <!-- cl-kernel-binding from nico brings in clij-kernels, and clij version of the cleacl libraries.  Ugly, but the harsh truth if we want to use this code -->
       <dependency org="org.micromanager" name="cl-kernel-bindings" rev="0.1.1-SNAPSHOT"/>
 
-		<dependency conf="imagej" org="net.imagej" name="ij" rev="1.51s"/>
 
 
 		<dependency org="org.boofcv" name="boofcv-ip" rev="0.33.1"/>

--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -51,6 +51,9 @@
 		<dependency org="org.micro-manager.ndtiffstorage" name="NDTiffStorage" rev="0.1.0">
          <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
       </dependency>
+		<dependency org="org.micro-manager.pycro-manager" name="PycroManagerJava" rev="0.1.0">
+         <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
+      </dependency>
 
 		<dependency org="io.scif" name="scifio" rev="0.37.3"/>
 

--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -41,6 +41,9 @@
 		<!-- Magellan dependencies -->
 		<!-- https://mvnrepository.com/artifact/org.zeromq/jeromq -->
 		<dependency org="org.zeromq" name="jeromq" rev="0.5.1"/>
+		<dependency org="org.micro-manager.acqengj" name="AcqEngJ" rev="0.1.0"/>
+		<dependency org="org.micro-manager.ndviewer" name="NDViewer" rev="0.1.0"/>
+		<dependency org="org.micro-manager.ndtiffstorage" name="NDTiffStorage" rev="0.1.0"/>
 
 		<dependency org="io.scif" name="scifio" rev="0.37.3"/>
 

--- a/buildscripts/ivysettings.xml
+++ b/buildscripts/ivysettings.xml
@@ -2,12 +2,13 @@
 	<settings defaultResolver="resolver-chain"/>
 
 	<resolvers>
-		<ibiblio name="central" m2compatible="true"/>
+		<ibiblio name="central" m2compatible="true" root="https://repo1.maven.org/maven2"/>
       <ibiblio name="clearvolume" m2compatible="true" root="https://dl.bintray.com/clearvolume/ClearVolume"/>
       <ibiblio name="coremem" m2compatible="true" root="https://dl.bintray.com/clearcontrol/ClearControl"/>
 		<ibiblio name="imagej-net" m2compatible="true" root="https://maven.scijava.org/content/groups/public"/>
       <ibiblio name ="nico" m2compatible="true" root="https://valelab4.ucsf.edu/~nstuurman/maven"/>
       <ibiblio name ="robert" m2compatible="true" root="https://dl.bintray.com/haesleinhuepf/clij"/>
+      <ibiblio name ="bintray-micro-manager" m2compatible="true" root="https://dl.bintray.com/micro-manager/micro-manager"/>
 
 		<filesystem name="thirdpartypublic">
 			<artifact pattern="${ivy.settings.dir}/../../3rdpartypublic/classext/[artifact].[ext]"/>
@@ -28,7 +29,7 @@
 			<resolver ref="imagej-net"/>
 			<resolver ref="thirdpartypublic"/>
 			<resolver ref="thirdpartynonfree"/>
-			<resolver ref="thirdpartynonfree"/>
+			<resolver ref="bintray-micro-manager"/>
 			<resolver ref="clearvolume"/>
 			<resolver ref="coremem"/>
 			<resolver ref="robert"/>


### PR DESCRIPTION
Adds pom.xml in MMCodeJ_wrap that can be used to build MMCoreJ as a mavenized jar and deploy to dl.bintray.com/micro-manager.  Needs strict discipline to increase version numbers and re-run using maven whenever version is changed.  Needs automation in the near future. 