### PR TITLE
Allow log manager to deal with all Throwables instead of just Exceptions

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/LogManager.java
+++ b/mmstudio/src/main/java/org/micromanager/LogManager.java
@@ -55,13 +55,13 @@ public interface LogManager {
     * @param e - Java exception to be logged
     * @param msg - message to be shown
     */
-   public void logError(Exception e, String msg);
+   public void logError(Throwable e, String msg);
 
    /**
     * Writes a stacktrace to the Micro-Manager log.
     * @param e - Java exception to be logged
     */
-   public void logError(Exception e);
+   public void logError(Throwable e);
 
    /**
     * Writes an error to the Micro-Manager log (same as logMessage).
@@ -74,13 +74,13 @@ public interface LogManager {
     * @param e - Java exception to be shown and logged
     * @param msg - Error message to be shown and logged
     */
-   public void showError(Exception e, String msg);
+   public void showError(Throwable e, String msg);
 
    /**
     * Shows and logs a Java exception.
-    * @param e - Java excpetion to be shown and logged
+    * @param e - Java exception to be shown and logged
     */
-   public void showError(Exception e);
+   public void showError(Throwable e);
 
    /**
     * Shows an error message in the UI and logs to the Micro-Manager log.
@@ -94,14 +94,14 @@ public interface LogManager {
     * @param msg - Error message to be shown and logged
     * @param parent - frame in which to show dialog, or null for caller
     */
-   public void showError(Exception e, String msg, Component parent);
+   public void showError(Throwable e, String msg, Component parent);
 
    /**
     * Shows and logs a Java exception.
     * @param e - Java exception to be shown and logged
     * @param parent - frame in which to show dialog, or null for caller
     */
-   public void showError(Exception e, Component parent);
+   public void showError(Throwable e, Component parent);
 
    /**
     * Shows an error message in the UI and logs to the Micro-Manager log.

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ReportingUtils.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ReportingUtils.java
@@ -63,12 +63,12 @@ public final class ReportingUtils {
       }
 
       @Override
-      public void logError(Exception e, String msg) {
+      public void logError(Throwable e, String msg) {
          ReportingUtils.logError(e, msg);
       }
 
       @Override
-      public void logError(Exception e) {
+      public void logError(Throwable e) {
          ReportingUtils.logError(e);
       }
 
@@ -78,12 +78,12 @@ public final class ReportingUtils {
       }
 
       @Override
-      public void showError(Exception e, String msg) {
+      public void showError(Throwable e, String msg) {
          ReportingUtils.showError(e, msg);
       }
 
       @Override
-      public void showError(Exception e) {
+      public void showError(Throwable e) {
          ReportingUtils.showError(e);
       }
 
@@ -93,12 +93,12 @@ public final class ReportingUtils {
       }
 
       @Override
-      public void showError(Exception e, String msg, Component parent) {
+      public void showError(Throwable e, String msg, Component parent) {
          ReportingUtils.showError(e, msg, parent);
       }
 
       @Override
-      public void showError(Exception e, Component parent) {
+      public void showError(Throwable e, Component parent) {
          ReportingUtils.showError(e, parent);
       }
 


### PR DESCRIPTION
The `LogManager` and `ReportingUtils` are written such that they only work with `Exceptions`. However they only actually use methods from `Throwable`, a base class of `Exception`.

This means that the `LogManager` is unable to deal with other `Throwable`s such as `Error`s.

Even though non-`Exception` throwables are less common there is no reason no to allow the `LogManager` to deal with them.