### PR TITLE
Studio: MDA Dialog, close cell editors when user leaves window.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -93,6 +93,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -312,6 +313,22 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), "MDA");
 
       mmStudio_.events().registerForEvents(this);
+
+      // when focus is lots, ensure that channel cell editors close
+      WindowFocusListener windowFocusListener = new WindowFocusListener() {
+         @Override
+         public void windowGainedFocus(WindowEvent e) {
+         }
+         @Override
+         public void windowLostFocus(WindowEvent e) {
+            // may need to run the full applySettingsFromGUI()
+            AbstractCellEditor ae = (AbstractCellEditor) channelTable_.getCellEditor();
+            if (ae != null) {
+               ae.stopCellEditing();
+            }
+         }
+      };
+      super.addWindowFocusListener(windowFocusListener);
    }
 
 


### PR DESCRIPTION
Not doing so caused confusing behavior when exposure times were edited
while a cell editor in the MDA dialog channel section was active. Was reported 
by Matt Pearson.