### PR TITLE
Studio: Fix bug in removing translation component of affine transform.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
@@ -256,7 +256,8 @@ public class PixelCalibratorDialog extends MMFrame {
       // Set translation part zero.
       double[] m = new double[6];
       result.getMatrix(m);
-      m[2] = 0;
+      // See source of AffineTransform.java.  TranslateX has index 4, TranslateY has index 5
+      m[4] = 0;
       m[5] = 0;
       result = new AffineTransform(m);
 


### PR DESCRIPTION
The PixelCalibratorDialog takes the affine transform from the calibrator, and sets the translation component to zero.  To do so, the transform is converted in an array of doubles, two values in the array are zeroed, and the array is converted back into an AffineTransform.  However, the translation components have index 4 and 5, not 2 and 5 (see definitions and code in AffineTransform.java), hence ShearX and TranslationY were zeroed rather than TranslationX and TranslationY. 

Fixed now.