### PR TITLE
Fix bug with MMStudio startup arguments when running as ImageJ plugin

### DIFF
--- a/mmstudio/src/main/java/MMStudioPlugin.java
+++ b/mmstudio/src/main/java/MMStudioPlugin.java
@@ -50,7 +50,8 @@ public class MMStudioPlugin implements PlugIn, CommandListener {
     * @param arg the plugin argument (not used)
     */
    @Override
-   public void run(final String arg) {      
+   public void run(final String arg) {   
+      final String profileNameAutoStart = parseMacroOptions(); //This must be run from the same thread that the plugin is started in or Macro.getOptions will return null.
       SwingUtilities.invokeLater(new Runnable() {
          @Override
          public void run() {
@@ -77,7 +78,6 @@ public class MMStudioPlugin implements PlugIn, CommandListener {
                      Executer.addCommandListener(MMStudioPlugin.this);
                   }
 
-                  String profileNameAutoStart = parseMacroOptions();
                   studio_ = new MMStudio(true, profileNameAutoStart);
                }
             } catch (RuntimeException e) {
@@ -89,7 +89,7 @@ public class MMStudioPlugin implements PlugIn, CommandListener {
       });
    }
 
-    private String parseMacroOptions() {
+    private static String parseMacroOptions() {
         //This method parses the optional ImageJ macro options. Currently it only supports the specification of a profile to automatically load like so: run("Micro-Manager Studio", "-profile {MyProfileNameHere}");
         //This method could be expanded to support other startup arguments in the future.
         String optionalArgs = Macro.getOptions(); //If, in ImageJ you start this plugin as `run("Micro-Manager Studio", "-profile MyProfile")` then this line will return "-profile MyProfile"


### PR DESCRIPTION
The implementation of the ImageJ `MMStudioPlugin` allows specifying a user a profile to automatically start using a macro option. However the `ij.Macro.getOptions()` function needs to be run from the same thread as the `run` method of the plugin. This was not being done and so the macro options were not being received. Now this is fixed.