### PR TITLE
Fixes MDA Summary and ZProjector metadata

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -241,7 +241,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
              }
          }
       }
-      return nrImages;
+      return nrImages * getNumPositions();
    }
 
    public long getTotalMemory() {


### PR DESCRIPTION
MDA Summary now takes multiple positions into calculation of nr. of images and Dataset size.
ZProjector now uses metadata of the first image in the projection rather than a random image in the input dataset.