### PR TITLE
svnMerge: update to Andor device adapter

### DIFF
--- a/DeviceAdapters/Andor/Andor.h
+++ b/DeviceAdapters/Andor/Andor.h
@@ -176,6 +176,7 @@ public:
    int OnTimeOut(MM::PropertyBase* pProp, MM::ActionType eAct);  // kdb July-30-2009
    int OnCountConvert(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnCountConvertWavelength(MM::PropertyBase* pProp, MM::ActionType eAct);
+   int OnForceRunTillAbort(MM::PropertyBase* pProp, MM::ActionType eAct);
 
    int OnOptAcquireMode(MM::PropertyBase* pProp, MM::ActionType eAct);
    int OnROI(MM::PropertyBase* pProp, MM::ActionType eAct);
@@ -425,6 +426,8 @@ private:
    ReadModeControl* readModeControl_;
    SRRFControl *SRRFControl_;
    SRRFAndorCamera *SRRFAndorCamera_;
+
+   bool forceRunTillAbort;
 };
 
 


### PR DESCRIPTION
…cquisition mode Run till abort. This is necessary for users that want to acquire large image sets. New device property Force Run Till Abort On | Off

git-svn-id: https://valelab.ucsf.edu/svn/micromanager2/trunk@17378 d0ab736e-dc22-4aeb-8dc9-08def0aa14fd