### PR TITLE
BaslerAce: Changed project name and added TriggerSource property

### DIFF
--- a/DeviceAdapters/Basler/BaslerPylon6.vcxproj
+++ b/DeviceAdapters/Basler/BaslerPylon6.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{bd5dd57f-a092-4441-ba35-5b0701c7cce5}</ProjectGuid>
     <RootNamespace>Basler</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <ProjectName>BaslerPylon6</ProjectName>
+    <ProjectName>BaslerPylon</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
@@ -1202,7 +1202,6 @@ int BaslerCamera::OnHeight(MM::PropertyBase* pProp, MM::ActionType eAct)
 		try{
 			if(IsAvailable(Height) )
 				{
-               binningFactor_ = CDeviceUtils::ConvertToString ((long)Height->GetValue());
 					pProp->Set((long)Height->GetValue());	
 				}	
 		}
@@ -1258,7 +1257,6 @@ int BaslerCamera::OnWidth(MM::PropertyBase* pProp, MM::ActionType eAct)
 		try{
 			if(IsAvailable(Width) )
 				{
-               binningFactor_ = CDeviceUtils::ConvertToString ((long) Width->GetValue());
 					pProp->Set((long)Width->GetValue());	
 				}	
 		}

--- a/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
@@ -47,6 +47,7 @@ sma : 22.05.2019 prepared for Mac build
 sma : 06.03.2020 pylon version has been switched to V 6.1
 sma : 06.03.2020 camera class has been switched to CBaslerUniversalInstantCamera but not all code lines rewritten. In future you profit from the advantage of CBaslerUniversalInstantCamera for sure.
 iei : 06.08.2020 add support for additional camera properties; initialize camera by serial number
+iei : 06.18.2020 added trigger source property, removign hardcoded Line 1; fixed bug with binnigFactor
 
 */
 

--- a/DeviceAdapters/Basler/BaslerPylon6Camera.h
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.h
@@ -145,6 +145,7 @@ public:
 	int OnReverseY(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnAcqFramerateEnable(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnAcqFramerate(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnTriggerSource(MM::PropertyBase* pProp, MM::ActionType eAct);
 	
 
 private:

--- a/DeviceAdapters/Basler/BaslerPylon6Camera.h
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.h
@@ -140,7 +140,7 @@ public:
 	int OnAutoGain(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnAutoExpore(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnTemperature(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnTemperatureStatus(MM::PropertyBase* pProp, MM::ActionType eAct);
+	int OnTemperatureState(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnReverseX(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnReverseY(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnAcqFramerateEnable(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -171,7 +171,7 @@ private:
 	std::string sensorReadoutMode_;
 	std::string shutterMode_;
 	std::string setAcqFrm_;
-	std::string temperatureStatus_;
+	std::string temperatureState_;
 	std::string reverseX_, reverseY_;
 	void* imgBuffer_;
 	long imgBufferSize_;

--- a/micromanager.sln
+++ b/micromanager.sln
@@ -418,7 +418,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChuoSeiki_MD5000", "DeviceA
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChuoSeiki_QT", "DeviceAdapters\ChuoSeiki_QT\ChuoSeiki_QT.vcxproj", "{474D32D8-5BEC-453B-ADEA-ACF6F742DE0D}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BaslerPylon6", "DeviceAdapters\Basler\BaslerPylon6.vcxproj", "{BD5DD57F-A092-4441-BA35-5B0701C7CCE5}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BaslerPylon", "DeviceAdapters\Basler\BaslerPylon6.vcxproj", "{BD5DD57F-A092-4441-BA35-5B0701C7CCE5}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "VarispecLCTF", "DeviceAdapters\VarispecLCTF\VarispecLCTF.vcxproj", "{DFA5AB7B-A917-44BB-AB76-6AB1AECFADC8}"
 EndProject


### PR DESCRIPTION
* Changed BaslerAce device adapter to omit Pylon version
* Added TriggerSource property and removed hardcoded Line1 value. 
   * Trigger settings such as TriggerSelector, TriggerActivation, TriggerDelay and Line settings such as LineMode, LineSource, LineInverter, still need to be configured externally, e.g. in Pylon Viewer
* Fixed bug with binningFactor being taken from image Width and Height
* Renamed  TemperatureStatus to TemperatureState and fixed value enumeration