### PR TITLE
Pycro-manager-java to 0.8.9 to fix two small bugs

### DIFF
--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -51,7 +51,7 @@
 		<dependency org="org.micro-manager.ndtiffstorage" name="NDTiffStorage" rev="0.3.0">
          <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
       </dependency>
-		<dependency org="org.micro-manager.pycro-manager" name="PycroManagerJava" rev="0.8.8">
+		<dependency org="org.micro-manager.pycro-manager" name="PycroManagerJava" rev="0.8.9">
          <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
       </dependency>
 


### PR DESCRIPTION
 - exception when inspecting jar classpaths on windows
 - bug in translating calls to java