### PR TITLE
Proof of concept: Dockable windows

### DIFF
--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -39,6 +39,7 @@
 		<dependency org="org.jfree" name="jcommon" rev="1.0.24"/>
 		<dependency org="org.jfree" name="jfreechart" rev="1.5.0"/>
 		<dependency org="org.scijava" name="scijava-common" rev="2.77.0"/>
+		<dependency org="org.dockingframes" name="docking-frames-common" rev="1.1.1"/>
 		<!-- Magellan dependencies -->
 		<!-- https://mvnrepository.com/artifact/org.zeromq/jeromq -->
 		<dependency org="org.zeromq" name="jeromq" rev="0.5.1"/>
@@ -79,7 +80,6 @@
 		<dependency org="net.clearvolume" name="clearvolume" rev="1.4.1"/>
       <!-- cl-kernel-binding from nico brings in clij-kernels, and clij version of the cleacl libraries.  Ugly, but the harsh truth if we want to use this code -->
       <dependency org="org.micromanager" name="cl-kernel-bindings" rev="0.1.1-SNAPSHOT"/>
-
 
 
 		<dependency org="org.boofcv" name="boofcv-ip" rev="0.36"/>

--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
@@ -129,7 +129,7 @@ public final class AlertsWindow extends MMFrame {
       scroller.setBorder(null);
       alertsPanel_.add(new JLabel(NO_ALERTS_MSG));
       super.add(scroller, "push, grow");
-      super.pack();
+//      super.pack();
    }
 
       /**
@@ -227,7 +227,7 @@ public final class AlertsWindow extends MMFrame {
       SwingUtilities.invokeLater(new Runnable() {
          @Override
          public void run() {
-            pack();
+            //pack();
          }
       });
    }
@@ -257,7 +257,7 @@ public final class AlertsWindow extends MMFrame {
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
       if (!event.getIsCancelled()) {
-        dispose();
+        //dispose();
       }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/CategorizedAlert.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/CategorizedAlert.java
@@ -155,12 +155,12 @@ public final class CategorizedAlert extends DefaultAlert {
       text_ = text;
 
       // HACK: for some reason if we don't do this, our viewable area is tiny.
-      parent_.pack();
+      //parent_.pack();
       SwingUtilities.invokeLater(new Runnable() {
          @Override
          public void run() {
             invalidate();
-            parent_.validate();
+            //parent_.validate();
          }
       });
       parent_.textUpdated(this);

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
@@ -75,7 +75,7 @@ public final class InspectorController
    private final DataViewerCollection viewerCollection_;
    private final Studio studio_;
 
-   private JFrame frame_;
+   private MMFrame frame_;
    private JPanel headerPanel_;
    private JScrollPane scrollPane_;
    private VerticalMultiSplitPane sectionsPane_;
@@ -141,7 +141,7 @@ public final class InspectorController
 
    private void makeUI() {
       frame_ = new MMFrame(); // TODO
-      frame_.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+      /*frame_.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
       frame_.addWindowListener(new WindowAdapter() {
          @Override
          public void windowClosing(WindowEvent w) {
@@ -149,7 +149,7 @@ public final class InspectorController
          }
       });
       frame_.setAlwaysOnTop(false); // TODO
-      frame_.getRootPane().putClientProperty("Window.style", "small");
+      frame_.getRootPane().putClientProperty("Window.style", "small");*/
       frame_.setLayout(new MigLayout(
             new LC().fill().insets("0").gridGap("0", "0")));
 
@@ -191,11 +191,11 @@ public final class InspectorController
       frame_.add(headerPanel_, new CC().growX().pushX().wrap());
       frame_.add(scrollPane_, new CC().grow().push().wrap());
 
-      frame_.pack();
+      //frame_.pack();
 
       // The frame's minimum size will need to be updated when there are panels
       // inserted, but for now the packed size is the minimum.
-      frame_.setMinimumSize(frame_.getPreferredSize());
+      //frame_.setMinimumSize(frame_.getPreferredSize());
    }
 
    @Override
@@ -205,7 +205,7 @@ public final class InspectorController
       if (frame_ != null) {
          detachFromDataViewer();
          frame_.setVisible(false);
-         frame_.dispose();
+         //frame_.dispose();
          frame_ = null;
       }
       eventBus_.post(InspectorDidCloseEvent.create(this));
@@ -339,14 +339,14 @@ public final class InspectorController
 
       GraphicsConfiguration config = GUIUtils.getGraphicsConfigurationContaining(1, 1);
       // TODO Set initial (factory default) position of frame
-      WindowPositioning.setUpBoundsMemory(frame_, InspectorController.class, null);
+      //WindowPositioning.setUpBoundsMemory(frame_, InspectorController.class, null);
       // TODO Attach MM menus to frame
 
-      frame_.setMinimumSize(new Dimension(frame_.getPreferredSize().width + 16,
+      /*frame_.setMinimumSize(new Dimension(frame_.getPreferredSize().width + 16,
             frame_.getMinimumSize().height));
       frame_.setSize(
             Math.max(frame_.getWidth(), frame_.getMinimumSize().width),
-            frame_.getHeight());
+            frame_.getHeight());*/
    }
 
    void inspectorSectionWillChangeHeight(InspectorSectionController section) {
@@ -468,14 +468,14 @@ public final class InspectorController
          return;
       }
       if (viewer != viewer_) {
-         frame_.setTitle(String.format("Inspect \"%s\"", viewer.getName()));
+         frame_.setTitleText(String.format("Inspect \"%s\"", viewer.getName()));
          showPanelsForDataViewer(viewer);
          viewer_ = viewer;
       }
    }
 
    private void detachFromDataViewer() {
-      frame_.setTitle(String.format("Inspector: No Image"));
+      frame_.setTitleText(String.format("Inspector: No Image"));
       showPanelsForDataViewer(null);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -89,6 +89,7 @@ import org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEv
 import org.micromanager.display.internal.gearmenu.GearButton;
 import org.micromanager.display.overlay.Overlay;
 import org.micromanager.events.internal.ChannelColorEvent;
+import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.Geometry;
 import org.micromanager.internal.utils.MMFrame;
@@ -127,7 +128,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
 
    private final DisplayWindowControlsFactory controlsFactory_;
 
-   private JFrame frame_; // Not null iff not closed
+   private MMFrame frame_; // Not null iff not closed
    private JFrame fullScreenFrame_; // Not null iff in full-screen mode
 
    // We place all components in a JPanel, so that they can be transferred
@@ -238,7 +239,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
             controlsFactory, animationController);
       parent.registerForEvents(instance);
       studio.events().registerForEvents(instance);
-      instance.frame_.addWindowListener(instance);
+      //instance.frame_.addWindowListener(instance);
       return instance;
    }
 
@@ -255,7 +256,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
       frame_ = makeFrame(false);
       contentPanel_ = buildInitialUI();
       frame_.add(contentPanel_);
-      frame_.validate();
+      //frame_.validate();
    }
 
    public void setPerformanceMonitor(PerformanceMonitor perfMon) {
@@ -263,13 +264,13 @@ public final class DisplayUIController implements Closeable, WindowListener,
    }
 
    @MustCallOnEDT
-   private JFrame makeFrame(boolean fullScreen) {
-      JFrame frame;
-      if (!fullScreen) {
+   private MMFrame makeFrame(boolean fullScreen) {
+      MMFrame frame;
+      //if (!fullScreen) {
          // TODO LATER Eliminate MMFrame
          frame = new MMFrame("image display window", false);
-         frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-         ((MMFrame) frame).loadPosition(320, 320, 480, 320);
+         //frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+         //((MMFrame) frame).loadPosition(320, 320, 480, 320);
 
          // TODO Determine initial window bounds using a CascadingWindowPositioner:
          // - (Setting canvas zoom has been handled by DisplayController (ImageJLink))
@@ -295,16 +296,16 @@ public final class DisplayUIController implements Closeable, WindowListener,
          //   area.
          // - In any case, the screen to use is the screen in which a viewer window
          //   was last found (not created).
-      }
-      else {
+      //}
+      /*else {
          frame = new JFrame();
          frame.setUndecorated(true);
          frame.setResizable(false);
          frame.setBounds(
                GUIUtils.getFullScreenBounds(frame.getGraphicsConfiguration()));
          frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
-      }
-      setTitle(frame);
+      }*/
+      //setTitle(frame);
       return frame;
    }
 
@@ -321,14 +322,14 @@ public final class DisplayUIController implements Closeable, WindowListener,
          fullScreenFrame_ = null;
       }
       if (frame_ != null) {
-         frame_.dispose();
+         //frame_.dispose();
          frame_ = null;
       }
    }
 
    @MustCallOnEDT
    public JFrame getFrame() {
-      return fullScreenFrame_ == null ? frame_ : fullScreenFrame_;
+      return MMStudio.getFrame();
    }
 
    @MustCallOnEDT
@@ -371,10 +372,10 @@ public final class DisplayUIController implements Closeable, WindowListener,
       int minHeight = topControlPanel_.getMinimumSize().height +
             MIN_CANVAS_HEIGHT +
             bottomControlPanel_.getMinimumSize().height;
-      Insets frameInsets = frame_.getInsets();
-      minWidth += frameInsets.left + frameInsets.right;
-      minHeight += frameInsets.top + frameInsets.bottom;
-      frame_.setMinimumSize(new Dimension(minWidth, minHeight));
+      //Insets frameInsets = frame_.getInsets();
+      //minWidth += frameInsets.left + frameInsets.right;
+      //minHeight += frameInsets.top + frameInsets.bottom;
+      //frame_.setMinimumSize(new Dimension(minWidth, minHeight));
 
       return contentPanel;
    }
@@ -432,10 +433,10 @@ public final class DisplayUIController implements Closeable, WindowListener,
 
       fullScreenButton_ = new JButton();
       fullScreenButton_.setFont(GUIUtils.buttonFont);
-      fullScreenButton_.addActionListener((ActionEvent e) -> {
-         setFullScreenMode(!isFullScreenMode());
-      });
-      setFullScreenMode(isFullScreenMode()); // Sync button state
+      //fullScreenButton_.addActionListener((ActionEvent e) -> {
+      //   setFullScreenMode(!isFullScreenMode());
+      //});
+      //setFullScreenMode(isFullScreenMode()); // Sync button state
       buttonPanel.add(fullScreenButton_);
 
       zoomInButton_ = new JButton(
@@ -1156,7 +1157,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
       return fullScreenFrame_ != null;
    }
 
-   @MustCallOnEDT
+   /*@MustCallOnEDT
    void setFullScreenMode(boolean fullScreen) {
       if (fullScreen) {
          if (!isFullScreenMode()) {
@@ -1177,7 +1178,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
             fullScreenFrame_.setVisible(false);
             frame_.add(contentPanel_);
             contentPanel_.invalidate();
-            frame_.validate();
+            //frame_.validate();
             frame_.setVisible(true);
             fullScreenFrame_.dispose();
             fullScreenFrame_ = null;
@@ -1188,6 +1189,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
          fullScreenButton_.setToolTipText("View in full screen mode");
       }
    }
+   */
    
 
    public void updateTitle() {
@@ -1216,7 +1218,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
     * Actually sets the title to this Display
     */
    @MustCallOnEDT
-   private void setTitle(JFrame frame) {
+   private void setTitle(MMFrame frame) {
       StringBuilder sb = new StringBuilder();
       sb.append(displayController_.getName());
       isPreview_ = isPreview(displayController_.getName());
@@ -1228,7 +1230,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
          sb.append(" (100%)");
       }
       // TODO: add save status, and listen for changes
-      frame.setTitle(sb.toString());
+      frame.setTitleText(sb.toString());
    }
    
    private boolean isPreview(String title) {
@@ -1250,7 +1252,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
          fullScreenFrame_.validate();
       }
       else {
-         frame_.validate();
+         //frame_.validate();
       }
    }
 
@@ -1292,7 +1294,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
          fullScreenFrame_.validate();
       }
       else {
-         GraphicsConfiguration gConfig = frame_.getGraphicsConfiguration();
+         /*GraphicsConfiguration gConfig = frame_.getGraphicsConfiguration();
          Rectangle screenBounds = Geometry.insettedRectangle(
                gConfig.getBounds(),
                Toolkit.getDefaultToolkit().getScreenInsets(gConfig));
@@ -1310,7 +1312,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
                new Dimension(newCanvasWidth, newCanvasHeight));
          ijBridge_.getIJImageCanvas().invalidate();
 
-         frame_.pack(); // Includes validation
+         frame_.pack(); // Includes validation*/
 
          // NS: I find the autonomous movement of the window highly annoying
          // Uncomment if you disagree and want the window to move all by itself
@@ -1922,12 +1924,12 @@ public final class DisplayUIController implements Closeable, WindowListener,
 
    @Override
    public void windowClosing(WindowEvent e) {
-      if (e.getWindow() == frame_) {
+      /*if (e.getWindow() == frame_) {
          displayController_.requestToClose();
-      }
-      else if (e.getWindow() == fullScreenFrame_) {
-         setFullScreenMode(false);
-      }
+      }*/
+      //else if (e.getWindow() == fullScreenFrame_) {
+      //   setFullScreenMode(false);
+      //}
    }
 
    @Override
@@ -1966,10 +1968,10 @@ public final class DisplayUIController implements Closeable, WindowListener,
       }
       else {
          // Adjust window height
-         frame_.setSize(frame_.getWidth(),
-               frame_.getHeight() - oldHeight + newHeight);
+         //frame_.setSize(frame_.getWidth(),
+         //      frame_.getHeight() - oldHeight + newHeight);
          panel.setVisible(true);
-         frame_.validate();
+         //frame_.validate();
          // TODO Move frame up if bottom beyond screen bottom (which means we
          // also need to shrink window if too tall for screen)
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultSnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultSnapLiveManager.java
@@ -80,7 +80,7 @@ import org.micromanager.internal.navigation.UiMovesStageManager;
  *
  * @author Chris Weisiger and Mark A. Tsuchida
  */
-public final class SnapLiveManager extends DataViewerListener 
+public final class DefaultSnapLiveManager extends DataViewerListener 
         implements org.micromanager.SnapLiveManager {
    private static final String TITLE = "Preview";
 
@@ -156,7 +156,7 @@ public final class SnapLiveManager extends DataViewerListener
          
    }
 
-   public SnapLiveManager(MMStudio mmStudio, CMMCore core) {
+   public DefaultSnapLiveManager(MMStudio mmStudio, CMMCore core) {
       mmStudio_ = mmStudio;
       core_ = core;
       uiMovesStageManager_ = mmStudio_.getUiMovesStageManager();
@@ -278,7 +278,7 @@ public final class SnapLiveManager extends DataViewerListener
             public void run() {
                // We are started from within the monitor. Wait until that
                // monitor is released before starting.
-               synchronized (SnapLiveManager.this) {
+               synchronized (DefaultSnapLiveManager.this) {
                   if (scheduledGrab_ == null ||
                         liveModeStartCount_ != liveModeCount) {
                      return;
@@ -301,7 +301,7 @@ public final class SnapLiveManager extends DataViewerListener
                }
 
                long delayMs;
-               synchronized (SnapLiveManager.this) {
+               synchronized (DefaultSnapLiveManager.this) {
                   if (scheduledGrab_ == null ||
                         liveModeStartCount_ != liveModeCount) {
                      return;
@@ -417,7 +417,7 @@ public final class SnapLiveManager extends DataViewerListener
 
               try {
                   SwingUtilities.invokeAndWait(() -> {
-                     synchronized (SnapLiveManager.this) {
+                     synchronized (DefaultSnapLiveManager.this) {
                         if (scheduledGrab_ == null
                                 || liveModeStartCount_ != liveModeCount) {
                            throw new CancellationException();

--- a/mmstudio/src/main/java/org/micromanager/internal/LineProfile.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/LineProfile.java
@@ -35,17 +35,17 @@ public final class LineProfile {
             updateLineProfile();
          }
       });
-      profileWin_.addWindowListener(new WindowAdapter() {
+      /*profileWin_.addWindowListener(new WindowAdapter() {
          @Override
          public void windowClosing(WindowEvent event) {
             cleanup();
          }
-      });
-      profileWin_.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+      });*/
+      //profileWin_.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
       profileWin_.setData(lineProfileData_);
       profileWin_.setLabels("Pixel", "Intensity");
       profileWin_.setAutoScale();
-      profileWin_.setTitle("Line profile for " + display_.getName());
+      profileWin_.setTitleText("Line profile for " + display_.getName());
       profileWin_.setVisible(true);
    }
 
@@ -100,7 +100,7 @@ public final class LineProfile {
    public void cleanup() {
       display_.unregisterForEvents(this);
       if (profileWin_ != null) {
-         profileWin_.dispose();
+         //profileWin_.dispose();
       }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -139,40 +139,36 @@ public final class MainFrame extends MMFrame {
       mmStudio_ = mmStudio;
       core_ = core;
 
-      super.setTitle(String.format("%s %s", MICRO_MANAGER_TITLE,
+      super.setTitleText(String.format("%s %s", MICRO_MANAGER_TITLE,
                MMVersion.VERSION_STRING));
 
-      JPanel contents = new JPanel();
+      JPanel contents = (JPanel) this.getContentPane();
       // Minimize insets.
       contents.setLayout(new MigLayout("insets 1, gap 0, fill"));
-      super.setContentPane(contents);
 
       contents.add(createComponents(), "grow");
 
-      super.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+      //super.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
       setupWindowHandlers();
 
       // Add our own keyboard manager that handles Micro-Manager shortcuts
       MMKeyDispatcher mmKD = new MMKeyDispatcher();
       KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(mmKD);
-      DropTarget dropTarget = new DropTarget(this, new DragDropUtil(mmStudio_));
 
       setExitStrategy(OptionsDlg.getShouldCloseOnExit(mmStudio_));
-
-      super.setJMenuBar(mmStudio.getMMMenubar());
 
       setConfigText("");
       // Set minimum size so we can't resize smaller and hide some of our
       // contents. Our insets are only available after the first call to
       // pack().
-      super.pack();
-      super.setMinimumSize(super.getSize());
+      //super.pack();
+      //super.setMinimumSize(super.getSize());
       resetPosition();
       mmStudio_.events().registerForEvents(this);
    }
 
    private void setupWindowHandlers() {
-      addWindowListener(new WindowAdapter() {
+      /*addWindowListener(new WindowAdapter() {
          // HACK: on OSX, some kind of system bug can disable the entire
          // menu bar at times (it has something to do with modal dialogs and
          // possibly with errors resulting from the code that handles their
@@ -192,7 +188,7 @@ public final class MainFrame extends MMFrame {
          public void windowClosing(WindowEvent event) {
             mmStudio_.closeSequence(false);
          }
-      });
+      });*/
    }
 
    public void resetPosition() {
@@ -574,12 +570,12 @@ public final class MainFrame extends MMFrame {
    }
 
    public final void setExitStrategy(boolean closeOnExit) {
-      if (closeOnExit) {
+      /*if (closeOnExit) {
          setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
       }
       else {
          setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-      }
+      }*/
    }
 
    protected void setConfigSaveButtonStatus(boolean changed) {

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -89,7 +89,7 @@ public final class PropertyEditor extends MMFrame {
       createComponents();
       
       loadAndRestorePosition(100, 100, 550, 600);
-      setMinimumSize(new Dimension(420, 400));
+      //setMinimumSize(new Dimension(420, 400));
    }
 
    private void createTable() {
@@ -110,12 +110,12 @@ public final class PropertyEditor extends MMFrame {
    }
 
    private void createComponents() {
-      setIconImage(Toolkit.getDefaultToolkit().getImage(
-              getClass().getResource("/org/micromanager/icons/microscope.gif") ) );
+      setTitleIcon(new ImageIcon(Toolkit.getDefaultToolkit().getImage(
+              getClass().getResource("/org/micromanager/icons/microscope.gif") ) ));
 
       setLayout(new MigLayout("fill, insets 2, flowy"));
 
-      addWindowListener(new WindowAdapter() {
+      /*addWindowListener(new WindowAdapter() {
          @Override
          public void windowClosing(WindowEvent e) {
             flags_.save(PropertyEditor.class);
@@ -126,11 +126,11 @@ public final class PropertyEditor extends MMFrame {
             data_.update(false);
             data_.fireTableStructureChanged();
         }
-      });
-      setTitle("Device Property Browser");
+      });*/
+      setTitleText("Device Property Browser");
 
       loadAndRestorePosition(100, 100, 550, 600);
-      setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+      //setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
       
       final JButton refreshButton = new JButton("Refresh",
             new ImageIcon(getClass().getResource(

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -608,7 +608,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       closeButton.addActionListener((ActionEvent e) -> {
          saveSettings();
          saveAcqSettings();
-         AcqControlDlg.this.dispose();
+         //AcqControlDlg.this.dispose();
          mmStudio_.app().makeActive();
       });
       return closeButton;
@@ -766,26 +766,22 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
       mmStudio_ = mmStudio;
       profile_ = mmStudio_.getUserProfile();
-
-      super.setIconImage(Toolkit.getDefaultToolkit().getImage(
-              MMStudio.class.getResource(
-            "/org/micromanager/icons/microscope.gif")));
       
-      super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+      //super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 
       numberFormat_ = NumberFormat.getNumberInstance();
 
-      super.addWindowListener(new WindowAdapter() {
+      /*super.addWindowListener(new WindowAdapter() {
 
          @Override
          public void windowClosing(final WindowEvent e) {
             close();
          }
-      });
+      });*/
       acqEng_ = acqEng;
       acqEng.addSettingsListener(this);
 
-      super.setTitle("Multi-Dimensional Acquisition");
+      super.setTitleText("Multi-Dimensional Acquisition");
       super.setLayout(new MigLayout("fill, flowy, gap 2, insets 6",
                "[grow, fill]",
                "[][grow][][]"));
@@ -852,11 +848,11 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
       createToolTips();
 
-      super.pack();
-      Dimension size = super.getPreferredSize();
-      size.height += 10; // Compensate for inaccurate size given by Apple Java 6
-      super.setMinimumSize(size);
-      super.loadAndRestorePosition(100, 100, size.width, size.height);
+      //super.pack();
+      //Dimension size = super.getPreferredSize();
+      //size.height += 10; // Compensate for inaccurate size given by Apple Java 6
+      //super.setMinimumSize(size);
+      //super.loadAndRestorePosition(100, 100, size.width, size.height);
 
       mmStudio_.events().registerForEvents(this);
    }
@@ -956,7 +952,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
          ReportingUtils.logError(t, "in saveAcqSettings");
       }
       try {
-         dispose();
+         //dispose();
       } catch (Throwable t) {
          ReportingUtils.logError(t, "in dispose");
       }
@@ -1161,7 +1157,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
    }
 
    protected void setRootDirectory() {
-      File result = FileDialogs.openDir(this,
+      File result = FileDialogs.openDir(MMStudio.getFrame(),
               "Please choose a directory root for image data",
               FileDialogs.MM_DATA_SET);
       if (result != null) {
@@ -1194,7 +1190,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
    }
 
    protected void loadAcqSettingsFromFile() {
-      File f = FileDialogs.openFile(this, "Load acquisition settings", ACQ_SETTINGS_FILE);
+      File f = FileDialogs.openFile(MMStudio.getFrame(), "Load acquisition settings", ACQ_SETTINGS_FILE);
       if (f != null) {
          try {
             loadAcqSettingsFromFile(f.getAbsolutePath());
@@ -1232,7 +1228,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
    protected boolean saveAsAcqSettingsToFile() {
       saveAcqSettings();
-      File file = FileDialogs.save(this, "Save the acquisition settings file", ACQ_SETTINGS_FILE);
+      File file = FileDialogs.save(MMStudio.getFrame(), "Save the acquisition settings file", ACQ_SETTINGS_FILE);
       if (file != null) {
          try {
             SequenceSettings settings = acqEng_.getSequenceSettings();
@@ -1309,7 +1305,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
          ep.setEditable(false);
          ep.setBackground(label.getBackground());
 
-         int answer = JOptionPane.showConfirmDialog(this, ep,
+         int answer = JOptionPane.showConfirmDialog(MMStudio.getFrame(), ep,
                  "Not enough memory", JOptionPane.YES_NO_OPTION);
          return answer == JOptionPane.YES_OPTION;
       }
@@ -1318,7 +1314,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
    public Datastore runAcquisition() {
       if (acqEng_.isAcquisitionRunning()) {
-         JOptionPane.showMessageDialog(this, "Cannot start acquisition: previous acquisition still in progress.");
+         JOptionPane.showMessageDialog(MMStudio.getFrame(), "Cannot start acquisition: previous acquisition still in progress.");
          return null;
       }
 
@@ -1331,7 +1327,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
          saveAcqSettings();
          ChannelTableModel model = (ChannelTableModel) channelTable_.getModel();
          if (acqEng_.isChannelsSettingEnabled() && model.duplicateChannels()) {
-            JOptionPane.showMessageDialog(this, "Cannot start acquisition using the same channel twice");
+            JOptionPane.showMessageDialog(MMStudio.getFrame(), "Cannot start acquisition using the same channel twice");
             return null;
          }
          // Check for excessively long exposure times.
@@ -1348,7 +1344,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
             String message = String.format("I found unusually long exposure times for %s. Are you sure you want to run this acquisition?",
                   channelString);
             JCheckBox neverAgain = new JCheckBox("Do not ask me again.");
-            int response = JOptionPane.showConfirmDialog(this,
+            int response = JOptionPane.showConfirmDialog(MMStudio.getFrame(),
                   new Object[] {message, neverAgain},
                   "Confirm exposure times", JOptionPane.YES_NO_OPTION);
             setShouldCheckExposureSanity(!neverAgain.isSelected());
@@ -1366,7 +1362,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
 
    public Datastore runAcquisition(String acqName, String acqRoot) {
       if (acqEng_.isAcquisitionRunning()) {
-         JOptionPane.showMessageDialog(this, "Unable to start the new acquisition task: previous acquisition still in progress.");
+         JOptionPane.showMessageDialog(MMStudio.getFrame(), "Unable to start the new acquisition task: previous acquisition still in progress.");
          return null;
       }
 
@@ -1378,7 +1374,7 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
       try {
          ChannelTableModel model = (ChannelTableModel) channelTable_.getModel();
          if (acqEng_.isChannelsSettingEnabled() && model.duplicateChannels()) {
-            JOptionPane.showMessageDialog(this, "Cannot start acquisition using the same channel twice");
+            JOptionPane.showMessageDialog(MMStudio.getFrame(), "Cannot start acquisition using the same channel twice");
             return null;
          }
          acqEng_.setDirName(acqName);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AffineEditorPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AffineEditorPanel.java
@@ -123,7 +123,7 @@ public class AffineEditorPanel extends JPanel {
    
    public void cleanup() {
       if (pcd_ != null) {
-         pcd_.dispose();
+         //pcd_.dispose();
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -222,7 +222,7 @@ public final class OptionsDlg extends MMDialog {
       closeOnExitCheckBox.addActionListener((ActionEvent arg0) -> {
          boolean shouldClose = closeOnExitCheckBox.isSelected();
          setShouldCloseOnExit(mmStudio_, shouldClose);
-         MMStudio.getFrame().setExitStrategy(shouldClose);
+         //MMStudio.getFrame().setExitStrategy(shouldClose);
       });
 
       final JCheckBox metadataFileWithMultipageTiffCheckBox = new JCheckBox();

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -321,7 +321,7 @@ public final class StageControlFrame extends MMFrame {
          plusButtons_[MAX_NUM_Z_PANELS-1].setEnabled(false);
       }
 
-      this.addMouseListener(new MouseAdapter() {
+      /*this.addMouseListener(new MouseAdapter() {
          @Override
          public void mouseExited(MouseEvent e) {
             for (int i = 0; i < X_MOVEMENTS.length && i < Y_MOVEMENTS.length; i++) {
@@ -334,11 +334,11 @@ public final class StageControlFrame extends MMFrame {
                }
             }
          }
-      });
+      });*/
       
       updateStagePositions();  // make sure that positions are correct
       refreshTimer(); // start polling if enabled
-      pack();  // re-layout the frame depending on what is visible now
+      //pack();  // re-layout the frame depending on what is visible now
    }
 
    /**
@@ -346,9 +346,9 @@ public final class StageControlFrame extends MMFrame {
     *    them to JPanel, but they may be turned visible/invisible during operation.
     */
    private void initComponents() {
-      setTitle("Stage Control");
-      setLocationByPlatform(true);
-      setResizable(false);
+      setTitleText("Stage Control");
+      //setLocationByPlatform(true);
+      //setResizable(false);
       setLayout(new MigLayout("fill, insets 5, gap 2"));
 
       xyPanel_ = createXYPanel();
@@ -368,11 +368,9 @@ public final class StageControlFrame extends MMFrame {
       errorPanel_ = createErrorPanel();
       add(errorPanel_, "grow, hidemode 3");
       
-      pack();
    }
 
    private JPanel createXYPanel() {
-      final JFrame theWindow = this;
       JPanel result = new JPanel(new MigLayout("insets 0, gap 0"));
       result.add(new JLabel("XY Stage", JLabel.CENTER),
             "span, alignx center, wrap");
@@ -438,7 +436,7 @@ public final class StageControlFrame extends MMFrame {
                setRelativeXYStagePosition(dx * increment, dy * increment);
             }
             catch (ParseException ex) {
-               JOptionPane.showMessageDialog(theWindow, "XY Step size is not a number");
+               JOptionPane.showMessageDialog(MMStudio.getFrame(), "XY Step size is not a number");
             }
          });
          // Add the button to the panel.
@@ -514,7 +512,6 @@ public final class StageControlFrame extends MMFrame {
     * between the chevrons and the step size controls.
     */
    private JPanel createZPanel(final int idx) {
-      final JFrame theWindow = this;
       JPanel result = new JPanel(new MigLayout("insets 0, gap 0, flowy"));
       // result.add(new JLabel("Z Stage", JLabel.CENTER), "growx, alignx center");
       zDriveSelect_[idx] = new JComboBox<>();
@@ -575,7 +572,7 @@ public final class StageControlFrame extends MMFrame {
                stepSize = NumberUtils.displayStringToDouble(text.getText());
             }
             catch (ParseException ex) {
-               JOptionPane.showMessageDialog(theWindow, "Z-step value is not a number");
+               JOptionPane.showMessageDialog(MMStudio.getFrame(), "Z-step value is not a number");
                return;
             }
             setRelativeStagePosition(dz * stepSize, idx);
@@ -800,7 +797,7 @@ public final class StageControlFrame extends MMFrame {
    }
 
    private boolean confirmLargeMovementSetting(double movementUm) {
-      int response = JOptionPane.showConfirmDialog(this,
+      int response = JOptionPane.showConfirmDialog(MMStudio.getFrame(),
               String.format(NumberUtils.doubleToDisplayString(movementUm, 0) +
                       " microns could be dangerously large.  Are you sure you want to set this?",
               "Large movement requested",
@@ -834,22 +831,8 @@ public final class StageControlFrame extends MMFrame {
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
       if (!event.getIsCancelled()) {
-         this.dispose();
+         //this.dispose();
       }
-   }
-   
-   @Override
-   public void dispose() {
-      for (int i = 0; i < 3; i++) {
-         try {
-            settings_.putDouble(X_MOVEMENTS[i],
-                  NumberUtils.displayStringToDouble(xStepTexts_[i].getText()));
-         } catch (ParseException pex) {
-            // since we are closing, no need to warn the user
-         }
-      }
-      stopTimer();
-      super.dispose();
    }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/graph/GraphFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/graph/GraphFrame.java
@@ -120,13 +120,13 @@ public final class GraphFrame extends MMFrame {
    public GraphFrame(final Runnable refreshAction) {
       super("graph frame");
      
-      setFont(new Font("Arial", Font.PLAIN, 10));
+      //setFont(new Font("Arial", Font.PLAIN, 10));
       
-      setTitle("Graph");
+      setTitleText("Graph");
       springLayout = new SpringLayout();
       getContentPane().setLayout(springLayout);
       loadAndRestorePosition(100, 100, 542, 298);
-      setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+      //setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
       panel_ = new GraphPanel();
       panel_.setBorder(new LineBorder(Color.black, 1, false));

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
@@ -17,6 +17,7 @@ import org.micromanager.internal.MainFrame;
 import org.micromanager.internal.hcwizard.ConfigWizard;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.GUIUtils;
+import org.micromanager.internal.utils.MMMainFrame;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.profile.internal.gui.HardwareConfigurationManager;
 
@@ -159,7 +160,7 @@ public final class ConfigMenu {
 
          // run Configurator
          ConfigWizard cfg = null;
-         MainFrame frame = mmStudio_.getFrame();
+          MMMainFrame frame = mmStudio_.getFrame();
          try {
             frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
             cfg = new ConfigWizard(mmStudio_, mmStudio_.getSysConfigFile());

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -70,7 +70,7 @@ final public class PipelineFrame extends MMFrame
 
    public PipelineFrame(Studio studio) {
       super(TITLE);
-      setTitle(TITLE);
+      setTitleText(TITLE);
       studio_ = studio;
 
       setLayout(new MigLayout("fill, flowy, insets dialog",
@@ -172,21 +172,21 @@ final public class PipelineFrame extends MMFrame
       //
       // Overall constraints
       //
-      pack();
+      //pack();
       final Dimension contentSize = getContentPane().getPreferredSize();
       final Dimension minSize = getContentPane().getMinimumSize();
 
       // Compute the difference between the content pane's size and the
       // frame's size, so that we can constrain the frame's size.
-      final int widthDelta = getSize().width - getContentPane().getSize().width;
-      final int heightDelta = getSize().height - getContentPane().getSize().height;
+      //final int widthDelta = getSize().width - getContentPane().getSize().width;
+      //final int heightDelta = getSize().height - getContentPane().getSize().height;
 
-      final Dimension frameSize = new Dimension(contentSize.width + widthDelta,
-            contentSize.height + heightDelta);
-      final Dimension minFrameSize = new Dimension(minSize.width + widthDelta,
-            minSize.height + heightDelta);
-      setPreferredSize(frameSize);
-      setMinimumSize(minFrameSize);
+      //final Dimension frameSize = new Dimension(contentSize.width + widthDelta,
+            //contentSize.height + heightDelta);
+      //final Dimension minFrameSize = new Dimension(minSize.width + widthDelta,
+           //minSize.height + heightDelta);
+      //setPreferredSize(frameSize);
+      //setMinimumSize(minFrameSize);
       
       super.loadAndRestorePosition(200, 200);
 
@@ -410,9 +410,9 @@ final public class PipelineFrame extends MMFrame
       getTableModel().clearPipeline();
    }
 
-   @Override
+   /*@Override
    public void dispose() {
       super.dispose();
       getTableModel().cleanup();
-   }
+   }*/
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
@@ -393,13 +393,13 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
       public DialogFrame(Object caller) {
          caller_ = caller;
          explanationLabel_ = new JLabel();
-         super.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+         /*super.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
          super.addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent we) {
                dispose();
             }
-         });
+         });*/
          super.setLayout(new MigLayout());
          final String label1Text = "<html>This method creates an affine transform based on"
                  + " a <br>pixelSize of "
@@ -426,11 +426,11 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
          cancelButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-               dispose();
+               //dispose();
             }
          });
          super.add(cancelButton, "tag cancel, wrap");
-         super.pack();
+         //super.pack();
          super.loadAndRestorePosition(200, 200);
          super.setVisible(true);
       }
@@ -445,19 +445,6 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
              });
          }
          explanationLabel_.setText(newText);
-      }
-      
-      @Override
-      public void dispose() {
-         super.dispose();
-         if (dc_ != null) {
-            dc_.unregisterForEvents(caller_);
-         }
-         synchronized(CalibrationThread.class) {
-            CalibrationThread.class.notifyAll();
-         }
-         //running_.set(false);
-         dialog_.calibrationFailed(true);
       }
       
       public void setOKButtonVisible(boolean visible) {

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualSimpleCalibrationThread.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualSimpleCalibrationThread.java
@@ -114,7 +114,7 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
       }
       if (display == null) {
          ReportingUtils.showError("Preview window did not open. Is the exposure time very long?");
-         dialogFrame_.dispose();
+         //dialogFrame_.dispose();
       } else if (display instanceof DisplayController) {
          dc_ = (DisplayController) display;
          dc_.registerForEvents(this);
@@ -124,7 +124,7 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
             } catch (InterruptedException ie) {
 
             }
-            dialogFrame_.dispose();
+            //dialogFrame_.dispose();
          }
       }
    }
@@ -171,7 +171,7 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
                            dialogFrame_.setOKButtonVisible(true);
                         }
                      } else {
-                        dialogFrame_.dispose();
+                        //dialogFrame_.dispose();
                         dialog_.calibrationDone();
                         return;
                      }
@@ -239,13 +239,13 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
       
       public DialogFrame(Object caller) {
          caller_ = caller;
-         super.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+         /*super.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
          super.addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent we) {
                dispose();
             }
-         });
+         });*/
          super.setLayout(new MigLayout());
          final String label1Text = "<html>This method creates an affine transform based on"
                  + " a <br>pixelSize of "
@@ -273,11 +273,11 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
          cancelButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-               dispose();
+               //dispose();
             }
          });
          super.add(cancelButton, "tag cancel, wrap");
-         super.pack();
+         //super.pack();
          super.loadAndRestorePosition(200, 200);
          super.setVisible(true);
       }
@@ -294,7 +294,7 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
          explanationLabel_.setText(newText);
       }
 
-      @Override
+      /*@Override
       public void dispose() {
          super.dispose();
          if (dc_ != null) {
@@ -305,7 +305,7 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
          }
          //running_.set(false);
          dialog_.calibrationFailed(true);
-      }
+      }*/
       
       public void setOKButtonVisible(boolean visible) {
          okButton_.setVisible(visible);

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
@@ -37,6 +37,7 @@ import javax.swing.SwingUtilities;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.events.ShutdownCommencingEvent;
+import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.dialogs.PixelSizeProvider;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.GUIUtils;
@@ -95,17 +96,17 @@ public class PixelCalibratorDialog extends MMFrame {
       safeTravelRadiusComboBox_ = new JComboBox();
       methodComboBox_ = new JComboBox();
 
-      setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
-      setTitle("Pixel Calibrator");
-      setResizable(false);
-      addWindowListener(new java.awt.event.WindowAdapter() {
+      //setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
+      setTitleText("Pixel Calibrator");
+      //setResizable(false);
+      /*addWindowListener(new java.awt.event.WindowAdapter() {
          @Override
          public void windowClosing(java.awt.event.WindowEvent evt) {
             stopCalibration();
             setVisible(false);
             dispose();
          }
-      });
+      });*/
 
       explanationLabel_.setText("<html>This plugin measures the size " +
               "of the current camera's pixels at the sample plane.<br><br>" +
@@ -167,7 +168,7 @@ public class PixelCalibratorDialog extends MMFrame {
       super.add(stopButton_);
       super.add(calibrationProgressBar_, "wrap");
       
-      super.pack();
+      //super.pack();
 
    }
 
@@ -196,21 +197,21 @@ public class PixelCalibratorDialog extends MMFrame {
    }
 
 
-   @Override
+   /*@Override
    public void dispose() {
       stopCalibration();
       if (studio_ != null) {
          studio_.events().unregisterForEvents(this);
       }
       super.dispose();
-   }
+   }*/
    
    /**
     * @param event indicating that shutdown is happening
     */
    @Subscribe
    public void onShutdownCommencing(ShutdownCommencingEvent event) {
-      this.dispose();
+      //this.dispose();
    }
 
    
@@ -256,7 +257,7 @@ public class PixelCalibratorDialog extends MMFrame {
       double pixelSize = AffineUtils.deducePixelSize(result);
       double[] measurements = AffineUtils.affineToMeasurements(result);
 //      xScale, yScale, rotationDeg, shear
-      int response = JOptionPane.showConfirmDialog(this,
+      int response = JOptionPane.showConfirmDialog(MMStudio.getFrame(),
             String.format("Affine transform parameters: XScale=%.4f YScale=%.4f Rotation (degrees)=%.2f Shear=%.4f\n",                     
                     measurements[0], measurements[1], 
                     measurements[2], measurements[3]) + 
@@ -274,7 +275,7 @@ public class PixelCalibratorDialog extends MMFrame {
             pixelSizeProvider_.setAffineTransform(result);
          }
       } 
-      dispose();
+      //dispose();
    }
    
    private void showFailureMessage() {

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
@@ -38,12 +38,12 @@ public final class MMPositionListDlg extends PositionListDlg {
         super(studio, posList);
         acd_ = acd;
         
-        addWindowListener(new WindowAdapter() {
+        /*addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent arg0) {
                saveDims();
             }
-        });
+        });*/
         
     }
     
@@ -67,7 +67,7 @@ public final class MMPositionListDlg extends PositionListDlg {
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
       if (!event.getIsCancelled()) {
          saveDims();
-         dispose();
+         //dispose();
       }
    }   
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
@@ -32,6 +32,7 @@ import mmcorej.CMMCore;
 import mmcorej.DeviceType;
 import mmcorej.StrVector;
 import net.miginfocom.swing.MigLayout;
+import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.ReportingUtils;
 
@@ -60,8 +61,8 @@ class OffsetPositionsDialog extends MMDialog {
       axisInputs_ = new ArrayList<JTextField>();
 
       // center dialog on the parent dialog
-      int parentCenterX = (int) (parent.getX() + 0.5 * parent.getWidth());
-      int parentCenterY = (int) (parent.getY() + 0.5 * parent.getHeight());
+      int parentCenterX = (int) (MMStudio.getFrame().getX() + 0.5 * MMStudio.getFrame().getWidth());
+      int parentCenterY = (int) (MMStudio.getFrame().getY() + 0.5 * MMStudio.getFrame().getHeight());
       
       this.loadAndRestorePosition(parentCenterX - 160,parentCenterY - 150,
               320, 300);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -132,10 +132,10 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       bus_ = new EventBus(EventBusExceptionLogger.getInstance());
       bus_.register(this);
 
-      setTitle("Stage Position List");
+      setTitleText("Stage Position List");
       setLayout(new MigLayout("flowy, filly, insets 8", "[grow][]", 
               "[top]"));
-      setMinimumSize(new Dimension(275, 365));
+      //setMinimumSize(new Dimension(275, 365));
       super.loadAndRestorePosition(100, 100, 362, 595);
 
       arialSmallFont_ = new Font("Arial", Font.PLAIN, 10);
@@ -405,7 +405,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       closeButton.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent arg0) {
-            dispose();
+            //dispose();
          }
       });
       closeButton.setIcon(new ImageIcon(MMStudio.class.getResource(
@@ -473,7 +473,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    }
 
    protected boolean savePositionListAs() {
-      File f = FileDialogs.save(this, "Save the position list", POSITION_LIST_FILE);
+      File f = FileDialogs.save(MMStudio.getFrame(), "Save the position list", POSITION_LIST_FILE);
       if (f != null) {
          curFile_ = f;
          
@@ -500,7 +500,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    }
 
    protected void loadPositionList() {
-      File f = FileDialogs.openFile(this, "Load a position list", POSITION_LIST_FILE);
+      File f = FileDialogs.openFile(MMStudio.getFrame(), "Load a position list", POSITION_LIST_FILE);
       if (f != null) {
          curFile_ = f;
          try {
@@ -838,11 +838,11 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
     */
    private void calibrate() {
 
-      JOptionPane.showMessageDialog(this, "ALERT! Please REMOVE objectives! It may damage lens!", 
+      JOptionPane.showMessageDialog(MMStudio.getFrame(), "ALERT! Please REMOVE objectives! It may damage lens!", 
             "Calibrate the XY stage", JOptionPane.WARNING_MESSAGE);
 
       Object[] options = { "Yes", "No"};
-      if (JOptionPane.YES_OPTION != JOptionPane.showOptionDialog(this, "Really calibrate your XY stage?", "Are you sure?", JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[1]))
+      if (JOptionPane.YES_OPTION != JOptionPane.showOptionDialog(MMStudio.getFrame(), "Really calibrate your XY stage?", "Are you sure?", JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[1]))
          return ;
 
       // calibrate xy-axis stages
@@ -896,7 +896,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
 
             // popup a dialog that says stop the calibration
             Object[] options = { "Stop" };
-            int option = JOptionPane.showOptionDialog(d, "Stop calibration?", "Calibration", 
+            int option = JOptionPane.showOptionDialog(MMStudio.getFrame(), "Stop calibration?", "Calibration", 
                   JOptionPane.CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE,
                   null, options, options[0]);
 
@@ -918,7 +918,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
                }
 
                Object[] options2 = { "Yes", "No" };
-               option = JOptionPane.showOptionDialog(d, "RESUME calibration?", "Calibration", 
+               option = JOptionPane.showOptionDialog(MMStudio.getFrame(), "RESUME calibration?", "Calibration", 
                      JOptionPane.OK_OPTION, JOptionPane.QUESTION_MESSAGE,
                      null, options2, options2[0]);
 
@@ -1076,7 +1076,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       }     
       @Override
       public void run() {
-         JOptionPane.showMessageDialog(d, "Going back to the original position!");              
+         JOptionPane.showMessageDialog(MMStudio.getFrame(), "Going back to the original position!");              
       }
    } // End BackThread class
 

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -270,7 +271,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
                         readFileToTextArea(file, scriptArea_);
                         scriptFile_ = file;
                         scriptPaneSaved_ = true;
-                        setTitle(file.getName());
+                        setTitleText(file.getName());
                         model_.setLastMod(table_.getSelectedRow(), 0, file.lastModified());
                      } catch (IOException | MMScriptException ee) {
                         ReportingUtils.logError(ee);
@@ -319,16 +320,16 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
             ReportingUtils.logError("Failed to find Script Panel Beanshell startup script");
          }
       } catch (IOException e) {
-         ReportingUtils.showError("Failed to read Script Panel BeanShell startup script", this);
+         ReportingUtils.showError("Failed to read Script Panel BeanShell startup script");
       }
 
       if (tmpFile != null) {
          try {
             beanshellREPLint_.source(tmpFile.getAbsolutePath());
          } catch (FileNotFoundException e) {
-            ReportingUtils.showError(e, this);
+            ReportingUtils.showError(e);
          } catch (IOException | EvalError e) {
-            ReportingUtils.showError(e, this);
+            ReportingUtils.showError(e);
          }
       }
 
@@ -368,9 +369,9 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       createBeanshellREPL();
       
       // Needed when Cancel button is pressed upon save file warning
-      setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+      //setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 
-      addWindowListener(new WindowAdapter() {
+      /*addWindowListener(new WindowAdapter() {
          @Override
          public void windowClosing(WindowEvent arg0) {
             if (!promptToSave(-1))
@@ -382,17 +383,17 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
             saveScriptsToPrefs();
             setVisible(false);
          }
-      });
+      });*/
 
       setVisible(false);
 
       interp_ = new BeanshellEngine(this);
       interp_.setInterpreter(beanshellREPLint_);
       
-      setTitle("Script Panel");
-      setIconImage(Toolkit.getDefaultToolkit().getImage(
+      setTitleText("Script Panel");
+      setTitleIcon(new ImageIcon(Toolkit.getDefaultToolkit().getImage(
                MMStudio.class.getResource( 
-                       "/org/micromanager/icons/microscope.gif")));
+                       "/org/micromanager/icons/microscope.gif"))));
 
       int buttonHeight = 15;
       Dimension buttonSize = new Dimension(80, buttonHeight);
@@ -631,7 +632,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
          try {
             ij.plugin.BrowserLauncher.openURL("https://micro-manager.org/wiki/Version_2.0_Users_Guide#Script_Panel");
          } catch (IOException e1) {
-            ReportingUtils.showError(e1, scriptPanelFrame);
+            ReportingUtils.showError(e1);
          }
       });
       helpButton.setText("Help");
@@ -782,7 +783,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
 
       SearchResult found = SearchEngine.find(scriptArea_, context);
       if (!found.wasFound()) {
-         studio_.logs().showMessage("\"" + text + "\" was not found", this);
+         studio_.logs().showMessage("\"" + text + "\" was not found");
       }
       
    }
@@ -800,7 +801,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
          message = "Save changes to " + scriptFile_.getName() + "?";
       else
          message = "Save script?";
-      int result = JOptionPane.showConfirmDialog(this,
+      int result = JOptionPane.showConfirmDialog(MMStudio.getFrame(),
             message,
             APP_NAME, JOptionPane.YES_NO_OPTION,
             JOptionPane.INFORMATION_MESSAGE);
@@ -835,7 +836,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
          if (!promptToSave(-1))
             return;
 
-         File curFile = FileDialogs.openFile(this, "Select a Beanshell script", BSH_FILE);
+         File curFile = FileDialogs.openFile(MMStudio.getFrame(), "Select a Beanshell script", BSH_FILE);
 
          if (curFile != null) {
                studio_.profile().getSettings(ScriptPanel.class).putString(
@@ -866,7 +867,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       model_.fireTableDataChanged();
       scriptArea_.setText("");
       scriptPaneSaved_ = true;
-      this.setTitle("");
+      this.setTitleText("");
       scriptFile_ = null;
    }
 
@@ -885,7 +886,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
             row = scriptTable_.getSelectedRow();
          boolean modified = (scriptFile_.lastModified() != model_.getLastMod(row, 0));
          if (modified) {
-            int result = JOptionPane.showConfirmDialog(this,
+            int result = JOptionPane.showConfirmDialog(MMStudio.getFrame(),
                   "Script was changed on disk.  Continue saving anyways?",
                   APP_NAME, JOptionPane.YES_NO_OPTION,
                   JOptionPane.INFORMATION_MESSAGE);
@@ -907,7 +908,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
          model_.setLastMod(cellAddress[0], 0, scriptFile_.lastModified());
          showMessage("Saved file: " + scriptFile_.getName());
       } catch (IOException ioe){
-         ReportingUtils.showError(ioe, this);
+         ReportingUtils.showError(ioe);
       }
    }
 
@@ -916,7 +917,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
     */
    private void saveScriptAs () 
    {
-      File saveFile = FileDialogs.save(this, "Save beanshell script", BSH_FILE);
+      File saveFile = FileDialogs.save(MMStudio.getFrame(), "Save beanshell script", BSH_FILE);
       if (saveFile != null) {
          try {
             // Add .bsh extension if file did not have an extension itself
@@ -931,9 +932,9 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
             scriptFile_ = saveFile;
             settings_.putString(SCRIPT_FILE, saveFile.getAbsolutePath());
             scriptPaneSaved_ = true;
-            this.setTitle(saveFile.getName());
+            this.setTitleText(saveFile.getName());
          } catch (IOException ioe){
-            ReportingUtils.showError(ioe, this);
+            ReportingUtils.showError(ioe);
          }
       }
    }
@@ -958,7 +959,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       if (curFile != null) {
          boolean modified = (curFile.lastModified() != model_.getLastMod(scriptTable_.getSelectedRow(), 0));
          if (modified) {
-            int result = JOptionPane.showConfirmDialog(this,
+            int result = JOptionPane.showConfirmDialog(MMStudio.getFrame(),
                   "Script was changed on disk.  Re-load from disk?",
                   APP_NAME, JOptionPane.YES_NO_CANCEL_OPTION,
                   JOptionPane.INFORMATION_MESSAGE);
@@ -1066,7 +1067,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       scriptArea_.setText("");
       scriptPaneSaved_ = true;
       scriptFile_ = null;
-      this.setTitle("");
+      this.setTitleText("");
       scriptArea_.requestFocusInWindow();
    }
 
@@ -1078,7 +1079,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       if (!promptToSave(-1))
          return;
 
-      File curFile = FileDialogs.openFile(this, "Choose Beanshell script", BSH_FILE);
+      File curFile = FileDialogs.openFile(MMStudio.getFrame(), "Choose Beanshell script", BSH_FILE);
 
       if (curFile != null) {
          try {
@@ -1089,7 +1090,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
             readFileToTextArea(curFile, scriptArea_);
             scriptFile_ = curFile;
             scriptPaneSaved_ = true;
-            this.setTitle(curFile.getName());
+            this.setTitleText(curFile.getName());
          } catch (IOException | MMScriptException e) {
             handleException (e);
          } finally {
@@ -1146,7 +1147,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
          return;
       savePosition();
       saveScriptsToPrefs();
-      dispose();
+      //dispose();
    }
 
    /**
@@ -1154,7 +1155,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
     * @param e
     */
    public void handleException (Exception e) {
-      ReportingUtils.showError(e, this);
+      ReportingUtils.showError(e);
    }
 
    /**
@@ -1202,14 +1203,14 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
          try {
             beanshellREPLint_.eval("setAccessibility(true);");
          } catch (EvalError e1) {
-            ReportingUtils.showError(e1, this);
+            ReportingUtils.showError(e1);
          }
       }
       try {
          beanshellREPLint_.eval("bsh.console.text.setText(\"\");"
                + "setAccessibility("+originalAccessibility+");");
       } catch (EvalError e) {
-           ReportingUtils.showError(e, this);
+           ReportingUtils.showError(e);
       }
    }
 
@@ -1274,11 +1275,11 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       setVisible(false);
    }
    
-   @Override
+   /*@Override
    public void dispose() {
       finishUp();
       super.dispose();
-   }
+   }*/
 
    private String getExtension(File f) {
       String ext = null;


### PR DESCRIPTION
A typical session of Micro-Manager usually ends up with so many different windows opened that they can't all fit on the display without overlapping and it can become quite difficult to keep track of them, especially when other application windows are being switched to/from. This PR proposes solving this problem in the same way that most other complex programs solve it, by introducing a single main frame in which other frames are docked.

This PR was thrown together fairly quickly and introduces many bugs. Implementing this idea properly would be likely take a lot of work but I just wanted to put it up out there to get feedback on if this is a direction that Micro-Manager devs would be interested in moving towards.

This PR doesn't currently default to a very good initial layout but the idea is that a layout might look something like this:
![Untitled](https://user-images.githubusercontent.com/8433487/82839204-39c85480-9e94-11ea-81ef-9d3ec529cff8.png)

Users would be able to easily save and load custom layouts. By default there would be a central location for image display and, any new image displays that were opened would be tabbed on top of the existing display.
