### PR TITLE
Check EDT for calling updateGUIFromSequenceSettings() to support multi-thread contexts

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1084,120 +1084,108 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    }
 
    private void updateGUIFromSequenceSettings(final SequenceSettings sequenceSettings) {
-      if (disableGUItoSettings_)
-      {
+      if (disableGUItoSettings_) {
          return;
       }
       disableGUItoSettings_ = true;
 
-      numFrames_.setValue( sequenceSettings.numFrames() );
-      timeUnitCombo_.setSelectedIndex( sequenceSettings.displayTimeUnit() );
-      interval_.setText( numberFormat_.format( convertMsToTime(
+      numFrames_.setValue(sequenceSettings.numFrames());
+      timeUnitCombo_.setSelectedIndex(sequenceSettings.displayTimeUnit());
+      interval_.setText(numberFormat_.format(convertMsToTime(
               sequenceSettings.intervalMs(),
-              timeUnitCombo_.getSelectedIndex() ) ) );
+              timeUnitCombo_.getSelectedIndex())));
 
       boolean framesEnabled = sequenceSettings.useFrames();
-      framesPanel_.setSelected( framesEnabled );
-      defaultTimesPanel_.setVisible( !framesEnabled );
-      customTimesPanel_.setVisible( framesEnabled );
+      framesPanel_.setSelected(framesEnabled);
+      defaultTimesPanel_.setVisible(!framesEnabled);
+      customTimesPanel_.setVisible(framesEnabled);
 
       boolean isCustom = sequenceSettings.useCustomIntervals();
-      defaultTimesPanel_.setVisible( !isCustom );
-      customTimesPanel_.setVisible( isCustom );
+      defaultTimesPanel_.setVisible(!isCustom);
+      customTimesPanel_.setVisible(isCustom);
 
-      positionsPanel_.setSelected( sequenceSettings.usePositionList() );
+      positionsPanel_.setSelected(sequenceSettings.usePositionList());
 
-      zBottom_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZBottomUm() ) );
-      zTop_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZTopUm() ) );
-      zStep_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZStepUm() ) );
-      zBottom_.setEnabled( sequenceSettings.useSlices() );
-      zTop_.setEnabled( sequenceSettings.useSlices() );
-      zStep_.setEnabled( sequenceSettings.useSlices() );
-      zValCombo_.setEnabled( sequenceSettings.useSlices() );
+      zBottom_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZBottomUm()));
+      zTop_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZTopUm()));
+      zStep_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZStepUm()));
+      zBottom_.setEnabled(sequenceSettings.useSlices());
+      zTop_.setEnabled(sequenceSettings.useSlices());
+      zStep_.setEnabled(sequenceSettings.useSlices());
+      zValCombo_.setEnabled(sequenceSettings.useSlices());
       zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
-      zValCombo_.setSelectedIndex( zRelativeAbsolute_ );
-      stackKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenSlices() );
-      slicesPanel_.setSelected( sequenceSettings.useSlices() );
+      zValCombo_.setSelectedIndex(zRelativeAbsolute_);
+      stackKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenSlices());
+      slicesPanel_.setSelected(sequenceSettings.useSlices());
 
-      afPanel_.setSelected( sequenceSettings.useAutofocus() );
+      afPanel_.setSelected(sequenceSettings.useAutofocus());
 
-      channelsPanel_.setSelected( sequenceSettings.useChannels() );
-      channelGroupCombo_.setSelectedItem( sequenceSettings.channelGroup() );
-      acqEng_.setChannelGroup( sequenceSettings.channelGroup() );
-      model_.setChannels( sequenceSettings.channels() );
+      channelsPanel_.setSelected(sequenceSettings.useChannels());
+      channelGroupCombo_.setSelectedItem(sequenceSettings.channelGroup());
+      acqEng_.setChannelGroup(sequenceSettings.channelGroup());
+      model_.setChannels(sequenceSettings.channels());
       model_.fireTableStructureChanged();
-      chanKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenChannels() );
-      channelTable_.setAutoResizeMode( JTable.AUTO_RESIZE_ALL_COLUMNS );
+      chanKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenChannels());
+      channelTable_.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
       boolean selected = channelsPanel_.isSelected();
-      channelTable_.setEnabled( selected );
-      channelTable_.getTableHeader().setForeground( selected ? Color.black : Color.gray );
+      channelTable_.setEnabled(selected);
+      channelTable_.getTableHeader().setForeground(selected ? Color.black : Color.gray);
 
-      for ( AcqOrderMode mode : acqOrderModes_ )
-      {
-         mode.setEnabled( framesPanel_.isSelected(), positionsPanel_.isSelected(),
-                 slicesPanel_.isSelected(), channelsPanel_.isSelected() );
+      for (AcqOrderMode mode : acqOrderModes_) {
+         mode.setEnabled(framesPanel_.isSelected(), positionsPanel_.isSelected(),
+                 slicesPanel_.isSelected(), channelsPanel_.isSelected());
       }
       // add correct acquisition order options
       int selectedIndex = sequenceSettings.acqOrderMode();
       acqOrderBox_.removeAllItems();
-      if ( framesPanel_.isSelected() && positionsPanel_.isSelected()
-              && slicesPanel_.isSelected() && channelsPanel_.isSelected() )
-      {
-         acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-         acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-         acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-         acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+      if (framesPanel_.isSelected() && positionsPanel_.isSelected()
+              && slicesPanel_.isSelected() && channelsPanel_.isSelected()) {
+         acqOrderBox_.addItem(acqOrderModes_[0]);
+         acqOrderBox_.addItem(acqOrderModes_[1]);
+         acqOrderBox_.addItem(acqOrderModes_[2]);
+         acqOrderBox_.addItem(acqOrderModes_[3]);
       }
-      else if ( framesPanel_.isSelected() && positionsPanel_.isSelected() )
-      {
-         if ( selectedIndex == 0 || selectedIndex == 2 )
-         {
-            acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-            acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+      else if (framesPanel_.isSelected() && positionsPanel_.isSelected()) {
+         if (selectedIndex == 0 || selectedIndex == 2) {
+            acqOrderBox_.addItem(acqOrderModes_[0]);
+            acqOrderBox_.addItem(acqOrderModes_[2]);
          }
-         else
-         {
-            acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-            acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+         else {
+            acqOrderBox_.addItem(acqOrderModes_[1]);
+            acqOrderBox_.addItem(acqOrderModes_[3]);
          }
       }
-      else if ( channelsPanel_.isSelected() && slicesPanel_.isSelected() )
-      {
-         if ( selectedIndex == 0 || selectedIndex == 1 )
-         {
-            acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-            acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+      else if (channelsPanel_.isSelected() && slicesPanel_.isSelected()) {
+         if (selectedIndex == 0 || selectedIndex == 1) {
+            acqOrderBox_.addItem(acqOrderModes_[0]);
+            acqOrderBox_.addItem(acqOrderModes_[1]);
          }
-         else
-         {
-            acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-            acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+         else {
+            acqOrderBox_.addItem(acqOrderModes_[2]);
+            acqOrderBox_.addItem(acqOrderModes_[3]);
          }
       }
-      else
-      {
-         acqOrderBox_.addItem( acqOrderModes_[ selectedIndex ] );
+      else {
+         acqOrderBox_.addItem(acqOrderModes_[selectedIndex]);
       }
-      acqOrderBox_.setSelectedItem( acqOrderModes_[ sequenceSettings.acqOrderMode() ] );
+      acqOrderBox_.setSelectedItem(acqOrderModes_[sequenceSettings.acqOrderMode()]);
 
-      savePanel_.setSelected( sequenceSettings.save() );
-      nameField_.setText( sequenceSettings.prefix() );
-      rootField_.setText( sequenceSettings.root() );
+      savePanel_.setSelected(sequenceSettings.save());
+      nameField_.setText(sequenceSettings.prefix());
+      rootField_.setText(sequenceSettings.root());
 
-      commentTextArea_.setText( sequenceSettings.comment() );
+      commentTextArea_.setText(sequenceSettings.comment());
 
-      DefaultDatastore.setPreferredSaveMode( mmStudio_, sequenceSettings.saveMode() );
-      if ( sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES )
-      {
-         singleButton_.setSelected( true );
+      DefaultDatastore.setPreferredSaveMode(mmStudio_, sequenceSettings.saveMode());
+      if (sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES) {
+         singleButton_.setSelected(true);
       }
-      else if ( sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF )
-      {
-         multiButton_.setSelected( true );
+      else if (sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF) {
+         multiButton_.setSelected(true);
       }
 
       // update summary
-      summaryTextArea_.setText( acqEng_.getVerboseSummary() );
+      summaryTextArea_.setText(acqEng_.getVerboseSummary());
 
       framesPanel_.repaint();
       positionsPanel_.repaint();

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1080,131 +1080,138 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 	   if (!SwingUtilities.isEventDispatchThread())
 	   {
 		   SwingUtilities.invokeLater( () -> {
-			   if ( disableGUItoSettings_ )
-			   {
-				   return;
-			   }
-			   disableGUItoSettings_ = true;
-
-			   numFrames_.setValue( sequenceSettings.numFrames() );
-			   timeUnitCombo_.setSelectedIndex( sequenceSettings.displayTimeUnit() );
-			   interval_.setText( numberFormat_.format( convertMsToTime(
-					   sequenceSettings.intervalMs(),
-					   timeUnitCombo_.getSelectedIndex() ) ) );
-
-			   boolean framesEnabled = sequenceSettings.useFrames();
-			   framesPanel_.setSelected( framesEnabled );
-			   defaultTimesPanel_.setVisible( !framesEnabled );
-			   customTimesPanel_.setVisible( framesEnabled );
-
-			   boolean isCustom = sequenceSettings.useCustomIntervals();
-			   defaultTimesPanel_.setVisible( !isCustom );
-			   customTimesPanel_.setVisible( isCustom );
-
-			   positionsPanel_.setSelected( sequenceSettings.usePositionList() );
-
-			   zBottom_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZBottomUm() ) );
-			   zTop_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZTopUm() ) );
-			   zStep_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZStepUm() ) );
-			   zBottom_.setEnabled( sequenceSettings.useSlices() );
-			   zTop_.setEnabled( sequenceSettings.useSlices() );
-			   zStep_.setEnabled( sequenceSettings.useSlices() );
-			   zValCombo_.setEnabled( sequenceSettings.useSlices() );
-			   zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
-			   zValCombo_.setSelectedIndex( zRelativeAbsolute_ );
-			   stackKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenSlices() );
-			   slicesPanel_.setSelected( sequenceSettings.useSlices() );
-
-			   afPanel_.setSelected( sequenceSettings.useAutofocus() );
-
-			   channelsPanel_.setSelected( sequenceSettings.useChannels() );
-			   channelGroupCombo_.setSelectedItem( sequenceSettings.channelGroup() );
-			   acqEng_.setChannelGroup( sequenceSettings.channelGroup() );
-			   model_.setChannels( sequenceSettings.channels() );
-			   model_.fireTableStructureChanged();
-			   chanKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenChannels() );
-			   channelTable_.setAutoResizeMode( JTable.AUTO_RESIZE_ALL_COLUMNS );
-			   boolean selected = channelsPanel_.isSelected();
-			   channelTable_.setEnabled( selected );
-			   channelTable_.getTableHeader().setForeground( selected ? Color.black : Color.gray );
-
-			   for ( AcqOrderMode mode : acqOrderModes_ )
-			   {
-				   mode.setEnabled( framesPanel_.isSelected(), positionsPanel_.isSelected(),
-						   slicesPanel_.isSelected(), channelsPanel_.isSelected() );
-			   }
-			   // add correct acquisition order options
-			   int selectedIndex = sequenceSettings.acqOrderMode();
-			   acqOrderBox_.removeAllItems();
-			   if ( framesPanel_.isSelected() && positionsPanel_.isSelected()
-					   && slicesPanel_.isSelected() && channelsPanel_.isSelected() )
-			   {
-				   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-				   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-				   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-				   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
-			   }
-			   else if ( framesPanel_.isSelected() && positionsPanel_.isSelected() )
-			   {
-				   if ( selectedIndex == 0 || selectedIndex == 2 )
-				   {
-					   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-					   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-				   }
-				   else
-				   {
-					   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-					   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
-				   }
-			   }
-			   else if ( channelsPanel_.isSelected() && slicesPanel_.isSelected() )
-			   {
-				   if ( selectedIndex == 0 || selectedIndex == 1 )
-				   {
-					   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-					   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-				   }
-				   else
-				   {
-					   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-					   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
-				   }
-			   }
-			   else
-			   {
-				   acqOrderBox_.addItem( acqOrderModes_[ selectedIndex ] );
-			   }
-			   acqOrderBox_.setSelectedItem( acqOrderModes_[ sequenceSettings.acqOrderMode() ] );
-
-			   savePanel_.setSelected( sequenceSettings.save() );
-			   nameField_.setText( sequenceSettings.prefix() );
-			   rootField_.setText( sequenceSettings.root() );
-
-			   commentTextArea_.setText( sequenceSettings.comment() );
-
-			   DefaultDatastore.setPreferredSaveMode( mmStudio_, sequenceSettings.saveMode() );
-			   if ( sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES )
-			   {
-				   singleButton_.setSelected( true );
-			   }
-			   else if ( sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF )
-			   {
-				   multiButton_.setSelected( true );
-			   }
-
-			   // update summary
-			   summaryTextArea_.setText( acqEng_.getVerboseSummary() );
-
-			   framesPanel_.repaint();
-			   positionsPanel_.repaint();
-			   afPanel_.repaint();
-			   slicesPanel_.repaint();
-			   channelsPanel_.repaint();
-			   savePanel_.repaint();
-
-			   disableGUItoSettings_ = false;
+			   updateSwingGUIFromSequenceSettings(sequenceSettings);
 		   } );
+	   } else {
+		   updateSwingGUIFromSequenceSettings(sequenceSettings);
 	   }
+   }
+
+   private void updateSwingGUIFromSequenceSettings(final SequenceSettings sequenceSettings)
+   {
+	   if ( disableGUItoSettings_ )
+	   {
+		   return;
+	   }
+	   disableGUItoSettings_ = true;
+
+	   numFrames_.setValue( sequenceSettings.numFrames() );
+	   timeUnitCombo_.setSelectedIndex( sequenceSettings.displayTimeUnit() );
+	   interval_.setText( numberFormat_.format( convertMsToTime(
+			   sequenceSettings.intervalMs(),
+			   timeUnitCombo_.getSelectedIndex() ) ) );
+
+	   boolean framesEnabled = sequenceSettings.useFrames();
+	   framesPanel_.setSelected( framesEnabled );
+	   defaultTimesPanel_.setVisible( !framesEnabled );
+	   customTimesPanel_.setVisible( framesEnabled );
+
+	   boolean isCustom = sequenceSettings.useCustomIntervals();
+	   defaultTimesPanel_.setVisible( !isCustom );
+	   customTimesPanel_.setVisible( isCustom );
+
+	   positionsPanel_.setSelected( sequenceSettings.usePositionList() );
+
+	   zBottom_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZBottomUm() ) );
+	   zTop_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZTopUm() ) );
+	   zStep_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZStepUm() ) );
+	   zBottom_.setEnabled( sequenceSettings.useSlices() );
+	   zTop_.setEnabled( sequenceSettings.useSlices() );
+	   zStep_.setEnabled( sequenceSettings.useSlices() );
+	   zValCombo_.setEnabled( sequenceSettings.useSlices() );
+	   zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
+	   zValCombo_.setSelectedIndex( zRelativeAbsolute_ );
+	   stackKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenSlices() );
+	   slicesPanel_.setSelected( sequenceSettings.useSlices() );
+
+	   afPanel_.setSelected( sequenceSettings.useAutofocus() );
+
+	   channelsPanel_.setSelected( sequenceSettings.useChannels() );
+	   channelGroupCombo_.setSelectedItem( sequenceSettings.channelGroup() );
+	   acqEng_.setChannelGroup( sequenceSettings.channelGroup() );
+	   model_.setChannels( sequenceSettings.channels() );
+	   model_.fireTableStructureChanged();
+	   chanKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenChannels() );
+	   channelTable_.setAutoResizeMode( JTable.AUTO_RESIZE_ALL_COLUMNS );
+	   boolean selected = channelsPanel_.isSelected();
+	   channelTable_.setEnabled( selected );
+	   channelTable_.getTableHeader().setForeground( selected ? Color.black : Color.gray );
+
+	   for ( AcqOrderMode mode : acqOrderModes_ )
+	   {
+		   mode.setEnabled( framesPanel_.isSelected(), positionsPanel_.isSelected(),
+				   slicesPanel_.isSelected(), channelsPanel_.isSelected() );
+	   }
+	   // add correct acquisition order options
+	   int selectedIndex = sequenceSettings.acqOrderMode();
+	   acqOrderBox_.removeAllItems();
+	   if ( framesPanel_.isSelected() && positionsPanel_.isSelected()
+			   && slicesPanel_.isSelected() && channelsPanel_.isSelected() )
+	   {
+		   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+		   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+		   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+		   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+	   }
+	   else if ( framesPanel_.isSelected() && positionsPanel_.isSelected() )
+	   {
+		   if ( selectedIndex == 0 || selectedIndex == 2 )
+		   {
+			   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+			   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+		   }
+		   else
+		   {
+			   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+			   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+		   }
+	   }
+	   else if ( channelsPanel_.isSelected() && slicesPanel_.isSelected() )
+	   {
+		   if ( selectedIndex == 0 || selectedIndex == 1 )
+		   {
+			   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+			   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+		   }
+		   else
+		   {
+			   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+			   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+		   }
+	   }
+	   else
+	   {
+		   acqOrderBox_.addItem( acqOrderModes_[ selectedIndex ] );
+	   }
+	   acqOrderBox_.setSelectedItem( acqOrderModes_[ sequenceSettings.acqOrderMode() ] );
+
+	   savePanel_.setSelected( sequenceSettings.save() );
+	   nameField_.setText( sequenceSettings.prefix() );
+	   rootField_.setText( sequenceSettings.root() );
+
+	   commentTextArea_.setText( sequenceSettings.comment() );
+
+	   DefaultDatastore.setPreferredSaveMode( mmStudio_, sequenceSettings.saveMode() );
+	   if ( sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES )
+	   {
+		   singleButton_.setSelected( true );
+	   }
+	   else if ( sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF )
+	   {
+		   multiButton_.setSelected( true );
+	   }
+
+	   // update summary
+	   summaryTextArea_.setText( acqEng_.getVerboseSummary() );
+
+	   framesPanel_.repaint();
+	   positionsPanel_.repaint();
+	   afPanel_.repaint();
+	   slicesPanel_.repaint();
+	   channelsPanel_.repaint();
+	   savePanel_.repaint();
+
+	   disableGUItoSettings_ = false;
    }
 
    public synchronized void saveAcqSettingsToProfile() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1472,8 +1472,9 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
     @Override
    public void settingsChanged() {
-     if(this.isDisplayable())
-       updateGUIContents();
+      if (this.isDisplayable()) {
+         updateGUIContents();
+      }
    }
 
    private void applySettingsFromGUI() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1077,7 +1077,6 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    }
 
    private void updateGUIFromSequenceSettings(final SequenceSettings sequenceSettings) {
-      SwingUtilities.invokeLater(() -> {
          if (disableGUItoSettings_) {
             return;
          }
@@ -1188,8 +1187,6 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
          savePanel_.repaint();
 
          disableGUItoSettings_ = false;
-
-      });
    }
 
    public synchronized void saveAcqSettingsToProfile() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1077,116 +1077,131 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    }
 
    private void updateGUIFromSequenceSettings(final SequenceSettings sequenceSettings) {
-         if (disableGUItoSettings_) {
-            return;
-         }
-         disableGUItoSettings_ = true;
+	   ( ( Runnable ) () -> {
+		   if ( disableGUItoSettings_ )
+		   {
+			   return;
+		   }
+		   disableGUItoSettings_ = true;
 
-         numFrames_.setValue(sequenceSettings.numFrames());
-         timeUnitCombo_.setSelectedIndex(sequenceSettings.displayTimeUnit());
-         interval_.setText(numberFormat_.format(convertMsToTime(
-                 sequenceSettings.intervalMs(),
-                 timeUnitCombo_.getSelectedIndex())));
+		   numFrames_.setValue( sequenceSettings.numFrames() );
+		   timeUnitCombo_.setSelectedIndex( sequenceSettings.displayTimeUnit() );
+		   interval_.setText( numberFormat_.format( convertMsToTime(
+				   sequenceSettings.intervalMs(),
+				   timeUnitCombo_.getSelectedIndex() ) ) );
 
-         boolean framesEnabled = sequenceSettings.useFrames();
-         framesPanel_.setSelected(framesEnabled);
-         defaultTimesPanel_.setVisible(!framesEnabled);
-         customTimesPanel_.setVisible(framesEnabled);
+		   boolean framesEnabled = sequenceSettings.useFrames();
+		   framesPanel_.setSelected( framesEnabled );
+		   defaultTimesPanel_.setVisible( !framesEnabled );
+		   customTimesPanel_.setVisible( framesEnabled );
 
-         boolean isCustom = sequenceSettings.useCustomIntervals();
-         defaultTimesPanel_.setVisible(!isCustom);
-         customTimesPanel_.setVisible(isCustom);
+		   boolean isCustom = sequenceSettings.useCustomIntervals();
+		   defaultTimesPanel_.setVisible( !isCustom );
+		   customTimesPanel_.setVisible( isCustom );
 
-         positionsPanel_.setSelected(sequenceSettings.usePositionList());
+		   positionsPanel_.setSelected( sequenceSettings.usePositionList() );
 
-         zBottom_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZBottomUm()));
-         zTop_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZTopUm()));
-         zStep_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZStepUm()));
-         zBottom_.setEnabled(sequenceSettings.useSlices());
-         zTop_.setEnabled(sequenceSettings.useSlices());
-         zStep_.setEnabled(sequenceSettings.useSlices());
-         zValCombo_.setEnabled(sequenceSettings.useSlices());
-         zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
-         zValCombo_.setSelectedIndex(zRelativeAbsolute_);
-         stackKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenSlices());
-         slicesPanel_.setSelected(sequenceSettings.useSlices());
+		   zBottom_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZBottomUm() ) );
+		   zTop_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZTopUm() ) );
+		   zStep_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZStepUm() ) );
+		   zBottom_.setEnabled( sequenceSettings.useSlices() );
+		   zTop_.setEnabled( sequenceSettings.useSlices() );
+		   zStep_.setEnabled( sequenceSettings.useSlices() );
+		   zValCombo_.setEnabled( sequenceSettings.useSlices() );
+		   zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
+		   zValCombo_.setSelectedIndex( zRelativeAbsolute_ );
+		   stackKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenSlices() );
+		   slicesPanel_.setSelected( sequenceSettings.useSlices() );
 
-         afPanel_.setSelected(sequenceSettings.useAutofocus());
+		   afPanel_.setSelected( sequenceSettings.useAutofocus() );
 
-         channelsPanel_.setSelected(sequenceSettings.useChannels());
-         channelGroupCombo_.setSelectedItem(sequenceSettings.channelGroup());
-         acqEng_.setChannelGroup(sequenceSettings.channelGroup());
-         model_.setChannels(sequenceSettings.channels());
-         model_.fireTableStructureChanged();
-         chanKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenChannels());
-         channelTable_.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
-         boolean selected = channelsPanel_.isSelected();
-         channelTable_.setEnabled(selected);
-         channelTable_.getTableHeader().setForeground(selected ? Color.black : Color.gray);
+		   channelsPanel_.setSelected( sequenceSettings.useChannels() );
+		   channelGroupCombo_.setSelectedItem( sequenceSettings.channelGroup() );
+		   acqEng_.setChannelGroup( sequenceSettings.channelGroup() );
+		   model_.setChannels( sequenceSettings.channels() );
+		   model_.fireTableStructureChanged();
+		   chanKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenChannels() );
+		   channelTable_.setAutoResizeMode( JTable.AUTO_RESIZE_ALL_COLUMNS );
+		   boolean selected = channelsPanel_.isSelected();
+		   channelTable_.setEnabled( selected );
+		   channelTable_.getTableHeader().setForeground( selected ? Color.black : Color.gray );
 
-         for (AcqOrderMode mode : acqOrderModes_) {
-            mode.setEnabled(framesPanel_.isSelected(), positionsPanel_.isSelected(),
-                    slicesPanel_.isSelected(), channelsPanel_.isSelected());
-         }
-         // add correct acquisition order options
-         int selectedIndex = sequenceSettings.acqOrderMode();
-         acqOrderBox_.removeAllItems();
-         if (framesPanel_.isSelected() && positionsPanel_.isSelected()
-                 && slicesPanel_.isSelected() && channelsPanel_.isSelected()) {
-            acqOrderBox_.addItem(acqOrderModes_[0]);
-            acqOrderBox_.addItem(acqOrderModes_[1]);
-            acqOrderBox_.addItem(acqOrderModes_[2]);
-            acqOrderBox_.addItem(acqOrderModes_[3]);
-         }
-         else if (framesPanel_.isSelected() && positionsPanel_.isSelected()) {
-            if (selectedIndex == 0 || selectedIndex == 2) {
-               acqOrderBox_.addItem(acqOrderModes_[0]);
-               acqOrderBox_.addItem(acqOrderModes_[2]);
-            }
-            else {
-               acqOrderBox_.addItem(acqOrderModes_[1]);
-               acqOrderBox_.addItem(acqOrderModes_[3]);
-            }
-         }
-         else if (channelsPanel_.isSelected() && slicesPanel_.isSelected()) {
-            if (selectedIndex == 0 || selectedIndex == 1) {
-               acqOrderBox_.addItem(acqOrderModes_[0]);
-               acqOrderBox_.addItem(acqOrderModes_[1]);
-            }
-            else {
-               acqOrderBox_.addItem(acqOrderModes_[2]);
-               acqOrderBox_.addItem(acqOrderModes_[3]);
-            }
-         }
-         else {
-            acqOrderBox_.addItem(acqOrderModes_[selectedIndex]);
-         }
-         acqOrderBox_.setSelectedItem(acqOrderModes_[sequenceSettings.acqOrderMode()]);
+		   for ( AcqOrderMode mode : acqOrderModes_ )
+		   {
+			   mode.setEnabled( framesPanel_.isSelected(), positionsPanel_.isSelected(),
+					   slicesPanel_.isSelected(), channelsPanel_.isSelected() );
+		   }
+		   // add correct acquisition order options
+		   int selectedIndex = sequenceSettings.acqOrderMode();
+		   acqOrderBox_.removeAllItems();
+		   if ( framesPanel_.isSelected() && positionsPanel_.isSelected()
+				   && slicesPanel_.isSelected() && channelsPanel_.isSelected() )
+		   {
+			   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+			   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+			   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+			   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+		   }
+		   else if ( framesPanel_.isSelected() && positionsPanel_.isSelected() )
+		   {
+			   if ( selectedIndex == 0 || selectedIndex == 2 )
+			   {
+				   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+				   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+			   }
+			   else
+			   {
+				   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+				   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+			   }
+		   }
+		   else if ( channelsPanel_.isSelected() && slicesPanel_.isSelected() )
+		   {
+			   if ( selectedIndex == 0 || selectedIndex == 1 )
+			   {
+				   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+				   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+			   }
+			   else
+			   {
+				   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+				   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+			   }
+		   }
+		   else
+		   {
+			   acqOrderBox_.addItem( acqOrderModes_[ selectedIndex ] );
+		   }
+		   acqOrderBox_.setSelectedItem( acqOrderModes_[ sequenceSettings.acqOrderMode() ] );
 
-         savePanel_.setSelected(sequenceSettings.save());
-         nameField_.setText(sequenceSettings.prefix());
-         rootField_.setText(sequenceSettings.root());
+		   savePanel_.setSelected( sequenceSettings.save() );
+		   nameField_.setText( sequenceSettings.prefix() );
+		   rootField_.setText( sequenceSettings.root() );
 
-         commentTextArea_.setText(sequenceSettings.comment());
+		   commentTextArea_.setText( sequenceSettings.comment() );
 
-         DefaultDatastore.setPreferredSaveMode(mmStudio_, sequenceSettings.saveMode());
-         if (sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES) {
-            singleButton_.setSelected(true);
-         } else if (sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF) {
-            multiButton_.setSelected(true);
-         }
+		   DefaultDatastore.setPreferredSaveMode( mmStudio_, sequenceSettings.saveMode() );
+		   if ( sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES )
+		   {
+			   singleButton_.setSelected( true );
+		   }
+		   else if ( sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF )
+		   {
+			   multiButton_.setSelected( true );
+		   }
 
-         // update summary
-         summaryTextArea_.setText(acqEng_.getVerboseSummary());
+		   // update summary
+		   summaryTextArea_.setText( acqEng_.getVerboseSummary() );
 
-         framesPanel_.repaint();
-         positionsPanel_.repaint();
-         afPanel_.repaint();
-         slicesPanel_.repaint();
-         channelsPanel_.repaint();
-         savePanel_.repaint();
+		   framesPanel_.repaint();
+		   positionsPanel_.repaint();
+		   afPanel_.repaint();
+		   slicesPanel_.repaint();
+		   channelsPanel_.repaint();
+		   savePanel_.repaint();
 
-         disableGUItoSettings_ = false;
+		   disableGUItoSettings_ = false;
+	   }).run();
    }
 
    public synchronized void saveAcqSettingsToProfile() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1073,145 +1073,140 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
    public final void updateGUIContents() {
       SequenceSettings sequenceSettings = acqEng_.getSequenceSettings();
-      updateGUIFromSequenceSettings(sequenceSettings);
+	   if (!SwingUtilities.isEventDispatchThread()) {
+	     SwingUtilities.invokeLater(() -> {
+           updateGUIFromSequenceSettings(sequenceSettings);
+	     } );
+	   }
+      else {
+         updateGUIFromSequenceSettings(sequenceSettings);
+      }
    }
 
    private void updateGUIFromSequenceSettings(final SequenceSettings sequenceSettings) {
-	   if (!SwingUtilities.isEventDispatchThread())
-	   {
-		   SwingUtilities.invokeLater( () -> {
-			   updateSwingGUIFromSequenceSettings(sequenceSettings);
-		   } );
-	   } else {
-		   updateSwingGUIFromSequenceSettings(sequenceSettings);
-	   }
-   }
+      if ( disableGUItoSettings_ )
+      {
+         return;
+      }
+      disableGUItoSettings_ = true;
 
-   private void updateSwingGUIFromSequenceSettings(final SequenceSettings sequenceSettings)
-   {
-	   if ( disableGUItoSettings_ )
-	   {
-		   return;
-	   }
-	   disableGUItoSettings_ = true;
+      numFrames_.setValue( sequenceSettings.numFrames() );
+      timeUnitCombo_.setSelectedIndex( sequenceSettings.displayTimeUnit() );
+      interval_.setText( numberFormat_.format( convertMsToTime(
+              sequenceSettings.intervalMs(),
+              timeUnitCombo_.getSelectedIndex() ) ) );
 
-	   numFrames_.setValue( sequenceSettings.numFrames() );
-	   timeUnitCombo_.setSelectedIndex( sequenceSettings.displayTimeUnit() );
-	   interval_.setText( numberFormat_.format( convertMsToTime(
-			   sequenceSettings.intervalMs(),
-			   timeUnitCombo_.getSelectedIndex() ) ) );
+      boolean framesEnabled = sequenceSettings.useFrames();
+      framesPanel_.setSelected( framesEnabled );
+      defaultTimesPanel_.setVisible( !framesEnabled );
+      customTimesPanel_.setVisible( framesEnabled );
 
-	   boolean framesEnabled = sequenceSettings.useFrames();
-	   framesPanel_.setSelected( framesEnabled );
-	   defaultTimesPanel_.setVisible( !framesEnabled );
-	   customTimesPanel_.setVisible( framesEnabled );
+      boolean isCustom = sequenceSettings.useCustomIntervals();
+      defaultTimesPanel_.setVisible( !isCustom );
+      customTimesPanel_.setVisible( isCustom );
 
-	   boolean isCustom = sequenceSettings.useCustomIntervals();
-	   defaultTimesPanel_.setVisible( !isCustom );
-	   customTimesPanel_.setVisible( isCustom );
+      positionsPanel_.setSelected( sequenceSettings.usePositionList() );
 
-	   positionsPanel_.setSelected( sequenceSettings.usePositionList() );
+      zBottom_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZBottomUm() ) );
+      zTop_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZTopUm() ) );
+      zStep_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZStepUm() ) );
+      zBottom_.setEnabled( sequenceSettings.useSlices() );
+      zTop_.setEnabled( sequenceSettings.useSlices() );
+      zStep_.setEnabled( sequenceSettings.useSlices() );
+      zValCombo_.setEnabled( sequenceSettings.useSlices() );
+      zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
+      zValCombo_.setSelectedIndex( zRelativeAbsolute_ );
+      stackKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenSlices() );
+      slicesPanel_.setSelected( sequenceSettings.useSlices() );
 
-	   zBottom_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZBottomUm() ) );
-	   zTop_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZTopUm() ) );
-	   zStep_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZStepUm() ) );
-	   zBottom_.setEnabled( sequenceSettings.useSlices() );
-	   zTop_.setEnabled( sequenceSettings.useSlices() );
-	   zStep_.setEnabled( sequenceSettings.useSlices() );
-	   zValCombo_.setEnabled( sequenceSettings.useSlices() );
-	   zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
-	   zValCombo_.setSelectedIndex( zRelativeAbsolute_ );
-	   stackKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenSlices() );
-	   slicesPanel_.setSelected( sequenceSettings.useSlices() );
+      afPanel_.setSelected( sequenceSettings.useAutofocus() );
 
-	   afPanel_.setSelected( sequenceSettings.useAutofocus() );
+      channelsPanel_.setSelected( sequenceSettings.useChannels() );
+      channelGroupCombo_.setSelectedItem( sequenceSettings.channelGroup() );
+      acqEng_.setChannelGroup( sequenceSettings.channelGroup() );
+      model_.setChannels( sequenceSettings.channels() );
+      model_.fireTableStructureChanged();
+      chanKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenChannels() );
+      channelTable_.setAutoResizeMode( JTable.AUTO_RESIZE_ALL_COLUMNS );
+      boolean selected = channelsPanel_.isSelected();
+      channelTable_.setEnabled( selected );
+      channelTable_.getTableHeader().setForeground( selected ? Color.black : Color.gray );
 
-	   channelsPanel_.setSelected( sequenceSettings.useChannels() );
-	   channelGroupCombo_.setSelectedItem( sequenceSettings.channelGroup() );
-	   acqEng_.setChannelGroup( sequenceSettings.channelGroup() );
-	   model_.setChannels( sequenceSettings.channels() );
-	   model_.fireTableStructureChanged();
-	   chanKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenChannels() );
-	   channelTable_.setAutoResizeMode( JTable.AUTO_RESIZE_ALL_COLUMNS );
-	   boolean selected = channelsPanel_.isSelected();
-	   channelTable_.setEnabled( selected );
-	   channelTable_.getTableHeader().setForeground( selected ? Color.black : Color.gray );
+      for ( AcqOrderMode mode : acqOrderModes_ )
+      {
+         mode.setEnabled( framesPanel_.isSelected(), positionsPanel_.isSelected(),
+                 slicesPanel_.isSelected(), channelsPanel_.isSelected() );
+      }
+      // add correct acquisition order options
+      int selectedIndex = sequenceSettings.acqOrderMode();
+      acqOrderBox_.removeAllItems();
+      if ( framesPanel_.isSelected() && positionsPanel_.isSelected()
+              && slicesPanel_.isSelected() && channelsPanel_.isSelected() )
+      {
+         acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+         acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+         acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+         acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+      }
+      else if ( framesPanel_.isSelected() && positionsPanel_.isSelected() )
+      {
+         if ( selectedIndex == 0 || selectedIndex == 2 )
+         {
+            acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+            acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+         }
+         else
+         {
+            acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+            acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+         }
+      }
+      else if ( channelsPanel_.isSelected() && slicesPanel_.isSelected() )
+      {
+         if ( selectedIndex == 0 || selectedIndex == 1 )
+         {
+            acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+            acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+         }
+         else
+         {
+            acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+            acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+         }
+      }
+      else
+      {
+         acqOrderBox_.addItem( acqOrderModes_[ selectedIndex ] );
+      }
+      acqOrderBox_.setSelectedItem( acqOrderModes_[ sequenceSettings.acqOrderMode() ] );
 
-	   for ( AcqOrderMode mode : acqOrderModes_ )
-	   {
-		   mode.setEnabled( framesPanel_.isSelected(), positionsPanel_.isSelected(),
-				   slicesPanel_.isSelected(), channelsPanel_.isSelected() );
-	   }
-	   // add correct acquisition order options
-	   int selectedIndex = sequenceSettings.acqOrderMode();
-	   acqOrderBox_.removeAllItems();
-	   if ( framesPanel_.isSelected() && positionsPanel_.isSelected()
-			   && slicesPanel_.isSelected() && channelsPanel_.isSelected() )
-	   {
-		   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-		   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-		   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-		   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
-	   }
-	   else if ( framesPanel_.isSelected() && positionsPanel_.isSelected() )
-	   {
-		   if ( selectedIndex == 0 || selectedIndex == 2 )
-		   {
-			   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-			   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-		   }
-		   else
-		   {
-			   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-			   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
-		   }
-	   }
-	   else if ( channelsPanel_.isSelected() && slicesPanel_.isSelected() )
-	   {
-		   if ( selectedIndex == 0 || selectedIndex == 1 )
-		   {
-			   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-			   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-		   }
-		   else
-		   {
-			   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-			   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
-		   }
-	   }
-	   else
-	   {
-		   acqOrderBox_.addItem( acqOrderModes_[ selectedIndex ] );
-	   }
-	   acqOrderBox_.setSelectedItem( acqOrderModes_[ sequenceSettings.acqOrderMode() ] );
+      savePanel_.setSelected( sequenceSettings.save() );
+      nameField_.setText( sequenceSettings.prefix() );
+      rootField_.setText( sequenceSettings.root() );
 
-	   savePanel_.setSelected( sequenceSettings.save() );
-	   nameField_.setText( sequenceSettings.prefix() );
-	   rootField_.setText( sequenceSettings.root() );
+      commentTextArea_.setText( sequenceSettings.comment() );
 
-	   commentTextArea_.setText( sequenceSettings.comment() );
+      DefaultDatastore.setPreferredSaveMode( mmStudio_, sequenceSettings.saveMode() );
+      if ( sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES )
+      {
+         singleButton_.setSelected( true );
+      }
+      else if ( sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF )
+      {
+         multiButton_.setSelected( true );
+      }
 
-	   DefaultDatastore.setPreferredSaveMode( mmStudio_, sequenceSettings.saveMode() );
-	   if ( sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES )
-	   {
-		   singleButton_.setSelected( true );
-	   }
-	   else if ( sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF )
-	   {
-		   multiButton_.setSelected( true );
-	   }
+      // update summary
+      summaryTextArea_.setText( acqEng_.getVerboseSummary() );
 
-	   // update summary
-	   summaryTextArea_.setText( acqEng_.getVerboseSummary() );
+      framesPanel_.repaint();
+      positionsPanel_.repaint();
+      afPanel_.repaint();
+      slicesPanel_.repaint();
+      channelsPanel_.repaint();
+      savePanel_.repaint();
 
-	   framesPanel_.repaint();
-	   positionsPanel_.repaint();
-	   afPanel_.repaint();
-	   slicesPanel_.repaint();
-	   channelsPanel_.repaint();
-	   savePanel_.repaint();
-
-	   disableGUItoSettings_ = false;
+      disableGUItoSettings_ = false;
    }
 
    public synchronized void saveAcqSettingsToProfile() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1477,7 +1477,8 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
     @Override
    public void settingsChanged() {
-      updateGUIContents();
+     if(this.isDisplayable())
+       updateGUIContents();
    }
 
    private void applySettingsFromGUI() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1073,14 +1073,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
    public final void updateGUIContents() {
       SequenceSettings sequenceSettings = acqEng_.getSequenceSettings();
-      if (!SwingUtilities.isEventDispatchThread()) {
-         SwingUtilities.invokeLater(() -> {
-            updateGUIFromSequenceSettings(sequenceSettings);
-         });
-      }
-      else {
-         updateGUIFromSequenceSettings(sequenceSettings);
-      }
+      updateGUIFromSequenceSettings(sequenceSettings);
    }
 
    private void updateGUIFromSequenceSettings(final SequenceSettings sequenceSettings) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1084,117 +1084,123 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    }
 
    private void updateGUIFromSequenceSettings(final SequenceSettings sequenceSettings) {
-      if (disableGUItoSettings_) {
-         return;
-      }
-      disableGUItoSettings_ = true;
-
-      numFrames_.setValue(sequenceSettings.numFrames());
-      timeUnitCombo_.setSelectedIndex(sequenceSettings.displayTimeUnit());
-      interval_.setText(numberFormat_.format(convertMsToTime(
-              sequenceSettings.intervalMs(),
-              timeUnitCombo_.getSelectedIndex())));
-
-      boolean framesEnabled = sequenceSettings.useFrames();
-      framesPanel_.setSelected(framesEnabled);
-      defaultTimesPanel_.setVisible(!framesEnabled);
-      customTimesPanel_.setVisible(framesEnabled);
-
-      boolean isCustom = sequenceSettings.useCustomIntervals();
-      defaultTimesPanel_.setVisible(!isCustom);
-      customTimesPanel_.setVisible(isCustom);
-
-      positionsPanel_.setSelected(sequenceSettings.usePositionList());
-
-      zBottom_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZBottomUm()));
-      zTop_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZTopUm()));
-      zStep_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZStepUm()));
-      zBottom_.setEnabled(sequenceSettings.useSlices());
-      zTop_.setEnabled(sequenceSettings.useSlices());
-      zStep_.setEnabled(sequenceSettings.useSlices());
-      zValCombo_.setEnabled(sequenceSettings.useSlices());
-      zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
-      zValCombo_.setSelectedIndex(zRelativeAbsolute_);
-      stackKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenSlices());
-      slicesPanel_.setSelected(sequenceSettings.useSlices());
-
-      afPanel_.setSelected(sequenceSettings.useAutofocus());
-
-      channelsPanel_.setSelected(sequenceSettings.useChannels());
-      channelGroupCombo_.setSelectedItem(sequenceSettings.channelGroup());
-      acqEng_.setChannelGroup(sequenceSettings.channelGroup());
-      model_.setChannels(sequenceSettings.channels());
-      model_.fireTableStructureChanged();
-      chanKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenChannels());
-      channelTable_.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
-      boolean selected = channelsPanel_.isSelected();
-      channelTable_.setEnabled(selected);
-      channelTable_.getTableHeader().setForeground(selected ? Color.black : Color.gray);
-
-      for (AcqOrderMode mode : acqOrderModes_) {
-         mode.setEnabled(framesPanel_.isSelected(), positionsPanel_.isSelected(),
-                 slicesPanel_.isSelected(), channelsPanel_.isSelected());
-      }
-      // add correct acquisition order options
-      int selectedIndex = sequenceSettings.acqOrderMode();
-      acqOrderBox_.removeAllItems();
-      if (framesPanel_.isSelected() && positionsPanel_.isSelected()
-              && slicesPanel_.isSelected() && channelsPanel_.isSelected()) {
-         acqOrderBox_.addItem(acqOrderModes_[0]);
-         acqOrderBox_.addItem(acqOrderModes_[1]);
-         acqOrderBox_.addItem(acqOrderModes_[2]);
-         acqOrderBox_.addItem(acqOrderModes_[3]);
-      }
-      else if (framesPanel_.isSelected() && positionsPanel_.isSelected()) {
-         if (selectedIndex == 0 || selectedIndex == 2) {
-            acqOrderBox_.addItem(acqOrderModes_[0]);
-            acqOrderBox_.addItem(acqOrderModes_[2]);
-         }
-         else {
-            acqOrderBox_.addItem(acqOrderModes_[1]);
-            acqOrderBox_.addItem(acqOrderModes_[3]);
-         }
-      }
-      else if (channelsPanel_.isSelected() && slicesPanel_.isSelected()) {
-         if (selectedIndex == 0 || selectedIndex == 1) {
-            acqOrderBox_.addItem(acqOrderModes_[0]);
-            acqOrderBox_.addItem(acqOrderModes_[1]);
-         }
-         else {
-            acqOrderBox_.addItem(acqOrderModes_[2]);
-            acqOrderBox_.addItem(acqOrderModes_[3]);
-         }
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            updateGUIFromSequenceSettings(sequenceSettings);
+         } );
       }
       else {
-         acqOrderBox_.addItem(acqOrderModes_[selectedIndex]);
+         if (disableGUItoSettings_) {
+            return;
+         }
+         disableGUItoSettings_ = true;
+
+         numFrames_.setValue(sequenceSettings.numFrames());
+         timeUnitCombo_.setSelectedIndex(sequenceSettings.displayTimeUnit());
+         interval_.setText(numberFormat_.format(convertMsToTime(
+                 sequenceSettings.intervalMs(),
+                 timeUnitCombo_.getSelectedIndex())));
+
+         boolean framesEnabled = sequenceSettings.useFrames();
+         framesPanel_.setSelected(framesEnabled);
+         defaultTimesPanel_.setVisible(!framesEnabled);
+         customTimesPanel_.setVisible(framesEnabled);
+
+         boolean isCustom = sequenceSettings.useCustomIntervals();
+         defaultTimesPanel_.setVisible(!isCustom);
+         customTimesPanel_.setVisible(isCustom);
+
+         positionsPanel_.setSelected(sequenceSettings.usePositionList());
+
+         zBottom_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZBottomUm()));
+         zTop_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZTopUm()));
+         zStep_.setText(NumberUtils.doubleToDisplayString(sequenceSettings.sliceZStepUm()));
+         zBottom_.setEnabled(sequenceSettings.useSlices());
+         zTop_.setEnabled(sequenceSettings.useSlices());
+         zStep_.setEnabled(sequenceSettings.useSlices());
+         zValCombo_.setEnabled(sequenceSettings.useSlices());
+         zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
+         zValCombo_.setSelectedIndex(zRelativeAbsolute_);
+         stackKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenSlices());
+         slicesPanel_.setSelected(sequenceSettings.useSlices());
+
+         afPanel_.setSelected(sequenceSettings.useAutofocus());
+
+         channelsPanel_.setSelected(sequenceSettings.useChannels());
+         channelGroupCombo_.setSelectedItem(sequenceSettings.channelGroup());
+         acqEng_.setChannelGroup(sequenceSettings.channelGroup());
+         model_.setChannels(sequenceSettings.channels());
+         model_.fireTableStructureChanged();
+         chanKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenChannels());
+         channelTable_.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+         boolean selected = channelsPanel_.isSelected();
+         channelTable_.setEnabled(selected);
+         channelTable_.getTableHeader().setForeground(selected ? Color.black : Color.gray);
+
+         for (AcqOrderMode mode : acqOrderModes_) {
+            mode.setEnabled(framesPanel_.isSelected(), positionsPanel_.isSelected(),
+                    slicesPanel_.isSelected(), channelsPanel_.isSelected());
+         }
+         // add correct acquisition order options
+         int selectedIndex = sequenceSettings.acqOrderMode();
+         acqOrderBox_.removeAllItems();
+         if (framesPanel_.isSelected() && positionsPanel_.isSelected()
+                 && slicesPanel_.isSelected() && channelsPanel_.isSelected()) {
+            acqOrderBox_.addItem(acqOrderModes_[0]);
+            acqOrderBox_.addItem(acqOrderModes_[1]);
+            acqOrderBox_.addItem(acqOrderModes_[2]);
+            acqOrderBox_.addItem(acqOrderModes_[3]);
+         }
+         else if (framesPanel_.isSelected() && positionsPanel_.isSelected()) {
+            if (selectedIndex == 0 || selectedIndex == 2) {
+               acqOrderBox_.addItem(acqOrderModes_[0]);
+               acqOrderBox_.addItem(acqOrderModes_[2]);
+            }
+            else {
+               acqOrderBox_.addItem(acqOrderModes_[1]);
+               acqOrderBox_.addItem(acqOrderModes_[3]);
+            }
+         }
+         else if (channelsPanel_.isSelected() && slicesPanel_.isSelected()) {
+            if (selectedIndex == 0 || selectedIndex == 1) {
+               acqOrderBox_.addItem(acqOrderModes_[0]);
+               acqOrderBox_.addItem(acqOrderModes_[1]);
+            }
+            else {
+               acqOrderBox_.addItem(acqOrderModes_[2]);
+               acqOrderBox_.addItem(acqOrderModes_[3]);
+            }
+         }
+         else {
+            acqOrderBox_.addItem(acqOrderModes_[selectedIndex]);
+         }
+         acqOrderBox_.setSelectedItem(acqOrderModes_[sequenceSettings.acqOrderMode()]);
+
+         savePanel_.setSelected(sequenceSettings.save());
+         nameField_.setText(sequenceSettings.prefix());
+         rootField_.setText(sequenceSettings.root());
+
+         commentTextArea_.setText(sequenceSettings.comment());
+
+         DefaultDatastore.setPreferredSaveMode(mmStudio_, sequenceSettings.saveMode());
+         if (sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES) {
+            singleButton_.setSelected(true);
+         } else if (sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF) {
+            multiButton_.setSelected(true);
+         }
+
+         // update summary
+         summaryTextArea_.setText(acqEng_.getVerboseSummary());
+
+         framesPanel_.repaint();
+         positionsPanel_.repaint();
+         afPanel_.repaint();
+         slicesPanel_.repaint();
+         channelsPanel_.repaint();
+         savePanel_.repaint();
+
+         disableGUItoSettings_ = false;
       }
-      acqOrderBox_.setSelectedItem(acqOrderModes_[sequenceSettings.acqOrderMode()]);
-
-      savePanel_.setSelected(sequenceSettings.save());
-      nameField_.setText(sequenceSettings.prefix());
-      rootField_.setText(sequenceSettings.root());
-
-      commentTextArea_.setText(sequenceSettings.comment());
-
-      DefaultDatastore.setPreferredSaveMode(mmStudio_, sequenceSettings.saveMode());
-      if (sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES) {
-         singleButton_.setSelected(true);
-      }
-      else if (sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF) {
-         multiButton_.setSelected(true);
-      }
-
-      // update summary
-      summaryTextArea_.setText(acqEng_.getVerboseSummary());
-
-      framesPanel_.repaint();
-      positionsPanel_.repaint();
-      afPanel_.repaint();
-      slicesPanel_.repaint();
-      channelsPanel_.repaint();
-      savePanel_.repaint();
-
-      disableGUItoSettings_ = false;
    }
 
    public synchronized void saveAcqSettingsToProfile() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1073,18 +1073,18 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
    public final void updateGUIContents() {
       SequenceSettings sequenceSettings = acqEng_.getSequenceSettings();
-	   if (!SwingUtilities.isEventDispatchThread()) {
-	     SwingUtilities.invokeLater(() -> {
-           updateGUIFromSequenceSettings(sequenceSettings);
-	     } );
-	   }
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            updateGUIFromSequenceSettings(sequenceSettings);
+         });
+      }
       else {
          updateGUIFromSequenceSettings(sequenceSettings);
       }
    }
 
    private void updateGUIFromSequenceSettings(final SequenceSettings sequenceSettings) {
-      if ( disableGUItoSettings_ )
+      if (disableGUItoSettings_)
       {
          return;
       }
@@ -1470,7 +1470,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    }
 
 
-    @Override
+   @Override
    public void settingsChanged() {
       if (this.isDisplayable()) {
          updateGUIContents();

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1077,131 +1077,134 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    }
 
    private void updateGUIFromSequenceSettings(final SequenceSettings sequenceSettings) {
-	   ( ( Runnable ) () -> {
-		   if ( disableGUItoSettings_ )
-		   {
-			   return;
-		   }
-		   disableGUItoSettings_ = true;
-
-		   numFrames_.setValue( sequenceSettings.numFrames() );
-		   timeUnitCombo_.setSelectedIndex( sequenceSettings.displayTimeUnit() );
-		   interval_.setText( numberFormat_.format( convertMsToTime(
-				   sequenceSettings.intervalMs(),
-				   timeUnitCombo_.getSelectedIndex() ) ) );
-
-		   boolean framesEnabled = sequenceSettings.useFrames();
-		   framesPanel_.setSelected( framesEnabled );
-		   defaultTimesPanel_.setVisible( !framesEnabled );
-		   customTimesPanel_.setVisible( framesEnabled );
-
-		   boolean isCustom = sequenceSettings.useCustomIntervals();
-		   defaultTimesPanel_.setVisible( !isCustom );
-		   customTimesPanel_.setVisible( isCustom );
-
-		   positionsPanel_.setSelected( sequenceSettings.usePositionList() );
-
-		   zBottom_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZBottomUm() ) );
-		   zTop_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZTopUm() ) );
-		   zStep_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZStepUm() ) );
-		   zBottom_.setEnabled( sequenceSettings.useSlices() );
-		   zTop_.setEnabled( sequenceSettings.useSlices() );
-		   zStep_.setEnabled( sequenceSettings.useSlices() );
-		   zValCombo_.setEnabled( sequenceSettings.useSlices() );
-		   zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
-		   zValCombo_.setSelectedIndex( zRelativeAbsolute_ );
-		   stackKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenSlices() );
-		   slicesPanel_.setSelected( sequenceSettings.useSlices() );
-
-		   afPanel_.setSelected( sequenceSettings.useAutofocus() );
-
-		   channelsPanel_.setSelected( sequenceSettings.useChannels() );
-		   channelGroupCombo_.setSelectedItem( sequenceSettings.channelGroup() );
-		   acqEng_.setChannelGroup( sequenceSettings.channelGroup() );
-		   model_.setChannels( sequenceSettings.channels() );
-		   model_.fireTableStructureChanged();
-		   chanKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenChannels() );
-		   channelTable_.setAutoResizeMode( JTable.AUTO_RESIZE_ALL_COLUMNS );
-		   boolean selected = channelsPanel_.isSelected();
-		   channelTable_.setEnabled( selected );
-		   channelTable_.getTableHeader().setForeground( selected ? Color.black : Color.gray );
-
-		   for ( AcqOrderMode mode : acqOrderModes_ )
-		   {
-			   mode.setEnabled( framesPanel_.isSelected(), positionsPanel_.isSelected(),
-					   slicesPanel_.isSelected(), channelsPanel_.isSelected() );
-		   }
-		   // add correct acquisition order options
-		   int selectedIndex = sequenceSettings.acqOrderMode();
-		   acqOrderBox_.removeAllItems();
-		   if ( framesPanel_.isSelected() && positionsPanel_.isSelected()
-				   && slicesPanel_.isSelected() && channelsPanel_.isSelected() )
-		   {
-			   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-			   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-			   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
-			   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
-		   }
-		   else if ( framesPanel_.isSelected() && positionsPanel_.isSelected() )
-		   {
-			   if ( selectedIndex == 0 || selectedIndex == 2 )
+	   if (!SwingUtilities.isEventDispatchThread())
+	   {
+		   SwingUtilities.invokeLater( () -> {
+			   if ( disableGUItoSettings_ )
 			   {
-				   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
-				   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+				   return;
 			   }
-			   else
+			   disableGUItoSettings_ = true;
+
+			   numFrames_.setValue( sequenceSettings.numFrames() );
+			   timeUnitCombo_.setSelectedIndex( sequenceSettings.displayTimeUnit() );
+			   interval_.setText( numberFormat_.format( convertMsToTime(
+					   sequenceSettings.intervalMs(),
+					   timeUnitCombo_.getSelectedIndex() ) ) );
+
+			   boolean framesEnabled = sequenceSettings.useFrames();
+			   framesPanel_.setSelected( framesEnabled );
+			   defaultTimesPanel_.setVisible( !framesEnabled );
+			   customTimesPanel_.setVisible( framesEnabled );
+
+			   boolean isCustom = sequenceSettings.useCustomIntervals();
+			   defaultTimesPanel_.setVisible( !isCustom );
+			   customTimesPanel_.setVisible( isCustom );
+
+			   positionsPanel_.setSelected( sequenceSettings.usePositionList() );
+
+			   zBottom_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZBottomUm() ) );
+			   zTop_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZTopUm() ) );
+			   zStep_.setText( NumberUtils.doubleToDisplayString( sequenceSettings.sliceZStepUm() ) );
+			   zBottom_.setEnabled( sequenceSettings.useSlices() );
+			   zTop_.setEnabled( sequenceSettings.useSlices() );
+			   zStep_.setEnabled( sequenceSettings.useSlices() );
+			   zValCombo_.setEnabled( sequenceSettings.useSlices() );
+			   zRelativeAbsolute_ = sequenceSettings.relativeZSlice() ? 0 : 1;
+			   zValCombo_.setSelectedIndex( zRelativeAbsolute_ );
+			   stackKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenSlices() );
+			   slicesPanel_.setSelected( sequenceSettings.useSlices() );
+
+			   afPanel_.setSelected( sequenceSettings.useAutofocus() );
+
+			   channelsPanel_.setSelected( sequenceSettings.useChannels() );
+			   channelGroupCombo_.setSelectedItem( sequenceSettings.channelGroup() );
+			   acqEng_.setChannelGroup( sequenceSettings.channelGroup() );
+			   model_.setChannels( sequenceSettings.channels() );
+			   model_.fireTableStructureChanged();
+			   chanKeepShutterOpenCheckBox_.setSelected( sequenceSettings.keepShutterOpenChannels() );
+			   channelTable_.setAutoResizeMode( JTable.AUTO_RESIZE_ALL_COLUMNS );
+			   boolean selected = channelsPanel_.isSelected();
+			   channelTable_.setEnabled( selected );
+			   channelTable_.getTableHeader().setForeground( selected ? Color.black : Color.gray );
+
+			   for ( AcqOrderMode mode : acqOrderModes_ )
 			   {
-				   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-				   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+				   mode.setEnabled( framesPanel_.isSelected(), positionsPanel_.isSelected(),
+						   slicesPanel_.isSelected(), channelsPanel_.isSelected() );
 			   }
-		   }
-		   else if ( channelsPanel_.isSelected() && slicesPanel_.isSelected() )
-		   {
-			   if ( selectedIndex == 0 || selectedIndex == 1 )
+			   // add correct acquisition order options
+			   int selectedIndex = sequenceSettings.acqOrderMode();
+			   acqOrderBox_.removeAllItems();
+			   if ( framesPanel_.isSelected() && positionsPanel_.isSelected()
+					   && slicesPanel_.isSelected() && channelsPanel_.isSelected() )
 			   {
 				   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
 				   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
-			   }
-			   else
-			   {
 				   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
 				   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
 			   }
-		   }
-		   else
-		   {
-			   acqOrderBox_.addItem( acqOrderModes_[ selectedIndex ] );
-		   }
-		   acqOrderBox_.setSelectedItem( acqOrderModes_[ sequenceSettings.acqOrderMode() ] );
+			   else if ( framesPanel_.isSelected() && positionsPanel_.isSelected() )
+			   {
+				   if ( selectedIndex == 0 || selectedIndex == 2 )
+				   {
+					   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+					   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+				   }
+				   else
+				   {
+					   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+					   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+				   }
+			   }
+			   else if ( channelsPanel_.isSelected() && slicesPanel_.isSelected() )
+			   {
+				   if ( selectedIndex == 0 || selectedIndex == 1 )
+				   {
+					   acqOrderBox_.addItem( acqOrderModes_[ 0 ] );
+					   acqOrderBox_.addItem( acqOrderModes_[ 1 ] );
+				   }
+				   else
+				   {
+					   acqOrderBox_.addItem( acqOrderModes_[ 2 ] );
+					   acqOrderBox_.addItem( acqOrderModes_[ 3 ] );
+				   }
+			   }
+			   else
+			   {
+				   acqOrderBox_.addItem( acqOrderModes_[ selectedIndex ] );
+			   }
+			   acqOrderBox_.setSelectedItem( acqOrderModes_[ sequenceSettings.acqOrderMode() ] );
 
-		   savePanel_.setSelected( sequenceSettings.save() );
-		   nameField_.setText( sequenceSettings.prefix() );
-		   rootField_.setText( sequenceSettings.root() );
+			   savePanel_.setSelected( sequenceSettings.save() );
+			   nameField_.setText( sequenceSettings.prefix() );
+			   rootField_.setText( sequenceSettings.root() );
 
-		   commentTextArea_.setText( sequenceSettings.comment() );
+			   commentTextArea_.setText( sequenceSettings.comment() );
 
-		   DefaultDatastore.setPreferredSaveMode( mmStudio_, sequenceSettings.saveMode() );
-		   if ( sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES )
-		   {
-			   singleButton_.setSelected( true );
-		   }
-		   else if ( sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF )
-		   {
-			   multiButton_.setSelected( true );
-		   }
+			   DefaultDatastore.setPreferredSaveMode( mmStudio_, sequenceSettings.saveMode() );
+			   if ( sequenceSettings.saveMode() == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES )
+			   {
+				   singleButton_.setSelected( true );
+			   }
+			   else if ( sequenceSettings.saveMode() == Datastore.SaveMode.MULTIPAGE_TIFF )
+			   {
+				   multiButton_.setSelected( true );
+			   }
 
-		   // update summary
-		   summaryTextArea_.setText( acqEng_.getVerboseSummary() );
+			   // update summary
+			   summaryTextArea_.setText( acqEng_.getVerboseSummary() );
 
-		   framesPanel_.repaint();
-		   positionsPanel_.repaint();
-		   afPanel_.repaint();
-		   slicesPanel_.repaint();
-		   channelsPanel_.repaint();
-		   savePanel_.repaint();
+			   framesPanel_.repaint();
+			   positionsPanel_.repaint();
+			   afPanel_.repaint();
+			   slicesPanel_.repaint();
+			   channelsPanel_.repaint();
+			   savePanel_.repaint();
 
-		   disableGUItoSettings_ = false;
-	   }).run();
+			   disableGUItoSettings_ = false;
+		   } );
+	   }
    }
 
    public synchronized void saveAcqSettingsToProfile() {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
@@ -208,8 +208,9 @@ public final class DaytimeNighttime implements ApplicationSkin {
             }
 
             // Alert any listeners of the change.
-            if(studio_ != null && studio_.events() != null)
-              studio_.events().post(new DefaultApplicationSkinEvent(mode));
+            if (studio_ != null && studio_.events() != null) {
+               studio_.events().post( new DefaultApplicationSkinEvent( mode ) );
+            }
          });
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
@@ -209,7 +209,7 @@ public final class DaytimeNighttime implements ApplicationSkin {
 
             // Alert any listeners of the change.
             if (studio_ != null && studio_.events() != null) {
-               studio_.events().post( new DefaultApplicationSkinEvent( mode ) );
+               studio_.events().post(new DefaultApplicationSkinEvent(mode));
             }
          });
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/DaytimeNighttime.java
@@ -208,7 +208,8 @@ public final class DaytimeNighttime implements ApplicationSkin {
             }
 
             // Alert any listeners of the change.
-            studio_.events().post(new DefaultApplicationSkinEvent(mode));
+            if(studio_ != null && studio_.events() != null)
+              studio_.events().post(new DefaultApplicationSkinEvent(mode));
          });
       }
    }


### PR DESCRIPTION
Dear @nicost @marktsuchida,

I found that invokeLater() causes a problem when JavaFX main application closes MMStudio frame.
Supposedly, there was a GUI synchronization calling invoked after MMCore was disposed.
Could you please remove this if you guys think it is fine with other references?

```
Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  mmcorej.MMCoreJJNI.CMMCore_getChannelGroup(JLmmcorej/CMMCore;)Ljava/lang/String;+0
j  mmcorej.CMMCore.getChannelGroup()Ljava/lang/String;+5
j  org.micromanager.acquisition.internal.AcquisitionWrapperEngine.setChannelGroup(Ljava/lang/String;)Z+4
j  org.micromanager.internal.dialogs.AcqControlDlg.lambda$createChannelsPanel$16(Ljava/awt/event/ActionEvent;)V+16
j  org.micromanager.internal.dialogs.AcqControlDlg$$Lambda$797.actionPerformed(Ljava/awt/event/ActionEvent;)V+5
j  javax.swing.JComboBox.fireActionEvent()V+126
j  javax.swing.JComboBox.setSelectedItem(Ljava/lang/Object;)V+134
j  org.micromanager.internal.dialogs.AcqControlDlg.lambda$updateGUIFromSequenceSettings$32(Lorg/micromanager/acquisition/SequenceSettings;)V+309
j  org.micromanager.internal.dialogs.AcqControlDlg$$Lambda$876.run()V+8
J 9309 C1 java.awt.event.InvocationEvent.dispatch()V (69 bytes) @ 0x0000000108bd0014 [0x0000000108bcfe00+0x214]
J 9359 C1 java.awt.EventQueue.dispatchEventImpl(Ljava/awt/AWTEvent;Ljava/lang/Object;)V (149 bytes) @ 0x0000000108c11d34 [0x0000000108c10240+0x1af4]
J 9321 C1 java.awt.EventQueue$3.run()Ljava/lang/Void; (60 bytes) @ 0x0000000108bb1354 [0x0000000108bb1140+0x214]
J 9306 C1 java.awt.EventQueue$3.run()Ljava/lang/Object; (5 bytes) @ 0x0000000108bc4f0c [0x0000000108bc4e80+0x8c]
v  ~StubRoutines::call_stub
J 2901  java.security.AccessController.doPrivileged(Ljava/security/PrivilegedAction;Ljava/security/AccessControlContext;)Ljava/lang/Object; (0 bytes) @ 0x0000000107ad72a3 [0x0000000107ad7240+0x63]
J 9320 C1 java.awt.EventQueue.dispatchEvent(Ljava/awt/AWTEvent;)V (80 bytes) @ 0x0000000108bacb14 [0x0000000108bac180+0x994]
J 9299 C1 java.awt.EventDispatchThread.pumpOneEventForFilters(I)V (190 bytes) @ 0x0000000108bcdb0c [0x0000000108bcc9c0+0x114c]
j  java.awt.EventDispatchThread.pumpEventsForFilter(ILjava/awt/Conditional;Ljava/awt/EventFilter;)V+35
j  java.awt.EventDispatchThread.pumpEventsForHierarchy(ILjava/awt/Conditional;Ljava/awt/Component;)V+11
j  java.awt.EventDispatchThread.pumpEvents(ILjava/awt/Conditional;)V+4
j  java.awt.EventDispatchThread.pumpEvents(Ljava/awt/Conditional;)V+3
j  java.awt.EventDispatchThread.run()V+9
v  ~StubRoutines::call_stub
```