### PR TITLE
Fix bug not providing slices with MDA acquisition settings

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -55,6 +55,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
 
    public void setSequenceSettings(SequenceSettings sequenceSettings) {
       sequenceSettings_ = sequenceSettings;
+      calculateSlices();
       settingsChanged();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -218,16 +218,17 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
 
    @Override
    public SequenceSettings getAcquisitionSettings() {
-      if (engine_ == null)
-         return new SequenceSettings();
+      if (engine_ == null) {
+         return new SequenceSettings.Builder().build();
+      }
       return engine_.getSequenceSettings();
    }
 
    @Override
    public void setAcquisitionSettings(SequenceSettings ss) {
-      if (engine_ == null)
+      if (engine_ == null) {
          return;
-
+      }
       engine_.setSequenceSettings(ss);
       mdaDialog_.updateGUIContents();
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -586,7 +586,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
             "skip 1, spanx, gaptop 0, alignx left");
 
       slicesPanel_.addActionListener((final ActionEvent e) -> {
-         // enable disable all related contrtols
+         // enable disable all related controls
          applySettingsFromGUI();
       });
       return slicesPanel_;
@@ -1508,14 +1508,12 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
          ssb.useCustomIntervals(acqEng_.getSequenceSettings().useCustomIntervals());
          ssb.customIntervalsMs(acqEng_.getSequenceSettings().customIntervalsMs());
 
-         ssb.sliceZBottomUm (NumberUtils.displayStringToDouble(zBottom_.getText()));
-         ssb.sliceZTopUm(NumberUtils.displayStringToDouble(zTop_.getText()));
-         ssb.sliceZTopUm(NumberUtils.displayStringToDouble(zTop_.getText()));
          ssb.sliceZBottomUm(NumberUtils.displayStringToDouble(zBottom_.getText()));
+         ssb.sliceZTopUm(NumberUtils.displayStringToDouble(zTop_.getText()));
          ssb.sliceZStepUm(NumberUtils.displayStringToDouble(zStep_.getText()));
          ssb.relativeZSlice(zRelativeAbsolute_ == 0);  // 0 == relative, 1 == absolute
-
          ssb.useSlices(slicesPanel_.isSelected());
+
          ssb.usePositionList(positionsPanel_.isSelected());
 
          ssb.useChannels(channelsPanel_.isSelected());


### PR DESCRIPTION
Bug reported by Kwasi on imagesc forum.  The script:

```
settings = mm.acquisitions().getAcquisitionSettings()
z =settings.slices()
```

would not provide the slices as defined in the MDA dialog.  This PR forces the acquisition wrapper engine (which provides the sequence settings) to calculate the slices whenever sequence settings in the engine are set.
