### PR TITLE
Studio: Handle more strange forms of binning property

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -168,8 +168,12 @@ public enum PropertyKey {
             dest.putInteger(key(), jp.getAsInt());
          }
          if (jp.isString()) { // "1x1", "2x2", ...
-            dest.putInteger(key(),
-                  Integer.parseInt(jp.getAsString().split("x", 2)[0]));
+            String token = jp.getAsString().split("x", 2)[0];
+            if (token.length() < 3) {
+               dest.putInteger(key(), Integer.parseInt(token));
+            } else {  // another crazy format for binning, no way to figure this out
+               dest.putInteger(key(), 1);
+            }
          }
       }
 


### PR DESCRIPTION
coming from camera device adapters.

The "Binning" property was meant to provide numbers, i.e. 1, 2, 4, etc.. Hamamatsu provided 1x1, 2x2, and we ended up parsing that string in the Java layer.  While testing the Spinnaker device adapter, I discoveerd that the Binning property provided the value "Mode0", which of course leads to Exceptions.  This PR works around this by testing for sane values, and if they are insane to set binning to 1.  Of course, it is desirable to fix this at the root (i.e. in the device adapter), so maybe this change is not desired.  Most importantly, there should be some kind of mechanism to make it impossible to write a device adapter that delivers anything but a number.  Maybe there should be a SetBinning() and GetBinning function in the api, and we should no longer use a property for binning?   