### PR TITLE
ChannelCorrector: Switch to nearest neighbor interpolation,

### DIFF
--- a/plugins/ChannelCorrector/src/main/java/org/micromanager/channelcorrector/ChannelCorrectorFrame.java
+++ b/plugins/ChannelCorrector/src/main/java/org/micromanager/channelcorrector/ChannelCorrectorFrame.java
@@ -164,8 +164,9 @@ public class ChannelCorrectorFrame extends JFrame {
       for (ChannelCorrectorPanel ccp : channelCorrectorPanels_) {
          affineTransforms.add(ccp.getAffineTransform());
       }
+      // Note that types other than Nearest Neighbor lead to strange pixel values
       ImageAffineTransform iat = new ImageAffineTransform(studio_, dataViewer_,
-              affineTransforms, AffineTransformOp.TYPE_BICUBIC);
+              affineTransforms, AffineTransformOp.TYPE_NEAREST_NEIGHBOR);
       iat.apply(settings_.getBoolean(USE_ALL_POS_KEY, false));
       studio_.alerts().postAlert("ChannelCorrector", this.getClass(),
               "Finished correcting " + dataViewerName);

--- a/plugins/ChannelCorrector/src/main/java/org/micromanager/channelcorrector/utils/ImageAffineTransform.java
+++ b/plugins/ChannelCorrector/src/main/java/org/micromanager/channelcorrector/utils/ImageAffineTransform.java
@@ -190,11 +190,14 @@ public class ImageAffineTransform {
       BufferedImage bi16 = testProc.get16BitBufferedImage();
       BufferedImage aOpResult = new BufferedImage(bi16.getWidth(),
               bi16.getHeight(), BufferedImage.TYPE_USHORT_GRAY);
+      aOp.filter(bi16, aOpResult);
       if (interpolationType_ == AffineTransformOp.TYPE_NEAREST_NEIGHBOR) {
          aOp.filter(bi16, aOpResult);
       } else {
          // work around bug in AffineTransformationOp, see:
          // http://stackoverflow.com/questions/2428109/java-error-on-bilinear-interpolation-of-16-bit-data
+         // Note: although the image looks alright, histogram values are strangely distorted
+         // presumably, since calculations are done with bytes rather than shorts
          Graphics2D g = aOpResult.createGraphics();
          g.transform(aOp.getTransform());
          g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, renderingHint_);


### PR DESCRIPTION
as Bicubic leads to weird grey scale distributions.
May need to switch to using BoofCV.