### PR TITLE
Ensure that SequenceSettings.channel can never have entries that are null

### DIFF
--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlExecution.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlExecution.java
@@ -68,7 +68,7 @@ public class ProjectorControlExecution {
       studio_.acquisitions().clearRunnables();
       if (repeat) {
          for (int i = firstFrame; 
-                 i < studio_.acquisitions().getAcquisitionSettings().numFrames * 10; 
+                 i < studio_.acquisitions().getAcquisitionSettings().numFrames() * 10;
                  i += frameRepeatInterval) {
             studio_.acquisitions().attachRunnable(i, -1, 0, 0, runPolygons);
          }
@@ -208,7 +208,7 @@ public class ProjectorControlExecution {
    // Save ROIs in the acquisition path, if it exists.
    private void recordPolygons(Roi[] individualRois_) {
       if (studio_.acquisitions().isAcquisitionRunning()) {
-         if (studio_.acquisitions().getAcquisitionSettings().save) {
+         if (studio_.acquisitions().getAcquisitionSettings().save()) {
             String location = store_ == null ? null : store_.getSavePath();
             if (location != null) {
                try {

--- a/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
@@ -80,7 +80,17 @@ public class SequenceSettings {
          useCustomIntervals = use; return this; }
       public Builder customIntervalsMs(ArrayList<Double> c) {
          customIntervalsMs = c; return this; }
-      public Builder channels(ArrayList<ChannelSpec> c) {channels = c; return this;}
+      public Builder channels(ArrayList<ChannelSpec> c) {
+         // avoid inserting null channels
+         channels = new ArrayList<>();
+         if (c!= null) {
+            for (ChannelSpec cs : c) {
+               if (cs != null) {
+                  channels.add(cs);
+               }
+            }
+         } return this;
+      }
       public Builder slices (ArrayList<Double> s) { slices = s; return this;}
       public Builder relativeZSlice(boolean r) {relativeZSlice = r; return this;}
       public Builder slicesFirst(boolean s) {slicesFirst = s; return this;}
@@ -211,10 +221,11 @@ public class SequenceSettings {
    public ArrayList<Double> customIntervalsMs = null;
    /**
     * an array of ChannelSpec settings (one for each channel)
+    * no member of the array should ever by null
     * @deprecated use Builder and channels() instead
     */
    @Deprecated
-   public ArrayList<ChannelSpec> channels = new ArrayList<>();
+   private ArrayList<ChannelSpec> channels = new ArrayList<>();
    /**
     * slice Z coordinates
     * @deprecated use Builder and slices() instead

--- a/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
@@ -77,13 +77,15 @@ public class SequenceSettings {
       public Builder intervalMs(double d) { intervalMs = d; return this;}
       public Builder displayTimeUnit(int d) { displayTimeUnit = d; return this; }
       public Builder useCustomIntervals (boolean use) {
-         useCustomIntervals = use; return this; }
+         useCustomIntervals = use; return this;
+      }
       public Builder customIntervalsMs(ArrayList<Double> c) {
-         customIntervalsMs = c; return this; }
+         customIntervalsMs = c; return this;
+      }
       public Builder channels(ArrayList<ChannelSpec> c) {
          // avoid inserting null channels
          channels = new ArrayList<>();
-         if (c!= null) {
+         if (c != null) {
             for (ChannelSpec cs : c) {
                if (cs != null) {
                   channels.add(cs);

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -222,18 +222,17 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
    }
 
    private int getNumChannels() {
+      if (!sequenceSettings_.useChannels()) {
+         return 1;
+      }
+      if (sequenceSettings_.channels() == null || sequenceSettings_.channels().size() == 0) {
+         return 1;
+      }
       int numChannels = 0;
-      if (sequenceSettings_.useChannels()) {
-         if (sequenceSettings_.channels() == null) {
-            return 0;
+      for (ChannelSpec channel : sequenceSettings_.channels()) {
+         if (channel != null && channel.useChannel()) {
+            ++numChannels;
          }
-         for (ChannelSpec channel : sequenceSettings_.channels()) {
-            if (channel.useChannel()) {
-               ++numChannels;
-            }
-         }
-      } else {
-         numChannels = 1;
       }
       return numChannels;
    }
@@ -267,7 +266,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
    }
 
    private int getTotalImages() {
-      if (!sequenceSettings_.useChannels()) {
+      if (!sequenceSettings_.useChannels() || sequenceSettings_.channels().size() == 0) {
          return getNumFrames() * getNumSlices() * getNumChannels() * getNumPositions();
       }
 
@@ -307,7 +306,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
          camChannels.add(row,
                  channels.get(row).copyBuilder().camera(getSource(channels.get(row))).build());
       }
-      sequenceSettings_.channels = camChannels;
+      sequenceSettings_ = sequenceSettings_.copyBuilder().channels(camChannels).build();
    }
 
    /*

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -622,10 +622,10 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
       JSpinner.DefaultEditor editor = (JSpinner.DefaultEditor) afSkipInterval_.getEditor();
       editor.setFont(DEFAULT_FONT);
       editor.getTextField().setColumns(3);
-      afSkipInterval_.setValue(acqEng_.getSequenceSettings().skipAutofocusCount);
+      afSkipInterval_.setValue(acqEng_.getSequenceSettings().skipAutofocusCount());
       afSkipInterval_.addChangeListener((ChangeEvent e) -> {
          applySettingsFromGUI();
-         afSkipInterval_.setValue(acqEng_.getSequenceSettings().skipAutofocusCount);
+         afSkipInterval_.setValue(acqEng_.getSequenceSettings().skipAutofocusCount());
       });
       afPanel_.add(afSkipInterval_);
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -2,6 +2,7 @@ package org.micromanager.internal.dialogs;
 
 import org.micromanager.Studio;
 import org.micromanager.acquisition.ChannelSpec;
+import org.micromanager.acquisition.SequenceSettings;
 import org.micromanager.acquisition.internal.AcquisitionEngine;
 import org.micromanager.display.internal.RememberedSettings;
 import org.micromanager.events.internal.ChannelColorEvent;
@@ -124,7 +125,7 @@ public final class ChannelTableModel extends AbstractTableModel  {
       } else if (col == 1) {
          cb.config (value.toString());
          ChannelSpec cs = ChannelSpec.fromJSONStream(
-                 settings_.getString(channelProfileKey(acqEng_.getSequenceSettings().channelGroup,
+                 settings_.getString(channelProfileKey(acqEng_.getSequenceSettings().channelGroup(),
                          value.toString()), ""));
          if (cs == null) {
             // Our fallback color is the colorblind-friendly color for our
@@ -142,10 +143,10 @@ public final class ChannelTableModel extends AbstractTableModel  {
       } else if (col == 2) {
          cb.exposure (((Double) value));
          if (AcqControlDlg.getShouldSyncExposure()) {
-            studio_.app().setChannelExposureTime(acqEng_.getSequenceSettings().channelGroup,
+            studio_.app().setChannelExposureTime(acqEng_.getSequenceSettings().channelGroup(),
                     channel.config(), (Double) value);
          } else {
-            this.setChannelExposureTime(acqEng_.getSequenceSettings().channelGroup,
+            this.setChannelExposureTime(acqEng_.getSequenceSettings().channelGroup(),
                     channel.config(), (Double) value);
          }
       } else if (col == 3) {
@@ -309,9 +310,12 @@ public final class ChannelTableModel extends AbstractTableModel  {
          for (String newConfig : newConfigNames) {
             ChannelSpec cs = ChannelSpec.fromJSONStream(
                     settings_.getString(channelProfileKey(newChannelGroup, newConfig), ""));
-            channels_.add(cs);
+            if (cs != null) {
+               channels_.add(cs);
+            }
          }
-         acqEng_.getSequenceSettings().channels = channels_;
+         acqEng_.setSequenceSettings(acqEng_.getSequenceSettings().
+                 copyBuilder().channels(channels_).build());
          fireTableDataChanged();
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -218,11 +218,11 @@ public final class ChannelTableModel extends AbstractTableModel  {
          } else {
             // Pick a non-white default color if possible.
             Color defaultColor = ColorPalettes.getFromDefaultPalette(channels_.size());
-            cb.channelGroup(acqEng_.getSequenceSettings().channelGroup);
+            cb.channelGroup(acqEng_.getSequenceSettings().channelGroup());
             cb.color(RememberedSettings.loadChannel(studio_,
-                    acqEng_.getSequenceSettings().channelGroup, config, defaultColor).getColor());
+                    acqEng_.getSequenceSettings().channelGroup(), config, defaultColor).getColor());
             cb.exposure(this.getChannelExposureTime(
-                  acqEng_.getSequenceSettings().channelGroup, config, 10.0));
+                  acqEng_.getSequenceSettings().channelGroup(), config, 10.0));
             channels_.add(cb.build());
          }
       }
@@ -304,7 +304,7 @@ public final class ChannelTableModel extends AbstractTableModel  {
       settings_.putStringList("CG:" + channelGroup, configNames);
 
       // Restore channels from profile
-      String newChannelGroup = acqEng_.getSequenceSettings().channelGroup;
+      String newChannelGroup = acqEng_.getSequenceSettings().channelGroup();
       if (!channelGroup.equals(newChannelGroup)) {
          List<String> newConfigNames = settings_.getStringList("CG:" + newChannelGroup);
          for (String newConfig : newConfigNames) {
@@ -346,7 +346,7 @@ public final class ChannelTableModel extends AbstractTableModel  {
     */
    public void setChannelExposureTime(String channelGroup, String channel, 
            double exposure) {
-      if (!channelGroup.equals(acqEng_.getSequenceSettings().channelGroup))
+      if (!channelGroup.equals(acqEng_.getSequenceSettings().channelGroup()))
          return;
       for (int row = 0; row < channels_.size(); row++) {
          ChannelSpec cs = channels_.get(row);
@@ -359,7 +359,7 @@ public final class ChannelTableModel extends AbstractTableModel  {
    }
 
    public boolean hasChannel(String channelGroup, String channel) {
-      if (!channelGroup.equals(acqEng_.getSequenceSettings().channelGroup)) {
+      if (!channelGroup.equals(acqEng_.getSequenceSettings().channelGroup())) {
          return false;
       }
       for (ChannelSpec cs : channels_) {
@@ -380,7 +380,7 @@ public final class ChannelTableModel extends AbstractTableModel  {
     */
    public double getChannelExposureTime(String channelGroup, String channel,
                                       double defaultExposure) {
-      if (!channelGroup.equals(acqEng_.getSequenceSettings().channelGroup))
+      if (!channelGroup.equals(acqEng_.getSequenceSettings().channelGroup()))
          return defaultExposure;
       for (ChannelSpec cs : channels_) {
          if (cs.config().equals(channel)) {
@@ -398,7 +398,7 @@ public final class ChannelTableModel extends AbstractTableModel  {
     * @param color         New color of the channel
     */
    public void setChannelColor(String channelGroup, String channelName, Color color) {
-      if (!channelGroup.equals(acqEng_.getSequenceSettings().channelGroup))
+      if (!channelGroup.equals(acqEng_.getSequenceSettings().channelGroup()))
          return;
       for (int row = 0; row < channels_.size(); row++) {
          ChannelSpec cs = channels_.get(row);
@@ -412,7 +412,7 @@ public final class ChannelTableModel extends AbstractTableModel  {
    }
 
    public void storeChannels() {
-      String channelGroup = acqEng_.getSequenceSettings().channelGroup;
+      String channelGroup = acqEng_.getSequenceSettings().channelGroup();
       List<String> configNames = new ArrayList<>(channels_.size());
       for (ChannelSpec cs : channels_) {
          if (!cs.config().contentEquals("")) {
@@ -427,8 +427,8 @@ public final class ChannelTableModel extends AbstractTableModel  {
       }
       // Stores the config names that we had for the old channelGroup
       settings_.putStringList("CG:" + channelGroup, configNames);
-      acqEng_.getSequenceSettings().channels.clear();
-      acqEng_.getSequenceSettings().channels.addAll(channels_);
+      acqEng_.setSequenceSettings(acqEng_.getSequenceSettings().copyBuilder().
+              channels(channels_).build());
    }
 
     private static String channelProfileKey(String channelGroup, String config) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CustomTimeIntervalsPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CustomTimeIntervalsPanel.java
@@ -184,13 +184,14 @@ public final class CustomTimeIntervalsPanel extends JPanel {
         buttonsPanel_.add(new JLabel("      ")); //spacer
         
         useIntervalsCheckBox_ = new JCheckBox("Use custom intervals");
-        useIntervalsCheckBox_.setEnabled(acqEng_.getSequenceSettings().customIntervalsMs != null);
-        useIntervalsCheckBox_.setSelected(acqEng_.getSequenceSettings().useCustomIntervals);
+        useIntervalsCheckBox_.setEnabled(acqEng_.getSequenceSettings().customIntervalsMs() != null);
+        useIntervalsCheckBox_.setSelected(acqEng_.getSequenceSettings().useCustomIntervals());
         buttonsPanel_.add(useIntervalsCheckBox_);
         useIntervalsCheckBox_.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                acqEng_.getSequenceSettings().useCustomIntervals = useIntervalsCheckBox_.isSelected();
+                acqEng_.setSequenceSettings(acqEng_.getSequenceSettings().copyBuilder().
+                        useCustomIntervals(useIntervalsCheckBox_.isSelected()).build());
             }
         });
         
@@ -209,8 +210,8 @@ public final class CustomTimeIntervalsPanel extends JPanel {
     }
  
      public void syncCheckBoxFromAcqEng() {
-         useIntervalsCheckBox_.setEnabled(acqEng_.getSequenceSettings().customIntervalsMs != null);
-         useIntervalsCheckBox_.setSelected(acqEng_.getSequenceSettings().useCustomIntervals);
+         useIntervalsCheckBox_.setEnabled(acqEng_.getSequenceSettings().customIntervalsMs() != null);
+         useIntervalsCheckBox_.setSelected(acqEng_.getSequenceSettings().useCustomIntervals());
      }  
      
      public void syncIntervalsFromAcqEng() {
@@ -748,21 +749,23 @@ public final class CustomTimeIntervalsPanel extends JPanel {
         
         private void sendIntervalsToAcqEng() {
             if (timeIntervals_ == null || timeIntervals_.isEmpty()) {
-                acqEng_.getSequenceSettings().customIntervalsMs = null;
+               acqEng_.setSequenceSettings(acqEng_.getSequenceSettings().copyBuilder().
+                    customIntervalsMs(null).build());
             } else {
                 ArrayList<Double> intervals = new ArrayList<>(timeIntervals_.size());
                for (Double aDouble : timeIntervals_) {
                   intervals.add(aDouble);
                }
-                acqEng_.getSequenceSettings().customIntervalsMs = intervals;
+               acqEng_.setSequenceSettings(acqEng_.getSequenceSettings().copyBuilder().
+                       customIntervalsMs(intervals).build());
             }
            fireTableDataChanged();
         }
         
         public final void syncIntervalsFromAcqEng() {
             timeIntervals_.clear();
-            if (acqEng_.getSequenceSettings().customIntervalsMs != null) {
-               timeIntervals_.addAll(acqEng_.getSequenceSettings().customIntervalsMs);
+            if (acqEng_.getSequenceSettings().customIntervalsMs() != null) {
+               timeIntervals_.addAll(acqEng_.getSequenceSettings().customIntervalsMs());
             }
             fireTableDataChanged();
         }

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/data/AcquisitionSettings.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/data/AcquisitionSettings.java
@@ -126,9 +126,9 @@ public class AcquisitionSettings {
     * @return MM Sequence Settings
     */
    public SequenceSettings getSequenceSettings() {
-      SequenceSettings mmss = new SequenceSettings();
-      mmss.numFrames = this.numTimepoints;
-      mmss.channelGroup = this.channelGroup;
+      SequenceSettings.Builder mmssb = new SequenceSettings.Builder();
+      mmssb.numFrames(this.numTimepoints);
+      mmssb.channelGroup(this.channelGroup);
       //mmss.channels = new ArrayList<ChannelSpec>(Arrays.asList(this.channels));
 
       ArrayList<Double> slices = new ArrayList<Double>(this.numSlices);
@@ -136,11 +136,11 @@ public class AcquisitionSettings {
          // todo: add the start z position
          slices.add(this.stepSizeUm * (double) z);
       }      
-      mmss.slices = slices;     
+      mmssb.slices(slices);
       
-      mmss.usePositionList = this.useMultiPositions;
+      mmssb.usePositionList(this.useMultiPositions);
       
-      return mmss;
+      return mmssb.build();
    }
    
 }

--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
@@ -255,10 +255,10 @@ public class AcquireMultipleRegionsForm extends javax.swing.JFrame {
             try {
                 statusText.setText("Acquiring region " + String.valueOf(i));
                 //turn on position list, turn off time lapse
-                SequenceSettings currSettings = gui_.acquisitions().getAcquisitionSettings();
-                currSettings.usePositionList = true;
-                currSettings.numFrames = 1;
-                gui_.acquisitions().setAcquisitionSettings(currSettings);
+                SequenceSettings.Builder currSettingsB = gui_.acquisitions().getAcquisitionSettings().copyBuilder();
+                currSettingsB.usePositionList(true);
+                currSettingsB.numFrames(1);
+                gui_.acquisitions().setAcquisitionSettings(currSettingsB.build());
                 // TODO: ensure saving chooses the correct format. This logic
                 // became lost in the MM2.0 refactoring.
 //                gui_.compat().setImageSavingFormat(org.micromanager.acquisition.internal.TaggedImageStorageMultipageTiff.class);

--- a/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombiner.java
+++ b/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombiner.java
@@ -73,7 +73,7 @@ public class FrameCombiner extends Processor {
          return;
       }
       // when running MDA without z stack and user want FrameCombiner to combin z frames => do nothing
-      if (studio_.getAcquisitionManager().getAcquisitionSettings().slices.size() == 0
+      if (studio_.getAcquisitionManager().getAcquisitionSettings().slices().size() == 0
               && processorDimension_.equals(FrameCombinerPlugin.PROCESSOR_DIMENSION_Z)) {
          context.outputImage(image);
          return;


### PR DESCRIPTION
Also avoid the use of private members of SequenceSettings in the code.  It would now be possible (at the risk of breaking code that is not in our repo) to make all Deprecated members private.

I believe this takes care of issue #915 