### PR TITLE
Fixes issues in display when image metadata does not contain pixel size info

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/VerticalMultiSplitPane.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/VerticalMultiSplitPane.java
@@ -183,11 +183,15 @@ public class VerticalMultiSplitPane extends JPanel implements Scrollable {
    }
 
    public void setComponentAtIndex(int index, JComponent child) {
-      splitPanes_.get(index).setTopComponent(child);
+      if (splitPanes_.size() > index) {
+         splitPanes_.get(index).setTopComponent(child);
+      }
    }
 
    public void setComponentResizeEnabled(int index, boolean enabled) {
-      splitPanes_.get(index).setEnabled(enabled);
+      if (splitPanes_.size() > index) {
+         splitPanes_.get(index).setEnabled(enabled);
+      }
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -44,7 +44,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private final int channelIndex_;
 
    private ImageStats stats_;
-   private int cameraBits_;
+   private Integer cameraBits_;
 
    private final JPanel channelPanel_ = new JPanel();
    private final JPanel histoPanel_ = new JPanel();
@@ -77,9 +77,14 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       }
 
       public ChannelDisplaySettings getBits(ChannelDisplaySettings settings, 
-              int cameraBits) {
+              Integer cameraBits) {
          int index = getIndexOf(getSelectedItem());
          if (index == 13) {
+            // in order to prevent null pointer exception when no cameraBits info is available
+            // I am not sure if this is the best default..
+            if (cameraBits == null) {
+               cameraBits = 16;
+            }
             return settings.copyBuilder().useCameraHistoRange(true).
                     histoRangeBits(cameraBits).build();
          }
@@ -427,9 +432,12 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          cameraBits_ = anyImage.getMetadata().getBitDepth(); // can throw IOException
          ChannelDisplaySettings cSettings = histoRangeComboBoxModel_.getBits(
                  viewer_.getDisplaySettings().getChannelSettings(0), cameraBits_);
-         int rangeBits = cameraBits_;
-         if (!cSettings.useCameraRange()) {
+
+         int rangeBits;
+         if (cameraBits_ == null || !cSettings.useCameraRange()) {
             rangeBits = cSettings.getHistoRangeBits();
+         } else {
+            rangeBits = cameraBits_;
          }
          long[] data = componentStats.getInRangeHistogram();
          int lengthToUse = Math.min(data.length, (1 << rangeBits) - 1);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -781,8 +781,11 @@ public final class DisplayUIController implements Closeable, WindowListener,
       // redrawing the info line (which may be expensive), check if pixelsize
       // changed (which can happen for the snap/live window) and only redraw the 
       // info label if it changed.
-      if (!cachedPixelSize_.equals(images.getRequest().getImage(0).getMetadata().
-              getPixelSizeUm())) {
+      Double currentPixelSize = images.getRequest().getImage(0).getMetadata().getPixelSizeUm();
+      if (currentPixelSize == null) {
+         currentPixelSize = 0.0;
+      }
+      if (!currentPixelSize.equals(cachedPixelSize_)) {
          infoLabel_.setText(this.getInfoString(images));
          ijBridge_.mm2ijSetMetadata();
          cachedPixelSize_ = images.getRequest().getImage(0).getMetadata().
@@ -1832,11 +1835,13 @@ public final class DisplayUIController implements Closeable, WindowListener,
          return "Failed to find image";
       }
 
-      double widthUm = getImageWidth() * pixelSize;
-      double heightUm = getImageHeight() * pixelSize;
-      infoStringB.append(NumberUtils.doubleToDisplayString(widthUm)).append("x").
-              append(NumberUtils.doubleToDisplayString(heightUm)).
-              append("\u00B5").append("m  ");
+      if (pixelSize != null && pixelSize != 0.0) {
+         double widthUm = getImageWidth() * pixelSize;
+         double heightUm = getImageHeight() * pixelSize;
+         infoStringB.append(NumberUtils.doubleToDisplayString(widthUm)).append("x").
+                 append(NumberUtils.doubleToDisplayString(heightUm)).
+                 append("\u00B5").append("m  ");
+      }
 
       infoStringB.append(getImageWidth()).append("x").append(getImageHeight());
       infoStringB.append("px  ");


### PR DESCRIPTION
Turns out, that the UI code would always set this field and set it to 0.0 (which is a bit weird).  This PR makes it possible to omit the field alltogether (at least, as far as I have tested things), and still provide a meaningful display. 