### PR TITLE
Studio: Ads DisplayManager.getDisplay(DataProivder) and

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
@@ -290,8 +290,19 @@ public interface DisplayManager extends EventPublisher {
     * @param store Datastore of interest to the caller
     * @return A list of all DisplayWindows Micro-Manager knows are associated
     *         with the specified Datastore, or null.
+    * @deprecated replaced by {@link #getDisplays(DataProvider)}
     */
+   @Deprecated
    List<DisplayWindow> getDisplays(Datastore store);
+
+   /**
+    * Return all associated DisplayWindows for the DataProvider. Returns null if
+    * the DataProvider is not managed.
+    * @param dataProvider DataProvider of interest to the caller
+    * @return A list of all DisplayWindows Micro-Manager knows are associated
+    *         with the specified Datastore, or null.
+    */
+   List<DisplayWindow> getDisplays(DataProvider dataProvider);
 
    /**
     * Return the DisplayWindow whose window is front-most.

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -372,7 +372,8 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    public synchronized List<DisplayWindow> getDisplays(Datastore store) {
       return new ArrayList<>(providerToDisplays_.get(store));
    }
-   
+
+   @Override
    public synchronized List<DisplayWindow> getDisplays(DataProvider provider) {
       return new ArrayList<>(providerToDisplays_.get(provider));
    }


### PR DESCRIPTION
deprecates overloaded Datastore version.