### PR TITLE
Navigation code functional again

### DIFF
--- a/Tutorial/Tutorial4/Tutorial4.java
+++ b/Tutorial/Tutorial4/Tutorial4.java
@@ -1,3 +1,7 @@
+import mmcorej.CMMCore;
+import mmcorej.StrVector;
+import mmcorej.Configuration;
+import mmcorej.PropertySetting;
 
 public class Tutorial4 {
    

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -972,8 +972,8 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       isClickToMoveEnabled_ = isEnabled;
       if (isEnabled) {
          IJ.setTool(Toolbar.HAND);
-         mmMenuBar_.getToolsMenu().setMouseMovesStage(isEnabled);
       }
+      mmMenuBar_.getToolsMenu().setMouseMovesStage(isEnabled);
       events().post(new MouseMovesStageStateChangeEvent(isEnabled));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -530,6 +530,7 @@ public final class MainFrame extends MMFrame {
          boolean isSelected = handMovesButton_.isSelected();
          mmStudio_.updateCenterAndDragListener(isSelected);
       });
+      setHandMovesButton(mmStudio_.getMMMenubar().getToolsMenu().getMouseMovesStage());
       stagePanel.add(handMovesButton_, SMALLBUTTON_SIZE);
 
       AbstractButton listButton = createButton(null, "application_view_list.png",
@@ -677,10 +678,14 @@ public final class MainFrame extends MMFrame {
 
    @Subscribe
    public void onMouseMovesStage(MouseMovesStageStateChangeEvent event) {
-      String path = event.getIsEnabled() ? "move_hand_on.png" : "move_hand.png";
+      setHandMovesButton(event.getIsEnabled());
+   }
+
+   private void setHandMovesButton(boolean state) {
+      String icon = state ? "move_hand_on.png" : "move_hand.png";
       handMovesButton_.setIcon(IconLoader.getIcon(
-              "/org/micromanager/icons/" + path));
-      handMovesButton_.setSelected(event.getIsEnabled());
+              "/org/micromanager/icons/" + icon));
+      handMovesButton_.setSelected(state);
    }
 
    @Subscribe

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
@@ -84,12 +84,16 @@ public final class ToolsMenu {
               "Mouse Moves Stage (Use Hand Tool)",
               "When enabled, double clicking or dragging in the snap/live\n"
               + "window moves the XY-stage. Requires the hand tool.", () -> {
-                 mmStudio_.updateCenterAndDragListener(
-                         centerAndDragMenuItem_.isSelected());
+                 boolean state = centerAndDragMenuItem_.isSelected();
+                 mmStudio_.updateCenterAndDragListener(state);
+                 String icon = state ? "move_hand_on.png" : "move_hand.png";
+                 centerAndDragMenuItem_.setIcon(IconLoader.getIcon(
+                         "/org/micromanager/icons/" + icon));
               },
-              getMouseMovesStage());
-      centerAndDragMenuItem_.setIcon(
-              IconLoader.getIcon("/org/micromanager/icons/move_hand.png"));
+              getMouseMovesStage() );
+      String icon = getMouseMovesStage() ? "move_hand_on.png" : "move_hand.png";
+      centerAndDragMenuItem_.setIcon(IconLoader.getIcon(
+              "/org/micromanager/icons/" + icon));
 
       GUIUtils.addMenuItem(toolsMenu_, "Stage Position List...",
               "Open the stage position list window", () -> {
@@ -189,6 +193,9 @@ public final class ToolsMenu {
 
    @Subscribe
    public void onMouseMovesStage(MouseMovesStageStateChangeEvent event) {
+      String icon = event.getIsEnabled() ? "move_hand_on.png" : "move_hand.png";
+      centerAndDragMenuItem_.setIcon(IconLoader.getIcon(
+              "/org/micromanager/icons/" + icon));
       centerAndDragMenuItem_.setSelected(event.getIsEnabled());
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
@@ -28,7 +28,6 @@ public final class ToolsMenu {
 
    private static final String MOUSE_MOVES_STAGE = "whether or not the hand tool can be used to move the stage";
 
-   private final JMenu toolsMenu_;
    private final JMenu quickAccessMenu_;
    private JCheckBoxMenuItem centerAndDragMenuItem_;
 
@@ -41,7 +40,7 @@ public final class ToolsMenu {
       core_ = mmStudio_.core();
       quickAccessMenu_ = new JMenu("Quick Access Panels");
 
-      toolsMenu_ = GUIUtils.createMenuInMenuBar(menuBar, "Tools");
+      JMenu toolsMenu_ = GUIUtils.createMenuInMenuBar(menuBar, "Tools");
 
       GUIUtils.addMenuItem(toolsMenu_, "Refresh GUI",
               "Refresh all GUI controls directly from the hardware", () -> {
@@ -53,31 +52,26 @@ public final class ToolsMenu {
       toolsMenu_.addSeparator();
 
       GUIUtils.addMenuItem(toolsMenu_, "Script Panel...",
-              "Open Micro-Manager script editor window", () -> {
-                 mmStudio_.showScriptPanel();
-              });
+              "Open Micro-Manager script editor window",
+              mmStudio_::showScriptPanel);
 
       populateQuickAccessMenu();
       toolsMenu_.add(quickAccessMenu_);
 
       GUIUtils.addMenuItem(toolsMenu_, "Shortcuts...",
               "Create keyboard shortcuts to activate image acquisition, mark positions, or run custom scripts",
-              () -> {
-                 HotKeysDialog hk = new HotKeysDialog();
-              });
+              HotKeysDialog::new);
 
       GUIUtils.addMenuItem(toolsMenu_, "Messages...",
-              "Show the Messages window", () -> {
-                 ((DefaultAlertManager) mmStudio_.alerts()).alertsWindow().showWithoutFocus();
-              },
+              "Show the Messages window", () -> ((DefaultAlertManager)
+                      mmStudio_.alerts()).alertsWindow().showWithoutFocus(),
               "bell.png");
 
       toolsMenu_.addSeparator();
 
       GUIUtils.addMenuItem(toolsMenu_, "Stage Control...",
-              "Control the stage position with a virtual joystick", () -> {
-                 StageControlFrame.showStageControl(mmStudio_);
-              },
+              "Control the stage position with a virtual joystick",
+               () -> StageControlFrame.showStageControl(mmStudio_),
               "move.png");
 
       centerAndDragMenuItem_ = GUIUtils.addCheckBoxMenuItem(toolsMenu_,
@@ -96,17 +90,15 @@ public final class ToolsMenu {
               "/org/micromanager/icons/" + icon));
 
       GUIUtils.addMenuItem(toolsMenu_, "Stage Position List...",
-              "Open the stage position list window", () -> {
-                 mmStudio_.app().showPositionList();
-              },
+              "Open the stage position list window",
+              () -> mmStudio_.app().showPositionList(),
               "application_view_list.png");
 
       toolsMenu_.addSeparator();
 
       GUIUtils.addMenuItem(toolsMenu_, "Multi-Dimensional Acquisition...",
-              "Open multi-dimensional acquisition setup window", () -> {
-                 mmStudio_.openAcqControlDialog();
-              },
+              "Open multi-dimensional acquisition setup window",
+              mmStudio_::openAcqControlDialog,
               "film.png");
 
       toolsMenu_.addSeparator();
@@ -134,9 +126,8 @@ public final class ToolsMenu {
    private void populateQuickAccessMenu() {
       quickAccessMenu_.removeAll();
       GUIUtils.addMenuItem(quickAccessMenu_, "Create New Panel",
-              "Create a new Quick Access Panel, for easy access to commonly-used controls.", () -> {
-                 ((DefaultQuickAccessManager) mmStudio_.quickAccess()).createNewPanel();
-              });
+              "Create a new Quick Access Panel, for easy access to commonly-used controls.",
+              () -> ((DefaultQuickAccessManager) mmStudio_.quickAccess()).createNewPanel());
 
       final Map<String, JFrame> titleToFrame = mmStudio_.quickAccess().getPanels();
       ArrayList<String> titles = new ArrayList<>(titleToFrame.keySet());
@@ -145,23 +136,20 @@ public final class ToolsMenu {
       JMenu deleteMenu = new JMenu("Delete...");
       deleteMenu.setEnabled(titles.size() > 0);
       for (final String title : titles) {
-         GUIUtils.addMenuItem(deleteMenu, title, "Delete this panel", () -> {
-            ((DefaultQuickAccessManager) mmStudio_.quickAccess()).promptToDelete(
-                    titleToFrame.get(title));
-         });
+         GUIUtils.addMenuItem(deleteMenu, title, "Delete this panel",
+                 () -> ((DefaultQuickAccessManager)
+                         mmStudio_.quickAccess()).promptToDelete(titleToFrame.get(title)));
       }
       quickAccessMenu_.add(deleteMenu);
       quickAccessMenu_.addSeparator();
       JMenuItem show = GUIUtils.addMenuItem(quickAccessMenu_, "Show all",
-              "Show all Quick Access Panels; create a new one if necessary", () -> {
-                 mmStudio_.quickAccess().showPanels();
-              });
+              "Show all Quick Access Panels; create a new one if necessary",
+              () -> mmStudio_.quickAccess().showPanels());
       show.setEnabled(titles.size() > 0);
 
       for (final String title : titles) {
-         GUIUtils.addMenuItem(quickAccessMenu_, title, "", () -> {
-            titleToFrame.get(title).setVisible(true);
-         });
+         GUIUtils.addMenuItem(quickAccessMenu_, title, "",
+                 () -> titleToFrame.get(title).setVisible(true));
       }
 
       quickAccessMenu_.addSeparator();

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/CenterAndDragListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/CenterAndDragListener.java
@@ -26,7 +26,6 @@ import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import org.micromanager.Studio;
 import org.micromanager.display.internal.event.DisplayMouseEvent;
-import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
 
 /**
  * @author OD, nico
@@ -36,13 +35,11 @@ public final class CenterAndDragListener  {
 
    private final Studio studio_;
    private final XYNavigator xyNavigator_;
-   private boolean active_;
    private int lastX_, lastY_;
 
    public CenterAndDragListener(final Studio studio, final XYNavigator xyNavigator) {
       studio_ = studio;
       xyNavigator_ = xyNavigator;
-      active_ = false;
    }
    
 
@@ -56,9 +53,6 @@ public final class CenterAndDragListener  {
     */
    @Subscribe
    public void onDisplayMouseEvent(DisplayMouseEvent dme) {
-      if (!active_) {
-         return;
-      }
       // only take action when the users selected the Hand tool
       if (dme.getToolId() != ij.gui.Toolbar.HAND) {
          return;
@@ -111,11 +105,6 @@ public final class CenterAndDragListener  {
 
             break;
       }
-   }
-
-   @Subscribe
-   public void onActiveChange (MouseMovesStageStateChangeEvent mouseMovesStageStateChangeEvent) {
-       active_ = mouseMovesStageStateChangeEvent.getIsEnabled();
    }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/CenterAndDragListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/CenterAndDragListener.java
@@ -35,7 +35,7 @@ import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
 public final class CenterAndDragListener  {
 
    private final Studio studio_;
-   private XYNavigator xyNavigator_;
+   private final XYNavigator xyNavigator_;
    private boolean active_;
    private int lastX_, lastY_;
 
@@ -115,11 +115,7 @@ public final class CenterAndDragListener  {
 
    @Subscribe
    public void onActiveChange (MouseMovesStageStateChangeEvent mouseMovesStageStateChangeEvent) {
-      if (mouseMovesStageStateChangeEvent.getIsEnabled()) {
-         active_ = true;
-      } else {
-         active_ = false;
-      }
+       active_ = mouseMovesStageStateChangeEvent.getIsEnabled();
    }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/UiMovesStageManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/UiMovesStageManager.java
@@ -55,6 +55,7 @@ public final class UiMovesStageManager {
     * @param display Display to which we will listen for events
     */
    public void activate(final DisplayController display) {
+      deActivate(display); // ensure that there will always be only one listener per display
       CenterAndDragListener dragListener = null;
       ZWheelListener wheelListener = null;
       XYZKeyListener keyListener = null;

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/UiMovesStageManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/UiMovesStageManager.java
@@ -25,7 +25,6 @@ import org.micromanager.Studio;
 import org.micromanager.display.DataViewer;
 import org.micromanager.display.internal.displaywindow.DisplayController;
 import org.micromanager.display.internal.event.DataViewerWillCloseEvent;
-import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
 import org.micromanager.internal.MMStudio;
 
 /**

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
@@ -22,7 +22,6 @@ import com.google.common.eventbus.Subscribe;
 import mmcorej.CMMCore;
 import org.micromanager.Studio;
 import org.micromanager.display.internal.event.DisplayKeyPressEvent;
-import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 import java.awt.event.KeyEvent;

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
@@ -45,7 +45,6 @@ public final class XYZKeyListener  {
 	double[] xMovesMicron_;
 	double[] yMovesMicron_;
 	double[] zMovesMicron_;
-	private boolean active_;
 
 	/**
 	 * The XYZKeyListener receives settings from the StageControl plugin
@@ -73,17 +72,12 @@ public final class XYZKeyListener  {
        yMovesMicron_ = new double[] {1.0, core_.getImageHeight() / 4, core_.getImageHeight()};
        zMovesMicron_ = new double[] {1.0, 10.0};
 
-       active_ = false;
-
        settings_ = studio.profile().getSettings(
        		org.micromanager.internal.dialogs.StageControlFrame.class);
 	}
 
 	@Subscribe
 	public void keyPressed(DisplayKeyPressEvent dkpe) {
-		if (!active_) {
-			return;
-		}
 		KeyEvent e = dkpe.getKeyEvent();
 		boolean consumed = false;
 		for (int i = 0; i < xMovesMicron_.length; ++i) {
@@ -164,15 +158,6 @@ public final class XYZKeyListener  {
 			return;
 
 		zNavigator_.setPosition(zStage, micron);
-	}
-
-	@Subscribe
-	public void onActiveChange (MouseMovesStageStateChangeEvent mouseMovesStageStateChangeEvent) {
-		if (mouseMovesStageStateChangeEvent.getIsEnabled()) {
-			active_ = true;
-		} else {
-			active_ = false;
-		}
 	}
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/ZWheelListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/ZWheelListener.java
@@ -23,7 +23,6 @@ package org.micromanager.internal.navigation;
 import com.google.common.eventbus.Subscribe;
 import org.micromanager.Studio;
 import org.micromanager.display.internal.event.DisplayMouseWheelEvent;
-import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
 
 /**
 */
@@ -31,12 +30,10 @@ public final class ZWheelListener  {
    private static final double MOVE_INCREMENT = 0.20;
    private final Studio studio_;
    private final ZNavigator zNavigator_;
-   private boolean active_;
 
    public ZWheelListener(final Studio studio, final ZNavigator zNavigator) {
       studio_ = studio;
       zNavigator_ = zNavigator;
-      active_ = false;
    }
    
 
@@ -50,9 +47,6 @@ public final class ZWheelListener  {
     */
    @Subscribe
    public void mouseWheelMoved(DisplayMouseWheelEvent e) {
-      if (!active_) {
-         return;
-      }
       synchronized (this) {
          // Get needed info from core
          String zStage = studio_.core().getFocusDevice();
@@ -73,9 +67,5 @@ public final class ZWheelListener  {
       }
    }
 
-   @Subscribe
-   public void onActiveChange (MouseMovesStageStateChangeEvent mouseMovesStageStateChangeEvent) {
-       active_ = mouseMovesStageStateChangeEvent.getIsEnabled();
-   }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/ZWheelListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/ZWheelListener.java
@@ -21,22 +21,16 @@
 package org.micromanager.internal.navigation;
 
 import com.google.common.eventbus.Subscribe;
-import com.google.common.util.concurrent.AtomicDouble;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import org.micromanager.Studio;
 import org.micromanager.display.internal.event.DisplayMouseWheelEvent;
-import org.micromanager.events.StagePositionChangedEvent;
-import org.micromanager.events.internal.DefaultEventManager;
 import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
-import org.micromanager.internal.utils.ReportingUtils;
 
 /**
 */
 public final class ZWheelListener  {
    private static final double MOVE_INCREMENT = 0.20;
    private final Studio studio_;
-   private ZNavigator zNavigator_;
+   private final ZNavigator zNavigator_;
    private boolean active_;
 
    public ZWheelListener(final Studio studio, final ZNavigator zNavigator) {
@@ -81,11 +75,7 @@ public final class ZWheelListener  {
 
    @Subscribe
    public void onActiveChange (MouseMovesStageStateChangeEvent mouseMovesStageStateChangeEvent) {
-      if (mouseMovesStageStateChangeEvent.getIsEnabled()) {
-         active_ = true;
-      } else {
-         active_ = false;
-      }
+       active_ = mouseMovesStageStateChangeEvent.getIsEnabled();
    }
 
 }


### PR DESCRIPTION
Main issue was that a manager and the listeners themselves were listening for changes in mousemovesstage state.  Now, the listeners are always active, and the manager removes listeners when mousemovesstage is switched off, and creates new ones when it is switched on. Tutorial code missing imports slipped in as well.