### PR TITLE
Studio: Changing core channel group now changes MDA Dialog Correctly.  

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -521,6 +521,13 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
       return core_.getChannelGroup();
    }
 
+   /**
+    * Sets the channel group in the core
+    * Replies on callbacks to update the UI as well as sequenceSettings
+    * (SequenceSettings are updated in the callback function in AcqControlDlg)
+    * @param group name of group to set as the new Channel Group
+    * @return true when successful, false if no change is needed or when the change fails
+    */
    @Override
    public boolean setChannelGroup(String group) {
       String curGroup = core_.getChannelGroup();
@@ -532,11 +539,9 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
       if (groupIsEligibleChannel(group)) {
          try {
             core_.setChannelGroup(group);
-            sequenceSettings_ = sequenceSettings_.copyBuilder().channelGroup(group).build();
          } catch (Exception e) {
             try {
                core_.setChannelGroup("");
-               sequenceSettings_ = sequenceSettings_.copyBuilder().channelGroup("").build();
             } catch (Exception ex) {
                 ReportingUtils.logError(ex);
             }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -966,6 +966,8 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
    @Subscribe
    public void onChannelGroupChanged(ChannelGroupChangedEvent event) {
+      acqEng_.setSequenceSettings(acqEng_.getSequenceSettings().copyBuilder().
+              channelGroup(event.getNewChannelGroup()).build());
       updateChannelAndGroupCombo();
    }
 


### PR DESCRIPTION
Closing #939 

The UI and the Acquisition Sequence Settings are now only updated in
a callback, that is started in the core when the channel group changes.