### PR TITLE
add iterator interface for more MMCoreJ "vectors"

### DIFF
--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -911,6 +911,144 @@
 // instantiate STL mappings
 
 namespace std {
+	%typemap(javaimports) vector<char> %{
+		import java.lang.Iterable;
+		import java.util.Iterator;
+		import java.util.NoSuchElementException;
+		import java.lang.UnsupportedOperationException;
+	%}
+
+   %typemap(javainterfaces) vector<char> %{ Iterable<Character>%}
+
+   %typemap(javacode) vector<char> %{
+      public Iterator<Character> iterator() {
+         return new Iterator<Character>() {
+
+            private int i_=0;
+
+            public boolean hasNext() {
+               return (i_<size());
+            }
+
+            public Character next() throws NoSuchElementException {
+               if (hasNext()) {
+                  ++i_;
+                  return get(i_-1);
+               } else {
+                  throw new NoSuchElementException();
+               }
+            }
+
+            public void remove() throws UnsupportedOperationException {
+               throw new UnsupportedOperationException();
+            }
+         };
+      }
+
+      public Character[] toArray() {
+         if (0==size())
+            return new Character[0];
+
+         Character ints[] = new Character[(int) size()];
+         for (int i=0; i<size(); ++i) {
+            ints[i] = get(i);
+         }
+         return ints;
+      }
+   %}
+   
+   %typemap(javaimports) vector<long> %{
+		import java.lang.Iterable;
+		import java.util.Iterator;
+		import java.util.NoSuchElementException;
+		import java.lang.UnsupportedOperationException;
+	%}
+
+   %typemap(javainterfaces) vector<long> %{ Iterable<Long>%}
+
+   %typemap(javacode) vector<long> %{
+      public Iterator<Long> iterator() {
+         return new Iterator<Long>() {
+
+            private int i_=0;
+
+            public boolean hasNext() {
+               return (i_<size());
+            }
+
+            public Long next() throws NoSuchElementException {
+               if (hasNext()) {
+                  ++i_;
+                  return (long) get(i_-1); //For some reason the automatically generated `get` method returns `int`
+               } else {
+                  throw new NoSuchElementException();
+               }
+            }
+
+            public void remove() throws UnsupportedOperationException {
+               throw new UnsupportedOperationException();
+            }
+         };
+      }
+
+      public Long[] toArray() {
+         if (0==size())
+            return new Long[0];
+
+         Long ints[] = new Long[(int) size()];
+         for (int i=0; i<size(); ++i) {
+            ints[i] = (long) get(i); //For some reason the automatically generated `get` method returns `int`
+         }
+         return ints;
+      }
+   %}
+   
+   %typemap(javaimports) vector<double> %{
+		import java.lang.Iterable;
+		import java.util.Iterator;
+		import java.util.NoSuchElementException;
+		import java.lang.UnsupportedOperationException;
+	%}
+
+   %typemap(javainterfaces) vector<double> %{ Iterable<Double>%}
+
+   %typemap(javacode) vector<double> %{
+      public Iterator<Double> iterator() {
+         return new Iterator<Double>() {
+
+            private int i_=0;
+
+            public boolean hasNext() {
+               return (i_<size());
+            }
+
+            public Double next() throws NoSuchElementException {
+               if (hasNext()) {
+                  ++i_;
+                  return get(i_-1);
+               } else {
+                  throw new NoSuchElementException();
+               }
+            }
+
+            public void remove() throws UnsupportedOperationException {
+               throw new UnsupportedOperationException();
+            }
+         };
+      }
+
+      public Double[] toArray() {
+         if (0==size())
+            return new Double[0];
+
+         Double ints[] = new Double[(int) size()];
+         for (int i=0; i<size(); ++i) {
+            ints[i] = get(i);
+         }
+         return ints;
+      }
+   %}
+
 
 	%typemap(javaimports) vector<string> %{
 		import java.lang.Iterable;

--- a/MMCoreJ_wrap/MMCoreJ.i
+++ b/MMCoreJ_wrap/MMCoreJ.i
@@ -957,6 +957,11 @@ namespace std {
       }
    %}
    
+   /* 
+   * On most platforms a c++ `long` will be 32bit and therefore should map to a Java `Integer`. However 
+   * on some platforms a c++ `long` could be 64bit which could potentially cause issues. Ideally we should just avoid using vector<long> in MMCore interfaces.
+   */
+   
    %typemap(javaimports) vector<long> %{
 		import java.lang.Iterable;
 		import java.util.Iterator;
@@ -964,11 +969,11 @@ namespace std {
 		import java.lang.UnsupportedOperationException;
 	%}
 
-   %typemap(javainterfaces) vector<long> %{ Iterable<Long>%}
+   %typemap(javainterfaces) vector<long> %{ Iterable<Integer>%}
 
    %typemap(javacode) vector<long> %{
-      public Iterator<Long> iterator() {
-         return new Iterator<Long>() {
+      public Iterator<Integer> iterator() {
+         return new Iterator<Integer>() {
 
             private int i_=0;
 
@@ -976,10 +981,10 @@ namespace std {
                return (i_<size());
             }
 
-            public Long next() throws NoSuchElementException {
+            public Integer next() throws NoSuchElementException {
                if (hasNext()) {
                   ++i_;
-                  return (long) get(i_-1); //For some reason the automatically generated `get` method returns `int`
+                  return get(i_-1); 
                } else {
                   throw new NoSuchElementException();
                }
@@ -991,13 +996,13 @@ namespace std {
          };
       }
 
-      public Long[] toArray() {
+      public Integer[] toArray() {
          if (0==size())
-            return new Long[0];
+            return new Integer[0];
 
-         Long ints[] = new Long[(int) size()];
+         Integer ints[] = new Integer[(int) size()];
          for (int i=0; i<size(); ++i) {
-            ints[i] = (long) get(i); //For some reason the automatically generated `get` method returns `int`
+            ints[i] = get(i);
          }
          return ints;
       }


### PR DESCRIPTION
The current version of MMCoreJ extends the autogenerated code for `StrVector`, `BoolVector`, and `UnsignedVector` so that they implement the `Iterable` interface.  This makes it much simpler to work with these classes in Java.

This PR simply applies the same treatment to `LongVector`, `DoubleVector`, and `CharVector`.

If this looks acceptable I have one question before merging. The autogenerated `get()` method of `LongVector` returns `int` rather than `long`. This means that we have to cast from `int` to `long` in order to act as an `Iterable<Long>`, is this ok or should `LongVector` actually implement `Iterable<Integer>`?