### PR TITLE
Fix issue#953 by checking the connection.

### DIFF
--- a/DeviceAdapters/Aladdin/Aladdin.cpp
+++ b/DeviceAdapters/Aladdin/Aladdin.cpp
@@ -132,17 +132,20 @@ int AladdinController::Initialize()
 {
    this->LogMessage("AladdinController::Initialize()");
 
-   GeneratePropertyVolume();
-   GeneratePropertyDiameter();
-   GeneratePropertyRate();
-   GeneratePropertyDirection();
-   GeneratePropertyRun();
-   
-   CreateDefaultProgram();
+   // Check if the device is connected. If not, return immediately without doing any initialization.
+   Purge();
+   if(error_ != DEVICE_SERIAL_COMMAND_FAILED) {
+      GeneratePropertyVolume();
+      GeneratePropertyDiameter();
+      GeneratePropertyRate();
+      GeneratePropertyDirection();
+      GeneratePropertyRun();
+      
+      CreateDefaultProgram();
 
-   initialized_ = true;
+      initialized_ = true;
+   }
    return HandleErrors();
-
 }
 
 /////////////////////////////////////////////


### PR DESCRIPTION
A check on connection to the device is added before doing any initialization. 
If no connection is detected, the program will return an error code immediately.