### PR TITLE
Studio: Fixes bug in remembering Channel Exposures.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -902,10 +902,12 @@ public final class AcqControlDlg extends MMFrame implements PropertyChangeListen
          try {
             String channelGroup = mmStudio_.core().getChannelGroup();
             String channel = mmStudio_.core().getCurrentConfig(channelGroup);
-            double exposure = model_.getChannelExposureTime(
-                  channelGroup, channel, 10.0);
-            mmStudio_.app().setChannelExposureTime(channelGroup, channel,
-                  exposure);
+            if (model_.hasChannel(channelGroup, channel)) {
+               double exposure = model_.getChannelExposureTime(
+                       channelGroup, channel, 10.0);
+               mmStudio_.app().setChannelExposureTime(channelGroup, channel,
+                       exposure);
+            }
          }
          catch (Exception e) {
             mmStudio_.logs().logError(e, "Error getting channel exposure time");

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -333,6 +333,19 @@ public final class ChannelTableModel extends AbstractTableModel  {
       }
    }
 
+   public boolean hasChannel(String channelGroup, String channel) {
+      if (!channelGroup.equals(acqEng_.getChannelGroup())) {
+         return false;
+      }
+      for (int row = 0; row < channels_.size(); row++) {
+         ChannelSpec cs = channels_.get(row);
+         if (cs.config().equals(channel)) {
+            return true;
+         }
+      }
+      return false;
+   }
+
    /**
     * Returns the exposure time of the given preset
     *


### PR DESCRIPTION
When setting the channel exposure for a channel that is not listed in the
MDA window, the code would previously set the exposure for that channel
back to the default.  This change ensures that the AcqEngine will not
touch the exposures of channels it has no knowledge about.
In general, the channel exposure code is still complicated, and the
GUI code goes through the same function many times.  This may be another
example of the complexity of the GUI code and the use of multple similar
mechanisms for the same purpose.  Complete refactoring is desirable, but
currently out of the scope of the achievable.