### PR TITLE
Showing a DisplayWindow uncoupled from its creation

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/DisplayWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayWindow.java
@@ -321,4 +321,10 @@ public interface DisplayWindow extends DataViewer, Closeable {
     * default
     */
    public void setCustomTitle(String title);
+
+   /**
+    * DisplayWindows are not shown by default.  Call this function after
+    * construction, and after attaching listeners as needed, to show the Window.
+    */
+   void show();
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -256,8 +256,9 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    @Override
    public DisplayWindow createDisplay(DataProvider provider) {
       DisplayWindow ret = new DisplayController.Builder(provider).
-            linkManager(linkManager_).shouldShow(true).build(studio_);
+            linkManager(linkManager_).build(studio_);
       addViewer(ret);
+      ret.show();
       return ret;
    }
 
@@ -266,9 +267,9 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
          DisplayWindowControlsFactory factory)
    {
       DisplayWindow ret = new DisplayController.Builder(provider).
-            linkManager(linkManager_).shouldShow(true).
-            controlsFactory(factory).build(studio_);
+            linkManager(linkManager_).controlsFactory(factory).build(studio_);
       addViewer(ret);
+      ret.show();
       return ret;
    }
 
@@ -356,10 +357,11 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
          // instead of using the createDisplay function, set the correct 
          // displaySettings right away
          DisplayWindow tmp = new DisplayController.Builder(store).
-            linkManager(linkManager_).shouldShow(true).
+            linkManager(linkManager_).
                  initialDisplaySettings(displaySettings).build(studio_);
          addViewer(tmp);
          result.add(tmp);
+         tmp.show();
       }
       if (result.isEmpty()) {
          // No path, or no display settings at the path.  Just create a blank

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
@@ -162,8 +162,7 @@ public final class DisplayController extends DisplayWindowAPIAdapter
    public static class Builder {
       private DataProvider dataProvider_;
       private DisplaySettings displaySettings_;
-      private LinkManager linkManager_ = DefaultLinkManager.create();;
-      private boolean shouldShow_;
+      private LinkManager linkManager_ = DefaultLinkManager.create();
       private DisplayWindowControlsFactory controlsFactory_;
 
       public Builder(DataProvider dataProvider)
@@ -187,11 +186,6 @@ public final class DisplayController extends DisplayWindowAPIAdapter
 
       public Builder linkManager(LinkManager manager) {
          linkManager_ = manager;
-         return this;
-      }
-
-      public Builder shouldShow(boolean flag) {
-         shouldShow_ = flag;
          return this;
       }
 
@@ -226,15 +220,6 @@ public final class DisplayController extends DisplayWindowAPIAdapter
       instance.initialize();
 
       instance.computeQueue_.addListener(instance);
-
-      if (builder.shouldShow_) {
-         // Show the window in a later event handler in order to give the
-         // calling code a chance to register for events.
-         SwingUtilities.invokeLater(() -> {
-            instance.setFrameVisible(true);
-            instance.toFront();
-         });
-      }
 
       if (instance.dataProvider_.getNumImages() > 0) {
          Coords.Builder b = Coordinates.builder();
@@ -313,6 +298,12 @@ public final class DisplayController extends DisplayWindowAPIAdapter
 
    void frameDidBecomeActive() {
       postEvent(DataViewerDidBecomeActiveEvent.create(this));
+   }
+
+   @Override
+   public void show() {
+      setFrameVisible(true);
+      toFront();
    }
 
 

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -474,8 +474,7 @@ public final class SnapLiveManager extends DataViewerListener
       DisplayWindowControlsFactory controlsFactory = 
               (DisplayWindow display) -> createControls();
       display_ = new DisplayController.Builder(store_).
-            controlsFactory(controlsFactory).
-            shouldShow(true).build(mmStudio_);
+            controlsFactory(controlsFactory).build(mmStudio_);
       DisplaySettings ds = DefaultDisplaySettings.restoreFromProfile(
               mmStudio_.profile(), 
               PropertyKey.SNAP_LIVE_DISPLAY_SETTINGS.key() );
@@ -500,6 +499,7 @@ public final class SnapLiveManager extends DataViewerListener
       if (mmStudio_.getMMMenubar().getToolsMenu().getMouseMovesStage() && display_ != null) {
          uiMovesStageManager_.activate(display_);
       }
+      display_.show();
       
       synchronized (lastImageForEachChannel_) {
          lastImageForEachChannel_.clear();

--- a/plugins/ChannelCorrector/src/main/java/org/micromanager/channelcorrector/ChannelCorrectorFrame.java
+++ b/plugins/ChannelCorrector/src/main/java/org/micromanager/channelcorrector/ChannelCorrectorFrame.java
@@ -125,6 +125,7 @@ public class ChannelCorrectorFrame extends JFrame {
                super.remove(ccp);
             }
             channelCorrectorPanels_.clear();
+            super.pack();
          }
       }
    }


### PR DESCRIPTION
Studio: DisplayWindow no longer shows itself. This lead to subtle bugs that were anticipated by the previous author.  A displaywindow showing itself during creation would create a number of events that other behavior relies on.  However, since other code can only register for events after creation, these events were missed.  The previous work-around was to put the code showing the Window in an EDT-InvokeLater call, with the explicit hope that other code would register itself before the window was actually shown.  Of course, this wouldwork sometimes, and not other times. This PR no longer shows the DisplayWindow during creation.  Instread, there is an API call show() that needs to be called by the calling code after registering for events.
