### PR TITLE
Studio: convert RGB ImageJ imaged back to MM format correctly

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -277,6 +277,8 @@ public final class DefaultDataManager implements DataManager {
          pixelClone = ((byte[]) pixels).clone();
       } else if (pixels instanceof short[]) {
          pixelClone = ((short[]) pixels).clone();
+      } else if (pixels instanceof int[]) {
+         pixelClone = ((int[]) pixels).clone();
       } else {
          throw new IllegalArgumentException("Pixel type is not supported.  It could not be cloned");
       }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImageJConverter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImageJConverter.java
@@ -131,6 +131,7 @@ public final class DefaultImageJConverter implements ImageJConverter {
    @Override
    public Image createImage(ImageProcessor processor, Coords coords,
          Metadata metadata) {
+      Object pixels = processor.getPixels();
       int bytesPerPixel = -1;
       int numComponents = -1;
       if (processor instanceof ByteProcessor) {
@@ -146,14 +147,16 @@ public final class DefaultImageJConverter implements ImageJConverter {
          numComponents = 1;
       }
       else if (processor instanceof ColorProcessor) {
-         bytesPerPixel = 1;
+         bytesPerPixel = 4;
          numComponents = 3;
+
+         pixels = ImageUtils.convertRGB32IntToBytes((int[])processor.getPixels());
       }
       else {
          ReportingUtils.logError("Unrecognized processor type " + processor.getClass().getName());
       }
-      return studio_.data().createImage(
-            processor.getPixels(), processor.getWidth(), processor.getHeight(),
-            bytesPerPixel, numComponents, coords, metadata);
+      return studio_.data().createImage(pixels,
+              processor.getWidth(), processor.getHeight(), bytesPerPixel,
+              numComponents, coords, metadata);
    }
 }


### PR DESCRIPTION
Converts ImageJ ColorProcessors back to Micro-Manager RGB32 images.  Converting back and forth is very inefficient, so should be avoided. Fixes issue #820