### PR TITLE
When MMstudio is started with a profile name startup argument, make sure to apply the correct skin for the profile.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -384,6 +384,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
                 if (name.equals(profileNameAutoStart)){
                     UserProfile profile = profileAdmin.getNonSavingProfile(entry.getKey());
                     profileAdmin.setCurrentUserProfile(entry.getKey());
+                    daytimeNighttimeManager_.setSkin(daytimeNighttimeManager_.getSkin());
                     sysConfigFile_ = HardwareConfigurationManager.getRecentlyUsedConfigFilesFromProfile(profile).get(0);
                     break;
                 }


### PR DESCRIPTION
This PR applies a treatment similar to 9ee975aaeadbccd2924152faf8f6d90617bed880 for when MMStudio is started using a `profileNameAutoStart` startup argument.

Previously user profiles that wanted to use the "Day" skin would cause the UI to load improperly when the startup argument was used, now it works as expected.