### PR TITLE
Studio: Attempt to deal with MouseDisplayInfo bug.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/Coords.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Coords.java
@@ -337,6 +337,10 @@ public interface Coords {
    @Deprecated
    public boolean matches(Coords alt);
 
+   /**
+    * Provides a Builder pre-loaded with a copy of this Coords
+    * @return copyBuilder
+    */
    public Builder copyBuilder();
 
    /**
@@ -346,6 +350,21 @@ public interface Coords {
    @Deprecated
    public CoordsBuilder copy();
 
+
+   /**
+    * Removes the axes provided as varargs from this Coord
+    * @param axes One or more Strings naming the axes to be removed
+    * @return COpy of this Coords without the listed axes
+    */
    Coords copyRemovingAxes(String... axes);
+
+   /**
+    * Name of this function is very unclear.  It seems that its functionality is
+    * to provide a copy of the given Coords, but only for the axes provided
+    * in the input strings.
+    * A more useful name may be: copyProvidedAxes, or copyAxes
+    * @param axes Names of axes to be represented in the output
+    * @return Copy of this Coords, but only with the subset of axes provided in the axes param
+    */
    Coords copyRetainingAxes(String... axes);
 }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultCoords.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultCoords.java
@@ -208,7 +208,7 @@ public final class DefaultCoords implements Coords {
    @Override
    public Coords copyRetainingAxes(String... axes) {
       Builder b = new Builder();
-      for (String axis : getAxes()) {
+      for (String axis : axes_) {
          if (ArrayUtils.contains(axes, axis)) {
             b.index(axis, getIndex(axis));
          }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1455,7 +1455,11 @@ public final class DisplayUIController implements Closeable, WindowListener,
                fromAxesAndImages(center.x, center.y,
                      new String[] { Coords.CHANNEL }, images));
          } catch (IllegalArgumentException iea) {
-            ReportingUtils.logError(iea);
+            String coordString = "";
+            for (Image img : images) {
+               coordString += img.getCoords().toString() + " ";
+            }
+            ReportingUtils.logError("Request to display mousePixel Info failed for these images : " + coordString);
             displayController_.postDisplayEvent(
                DataViewerMousePixelInfoChangedEvent.createUnavailable());
          }


### PR DESCRIPTION
Occassionally, the Precheck Condition at: org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEvent.<init>(DataViewerMousePixelInfoChangedEvent.java:96) fails.  It is unclear why, or how to reproduce that situation, but I suspect that it leads to crashes when users leave the mouse in the display window during long acquisitions.  This change no longer produces the complete stacktrace in the output, but instead logs the offending Coords (which is more useful information at this point). Hopefully this will also avoid crashes, and can help to pinpoint the underlying bug that cause this problem.
In addition some Javadoc was added to Coords, and an unnecessary copy in DefaultsCoords was removed.