### PR TITLE
Expand on BaslerPylon device adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tags
 *.vcproj.*.user
 *.vcxproj.user
 ipch/
+*.vs
 
 # GNU build system
 *.la

--- a/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
@@ -46,6 +46,7 @@ sma : 06.05.2019 Improvement in Gain range handling. In some camera model the ga
 sma : 22.05.2019 prepared for Mac build
 sma : 06.03.2020 pylon version has been switched to V 6.1
 sma : 06.03.2020 camera class has been switched to CBaslerUniversalInstantCamera but not all code lines rewritten. In future you profit from the advantage of CBaslerUniversalInstantCamera for sure.
+iei : 06.08.2020 add support for additional camera properties; initialize camera by serial number
 
 */
 
@@ -572,8 +573,7 @@ int BaslerCamera::Initialize()
 		 }
 
 
-		////Shutter mode//////
-	
+		////Shutter mode//////	
 		CEnumerationPtr shutterMode( nodeMap_->GetNode( "ShutterMode"));
 		if(IsAvailable(shutterMode))
 		{

--- a/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
@@ -304,9 +304,11 @@ int BaslerCamera::Initialize()
 		//Sensor size
 		nodeMap_ = &camera_->GetNodeMap();
 		const CIntegerPtr width = nodeMap_->GetNode("Width");
-		maxWidth_ = (unsigned int) width->GetMax();
+		// maxWidth_ = (unsigned int) width->GetMax();
+		maxWidth_ = (unsigned int) CIntegerPtr(nodeMap_->GetNode("WidthMax"))->GetValue();
 		const CIntegerPtr height = nodeMap_->GetNode("Height");
-		maxHeight_ = (unsigned int) height->GetMax();
+		// maxHeight_ = (unsigned int) height->GetMax();
+		maxHeight_ = (unsigned int) CIntegerPtr(nodeMap_->GetNode("HeightMax"))->GetValue();
 
 
 		if(IsAvailable(width))

--- a/DeviceAdapters/Basler/BaslerPylon6Camera.h
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.h
@@ -44,16 +44,16 @@
 #include <iostream>
 
 
-
-
-
-
-
 //////////////////////////////////////////////////////////////////////////////
 // Error codes
 //
 //#define ERR_UNKNOWN_BINNING_MODE 410
-
+enum
+{
+	ERR_SERIAL_NUMBER_REQUIRED = 20001,
+	ERR_SERIAL_NUMBER_NOT_FOUND,
+	ERR_CANNOT_CONNECT,
+};
 
 //////////////////////////////////////////////////////////////////////////////
 // Basler USB Ace camera class

--- a/DeviceAdapters/Basler/BaslerPylon6Camera.h
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.h
@@ -139,6 +139,12 @@ public:
 	int OnTriggerMode(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnAutoGain(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnAutoExpore(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnTemperature(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnTemperatureStatus(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnReverseX(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnReverseY(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnAcqFramerateEnable(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnAcqFramerate(MM::PropertyBase* pProp, MM::ActionType eAct);
 	
 
 private:
@@ -154,6 +160,8 @@ private:
 	double exposure_us_, exposureMax_, exposureMin_;
 	double gain_, gainMax_, gainMin_;
 	double offset_, offsetMin_, offsetMax_;
+	double temperature_;
+	double acqFramerate_, acqFramerateMax_, acqFramerateMin_;
 	int64_t DeviceLinkThroughputLimit_;
 	int64_t InterPacketDelay_;
 	
@@ -161,6 +169,9 @@ private:
 	std::string binningFactor_;
 	std::string sensorReadoutMode_;
 	std::string shutterMode_;
+	std::string setAcqFrm_;
+	std::string temperatureStatus_;
+	std::string reverseX_, reverseY_;
 	void* imgBuffer_;
 	long imgBufferSize_;
 	ImgBuffer img_;


### PR DESCRIPTION
Exposed additional camera properties: Temperature, TemperatureStatus, ReverseX, ReverseY, AcquisitionFrameRate, AcquisitionFramerateEnable

Renamed ExternalTrigger property to TriggerMode for consistency with Pylon API

Added initialization by serial number. This part is with help from @marktsuchida 

