### PR TITLE
Fix issue #786. Remove uses of MMDialog and MMFrame.

### DIFF
--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
@@ -267,7 +267,7 @@ public class ProjectorControlForm extends JFrame {
       delayField_.setText(settings_.getString(Terms.DELAY, "0"));
       logDirectoryTextField_.setText(settings_.getString(Terms.LOGDIRECTORY, ""));
 
-      setLocation(500, 300);
+      super.setLocation(500, 300);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       updateROISettings();
    }

--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
@@ -267,7 +267,7 @@ public class ProjectorControlForm extends JFrame {
       delayField_.setText(settings_.getString(Terms.DELAY, "0"));
       logDirectoryTextField_.setText(settings_.getString(Terms.LOGDIRECTORY, ""));
 
-      super.setLocation(500, 300);
+      setLocation(500, 300);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       updateROISettings();
    }

--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
@@ -57,18 +57,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JSpinner;
-import javax.swing.JTabbedPane;
-import javax.swing.JTextField;
-import javax.swing.JToggleButton;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.text.DefaultFormatter;
 
@@ -87,6 +76,7 @@ import org.micromanager.events.AcquisitionEndedEvent;
 import org.micromanager.events.AcquisitionStartedEvent;
 import org.micromanager.events.SLMExposureChangedEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 import org.micromanager.projector.internal.devices.SLM;
@@ -99,7 +89,6 @@ import org.micromanager.projector.Mapping;
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.FileDialogs.FileType;
 import org.micromanager.display.internal.event.DataViewerDidBecomeActiveEvent;
@@ -109,7 +98,7 @@ import org.micromanager.display.internal.event.DisplayMouseEvent;
  * The main window for the Projector plugin. Contains logic for calibration,
  * and control for SLMs and Galvos.
 */
-public class ProjectorControlForm extends MMFrame {
+public class ProjectorControlForm extends JFrame {
    private static ProjectorControlForm formSingleton_;
    private final ProjectorControlExecution projectorControlExecution_;
    private final Object studioEventHandler_;
@@ -278,7 +267,8 @@ public class ProjectorControlForm extends MMFrame {
       delayField_.setText(settings_.getString(Terms.DELAY, "0"));
       logDirectoryTextField_.setText(settings_.getString(Terms.LOGDIRECTORY, ""));
 
-      super.loadAndRestorePosition(500, 300);
+      super.setLocation(500, 300);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       updateROISettings();
    }
    

--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
@@ -54,7 +54,7 @@ public final class AlertsWindow extends JFrame {
       studio_ = studio;
       studio.events().registerForEvents(this);
 
-      super.setLocation(300, 100);
+      setLocation(300, 100);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       
       super.setLayout(new MigLayout("fill, insets 2, gap 0"));

--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
@@ -31,21 +31,15 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.HashSet;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.events.internal.InternalShutdownCommencingEvent;
-import org.micromanager.internal.utils.MMFrame;
+import org.micromanager.internal.utils.WindowPositioning;
 
 
-
-public final class AlertsWindow extends MMFrame {
+public final class AlertsWindow extends JFrame {
    private static final String NO_ALERTS_MSG = "There are no messages at this time.";
    private static final String SHOULD_SHOW_WINDOW = "Show the Messages window when a message is received";
 
@@ -60,8 +54,8 @@ public final class AlertsWindow extends MMFrame {
       studio_ = studio;
       studio.events().registerForEvents(this);
 
-
-      super.loadAndRestorePosition(300, 100);
+      super.setLocation(300, 100);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       
       super.setLayout(new MigLayout("fill, insets 2, gap 0"));
 

--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
@@ -55,7 +55,7 @@ public final class AlertsWindow extends JFrame {
       studio.events().registerForEvents(this);
 
       setLocation(300, 100);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
       super.setLayout(new MigLayout("fill, insets 2, gap 0"));
 

--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
@@ -54,7 +54,7 @@ public final class AlertsWindow extends JFrame {
       studio_ = studio;
       studio.events().registerForEvents(this);
 
-      setLocation(300, 100);
+      super.setLocation(300, 100);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
       super.setLayout(new MigLayout("fill, insets 2, gap 0"));

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
@@ -53,7 +53,6 @@ import org.micromanager.display.internal.event.DataViewerWillCloseEvent;
 import org.micromanager.display.internal.event.InspectorDidCloseEvent;
 import org.micromanager.internal.utils.EventBusExceptionLogger;
 import org.micromanager.internal.utils.GUIUtils;
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.WindowPositioning;
 import org.scijava.plugin.Plugin;
 import org.micromanager.display.inspector.InspectorPanelController;
@@ -140,7 +139,7 @@ public final class InspectorController
    }
 
    private void makeUI() {
-      frame_ = new MMFrame(); // TODO
+      frame_ = new JFrame(); // TODO
       frame_.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
       frame_.addWindowListener(new WindowAdapter() {
          @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -89,20 +89,10 @@ import org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEv
 import org.micromanager.display.internal.gearmenu.GearButton;
 import org.micromanager.display.overlay.Overlay;
 import org.micromanager.events.internal.ChannelColorEvent;
-import org.micromanager.internal.utils.GUIUtils;
-import org.micromanager.internal.utils.Geometry;
-import org.micromanager.internal.utils.MMFrame;
-import org.micromanager.internal.utils.CoalescentEDTRunnablePool;
+import org.micromanager.internal.utils.*;
 import org.micromanager.internal.utils.CoalescentEDTRunnablePool.CoalescentRunnable;
-import org.micromanager.internal.utils.MustCallOnEDT;
-import org.micromanager.internal.utils.PopupButton;
-import org.micromanager.internal.utils.ThreadFactoryFactory;
 import org.micromanager.internal.utils.performance.PerformanceMonitor;
 import org.micromanager.internal.utils.performance.TimeIntervalRunningQuantile;
-import org.micromanager.internal.utils.JavaUtils;
-import org.micromanager.internal.utils.NumberUtils;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.ColorMaps;
 
 /**
  * Manages the JFrame(s) for image displays.
@@ -266,10 +256,11 @@ public final class DisplayUIController implements Closeable, WindowListener,
    private JFrame makeFrame(boolean fullScreen) {
       JFrame frame;
       if (!fullScreen) {
-         // TODO LATER Eliminate MMFrame
-         frame = new MMFrame("image display window", false);
+         frame = new JFrame("image display window");
          frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-         ((MMFrame) frame).loadPosition(320, 320, 480, 320);
+         frame.setLocation(320, 320);
+         frame.setSize(480, 320);
+         WindowPositioning.setUpBoundsMemory(frame, frame.getClass(), null);
 
          // TODO Determine initial window bounds using a CascadingWindowPositioner:
          // - (Setting canvas zoom has been handled by DisplayController (ImageJLink))

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -258,8 +258,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
       if (!fullScreen) {
          frame = new JFrame("image display window");
          frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-         frame.setLocation(320, 320);
-         frame.setSize(480, 320);
+         frame.setBounds(320, 320, 480, 320);
          WindowPositioning.setUpBoundsMemory(frame, frame.getClass(), null);
 
          // TODO Determine initial window bounds using a CascadingWindowPositioner:

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
@@ -55,7 +55,7 @@ import org.micromanager.internal.utils.ReportingUtils;
  * This dialog provides an interface for exporting (a portion of) a dataset
  * to an image sequence, complete with all MicroManager overlays.
  */
-public final class ExportMovieDlg extends JFrame {
+public final class ExportMovieDlg extends JDialog {
    private static final Icon ADD_ICON =
                IconLoader.getIcon("/org/micromanager/icons/plus_green.png");
    private static final Icon DELETE_ICON =

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
@@ -35,15 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import javax.swing.BorderFactory;
-import javax.swing.Icon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JSpinner;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import net.miginfocom.swing.MigLayout;
@@ -56,7 +48,6 @@ import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.ImageExporter;
 import org.micromanager.internal.utils.FileDialogs;
-import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.ReportingUtils;
 
 
@@ -64,7 +55,7 @@ import org.micromanager.internal.utils.ReportingUtils;
  * This dialog provides an interface for exporting (a portion of) a dataset
  * to an image sequence, complete with all MicroManager overlays.
  */
-public final class ExportMovieDlg extends MMDialog {
+public final class ExportMovieDlg extends JFrame {
    private static final Icon ADD_ICON =
                IconLoader.getIcon("/org/micromanager/icons/plus_green.png");
    private static final Icon DELETE_ICON =

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -162,7 +162,7 @@ public final class MainFrame extends JFrame {
       // pack().
       super.pack();
       super.setMinimumSize(super.getSize());
-      setBounds(100, 100, 644, 220);
+      super.setBounds(100, 100, 644, 220);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       mmStudio_.events().registerForEvents(this);
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -162,7 +162,8 @@ public final class MainFrame extends JFrame {
       // pack().
       super.pack();
       super.setMinimumSize(super.getSize());
-      resetPosition();
+      setBounds(100, 100, 644, 220);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       mmStudio_.events().registerForEvents(this);
    }
 
@@ -188,13 +189,6 @@ public final class MainFrame extends JFrame {
             mmStudio_.closeSequence(false);
          }
       });
-   }
-
-   public void resetPosition() {
-      // put frame back where it was last time if possible
-      super.setLocation(100, 100);
-      super.setSize(644, 220);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
    }
 
    public void initializeConfigPad() {
@@ -777,7 +771,6 @@ public final class MainFrame extends JFrame {
     * Save our settings to the user profile.
     */
    public void savePrefs() {
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       mmStudio_.profile().getSettings(MainFrame.class).putString(
             MAIN_EXPOSURE, textFieldExp_.getText());
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -73,19 +73,14 @@ import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
 import org.micromanager.events.internal.ShutterDevicesEvent;
 import org.micromanager.internal.dialogs.OptionsDlg;
 import org.micromanager.internal.dialogs.StageControlFrame;
-import org.micromanager.internal.utils.DragDropUtil;
-import org.micromanager.internal.utils.GUIUtils;
-import org.micromanager.internal.utils.MMFrame;
-import org.micromanager.internal.utils.MMKeyDispatcher;
-import org.micromanager.internal.utils.NumberUtils;
-import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.*;
 import org.micromanager.quickaccess.internal.QuickAccessFactory;
 import org.micromanager.quickaccess.internal.controls.ShutterControl;
 
 /**
  * GUI code for the primary window of the program. And nothing else.
  */
-public final class MainFrame extends MMFrame {
+public final class MainFrame extends JFrame {
 
    private static final String MICRO_MANAGER_TITLE = "Micro-Manager";
    private static final String MAIN_EXPOSURE = "exposure";
@@ -197,7 +192,9 @@ public final class MainFrame extends MMFrame {
 
    public void resetPosition() {
       // put frame back where it was last time if possible
-      loadAndRestorePosition(100, 100, 644, 220);
+      super.setLocation(100, 100);
+      super.setSize(644, 220);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
    }
 
    public void initializeConfigPad() {
@@ -780,7 +777,7 @@ public final class MainFrame extends MMFrame {
     * Save our settings to the user profile.
     */
    public void savePrefs() {
-      this.savePosition();
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       mmStudio_.profile().getSettings(MainFrame.class).putString(
             MAIN_EXPOSURE, textFieldExp_.getText());
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -47,16 +47,7 @@ import org.micromanager.Studio;
 import org.micromanager.events.PropertiesChangedEvent;
 import org.micromanager.events.PropertyChangedEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
-import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.MMFrame;
-import org.micromanager.internal.utils.PropertyItem;
-import org.micromanager.internal.utils.PropertyNameCellRenderer;
-import org.micromanager.internal.utils.PropertyTableData;
-import org.micromanager.internal.utils.PropertyValueCellEditor;
-import org.micromanager.internal.utils.PropertyValueCellRenderer;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.ShowFlags;
-import org.micromanager.internal.utils.ShowFlagsPanel;
+import org.micromanager.internal.utils.*;
 
 /**
  * JFrame based component for generic manipulation of device properties.
@@ -65,7 +56,7 @@ import org.micromanager.internal.utils.ShowFlagsPanel;
  *
  * aka the "Device/Property Browser"
  */
-public final class PropertyEditor extends MMFrame {
+public final class PropertyEditor extends JFrame {
    private static final long serialVersionUID = 1507097881635431043L;
 
    private JTable table_;
@@ -87,8 +78,10 @@ public final class PropertyEditor extends MMFrame {
 
       createTable();
       createComponents();
-      
-      loadAndRestorePosition(100, 100, 550, 600);
+
+      super.setLocation(100, 100);
+      super.setSize(550, 600);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       setMinimumSize(new Dimension(420, 400));
    }
 
@@ -129,7 +122,9 @@ public final class PropertyEditor extends MMFrame {
       });
       setTitle("Device Property Browser");
 
-      loadAndRestorePosition(100, 100, 550, 600);
+      super.setLocation(100, 100);
+      super.setSize(550, 600);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
       
       final JButton refreshButton = new JButton("Refresh",

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -79,8 +79,7 @@ public final class PropertyEditor extends JFrame {
       createTable();
       createComponents();
 
-      super.setLocation(100, 100);
-      super.setSize(550, 600);
+      setBounds(100, 100, 550, 600);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       setMinimumSize(new Dimension(420, 400));
    }
@@ -122,9 +121,6 @@ public final class PropertyEditor extends JFrame {
       });
       setTitle("Device Property Browser");
 
-      super.setLocation(100, 100);
-      super.setSize(550, 600);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
       
       final JButton refreshButton = new JButton("Refresh",

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -79,7 +79,7 @@ public final class PropertyEditor extends JFrame {
       createTable();
       createComponents();
 
-      setBounds(100, 100, 550, 600);
+      super.setBounds(100, 100, 550, 600);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       setMinimumSize(new Dimension(420, 400));
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
@@ -111,7 +111,7 @@ public final class CalibrationEditor extends JDialog {
       setTitle("Calibration Group Editor");
 
       setMinimumSize(new Dimension(490, 280));
-      setBounds(100, 100, 551, 562);
+      super.setBounds(100, 100, 551, 562);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       // setResizable(false);
       setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
@@ -91,12 +91,27 @@ public final class CalibrationEditor extends JDialog {
       
       springLayout = new SpringLayout();
       getContentPane().setLayout(springLayout);
-
+      addWindowListener(new WindowAdapter() {
+         @Override
+         public void windowClosing(WindowEvent e) {
+            flags_.save(CalibrationEditor.class);
+         }
+         @Override
+         public void windowOpened(WindowEvent e) {
+            // restore values from the previous session
+            data_.updateFlags();
+            data_.updateStatus();
+            data_.showOriginalSelection();
+         }
+         @Override
+         public void windowClosed(WindowEvent arg0) {
+            flags_.save(CalibrationEditor.class);
+         }
+      });
       setTitle("Calibration Group Editor");
 
       setMinimumSize(new Dimension(490, 280));
-      super.setLocation(100, 100);
-      super.setSize(551, 562);
+      setBounds(100, 100, 551, 562);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       // setResizable(false);
       setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationEditor.java
@@ -34,19 +34,7 @@ import java.awt.event.WindowEvent;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import javax.swing.AbstractCellEditor;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.ListSelectionModel;
-import javax.swing.SpringLayout;
-import javax.swing.WindowConstants;
+import javax.swing.*;
 import javax.swing.border.BevelBorder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellEditor;
@@ -59,19 +47,12 @@ import mmcorej.PropertySetting;
 import mmcorej.PropertyType;
 import mmcorej.StrVector;
 import org.micromanager.Studio;
-import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.MMDialog;
-import org.micromanager.internal.utils.NumberUtils;
-import org.micromanager.internal.utils.PropertyItem;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.ShowFlags;
-import org.micromanager.internal.utils.SliderPanel;
-import org.micromanager.internal.utils.SortFunctionObjects;
+import org.micromanager.internal.utils.*;
 
 /**
  * Dialog for editing of a pixel size configuration preset.
  */
-public final class CalibrationEditor extends MMDialog {
+public final class CalibrationEditor extends JDialog {
    private static final long serialVersionUID = 1L;
    private final JTextArea textArea_;
    private final JTextField presetSizeField_;
@@ -97,7 +78,7 @@ public final class CalibrationEditor extends MMDialog {
    private boolean tableEditable_ = true;
     
    public CalibrationEditor(Studio studio, String label, String pixelSize) {
-      super("calibration editor");
+      super();
       setModal(true);
       studio_ = studio;
       label_ = label;
@@ -110,29 +91,13 @@ public final class CalibrationEditor extends MMDialog {
       
       springLayout = new SpringLayout();
       getContentPane().setLayout(springLayout);
-      addWindowListener(new WindowAdapter() {
-         @Override
-         public void windowClosing(WindowEvent e) {
-            savePosition();
-            flags_.save(CalibrationEditor.class);
-         }
-         @Override
-         public void windowOpened(WindowEvent e) {
-            // restore values from the previous session
-            data_.updateFlags();
-            data_.updateStatus();
-            data_.showOriginalSelection();
-        }
-         @Override
-         public void windowClosed(WindowEvent arg0) {
-            savePosition();
-            flags_.save(CalibrationEditor.class);
-         }
-      });
+
       setTitle("Calibration Group Editor");
 
       setMinimumSize(new Dimension(490, 280));
-      loadPosition(100, 100, 551, 562);
+      super.setLocation(100, 100);
+      super.setSize(551, 562);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       // setResizable(false);
       setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
@@ -148,9 +148,8 @@ public final class CalibrationListDlg extends JDialog {
 
       super.setMinimumSize(new Dimension(263, 239));
 
-      super.setLocation(100, 100);
-      super.setSize(365, 495);
-      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+      setBounds(100, 100, 365, 495);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       Rectangle r = super.getBounds();
       r.x +=1;

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
@@ -34,17 +34,13 @@ import mmcorej.Configuration;
 import org.micromanager.Studio;
 import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.utils.Calibration;
-import org.micromanager.internal.utils.CalibrationList;
-import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.MMDialog;
-import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.*;
 
 /*
  * Dialog for listing pixel size configuration presets and the corresponding
  * pixel size for each.
  */
-public final class CalibrationListDlg extends MMDialog {
+public final class CalibrationListDlg extends JDialog {
    private static final long serialVersionUID = 1L;
    private static final String TITLE = "Calibration Editor";
    public static final String PIXEL_SIZE_GROUP = "ConfigPixelSize";
@@ -144,14 +140,18 @@ public final class CalibrationListDlg extends MMDialog {
     * @param core - The Micro-Manager core object
     */
    public CalibrationListDlg(CMMCore core) {
-      super("calibration list");
+      super();
       core_ = core;
       super.setTitle("Pixel Size Calibration");
       springLayout = new SpringLayout();
       super.getContentPane().setLayout(springLayout);
 
       super.setMinimumSize(new Dimension(263, 239));
-      super.loadAndRestorePosition(100, 100, 365, 495);
+
+      super.setLocation(100, 100);
+      super.setSize(365, 495);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+
       Rectangle r = super.getBounds();
       r.x +=1;
       

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
@@ -148,7 +148,7 @@ public final class CalibrationListDlg extends JDialog {
 
       super.setMinimumSize(new Dimension(263, 239));
 
-      setBounds(100, 100, 365, 495);
+      super.setBounds(100, 100, 365, 495);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       Rectangle r = super.getBounds();

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
@@ -28,20 +28,7 @@ import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import javax.swing.AbstractAction;
-import javax.swing.ActionMap;
-import javax.swing.InputMap;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.KeyStroke;
-import javax.swing.ListSelectionModel;
+import javax.swing.*;
 import javax.swing.border.BevelBorder;
 import javax.swing.table.TableColumn;
 import java.awt.event.WindowAdapter;
@@ -53,22 +40,12 @@ import org.micromanager.Studio;
 import org.micromanager.events.PropertiesChangedEvent;
 import org.micromanager.events.PropertyChangedEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
-import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.MMDialog;
-import org.micromanager.internal.utils.PropertyNameCellRenderer;
-import org.micromanager.internal.utils.PropertyTableData;
-import org.micromanager.internal.utils.PropertyUsageCellEditor;
-import org.micromanager.internal.utils.PropertyUsageCellRenderer;
-import org.micromanager.internal.utils.PropertyValueCellEditor;
-import org.micromanager.internal.utils.PropertyValueCellRenderer;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.ShowFlags;
-import org.micromanager.internal.utils.ShowFlagsPanel;
+import org.micromanager.internal.utils.*;
 
 /*
  * A base class from which GroupEditor and PresetEditor are derived.
  */
-public abstract class ConfigDialog extends MMDialog {
+public abstract class ConfigDialog extends JDialog {
 
    private static final long serialVersionUID = 5819669941239786807L;
 
@@ -114,7 +91,7 @@ public abstract class ConfigDialog extends MMDialog {
 
    public ConfigDialog(String groupName, String presetName, Studio studio, 
            boolean newItem) {
-      super("config editing for " + groupName);
+      super();
       groupName_ = groupName;
       presetName_ = presetName;
       newItem_ = newItem;
@@ -321,7 +298,8 @@ public abstract class ConfigDialog extends MMDialog {
    public void dispose() {
       studio_.events().unregisterForEvents(this);
       super.dispose();
-      savePosition();
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+
       studio_.app().refreshGUI();
    }
    

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
@@ -298,8 +298,6 @@ public abstract class ConfigDialog extends JDialog {
    public void dispose() {
       studio_.events().unregisterForEvents(this);
       super.dispose();
-      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
-
       studio_.app().refreshGUI();
    }
    

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CustomTimeIntervalsPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CustomTimeIntervalsPanel.java
@@ -3,23 +3,9 @@ package org.micromanager.internal.dialogs;
 import org.micromanager.Studio;
 import org.micromanager.acquisition.internal.AcquisitionEngine;
 import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.TooltipTextMaker;
 
-import javax.swing.BoxLayout;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JFormattedTextField;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.SpinnerModel;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import javax.swing.event.CaretEvent;
 import javax.swing.event.CaretListener;
 import javax.swing.event.ChangeEvent;
@@ -218,7 +204,7 @@ public final class CustomTimeIntervalsPanel extends JPanel {
          intervalTableModel_.syncIntervalsFromAcqEng();
      }
 
-    private class LogTimeDialog extends MMDialog {
+    private class LogTimeDialog extends JDialog {
 
 
         private JComboBox creationTypeCombo_;
@@ -234,7 +220,7 @@ public final class CustomTimeIntervalsPanel extends JPanel {
        private int n_;
 
         public LogTimeDialog() {
-            super("logarithmic spacing");
+            super();
             this.setModal(true);
             this.setSize(new Dimension(520, 300));
             this.setResizable(false);
@@ -579,7 +565,7 @@ public final class CustomTimeIntervalsPanel extends JPanel {
         }
     }
 
-    private class LinearTimeDialog extends MMDialog {
+    private class LinearTimeDialog extends JDialog {
 
         private JSpinner numFrames_;
         private JFormattedTextField interval_;
@@ -587,7 +573,7 @@ public final class CustomTimeIntervalsPanel extends JPanel {
         private JComboBox creationTypeCombo_;
 
         public LinearTimeDialog() {
-            super("linear spacing");
+            super();
             this.setModal(true);
             this.setSize(new Dimension(350, 200));
             this.setResizable(false);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CustomTimesDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CustomTimesDialog.java
@@ -13,7 +13,6 @@ import javax.swing.JPanel;
 import org.micromanager.Studio;
 import org.micromanager.acquisition.internal.AcquisitionEngine;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.WindowPositioning;
 
 /**

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
@@ -57,7 +57,7 @@ public final class GroupEditor extends ConfigDialog {
       initializeData();
       data_.setColumnNames("Property Name", "Use in Group?", "Current Property Value");
       initialize();
-      setBounds(100, 100, 550, 600);
+      super.setBounds(100, 100, 550, 600);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(520, 400));
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
@@ -34,10 +34,7 @@ import mmcorej.StrVector;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.utils.PropertyItem;
-import org.micromanager.internal.utils.PropertyTableData;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.SortFunctionObjects;
+import org.micromanager.internal.utils.*;
 
 public final class GroupEditor extends ConfigDialog {
 
@@ -60,7 +57,9 @@ public final class GroupEditor extends ConfigDialog {
       initializeData();
       data_.setColumnNames("Property Name", "Use in Group?", "Current Property Value");
       initialize();
-      super.loadAndRestorePosition(100, 100, 550, 600);
+      super.setLocation(100, 100);
+      super.setSize(550, 600);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(520, 400));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
@@ -57,9 +57,8 @@ public final class GroupEditor extends ConfigDialog {
       initializeData();
       data_.setColumnNames("Property Name", "Use in Group?", "Current Property Value");
       initialize();
-      super.setLocation(100, 100);
-      super.setSize(550, 600);
-      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+      setBounds(100, 100, 550, 600);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(520, 400));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -75,7 +75,7 @@ public final class OptionsDlg extends JDialog {
       super.setAlwaysOnTop(true);
       super.setTitle("Micro-Manager Options");
 
-      setLocation(100, 100);
+      super.setLocation(100, 100);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -75,7 +75,7 @@ public final class OptionsDlg extends JDialog {
       super.setAlwaysOnTop(true);
       super.setTitle("Micro-Manager Options");
 
-      super.setLocation(100, 100);
+      setLocation(100, 100);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -25,14 +25,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.text.ParseException;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JSeparator;
-import javax.swing.JTextField;
-import javax.swing.WindowConstants;
+import javax.swing.*;
+
 import mmcorej.CMMCore;
 import org.micromanager.ApplicationSkin.SkinMode;
 import org.micromanager.Studio;
@@ -42,17 +36,14 @@ import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.StartupSettings;
 import org.micromanager.internal.logging.LogFileManager;
 import org.micromanager.internal.script.ScriptPanel;
-import org.micromanager.internal.utils.MMDialog;
-import org.micromanager.internal.utils.NumberUtils;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.UIMonitor;
+import org.micromanager.internal.utils.*;
 import org.micromanager.internal.zmq.ZMQSocketWrapper;
 
 /**
  * Options dialog for MMStudio.
  *
  */
-public final class OptionsDlg extends MMDialog {
+public final class OptionsDlg extends JDialog {
    private static final long serialVersionUID = 1L;
    private static final String IS_DEBUG_LOG_ENABLED = "is debug logging enabled";
    private static final String SHOULD_CLOSE_ON_EXIT = "should close the entire program when the Micro-Manager plugin is closed";
@@ -72,7 +63,7 @@ public final class OptionsDlg extends MMDialog {
     * @param mmStudio - MMStudio object (including Studio implementation) 
     */
    public OptionsDlg(CMMCore core, MMStudio mmStudio) {
-      super("global micro-manager options");
+      super();
       mmStudio_ = mmStudio;
       core_ = core;
 
@@ -84,7 +75,8 @@ public final class OptionsDlg extends MMDialog {
       super.setAlwaysOnTop(true);
       super.setTitle("Micro-Manager Options");
 
-      super.loadAndRestorePosition(100, 100);
+      super.setLocation(100, 100);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
       super.addWindowListener(new WindowAdapter() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
@@ -25,11 +25,7 @@ import java.awt.geom.AffineTransform;
 import java.text.ParseException;
 import mmcorej.StrVector;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.utils.AffineUtils;
-import org.micromanager.internal.utils.NumberUtils;
-import org.micromanager.internal.utils.PropertyItem;
-import org.micromanager.internal.utils.PropertyTableData;
-import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.*;
 
 /**
  *
@@ -68,7 +64,9 @@ public class PixelConfigEditor extends ConfigDialog implements PixelSizeProvider
       affineEditorPanel_ = new AffineEditorPanel(parent.getStudio(), this, 
             AffineUtils.noTransform());
       super.initialize();
-      super.loadAndRestorePosition(100, 100, 550, 600);
+      super.setLocation(100, 100);
+      super.setSize(550, 600);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(500, 530));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
@@ -64,7 +64,7 @@ public class PixelConfigEditor extends ConfigDialog implements PixelSizeProvider
       affineEditorPanel_ = new AffineEditorPanel(parent.getStudio(), this, 
             AffineUtils.noTransform());
       super.initialize();
-      setBounds(100, 100, 550, 600);
+      super.setBounds(100, 100, 550, 600);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(500, 530));
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
@@ -64,9 +64,8 @@ public class PixelConfigEditor extends ConfigDialog implements PixelSizeProvider
       affineEditorPanel_ = new AffineEditorPanel(parent.getStudio(), this, 
             AffineUtils.noTransform());
       super.initialize();
-      super.setLocation(100, 100);
-      super.setSize(550, 600);
-      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+      setBounds(100, 100, 550, 600);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(500, 530));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
@@ -79,7 +79,7 @@ public class PixelPresetEditor extends ConfigDialog implements PixelSizeProvider
       affineEditorPanel_ = new AffineEditorPanel(parent_.getStudio(), this, affineTransform_);
 
       super.initialize();  // will call initializeWidgets, which overrides the base class
-      setBounds(100, 100, 450, 400);
+      super.setBounds(100, 100, 450, 400);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(380, 350));
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
@@ -79,7 +79,9 @@ public class PixelPresetEditor extends ConfigDialog implements PixelSizeProvider
       affineEditorPanel_ = new AffineEditorPanel(parent_.getStudio(), this, affineTransform_);
 
       super.initialize();  // will call initializeWidgets, which overrides the base class
-      super.loadAndRestorePosition(100, 100, 450, 400);
+      super.setLocation(100, 100);
+      super.setSize(450, 400);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(380, 350));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
@@ -79,9 +79,8 @@ public class PixelPresetEditor extends ConfigDialog implements PixelSizeProvider
       affineEditorPanel_ = new AffineEditorPanel(parent_.getStudio(), this, affineTransform_);
 
       super.initialize();  // will call initializeWidgets, which overrides the base class
-      super.setLocation(100, 100);
-      super.setSize(450, 400);
-      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+      setBounds(100, 100, 450, 400);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(380, 350));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
@@ -52,7 +52,7 @@ public final class PresetEditor extends ConfigDialog {
       data_.setColumnNames("Property Name","Preset Value","");
       data_.setShowReadOnly(true);
       initialize();
-      setBounds(100, 100, 420, 300);
+      super.setBounds(100, 100, 420, 300);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(400, 250));
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
@@ -52,9 +52,8 @@ public final class PresetEditor extends ConfigDialog {
       data_.setColumnNames("Property Name","Preset Value","");
       data_.setShowReadOnly(true);
       initialize();
-      super.setLocation(100, 100);
-      super.setSize(420, 300);
-      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+      setBounds(100, 100, 420, 300);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(400, 250));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
@@ -29,6 +29,7 @@ import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.PropertyItem;
 import org.micromanager.internal.utils.PropertyTableData;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 public final class PresetEditor extends ConfigDialog {
 
@@ -51,7 +52,9 @@ public final class PresetEditor extends ConfigDialog {
       data_.setColumnNames("Property Name","Preset Value","");
       data_.setShowReadOnly(true);
       initialize();
-      super.loadAndRestorePosition(100, 100, 420, 300);
+      super.setLocation(100, 100);
+      super.setSize(420, 300);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setMinimumSize(new Dimension(400, 250));
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -149,7 +149,7 @@ public final class StageControlFrame extends JFrame {
 
       initComponents();
 
-      setLocation(FRAME_X_DEFAULT_POS, FRAME_Y_DEFAULT_POS);
+      super.setLocation(FRAME_X_DEFAULT_POS, FRAME_Y_DEFAULT_POS);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -149,8 +149,8 @@ public final class StageControlFrame extends JFrame {
 
       initComponents();
 
-      super.setLocation(FRAME_X_DEFAULT_POS, FRAME_Y_DEFAULT_POS);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(FRAME_X_DEFAULT_POS, FRAME_Y_DEFAULT_POS);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -46,9 +46,9 @@ import org.micromanager.events.XYStagePositionChangedEvent;
 import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.navigation.UiMovesStageManager;
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.TextUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 import javax.swing.BorderFactory;
@@ -74,7 +74,7 @@ import javax.swing.JRadioButton;
  * keypress should move each stage from this dialog.  The Dialog should also
  * show which keys do what, and possibly provide the option to change these keys.
  */
-public final class StageControlFrame extends MMFrame {
+public final class StageControlFrame extends JFrame {
    private final Studio studio_;
    private final CMMCore core_;
    private final UiMovesStageManager uiMovesStageManager_;
@@ -149,7 +149,8 @@ public final class StageControlFrame extends MMFrame {
 
       initComponents();
 
-      super.loadAndRestorePosition(FRAME_X_DEFAULT_POS, FRAME_Y_DEFAULT_POS);
+      super.setLocation(FRAME_X_DEFAULT_POS, FRAME_Y_DEFAULT_POS);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/graph/GraphFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/graph/GraphFrame.java
@@ -22,6 +22,8 @@
 //
 
 package org.micromanager.internal.graph;
+import org.micromanager.internal.utils.WindowPositioning;
+
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
@@ -33,13 +35,12 @@ import javax.swing.JLabel;
 import javax.swing.JTextField;
 import javax.swing.SpringLayout;
 import javax.swing.border.LineBorder;
-import org.micromanager.internal.utils.MMFrame;
 
 /**
  * XY Graph window.
  *
  */
-public final class GraphFrame extends MMFrame {
+public final class GraphFrame extends JFrame {
 
    /**
     * 
@@ -125,7 +126,9 @@ public final class GraphFrame extends MMFrame {
       setTitle("Graph");
       springLayout = new SpringLayout();
       getContentPane().setLayout(springLayout);
-      loadAndRestorePosition(100, 100, 542, 298);
+      super.setLocation(100, 100);
+      super.setSize(542, 298);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
       panel_ = new GraphPanel();

--- a/mmstudio/src/main/java/org/micromanager/internal/graph/GraphFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/graph/GraphFrame.java
@@ -126,7 +126,7 @@ public final class GraphFrame extends JFrame {
       setTitle("Graph");
       springLayout = new SpringLayout();
       getContentPane().setLayout(springLayout);
-      setBounds(100, 100, 542, 298);
+      super.setBounds(100, 100, 542, 298);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 

--- a/mmstudio/src/main/java/org/micromanager/internal/graph/GraphFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/graph/GraphFrame.java
@@ -126,8 +126,7 @@ public final class GraphFrame extends JFrame {
       setTitle("Graph");
       springLayout = new SpringLayout();
       getContentPane().setLayout(springLayout);
-      super.setLocation(100, 100);
-      super.setSize(542, 298);
+      setBounds(100, 100, 542, 298);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigWizard.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigWizard.java
@@ -23,7 +23,6 @@ package org.micromanager.internal.hcwizard;
 
 import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.BufferedReader;
@@ -44,28 +43,23 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
+import javax.swing.*;
+
 import mmcorej.CMMCore;
 import mmcorej.StrVector;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.HttpUtils;
-import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 /**
  * Configuration Wizard main panel.
  * Based on the dialog frame to be activated as part of the
  * MMStudio
  */
-public final class ConfigWizard extends MMDialog {
+public final class ConfigWizard extends JDialog {
 
    private static final long serialVersionUID = 1L;
    private JPanel pagePanel_;
@@ -88,7 +82,7 @@ public final class ConfigWizard extends MMDialog {
     * @param defFile
     */
    public ConfigWizard(Studio studio, String defFile) {
-      super("hardware configuration wizard");
+      super();
       studio_ = studio;
       core_ = studio_.core();
       defaultPath_ = defFile;
@@ -111,7 +105,9 @@ public final class ConfigWizard extends MMDialog {
       });
       getContentPane().setLayout(new MigLayout());
       setTitle("Hardware Configuration Wizard");
-      loadPosition(50, 100);
+
+      super.setLocation(50, 100);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       titleLabel_ = new JLabel();
       titleLabel_.setText("Title");
@@ -332,7 +328,8 @@ public final class ConfigWizard extends MMDialog {
       for (int i = 0; i < pages_.length; i++) {
          pages_[i].saveSettings();
       }
-      savePosition();
+
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       if (microModel_.isModified()) {
          String[] buttons = new String[] {"Save As...", "Discard", "Cancel"};

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigWizard.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigWizard.java
@@ -106,7 +106,7 @@ public final class ConfigWizard extends JDialog {
       getContentPane().setLayout(new MigLayout());
       setTitle("Hardware Configuration Wizard");
 
-      setLocation(50, 100);
+      super.setLocation(50, 100);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       titleLabel_ = new JLabel();

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigWizard.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigWizard.java
@@ -106,8 +106,8 @@ public final class ConfigWizard extends JDialog {
       getContentPane().setLayout(new MigLayout());
       setTitle("Hardware Configuration Wizard");
 
-      super.setLocation(50, 100);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(50, 100);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       titleLabel_ = new JLabel();
       titleLabel_.setText("Title");
@@ -328,8 +328,6 @@ public final class ConfigWizard extends JDialog {
       for (int i = 0; i < pages_.length; i++) {
          pages_[i].saveSettings();
       }
-
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       if (microModel_.isModified()) {
          String[] buttons = new String[] {"Save As...", "Discard", "Cancel"};

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
@@ -46,8 +46,8 @@ public final class DeviceSetupDlg extends JDialog {
    public DeviceSetupDlg(MicroscopeModel mod, Studio studio, Device d) {
       super();
       setModal(true);
-      super.setLocation(100, 100);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(100, 100);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       model_ = mod;
       core_ = studio.core();
       studio_ = studio;
@@ -154,13 +154,11 @@ public final class DeviceSetupDlg extends JDialog {
    }
 
    protected void onCancel() {
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       dispose();
    }
 
    protected void onOK() {
       propTable_.editingStopped(null);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       String oldName = device_.getName();
       String newName = devName_.getText();
 

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
@@ -46,7 +46,7 @@ public final class DeviceSetupDlg extends JDialog {
    public DeviceSetupDlg(MicroscopeModel mod, Studio studio, Device d) {
       super();
       setModal(true);
-      setLocation(100, 100);
+      super.setLocation(100, 100);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       model_ = mod;
       core_ = studio.core();

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
@@ -1,5 +1,6 @@
 package org.micromanager.internal.hcwizard;
 
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
@@ -9,14 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.ListSelectionModel;
+import javax.swing.*;
 import javax.swing.table.TableColumn;
 import mmcorej.CMMCore;
 import mmcorej.DeviceDetectionStatus;
@@ -25,15 +19,9 @@ import mmcorej.MMCoreJ;
 import mmcorej.StrVector;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
-import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.MMDialog;
-import org.micromanager.internal.utils.PropertyItem;
-import org.micromanager.internal.utils.PropertyNameCellRenderer;
-import org.micromanager.internal.utils.PropertyValueCellEditor;
-import org.micromanager.internal.utils.PropertyValueCellRenderer;
-import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.*;
 
-public final class DeviceSetupDlg extends MMDialog {
+public final class DeviceSetupDlg extends JDialog {
    private static final long serialVersionUID = 1L;
    private static final String SCAN_PORTS = "Scan Ports";
 
@@ -56,9 +44,10 @@ public final class DeviceSetupDlg extends MMDialog {
     * Create the dialog.
     */
    public DeviceSetupDlg(MicroscopeModel mod, Studio studio, Device d) {
-      super("hardware config wizard: device setup dialog");
+      super();
       setModal(true);
-      loadPosition(100, 100);
+      super.setLocation(100, 100);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       model_ = mod;
       core_ = studio.core();
       studio_ = studio;
@@ -159,26 +148,19 @@ public final class DeviceSetupDlg extends MMDialog {
       buttonPane.add(cancelButton, "wrap");
       contents_.add(buttonPane, "spanx, growx, wrap");
 
-      addWindowListener(new WindowAdapter() {
-         @Override
-         public void windowClosing(final WindowEvent e) {
-            savePosition();
-         }
-      });
-
       pack();
       loadSettings();
       setVisible(true);
    }
 
    protected void onCancel() {
-      savePosition();
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       dispose();
    }
 
    protected void onOK() {
       propTable_.editingStopped(null);
-      savePosition();
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       String oldName = device_.getName();
       String newName = devName_.getText();
 

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PeripheralSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PeripheralSetupDlg.java
@@ -4,24 +4,16 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.util.Vector;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
+import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.AbstractTableModel;
 import mmcorej.CMMCore;
 import mmcorej.MMCoreJ;
 import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.MMDialog;
+import org.micromanager.internal.utils.WindowPositioning;
 
-public final class PeripheralSetupDlg extends MMDialog {
+public final class PeripheralSetupDlg extends JDialog {
 
    private static final long serialVersionUID = 1L;
    private static final int NAMECOLUMN = 0;
@@ -147,10 +139,10 @@ public final class PeripheralSetupDlg extends MMDialog {
    private Vector<Device> peripherals_;
 
    public PeripheralSetupDlg(MicroscopeModel mod, CMMCore c, String hub, Vector<Device> per) {
-      super("hardware config wizard: peripheral setup");
+      super();
       setTitle("Peripheral Devices Setup");
       setBounds(100, 100, 479, 353);
-      loadPosition(100, 100);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       //setModalityType(ModalityType.APPLICATION_MODAL);
       setModal(true);
       setResizable(false);
@@ -207,12 +199,6 @@ public final class PeripheralSetupDlg extends MMDialog {
             buttonPane.add(cancelButton);
          }
       }
-      addWindowListener(new WindowAdapter() {
-         @Override
-         public void windowClosing(final WindowEvent e) {
-            savePosition();
-         }
-      });
       
       rebuildTable();
    }
@@ -264,12 +250,12 @@ public final class PeripheralSetupDlg extends MMDialog {
 //      } finally {
 //         dispose();
 //      }
-      savePosition();
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       dispose();
    }
    
    public void onCancel() {
-      savePosition();
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       dispose();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PeripheralSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PeripheralSetupDlg.java
@@ -141,7 +141,7 @@ public final class PeripheralSetupDlg extends JDialog {
    public PeripheralSetupDlg(MicroscopeModel mod, CMMCore c, String hub, Vector<Device> per) {
       super();
       setTitle("Peripheral Devices Setup");
-      setBounds(100, 100, 479, 353);
+      super.setBounds(100, 100, 479, 353);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       //setModalityType(ModalityType.APPLICATION_MODAL);
       setModal(true);

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PeripheralSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PeripheralSetupDlg.java
@@ -250,12 +250,10 @@ public final class PeripheralSetupDlg extends JDialog {
 //      } finally {
 //         dispose();
 //      }
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       dispose();
    }
    
    public void onCancel() {
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       dispose();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -26,15 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.ListSelectionModel;
+import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import net.miginfocom.swing.MigLayout;
@@ -48,10 +40,10 @@ import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.events.StartupCompleteEvent;
 import org.micromanager.events.internal.NewPluginEvent;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.utils.MMFrame;
+import org.micromanager.internal.utils.WindowPositioning;
 
 
-final public class PipelineFrame extends MMFrame
+final public class PipelineFrame extends JFrame
       implements ListSelectionListener {
 
    private static final String TITLE = "On-The-Fly Processor Pipeline";
@@ -187,8 +179,9 @@ final public class PipelineFrame extends MMFrame
             minSize.height + heightDelta);
       setPreferredSize(frameSize);
       setMinimumSize(minFrameSize);
-      
-      super.loadAndRestorePosition(200, 200);
+
+      super.setLocation(200, 200);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       studio_.events().registerForEvents(this);
       reloadProcessors();

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -180,7 +180,7 @@ final public class PipelineFrame extends JFrame
       setPreferredSize(frameSize);
       setMinimumSize(minFrameSize);
 
-      setLocation(200, 200);
+      super.setLocation(200, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       studio_.events().registerForEvents(this);

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -181,7 +181,7 @@ final public class PipelineFrame extends JFrame
       setMinimumSize(minFrameSize);
 
       setLocation(200, 200);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       studio_.events().registerForEvents(this);
       reloadProcessors();

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -180,7 +180,7 @@ final public class PipelineFrame extends JFrame
       setPreferredSize(frameSize);
       setMinimumSize(minFrameSize);
 
-      super.setLocation(200, 200);
+      setLocation(200, 200);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       studio_.events().registerForEvents(this);

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ProcessExistingDataDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ProcessExistingDataDialog.java
@@ -193,7 +193,7 @@ public final class ProcessExistingDataDialog extends JDialog {
 
       super.add(contents);
       super.pack();
-      super.setLocation(200, 200);
+      setLocation(200, 200);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setVisible(true);
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ProcessExistingDataDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ProcessExistingDataDialog.java
@@ -19,15 +19,8 @@ import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
-import javax.swing.ButtonGroup;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JTextField;
-import javax.swing.ProgressMonitor;
+import javax.swing.*;
+
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.data.Coords;
@@ -40,13 +33,13 @@ import org.micromanager.data.PipelineErrorException;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.JavaUtils;
-import org.micromanager.internal.utils.MMDialog;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 /**
  * This class allows users to process files that already exist on disk.
  */
-public final class ProcessExistingDataDialog extends MMDialog {
+public final class ProcessExistingDataDialog extends JDialog {
    private static final String LOAD_FROM_DISK = "Load From Disk...";
    private static final String OUTPUT_OPTION = "Output Option";
    private static final String OPTION_SINGLE_TIFF = "Option Single";
@@ -73,7 +66,7 @@ public final class ProcessExistingDataDialog extends MMDialog {
    final private MutablePropertyMapView settings_;
 
    private ProcessExistingDataDialog(Studio studio) {
-      super("Process Existing Data");
+      super();
       super.setTitle("Process Existing Data");
       studio_ = studio;
       settings_ = studio_.getUserProfile().getSettings(this.getClass());
@@ -200,7 +193,8 @@ public final class ProcessExistingDataDialog extends MMDialog {
 
       super.add(contents);
       super.pack();
-      super.loadAndRestorePosition(200, 200);
+      super.setLocation(200, 200);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       super.setVisible(true);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ProcessExistingDataDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ProcessExistingDataDialog.java
@@ -193,7 +193,7 @@ public final class ProcessExistingDataDialog extends JDialog {
 
       super.add(contents);
       super.pack();
-      setLocation(200, 200);
+      super.setLocation(200, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setVisible(true);
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ProcessExistingDataDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ProcessExistingDataDialog.java
@@ -194,7 +194,7 @@ public final class ProcessExistingDataDialog extends JDialog {
       super.add(contents);
       super.pack();
       setLocation(200, 200);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setVisible(true);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
@@ -427,7 +427,7 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
          super.add(cancelButton, "tag cancel, wrap");
          super.pack();
 
-         super.setLocation(200, 200);
+         setLocation(200, 200);
          WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
          super.setVisible(true);
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
@@ -427,7 +427,7 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
          super.add(cancelButton, "tag cancel, wrap");
          super.pack();
 
-         setLocation(200, 200);
+         super.setLocation(200, 200);
          WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
          super.setVisible(true);
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
@@ -428,7 +428,7 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
          super.pack();
 
          setLocation(200, 200);
-         WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+         WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
          super.setVisible(true);
       }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualPreciseCalibrationThread.java
@@ -13,10 +13,8 @@ import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+
 import mmcorej.CMMCore;
 import mmcorej.TaggedImage;
 import net.miginfocom.swing.MigLayout;
@@ -24,10 +22,7 @@ import org.micromanager.Studio;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.internal.displaywindow.DisplayController;
 import org.micromanager.display.internal.event.DisplayMouseEvent;
-import org.micromanager.internal.utils.MMFrame;
-import org.micromanager.internal.utils.MathFunctions;
-import org.micromanager.internal.utils.NumberUtils;
-import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.*;
 
 /**
  * The idea is to calibrate the camera/stage spatial relation by displaying an 
@@ -383,13 +378,13 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
    }
    
    
-   private class DialogFrame extends MMFrame {
+   private class DialogFrame extends JFrame {
 
       private static final long serialVersionUID = -7944616693940334489L;
       private final Object caller_;
       private final JButton okButton_;
       private final JLabel explanationLabel_;
-      
+
       public DialogFrame(Object caller) {
          caller_ = caller;
          explanationLabel_ = new JLabel();
@@ -410,7 +405,7 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
                  + "on an object somehwere <br>near the center of the image.";
          explanationLabel_.setText(label1Text);
          super.add(explanationLabel_, "span 2, wrap");
-         
+
          okButton_ = new JButton("OK");
          okButton_.addActionListener(new ActionListener() {
             @Override
@@ -421,7 +416,7 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
          });
          okButton_.setVisible(false);
          super.add(okButton_, "tag ok");
-         
+
          JButton cancelButton = new JButton("Cancel");
          cancelButton.addActionListener(new ActionListener() {
             @Override
@@ -431,10 +426,12 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
          });
          super.add(cancelButton, "tag cancel, wrap");
          super.pack();
-         super.loadAndRestorePosition(200, 200);
+
+         super.setLocation(200, 200);
+         WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
          super.setVisible(true);
       }
-      
+
       public void setLabelText(String newText) {
          if (!SwingUtilities.isEventDispatchThread()) {
             SwingUtilities.invokeLater(new Runnable() {
@@ -446,7 +443,7 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
          }
          explanationLabel_.setText(newText);
       }
-      
+
       @Override
       public void dispose() {
          super.dispose();
@@ -459,11 +456,11 @@ public class ManualPreciseCalibrationThread extends CalibrationThread {
          //running_.set(false);
          dialog_.calibrationFailed(true);
       }
-      
+
       public void setOKButtonVisible(boolean visible) {
          okButton_.setVisible(visible);
       }
    }
 
-   
+
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualSimpleCalibrationThread.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/ManualSimpleCalibrationThread.java
@@ -28,10 +28,8 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+
 import mmcorej.CMMCore;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
@@ -39,9 +37,9 @@ import org.micromanager.display.DisplayWindow;
 import org.micromanager.display.internal.displaywindow.DisplayController;
 import org.micromanager.display.internal.event.DisplayMouseEvent;
 import org.micromanager.internal.utils.AffineUtils;
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 /**
  *
@@ -231,7 +229,7 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
       return at;
    }
 
-   private class DialogFrame extends MMFrame {
+   private class DialogFrame extends JFrame {
 
       private static final long serialVersionUID = -7944616693940334489L;
       private final Object caller_;
@@ -278,7 +276,8 @@ public class ManualSimpleCalibrationThread extends CalibrationThread {
          });
          super.add(cancelButton, "tag cancel, wrap");
          super.pack();
-         super.loadAndRestorePosition(200, 200);
+         super.setLocation(200, 200);
+         WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
          super.setVisible(true);
       }
       

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
@@ -74,7 +74,7 @@ public class PixelCalibratorDialog extends JFrame {
       studio_ = studio;
       pixelSizeProvider_ = psp;
       initComponents();
-      super.setLocation(200, 200);
+      setLocation(200, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setVisible(true);
       

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
@@ -26,28 +26,22 @@ import com.google.common.eventbus.Subscribe;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.geom.AffineTransform;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JProgressBar;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.internal.dialogs.PixelSizeProvider;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.GUIUtils;
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 /**
  *
  * @author arthur, Nico
  */
-public class PixelCalibratorDialog extends MMFrame {
+public class PixelCalibratorDialog extends JFrame {
 
    private static final long serialVersionUID = 8504268289532100411L;
    
@@ -80,7 +74,8 @@ public class PixelCalibratorDialog extends MMFrame {
       studio_ = studio;
       pixelSizeProvider_ = psp;
       initComponents();
-      super.loadPosition(200, 200);
+      super.setLocation(200, 200);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setVisible(true);
       
       studio_.events().registerForEvents(this);

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
@@ -74,7 +74,7 @@ public class PixelCalibratorDialog extends JFrame {
       studio_ = studio;
       pixelSizeProvider_ = psp;
       initComponents();
-      setLocation(200, 200);
+      super.setLocation(200, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setVisible(true);
       

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
@@ -60,7 +60,7 @@ class OffsetPositionsDialog extends JDialog {
       int parentCenterX = (int) (parent.getX() + 0.5 * parent.getWidth());
       int parentCenterY = (int) (parent.getY() + 0.5 * parent.getHeight());
 
-      setBounds(parentCenterX - 160,parentCenterY - 150, 320, 300);
+      super.setBounds(parentCenterX - 160,parentCenterY - 150, 320, 300);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
       setTitle("Add offset to stage positions");

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
@@ -23,24 +23,21 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
+import javax.swing.*;
+
 import mmcorej.CMMCore;
 import mmcorej.DeviceType;
 import mmcorej.StrVector;
 import net.miginfocom.swing.MigLayout;
-import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 /**
  * This class provides a dialog that allows the user to apply an offset to the
  * selected stage positions. Ultimately it calls
  * PositionListDlg.offsetSelectedSites to adjust positions.
  */
-class OffsetPositionsDialog extends MMDialog {
+class OffsetPositionsDialog extends JDialog {
    
    private PositionListDlg parent_;
    private final CMMCore core_;
@@ -62,9 +59,10 @@ class OffsetPositionsDialog extends MMDialog {
       // center dialog on the parent dialog
       int parentCenterX = (int) (parent.getX() + 0.5 * parent.getWidth());
       int parentCenterY = (int) (parent.getY() + 0.5 * parent.getHeight());
-      
-      this.loadAndRestorePosition(parentCenterX - 160,parentCenterY - 150,
-              320, 300);
+
+      this.setLocation(parentCenterX - 160,parentCenterY - 150);
+      this.setSize(320, 300);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
       setTitle("Add offset to stage positions");
       setResizable(false);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/OffsetPositionsDialog.java
@@ -60,8 +60,7 @@ class OffsetPositionsDialog extends JDialog {
       int parentCenterX = (int) (parent.getX() + 0.5 * parent.getWidth());
       int parentCenterY = (int) (parent.getY() + 0.5 * parent.getHeight());
 
-      this.setLocation(parentCenterX - 160,parentCenterY - 150);
-      this.setSize(320, 300);
+      setBounds(parentCenterX - 160,parentCenterY - 150, 320, 300);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
       setTitle("Add offset to stage positions");

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -34,14 +34,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.io.File;
 import java.util.ArrayList;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.table.TableCellRenderer;
@@ -57,18 +50,13 @@ import org.micromanager.UserProfile;
 import org.micromanager.events.StagePositionChangedEvent;
 import org.micromanager.events.XYStagePositionChangedEvent;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.EventBusExceptionLogger;
-import org.micromanager.internal.utils.FileDialogs;
+import org.micromanager.internal.utils.*;
 import org.micromanager.internal.utils.FileDialogs.FileType;
-import org.micromanager.internal.utils.GUIUtils;
-import org.micromanager.internal.utils.MMFrame;
-import org.micromanager.internal.utils.ReportingUtils;
 
 /**
  * The PositionListDlg class provides a convenient UI to generate, edit, load, and save PositionList objects.
  */
-public class PositionListDlg extends MMFrame implements MouseListener, ChangeListener {
+public class PositionListDlg extends JFrame implements MouseListener, ChangeListener {
    protected static final long serialVersionUID = 1L;
    protected String posListDir_;
    protected File curFile_;
@@ -136,7 +124,9 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       setLayout(new MigLayout("flowy, filly, insets 8", "[grow][]", 
               "[top]"));
       setMinimumSize(new Dimension(275, 365));
-      super.loadAndRestorePosition(100, 100, 362, 595);
+      super.setLocation(100, 100);
+      super.setSize(362, 595);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       arialSmallFont_ = new Font("Arial", Font.PLAIN, 10);
 
@@ -879,10 +869,10 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       double [] x1;
       double [] y1;
       String deviceName;
-      MMFrame d;
+      JFrame d;
       Thread otherThread;
 
-      public void setPara(Thread calThread, MMFrame d, String deviceName, double [] x1, double [] y1) {
+      public void setPara(Thread calThread, JFrame d, String deviceName, double [] x1, double [] y1) {
          this.otherThread = calThread;
          this.d = d;
          this.deviceName = deviceName;
@@ -999,10 +989,10 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       double [] x1;
       double [] y1;
       String deviceName;
-      MMFrame d;
+      JFrame d;
       Thread stopThread;
 
-      public void setPara(Thread stopThread, MMFrame d, String deviceName, double [] x1, double [] y1) {
+      public void setPara(Thread stopThread, JFrame d, String deviceName, double [] x1, double [] y1) {
          this.stopThread = stopThread;
          this.d = d;
          this.deviceName = deviceName;
@@ -1069,9 +1059,9 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
    } // End CalThread class
 
    class BackThread extends Thread {
-      MMFrame d;
+      JFrame d;
 
-      public void setPara(MMFrame d) {
+      public void setPara(JFrame d) {
          this.d = d;
       }     
       @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -124,8 +124,7 @@ public class PositionListDlg extends JFrame implements MouseListener, ChangeList
       setLayout(new MigLayout("flowy, filly, insets 8", "[grow][]", 
               "[top]"));
       setMinimumSize(new Dimension(275, 365));
-      super.setLocation(100, 100);
-      super.setSize(362, 595);
+      setBounds(100, 100, 362, 595);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       arialSmallFont_ = new Font("Arial", Font.PLAIN, 10);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -124,7 +124,7 @@ public class PositionListDlg extends JFrame implements MouseListener, ChangeList
       setLayout(new MigLayout("flowy, filly, insets 8", "[grow][]", 
               "[top]"));
       setMinimumSize(new Dimension(275, 365));
-      setBounds(100, 100, 362, 595);
+      super.setBounds(100, 100, 362, 595);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       arialSmallFont_ = new Font("Arial", Font.PLAIN, 10);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
@@ -25,15 +25,10 @@ import com.google.common.eventbus.Subscribe;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.text.DecimalFormat;
 import java.text.ParseException;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JTextField;
+import javax.swing.*;
+
 import mmcorej.CMMCore;
-import mmcorej.MMCoreJ;
 import mmcorej.StrVector;
 import org.micromanager.MultiStagePosition;
 import org.micromanager.PositionList;
@@ -41,14 +36,14 @@ import org.micromanager.StagePosition;
 import org.micromanager.Studio;
 import org.micromanager.events.PixelSizeChangedEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
-import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.internal.positionlist.utils.TileCreator;
 import org.micromanager.internal.positionlist.utils.ZGenerator;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
-public final class TileCreatorDlg extends MMDialog {
+public final class TileCreatorDlg extends JDialog {
    private static final long serialVersionUID = 1L;
    private final CMMCore core_;
    private final Studio studio_;
@@ -82,7 +77,7 @@ public final class TileCreatorDlg extends MMDialog {
     */
    public TileCreatorDlg(final CMMCore core, final Studio studio,
            final PositionListDlg positionListDlg) {
-      super("grid tile creator");
+      super();
       super.setResizable(false);
       super.setName("tileDialog");
       super.getContentPane().setLayout(null);
@@ -100,7 +95,8 @@ public final class TileCreatorDlg extends MMDialog {
 
       super.setTitle("Tile Creator");
 
-      super.loadAndRestorePosition(300, 300);
+      super.setLocation(300, 300);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setSize(344, 280);
 
       final JButton goToLeftButton = new JButton();
@@ -362,7 +358,7 @@ public final class TileCreatorDlg extends MMDialog {
          }
       });
       cancelButton.setText("Cancel");
-      super.setDefaultCloseOperation(MMDialog.DISPOSE_ON_CLOSE);
+      super.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
       super.getContentPane().add(cancelButton);
 
       final JButton resetButton = new JButton();

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
@@ -95,7 +95,7 @@ public final class TileCreatorDlg extends JDialog {
 
       super.setTitle("Tile Creator");
 
-      setLocation(300, 300);
+      super.setLocation(300, 300);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setSize(344, 280);
 

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/TileCreatorDlg.java
@@ -95,7 +95,7 @@ public final class TileCreatorDlg extends JDialog {
 
       super.setTitle("Tile Creator");
 
-      super.setLocation(300, 300);
+      setLocation(300, 300);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       super.setSize(344, 280);
 

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -376,7 +376,7 @@ public final class ScriptPanel extends JFrame implements MouseListener, ScriptCo
       Dimension buttonSize = new Dimension(80, buttonHeight);
       int gap = 5; // determines gap between buttons
 
-      setBounds(100, 100, 550, 495);
+      super.setBounds(100, 100, 550, 495);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       final JPanel leftPanel = new JPanel();

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -45,22 +45,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.BoxLayout;
-import javax.swing.InputMap;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.JTextPane;
-import javax.swing.KeyStroke;
-import javax.swing.ListSelectionModel;
-import javax.swing.SpringLayout;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
+import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
@@ -79,20 +64,13 @@ import org.fife.ui.rtextarea.SearchEngine;
 import org.fife.ui.rtextarea.SearchResult;
 import org.micromanager.ScriptController;
 import org.micromanager.Studio;
-import org.micromanager.UserProfile;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.utils.DaytimeNighttime;
-import org.micromanager.internal.utils.FileDialogs;
+import org.micromanager.internal.utils.*;
 import org.micromanager.internal.utils.FileDialogs.FileType;
-import org.micromanager.internal.utils.HotKeysDialog;
-import org.micromanager.internal.utils.MMFrame;
-import org.micromanager.internal.utils.MMScriptException;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.TooltipTextMaker;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 
-public final class ScriptPanel extends MMFrame implements MouseListener, ScriptController {
+public final class ScriptPanel extends JFrame implements MouseListener, ScriptController {
    private static final long serialVersionUID = 1L;
    private static final int HISTORYSIZE = 100;
    private static final String STARTUP_SCRIPT = "path to the Beanshell script to run when the program starts up";
@@ -362,7 +340,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       super("script panel");
       studio_ = studio;
       settings_ = studio_.profile().getSettings(ScriptPanel.class);
-      final MMFrame scriptPanelFrame = this;
+      final JFrame scriptPanelFrame = this;
 
       // Beanshell REPL Console
       createBeanshellREPL();
@@ -398,7 +376,9 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
       Dimension buttonSize = new Dimension(80, buttonHeight);
       int gap = 5; // determines gap between buttons
 
-      super.loadAndRestorePosition(100, 100, 550, 495);
+      super.setLocation(100, 100);
+      super.setSize(550, 495);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       final JPanel leftPanel = new JPanel();
       SpringLayout spLeft = new SpringLayout();
@@ -1144,7 +1124,7 @@ public final class ScriptPanel extends MMFrame implements MouseListener, ScriptC
    public void closePanel() {
       if (!promptToSave(-1))
          return;
-      savePosition();
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       saveScriptsToPrefs();
       dispose();
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -1123,7 +1123,6 @@ public final class ScriptPanel extends JFrame implements MouseListener, ScriptCo
    public void closePanel() {
       if (!promptToSave(-1))
          return;
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       saveScriptsToPrefs();
       dispose();
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -376,8 +376,7 @@ public final class ScriptPanel extends JFrame implements MouseListener, ScriptCo
       Dimension buttonSize = new Dimension(80, buttonHeight);
       int gap = 5; // determines gap between buttons
 
-      super.setLocation(100, 100);
-      super.setSize(550, 495);
+      setBounds(100, 100, 550, 495);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       final JPanel leftPanel = new JPanel();

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -107,7 +107,7 @@ public final class AutofocusPropertyEditor extends JDialog {
       });
       setTitle("Autofocus properties");
 
-      setBounds(100, 100, 400, 300);
+      super.setBounds(100, 100, 400, 300);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       scrollPane_ = new JScrollPane();

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -36,16 +36,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.text.ParseException;
 import java.util.ArrayList;
-import javax.swing.AbstractCellEditor;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.SpringLayout;
+import javax.swing.*;
 import javax.swing.border.BevelBorder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellEditor;
@@ -60,7 +51,7 @@ import org.micromanager.internal.MMStudio;
  * Represents the entire system state as a list of triplets:
  * device - property - value
  */
-public final class AutofocusPropertyEditor extends MMDialog {
+public final class AutofocusPropertyEditor extends JDialog {
    private final Studio studio_;
    private final SpringLayout springLayout;
    private static final long serialVersionUID = 1507097881635431043L;
@@ -77,7 +68,7 @@ public final class AutofocusPropertyEditor extends MMDialog {
    private JComboBox methodCombo_;
    
    public AutofocusPropertyEditor(Studio studio, DefaultAutofocusManager afmgr) {
-      super("autofocus property editor");
+      super();
       studio_ = studio;
       afMgr_ = afmgr;
       setModal(false);
@@ -116,7 +107,9 @@ public final class AutofocusPropertyEditor extends MMDialog {
       });
       setTitle("Autofocus properties");
 
-      loadAndRestorePosition(100, 100, 400, 300);
+      super.setLocation(100, 100);
+      super.setSize(400, 300);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       scrollPane_ = new JScrollPane();
       scrollPane_.setFont(new Font("Arial", Font.PLAIN, 10));

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -107,8 +107,7 @@ public final class AutofocusPropertyEditor extends JDialog {
       });
       setTitle("Autofocus properties");
 
-      super.setLocation(100, 100);
-      super.setSize(400, 300);
+      setBounds(100, 100, 400, 300);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       scrollPane_ = new JScrollPane();

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeysDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeysDialog.java
@@ -31,11 +31,7 @@ import java.awt.event.WindowEvent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Map;
-import javax.swing.AbstractCellEditor;
-import javax.swing.DefaultCellEditor;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
+import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellEditor;
@@ -45,7 +41,7 @@ import org.micromanager.internal.utils.FileDialogs.FileType;
  *
  * @author nico
  */
-public final class HotKeysDialog extends MMDialog {
+public final class HotKeysDialog extends JDialog {
    private final ShortCutTableModel sctModel_ = new ShortCutTableModel();
    private final JComboBox combo_ = new JComboBox();
    private Integer lastTypedKey_ = 0;
@@ -145,7 +141,9 @@ public final class HotKeysDialog extends MMDialog {
     public  HotKeysDialog() {
         initComponents();
 
-        super.loadAndRestorePosition(100, 100, 377, 378);
+        super.setLocation(100, 100);
+        super.setSize(377, 378);
+        WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
         readKeys();
 

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeysDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeysDialog.java
@@ -141,8 +141,7 @@ public final class HotKeysDialog extends JDialog {
     public  HotKeysDialog() {
         initComponents();
 
-        super.setLocation(100, 100);
-        super.setSize(377, 378);
+        setBounds(100, 100, 377, 378);
         WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
         readKeys();

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeysDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeysDialog.java
@@ -141,7 +141,7 @@ public final class HotKeysDialog extends JDialog {
     public  HotKeysDialog() {
         initComponents();
 
-        setBounds(100, 100, 377, 378);
+        super.setBounds(100, 100, 377, 378);
         WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
         readKeys();

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIMFrame.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIMFrame.java
@@ -400,7 +400,7 @@ public class ASIdiSPIMFrame extends SPIMFrame  {
       acquisitionPanel_.saveSettings();
       settingsPanel_.saveSettings();
 
-      // save tab location in prefs (dialog location now handled by MMDialog)
+      // save tab location in prefs (dialog location now handled by JDialog)
       prefs_.putInt(MAIN_PREF_NODE, Prefs.Keys.TAB_INDEX, tabbedPane_.getSelectedIndex());
    }
    

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIMFrame.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIMFrame.java
@@ -400,7 +400,7 @@ public class ASIdiSPIMFrame extends SPIMFrame  {
       acquisitionPanel_.saveSettings();
       settingsPanel_.saveSettings();
 
-      // save tab location in prefs (dialog location now handled by JDialog)
+      // save tab location in prefs (dialog location now handled by SPIMFrame)
       prefs_.putInt(MAIN_PREF_NODE, Prefs.Keys.TAB_INDEX, tabbedPane_.getSelectedIndex());
    }
    

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/SPIMFrame.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/SPIMFrame.java
@@ -69,7 +69,7 @@ public class SPIMFrame extends JFrame {
     * If not then it sets the prefs to the values specified.
     * Accounts for screen size changes between invocations or if screen
     * is removed (e.g. had 2 monitors and go to 1).
-    * TODO: this code is duplicated between here and MMDialog(MMDialog has been replaced by JDialog).
+    * TODO: this code is duplicated between here and MMDialog.
     * @param x new WINDOW_X position if current value isn't valid
     * @param y new WINDOW_Y position if current value isn't valid
     */

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/SPIMFrame.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/SPIMFrame.java
@@ -69,7 +69,7 @@ public class SPIMFrame extends JFrame {
     * If not then it sets the prefs to the values specified.
     * Accounts for screen size changes between invocations or if screen
     * is removed (e.g. had 2 monitors and go to 1).
-    * TODO: this code is duplicated between here and MMDialog.
+    * TODO: this code is duplicated between here and MMDialog(MMDialog has been replaced by JDialog).
     * @param x new WINDOW_X position if current value isn't valid
     * @param y new WINDOW_Y position if current value isn't valid
     */

--- a/plugins/Assemble/src/main/java/org/micromanager/assembledata/AssembleDataForm.java
+++ b/plugins/Assemble/src/main/java/org/micromanager/assembledata/AssembleDataForm.java
@@ -104,8 +104,7 @@ public class AssembleDataForm extends JDialog {
       super.setLayout(new MigLayout("flowx, fill, insets 8"));
       super.setTitle(AssembleData.MENUNAME);
 
-      super.setLocation(100, 100);
-      super.setSize(449, 327);
+      setBounds(100, 100, 449, 327);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       
       JRadioButton chooseDir = new JRadioButton("Choose Directory");

--- a/plugins/Assemble/src/main/java/org/micromanager/assembledata/AssembleDataForm.java
+++ b/plugins/Assemble/src/main/java/org/micromanager/assembledata/AssembleDataForm.java
@@ -37,19 +37,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultComboBoxModel;
+import javax.swing.*;
 
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JRadioButton;
-import javax.swing.JSeparator;
-import javax.swing.JSpinner;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
@@ -60,14 +49,14 @@ import org.micromanager.display.internal.event.DataViewerAddedEvent;
 import org.micromanager.display.internal.event.DataViewerWillCloseEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.internal.utils.FileDialogs;
-import org.micromanager.internal.utils.MMDialog;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 /**
  *
  * @author nico
  */
-public class AssembleDataForm extends MMDialog {
+public class AssembleDataForm extends JDialog {
    private final Studio studio_;
    private final MutablePropertyMapView profileSettings_;
    
@@ -114,7 +103,10 @@ public class AssembleDataForm extends MMDialog {
       
       super.setLayout(new MigLayout("flowx, fill, insets 8"));
       super.setTitle(AssembleData.MENUNAME);
-      super.loadAndRestorePosition(100, 100, 449, 327);
+
+      super.setLocation(100, 100);
+      super.setSize(449, 327);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       
       JRadioButton chooseDir = new JRadioButton("Choose Directory");
       super.add(chooseDir, "span 2, wrap");

--- a/plugins/Assemble/src/main/java/org/micromanager/assembledata/AssembleDataForm.java
+++ b/plugins/Assemble/src/main/java/org/micromanager/assembledata/AssembleDataForm.java
@@ -104,7 +104,7 @@ public class AssembleDataForm extends JDialog {
       super.setLayout(new MigLayout("flowx, fill, insets 8"));
       super.setTitle(AssembleData.MENUNAME);
 
-      setBounds(100, 100, 449, 327);
+      super.setBounds(100, 100, 449, 327);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       
       JRadioButton chooseDir = new JRadioButton("Choose Directory");

--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
@@ -29,13 +29,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.swing.JButton;
-import javax.swing.JFormattedTextField;
-import javax.swing.JLabel;
-import javax.swing.JSpinner;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.WindowConstants;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.text.DefaultFormatter;
 import net.miginfocom.swing.MigLayout;
@@ -49,14 +43,13 @@ import org.micromanager.display.DisplayWindow;
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.ProgressBar;
 
 /**
  *
  * @author nico
  */
-public class DuplicatorPluginFrame extends MMDialog {
+public class DuplicatorPluginFrame extends JDialog {
    private final Studio studio_;
    private final DisplayWindow ourWindow_;
    private final DataProvider ourProvider_;

--- a/plugins/Example/src/main/java/org/micromanager/plugins/example/ExampleFrame.java
+++ b/plugins/Example/src/main/java/org/micromanager/plugins/example/ExampleFrame.java
@@ -27,9 +27,7 @@ import java.awt.event.ActionListener;
 import java.awt.Font;
 import java.util.List;
 
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JTextField;
+import javax.swing.*;
 
 
 import net.miginfocom.swing.MigLayout;
@@ -43,10 +41,9 @@ import org.micromanager.Studio;
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 
 
-public class ExampleFrame extends MMFrame {
+public class ExampleFrame extends JFrame {
 
    private Studio studio_;
    private JTextField userText_;

--- a/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombinerConfigurator.java
+++ b/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombinerConfigurator.java
@@ -34,7 +34,7 @@ public class FrameCombinerConfigurator extends JFrame implements ProcessorConfig
       initComponents();
       loadSettingValue();
 
-      super.setLocation(200, 200);
+      setLocation(200, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
    }

--- a/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombinerConfigurator.java
+++ b/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombinerConfigurator.java
@@ -34,7 +34,7 @@ public class FrameCombinerConfigurator extends JFrame implements ProcessorConfig
       initComponents();
       loadSettingValue();
 
-      setLocation(200, 200);
+      super.setLocation(200, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
    }

--- a/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombinerConfigurator.java
+++ b/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombinerConfigurator.java
@@ -1,6 +1,7 @@
 package org.micromanager.plugins.framecombiner;
 
 import java.text.NumberFormat;
+import javax.swing.*;
 import javax.swing.text.NumberFormatter;
 
 
@@ -8,15 +9,15 @@ import org.micromanager.PropertyMap;
 import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.data.ProcessorConfigurator;
+import org.micromanager.internal.utils.WindowPositioning;
 
 // Imports for MMStudio internal packages
 // Plugins should not access internal packages, to ensure modularity and
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 
-public class FrameCombinerConfigurator extends MMFrame implements ProcessorConfigurator {
+public class FrameCombinerConfigurator extends JFrame implements ProcessorConfigurator {
 
    private static final String PROCESSOR_DIMENSION = "Dimension";
    private static final String PROCESSOR_ALGO = "Algorithm to apply on stack images";
@@ -32,7 +33,9 @@ public class FrameCombinerConfigurator extends MMFrame implements ProcessorConfi
 
       initComponents();
       loadSettingValue();
-      super.loadAndRestorePosition(200, 200);
+
+      super.setLocation(200, 200);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
    }
 

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -201,7 +201,7 @@ public class SiteGenerator extends JFrame implements ParentPlateGUI {
       super.setTitle("HCS Site Generator " + HCSPlugin.VERSION_INFO);
 
       setBounds(100, 100, 1000, 640);
-      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       platePanel_ = new PlatePanel(plate_, null, this, app);
       contentsPanel.add(platePanel_, "grow, push");

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -200,8 +200,7 @@ public class SiteGenerator extends JFrame implements ParentPlateGUI {
 
       super.setTitle("HCS Site Generator " + HCSPlugin.VERSION_INFO);
 
-      super.setLocation(100, 100);
-      super.setSize(1000, 640);
+      setBounds(100, 100, 1000, 640);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       platePanel_ = new PlatePanel(plate_, null, this, app);

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -14,15 +14,7 @@ import java.awt.Component;
 import java.awt.geom.AffineTransform;
 import java.io.File;
 
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JOptionPane;
-import javax.swing.JTextField;
-import javax.swing.JToggleButton;
-import javax.swing.ButtonGroup;
+import javax.swing.*;
 import javax.swing.border.LineBorder;
 
 import net.miginfocom.swing.MigLayout;
@@ -41,14 +33,14 @@ import mmcorej.CMMCore;
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
 import org.micromanager.internal.utils.NumberUtils;
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.TextUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 /**
  * This is the primary user interface for the plugin.
  * @author nenad
  */
-public class SiteGenerator extends MMFrame implements ParentPlateGUI {
+public class SiteGenerator extends JFrame implements ParentPlateGUI {
 
    private static final String EQUAL_SPACING = "Equal XY";
    private static final String DIFFERENT_SPACING = "Different XY";
@@ -207,7 +199,10 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       focusPlane_ = null;
 
       super.setTitle("HCS Site Generator " + HCSPlugin.VERSION_INFO);
-      super.loadAndRestorePosition(100, 100, 1000, 640);
+
+      super.setLocation(100, 100);
+      super.setSize(1000, 640);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       platePanel_ = new PlatePanel(plate_, null, this, app);
       contentsPanel.add(platePanel_, "grow, push");

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -200,7 +200,7 @@ public class SiteGenerator extends JFrame implements ParentPlateGUI {
 
       super.setTitle("HCS Site Generator " + HCSPlugin.VERSION_INFO);
 
-      setBounds(100, 100, 1000, 640);
+      super.setBounds(100, 100, 1000, 640);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       platePanel_ = new PlatePanel(plate_, null, this, app);

--- a/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperConfigurator.java
+++ b/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperConfigurator.java
@@ -27,8 +27,7 @@ import ij.process.ByteProcessor;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
+import javax.swing.*;
 
 import mmcorej.StrVector;
 
@@ -40,6 +39,7 @@ import org.micromanager.Studio;
 import org.micromanager.data.Image;
 import org.micromanager.data.ProcessorConfigurator;
 import org.micromanager.data.Coordinates;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 // Imports for MMStudio internal packages
@@ -47,9 +47,8 @@ import org.micromanager.propertymap.MutablePropertyMapView;
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 
-public class FlipperConfigurator extends MMFrame implements ProcessorConfigurator {
+public class FlipperConfigurator extends JFrame implements ProcessorConfigurator {
 
    private static final String DEFAULT_CAMERA = "Default camera for image flipper";
    private static final String DEFAULT_MIRRORED = "Whether or not to mirror the image flipper";
@@ -98,7 +97,8 @@ public class FlipperConfigurator extends MMFrame implements ProcessorConfigurato
          rotateComboBox_.addItem(item);
       }
       rotateComboBox_.setSelectedIndex(R_INTS.indexOf(rotation));
-      super.loadAndRestorePosition(frameXPos_, frameYPos_);
+      super.setLocation(frameXPos_, frameYPos_);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       updateCameras();
    }
 

--- a/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperConfigurator.java
+++ b/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperConfigurator.java
@@ -97,7 +97,7 @@ public class FlipperConfigurator extends JFrame implements ProcessorConfigurator
          rotateComboBox_.addItem(item);
       }
       rotateComboBox_.setSelectedIndex(R_INTS.indexOf(rotation));
-      setLocation(frameXPos_, frameYPos_);
+      super.setLocation(frameXPos_, frameYPos_);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       updateCameras();
    }

--- a/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperConfigurator.java
+++ b/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperConfigurator.java
@@ -97,7 +97,7 @@ public class FlipperConfigurator extends JFrame implements ProcessorConfigurator
          rotateComboBox_.addItem(item);
       }
       rotateComboBox_.setSelectedIndex(R_INTS.indexOf(rotation));
-      super.setLocation(frameXPos_, frameYPos_);
+      setLocation(frameXPos_, frameYPos_);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       updateCameras();
    }

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
@@ -122,7 +122,7 @@ public class CVViewer implements DataViewer, ImageStatsPublisher {
       public CVFrame() {
          super();
          setLocation(100, 100);
-         WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+         WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       }
    }
    

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
@@ -121,7 +121,7 @@ public class CVViewer implements DataViewer, ImageStatsPublisher {
    private class CVFrame extends JFrame {
       public CVFrame() {
          super();
-         setLocation(100, 100);
+         super.setLocation(100, 100);
          WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       }
    }

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
@@ -121,7 +121,7 @@ public class CVViewer implements DataViewer, ImageStatsPublisher {
    private class CVFrame extends JFrame {
       public CVFrame() {
          super();
-         super.setLocation(100, 100);
+         setLocation(100, 100);
          WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       }
    }

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
@@ -47,7 +47,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+
 import org.micromanager.LogManager;
 
 import org.micromanager.Studio;
@@ -87,7 +88,7 @@ import org.micromanager.display.internal.imagestats.ImageStatsRequest;
 import org.micromanager.display.internal.imagestats.ImagesAndStats;
 import org.micromanager.display.internal.imagestats.ImageStatsProcessor;
 import org.micromanager.display.internal.imagestats.IntegerComponentStats;
-import org.micromanager.internal.utils.MMFrame;
+import org.micromanager.internal.utils.WindowPositioning;
 
 import static org.micromanager.data.internal.BufferTools.NATIVE_ORDER;
 
@@ -117,10 +118,11 @@ public class CVViewer implements DataViewer, ImageStatsPublisher {
             Color.PINK, Color.CYAN, Color.YELLOW, Color.ORANGE};
    
    
-   private class CVFrame extends MMFrame {
+   private class CVFrame extends JFrame {
       public CVFrame() {
          super();
-         super.loadAndRestorePosition(100, 100);
+         super.setLocation(100, 100);
+         WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       }
    }
    

--- a/plugins/MultiAndor/src/main/java/org/micromanager/multicamera/MultiCameraFrame.java
+++ b/plugins/MultiAndor/src/main/java/org/micromanager/multicamera/MultiCameraFrame.java
@@ -110,8 +110,8 @@ public class MultiCameraFrame extends JFrame {
 
       initComponents();
 
-      super.setLocation(100, 100);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(100, 100);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       cameraSelectComboBox.removeAllItems();
 

--- a/plugins/MultiAndor/src/main/java/org/micromanager/multicamera/MultiCameraFrame.java
+++ b/plugins/MultiAndor/src/main/java/org/micromanager/multicamera/MultiCameraFrame.java
@@ -110,7 +110,7 @@ public class MultiCameraFrame extends JFrame {
 
       initComponents();
 
-      setLocation(100, 100);
+      super.setLocation(100, 100);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       cameraSelectComboBox.removeAllItems();

--- a/plugins/MultiAndor/src/main/java/org/micromanager/multicamera/MultiCameraFrame.java
+++ b/plugins/MultiAndor/src/main/java/org/micromanager/multicamera/MultiCameraFrame.java
@@ -14,11 +14,10 @@ import com.google.common.eventbus.Subscribe;
 
 import java.text.ParseException;
 
-import javax.swing.DefaultComboBoxModel;
+import javax.swing.*;
 
 import java.awt.event.ItemEvent;
 import java.util.ArrayList;
-import javax.swing.SwingUtilities;
 
 import mmcorej.CMMCore;
 import mmcorej.DeviceType;
@@ -33,14 +32,14 @@ import org.micromanager.Studio;
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.NumberUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 /**
  *
  * @author Nico Stuurman
  */
-public class MultiCameraFrame extends MMFrame {
+public class MultiCameraFrame extends JFrame {
    private static final long serialVersionUID = 1L;
    private final Studio gui_;
    private final CMMCore core_;
@@ -111,7 +110,8 @@ public class MultiCameraFrame extends MMFrame {
 
       initComponents();
 
-      super.loadAndRestorePosition(100, 100);
+      super.setLocation(100, 100);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       cameraSelectComboBox.removeAllItems();
 

--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
@@ -111,8 +111,7 @@ public class MultiChannelShadingMigForm extends JDialog implements ProcessorConf
       super.setLayout(new MigLayout("flowx, fill, insets 8"));
       super.setTitle(MultiChannelShading.MENUNAME);
 
-      super.setLocation(100, 100);
-      super.setSize(375, 375);
+      setBounds(100, 100, 375, 375);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       super.add(new JLabel("Uncheck and Recheck Use checkboxes in Pipeline after changing settings"),

--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
@@ -34,16 +34,8 @@ import java.awt.event.WindowEvent;
 import java.io.File;
 import java.util.ArrayList;
 
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextField;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
+import javax.swing.*;
+
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.data.ProcessorConfigurator;
 import org.micromanager.PropertyMap;
@@ -51,6 +43,7 @@ import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.events.ChannelGroupChangedEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 // Imports for MMStudio internal packages
@@ -59,14 +52,13 @@ import org.micromanager.propertymap.MutablePropertyMapView;
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
 import org.micromanager.internal.utils.FileDialogs;
-import org.micromanager.internal.utils.MMDialog;
 
 /**
  *
  * @author nico
  */
-public class MultiChannelShadingMigForm extends MMDialog implements ProcessorConfigurator {
-   private  MMDialog mcsPluginWindow;
+public class MultiChannelShadingMigForm extends JDialog implements ProcessorConfigurator {
+   private  JDialog mcsPluginWindow;
    private final Studio studio_;
    private final PropertyMap settings_;
    private final MutablePropertyMapView profileSettings_;
@@ -119,7 +111,9 @@ public class MultiChannelShadingMigForm extends MMDialog implements ProcessorCon
       super.setLayout(new MigLayout("flowx, fill, insets 8"));
       super.setTitle(MultiChannelShading.MENUNAME);
 
-      super.loadAndRestorePosition(100, 100, 375, 275);
+      super.setLocation(100, 100);
+      super.setSize(375, 375);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       super.add(new JLabel("Uncheck and Recheck Use checkboxes in Pipeline after changing settings"),
                "span 5, wrap");

--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/MultiChannelShadingMigForm.java
@@ -111,7 +111,7 @@ public class MultiChannelShadingMigForm extends JDialog implements ProcessorConf
       super.setLayout(new MigLayout("flowx, fill, insets 8"));
       super.setTitle(MultiChannelShading.MENUNAME);
 
-      setBounds(100, 100, 375, 375);
+      super.setBounds(100, 100, 375, 375);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       super.add(new JLabel("Uncheck and Recheck Use checkboxes in Pipeline after changing settings"),

--- a/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsExecutor.java
+++ b/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsExecutor.java
@@ -42,9 +42,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+
 import mmcorej.CMMCore;
 import mmcorej.TaggedImage;
 import net.miginfocom.swing.MigLayout;
@@ -61,9 +60,9 @@ import org.micromanager.data.SummaryMetadata;
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 public class PtcToolsExecutor extends Thread  {
    private final Studio studio_;
@@ -249,19 +248,20 @@ public class PtcToolsExecutor extends Thread  {
    
    
    private void showDialog(final String label, final PtcSequenceRunner sr) {
-      final MMFrame dialog = new MMFrame();
+      final JFrame dialog = new JFrame();
       dialog.setBounds(settings_.getInteger(PtcToolsTerms.WINDOWX, 100), 
               settings_.getInteger(PtcToolsTerms.WINDOWY, 100), 400, 100);
       dialog.addComponentListener(new ComponentAdapter() {
          @Override
          public void componentMoved(ComponentEvent e) {
-            dialog.savePosition();
+            WindowPositioning.setUpBoundsMemory(dialog, dialog.getClass(), null);
          }
       });
       dialog.setLayout(new MigLayout());
       dialog.setTitle("PTC Tools");
       dialog.add(new JLabel(label), "wrap");
       dialog.add(new JLabel("Press OK when ready"), "wrap");
+      WindowPositioning.setUpBoundsMemory(dialog, dialog.getClass(), null);
       JButton cancelButton = new JButton("Cancel");
       final JLabel resultLabel = new JLabel("Not started yet...");
       cancelButton.addActionListener((ActionEvent e) -> {

--- a/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsExecutor.java
+++ b/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsExecutor.java
@@ -251,12 +251,6 @@ public class PtcToolsExecutor extends Thread  {
       final JFrame dialog = new JFrame();
       dialog.setBounds(settings_.getInteger(PtcToolsTerms.WINDOWX, 100), 
               settings_.getInteger(PtcToolsTerms.WINDOWY, 100), 400, 100);
-      dialog.addComponentListener(new ComponentAdapter() {
-         @Override
-         public void componentMoved(ComponentEvent e) {
-            WindowPositioning.setUpBoundsMemory(dialog, dialog.getClass(), null);
-         }
-      });
       dialog.setLayout(new MigLayout());
       dialog.setTitle("PTC Tools");
       dialog.add(new JLabel(label), "wrap");

--- a/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsFrame.java
+++ b/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsFrame.java
@@ -65,7 +65,7 @@ public class PtcToolsFrame extends JFrame {
       
       initComponents();
 
-      setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
    }

--- a/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsFrame.java
+++ b/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsFrame.java
@@ -65,8 +65,8 @@ public class PtcToolsFrame extends JFrame {
       
       initComponents();
 
-      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
    }
 

--- a/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsFrame.java
+++ b/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsFrame.java
@@ -28,15 +28,12 @@ package org.micromanager.ptctools;
 
 
 import java.awt.event.ActionEvent;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JSpinner;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 
 import net.miginfocom.swing.MigLayout;
 
 import org.micromanager.Studio;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 // Imports for MMStudio internal packages
@@ -44,7 +41,6 @@ import org.micromanager.propertymap.MutablePropertyMapView;
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 
 /**
  * Micro-Manager plugin that can split the acquired image top-down or left-right
@@ -52,7 +48,7 @@ import org.micromanager.internal.utils.MMFrame;
  *
  * @author nico, modified by Chris Weisiger
  */
-public class PtcToolsFrame extends MMFrame {
+public class PtcToolsFrame extends JFrame {
    private static final int DEFAULT_WIN_X = 100;
    private static final int DEFAULT_WIN_Y = 100;
    public static Boolean WINDOWOPEN = false;
@@ -69,7 +65,8 @@ public class PtcToolsFrame extends MMFrame {
       
       initComponents();
 
-      super.loadAndRestorePosition(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
    }
 
@@ -99,7 +96,7 @@ public class PtcToolsFrame extends MMFrame {
               settings_.getInteger(PtcToolsTerms.NRFRAMES, 100), 1, null, 1));
       add(nrFramesSp_, "w 60, wrap");
       
-      MMFrame ptf = this;
+      JFrame ptf = this;
       JButton helpButton = new JButton("Help");
       helpButton.addActionListener((ActionEvent e) -> {
          new Thread(org.micromanager.internal.utils.GUIUtils.makeURLRunnable(

--- a/plugins/PipelineSaver/src/main/java/org/micromanager/pipelinesaver/SaverConfigurator.java
+++ b/plugins/PipelineSaver/src/main/java/org/micromanager/pipelinesaver/SaverConfigurator.java
@@ -24,12 +24,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
+import javax.swing.*;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -44,9 +39,9 @@ import org.micromanager.Studio;
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
 import org.micromanager.internal.utils.FileDialogs;
-import org.micromanager.internal.utils.MMFrame;
+import org.micromanager.internal.utils.WindowPositioning;
 
-public class SaverConfigurator extends MMFrame implements ProcessorConfigurator {
+public class SaverConfigurator extends JFrame implements ProcessorConfigurator {
    private static final String PREFERRED_FORMAT = "preferred format for saving mid-pipeline datasets";
    private static final String SHOULD_DISPLAY_PIPELINE_DATA = "whether or not to display mid-pipeline datasets";
    private static final String SAVE_PATH = "default save path for saving mid-pipeline datasets";
@@ -102,7 +97,8 @@ public class SaverConfigurator extends MMFrame implements ProcessorConfigurator 
       super.add(panel);
       updateControls();
 
-      super.loadAndRestorePosition(300, 300);
+      super.setLocation(300, 300);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
    }
 
    private void updateControls() {

--- a/plugins/PipelineSaver/src/main/java/org/micromanager/pipelinesaver/SaverConfigurator.java
+++ b/plugins/PipelineSaver/src/main/java/org/micromanager/pipelinesaver/SaverConfigurator.java
@@ -97,7 +97,7 @@ public class SaverConfigurator extends JFrame implements ProcessorConfigurator {
       super.add(panel);
       updateControls();
 
-      setLocation(300, 300);
+      super.setLocation(300, 300);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 

--- a/plugins/PipelineSaver/src/main/java/org/micromanager/pipelinesaver/SaverConfigurator.java
+++ b/plugins/PipelineSaver/src/main/java/org/micromanager/pipelinesaver/SaverConfigurator.java
@@ -97,8 +97,8 @@ public class SaverConfigurator extends JFrame implements ProcessorConfigurator {
       super.add(panel);
       updateControls();
 
-      super.setLocation(300, 300);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(300, 300);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 
    private void updateControls() {

--- a/plugins/PointAndShootAnalysis/src/main/java/org/micromanager/pointandshootanalysis/PointAndShootDialog.java
+++ b/plugins/PointAndShootAnalysis/src/main/java/org/micromanager/pointandshootanalysis/PointAndShootDialog.java
@@ -30,18 +30,12 @@ import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JSpinner;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.display.DataViewer;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.pointandshootanalysis.data.Terms;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
@@ -51,13 +45,12 @@ import org.micromanager.propertymap.MutablePropertyMapView;
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
 import org.micromanager.internal.utils.FileDialogs;
-import org.micromanager.internal.utils.MMDialog;
 
 /**
  *
  * @author nico
  */
-public class PointAndShootDialog extends MMDialog {
+public class PointAndShootDialog extends JDialog {
    
 
    private final Studio studio_;
@@ -73,7 +66,7 @@ public class PointAndShootDialog extends MMDialog {
       profileSettings_ = 
               studio_.profile().getSettings(PointAndShootDialog.class);
       wasDisposed_ = false;
-      final MMDialog ourDialog = this;
+      final JDialog ourDialog = this;
       
       super.setTitle("Point and Shoot Analysis");
       super.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
@@ -90,7 +83,9 @@ public class PointAndShootDialog extends MMDialog {
       final Dimension spinnerSize = new Dimension(80, 21);
       
       super.setLayout(new MigLayout());
-      super.loadAndRestorePosition(100, 100);
+
+      super.setLocation(100, 100);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       
       JLabel explanationLabel = new JLabel("Provide location of text file " +
              "containing Point and Shoot  timestamps and locations");

--- a/plugins/PointAndShootAnalysis/src/main/java/org/micromanager/pointandshootanalysis/PointAndShootDialog.java
+++ b/plugins/PointAndShootAnalysis/src/main/java/org/micromanager/pointandshootanalysis/PointAndShootDialog.java
@@ -84,7 +84,7 @@ public class PointAndShootDialog extends JDialog {
       
       super.setLayout(new MigLayout());
 
-      setLocation(100, 100);
+      super.setLocation(100, 100);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
       JLabel explanationLabel = new JLabel("Provide location of text file " +

--- a/plugins/PointAndShootAnalysis/src/main/java/org/micromanager/pointandshootanalysis/PointAndShootDialog.java
+++ b/plugins/PointAndShootAnalysis/src/main/java/org/micromanager/pointandshootanalysis/PointAndShootDialog.java
@@ -84,8 +84,8 @@ public class PointAndShootDialog extends JDialog {
       
       super.setLayout(new MigLayout());
 
-      super.setLocation(100, 100);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(100, 100);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
       JLabel explanationLabel = new JLabel("Provide location of text file " +
              "containing Point and Shoot  timestamps and locations");

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
@@ -37,10 +37,7 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.io.File;
 import java.text.ParseException;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JTextField;
+import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
@@ -53,6 +50,7 @@ import org.micromanager.data.ProcessorConfigurator;
 import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
 import org.micromanager.events.ChannelGroupChangedEvent;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 // Imports for MMStudio internal packages
@@ -61,7 +59,6 @@ import org.micromanager.propertymap.MutablePropertyMapView;
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
 import org.micromanager.internal.utils.FileDialogs;
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.NumberUtils;
 
 /**
@@ -69,7 +66,7 @@ import org.micromanager.internal.utils.NumberUtils;
  *
  * @author nico
  */
-public class RatioImagingFrame extends MMFrame implements ProcessorConfigurator {
+public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
    private static final int DEFAULT_WIN_X = 100;
    private static final int DEFAULT_WIN_Y = 100;
    static final String CHANNEL1 = "Channel1";
@@ -156,7 +153,8 @@ public class RatioImagingFrame extends MMFrame implements ProcessorConfigurator 
       
       super.pack();
 
-      super.loadAndRestorePosition(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
       
    }
 

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
@@ -153,7 +153,7 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
       
       super.pack();
 
-      setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
    }

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
@@ -153,8 +153,8 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
       
       super.pack();
 
-      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       
    }
 

--- a/plugins/SequenceBufferMonitor/src/main/java/org/micromanager/plugins/sequencebuffermonitor/SequenceBufferMonitorFrame.java
+++ b/plugins/SequenceBufferMonitor/src/main/java/org/micromanager/plugins/sequencebuffermonitor/SequenceBufferMonitorFrame.java
@@ -15,17 +15,16 @@
 
 package org.micromanager.plugins.sequencebuffermonitor;
 
+import org.micromanager.internal.utils.WindowPositioning;
+
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import javax.swing.JLabel;
-import javax.swing.JProgressBar;
-import javax.swing.JTextField;
-import javax.swing.Timer;
-import org.micromanager.internal.utils.MMFrame;
+import javax.swing.*;
 
 
-class SequenceBufferMonitorFrame extends MMFrame {
+
+class SequenceBufferMonitorFrame extends JFrame {
    org.micromanager.Studio app_;
    JProgressBar usageBar_;
    Timer timer_;
@@ -88,7 +87,9 @@ class SequenceBufferMonitorFrame extends MMFrame {
       });
 
       update();
-      loadAndRestorePosition(200, 200);
+
+      super.setLocation(200, 200);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 
    private void update() {

--- a/plugins/SequenceBufferMonitor/src/main/java/org/micromanager/plugins/sequencebuffermonitor/SequenceBufferMonitorFrame.java
+++ b/plugins/SequenceBufferMonitor/src/main/java/org/micromanager/plugins/sequencebuffermonitor/SequenceBufferMonitorFrame.java
@@ -88,7 +88,7 @@ class SequenceBufferMonitorFrame extends JFrame {
 
       update();
 
-      super.setLocation(200, 200);
+      setLocation(200, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 

--- a/plugins/SequenceBufferMonitor/src/main/java/org/micromanager/plugins/sequencebuffermonitor/SequenceBufferMonitorFrame.java
+++ b/plugins/SequenceBufferMonitor/src/main/java/org/micromanager/plugins/sequencebuffermonitor/SequenceBufferMonitorFrame.java
@@ -88,7 +88,7 @@ class SequenceBufferMonitorFrame extends JFrame {
 
       update();
 
-      setLocation(200, 200);
+      super.setLocation(200, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 

--- a/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/ConfigFrame.java
+++ b/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/ConfigFrame.java
@@ -36,25 +36,17 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.List;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSeparator;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.ListSelectionModel;
-import javax.swing.WindowConstants;
+import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import net.miginfocom.swing.MigLayout;
+import org.micromanager.internal.utils.WindowPositioning;
 
 // Imports for MMStudio internal packages
 // Plugins should not access internal packages, to ensure modularity and
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 
 /**
  * Allow user to enable/disable Snap-on-Move.
@@ -62,7 +54,7 @@ import org.micromanager.internal.utils.MMFrame;
  * Shows a check box to enable/disable movement monitoring.
  * This is for testing and may be removed or replaced in the final version.
  */
-final class ConfigFrame extends MMFrame {
+final class ConfigFrame extends JFrame {
    private static final String ENABLE_BUTTON = "Start";
    private static final String DISABLE_BUTTON = "Stop";
    
@@ -212,7 +204,9 @@ final class ConfigFrame extends MMFrame {
 
       setMinimumSize(new Dimension(360, 210));
       pack();
-      loadPosition(600, 200);
+
+      super.setLocation(600, 200);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
    }
 
    private void updateButtonStates() {

--- a/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/ConfigFrame.java
+++ b/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/ConfigFrame.java
@@ -205,7 +205,7 @@ final class ConfigFrame extends JFrame {
       setMinimumSize(new Dimension(360, 210));
       pack();
 
-      setLocation(600, 200);
+      super.setLocation(600, 200);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 

--- a/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/ConfigFrame.java
+++ b/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/ConfigFrame.java
@@ -205,8 +205,8 @@ final class ConfigFrame extends JFrame {
       setMinimumSize(new Dimension(360, 210));
       pack();
 
-      super.setLocation(600, 200);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      setLocation(600, 200);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
    }
 
    private void updateButtonStates() {

--- a/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/CriterionDialog.java
+++ b/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/CriterionDialog.java
@@ -43,19 +43,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JTextField;
+import javax.swing.*;
+
 import mmcorej.CMMCore;
 import mmcorej.DeviceType;
 import net.miginfocom.swing.MigLayout;
 
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.plugins.snaponmove.ChangeCriterion.XYDistanceCriterion;
 import org.micromanager.plugins.snaponmove.ChangeCriterion.ZDistanceCriterion;
 
@@ -65,12 +59,11 @@ import org.micromanager.plugins.snaponmove.ChangeCriterion.ZDistanceCriterion;
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
 import org.micromanager.internal.dialogs.ComponentTitledBorder;
-import org.micromanager.internal.utils.MMDialog;
 
 
 
 
-final class CriterionDialog extends MMDialog {
+final class CriterionDialog extends JDialog {
    private final MainController controller_;
    private ChangeCriterion result_;
 
@@ -105,6 +98,8 @@ final class CriterionDialog extends MMDialog {
       setModal(true);
       setResizable(false);
       setLocationRelativeTo(owner);
+
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
       addWindowListener(new WindowAdapter() {

--- a/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewFrame.java
+++ b/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewFrame.java
@@ -86,7 +86,7 @@ public class SplitViewFrame extends JFrame implements ProcessorConfigurator {
 
       initComponents();
 
-      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       lrRadio_.setSelected(orientation_.equals(LR));

--- a/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewFrame.java
+++ b/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewFrame.java
@@ -34,11 +34,7 @@ import java.awt.event.ActionListener;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 
-import javax.swing.ButtonGroup;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
+import javax.swing.*;
 
 import mmcorej.CMMCore;
 
@@ -48,13 +44,13 @@ import org.micromanager.data.ProcessorConfigurator;
 import org.micromanager.PropertyMap;
 import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
+import org.micromanager.internal.utils.WindowPositioning;
 
 // Imports for MMStudio internal packages
 // Plugins should not access internal packages, to ensure modularity and
 // maintainability. However, this plugin code is older than the current
 // MMStudio API, so it still uses internal classes and interfaces. New code
 // should not imitate this practice.
-import org.micromanager.internal.utils.MMFrame;
 
 /**
  * Micro-Manager plugin that can split the acquired image top-down or left-right
@@ -62,7 +58,7 @@ import org.micromanager.internal.utils.MMFrame;
  *
  * @author nico, modified by Chris Weisiger
  */
-public class SplitViewFrame extends MMFrame implements ProcessorConfigurator {
+public class SplitViewFrame extends JFrame implements ProcessorConfigurator {
    private static final int DEFAULT_WIN_X = 100;
    private static final int DEFAULT_WIN_Y = 100;
    private static final String ORIENTATION = "Orientation";
@@ -90,7 +86,8 @@ public class SplitViewFrame extends MMFrame implements ProcessorConfigurator {
 
       initComponents();
 
-      super.loadAndRestorePosition(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       lrRadio_.setSelected(orientation_.equals(LR));
       tbRadio_.setSelected(orientation_.equals(TB));

--- a/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewFrame.java
+++ b/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewFrame.java
@@ -87,7 +87,7 @@ public class SplitViewFrame extends JFrame implements ProcessorConfigurator {
       initComponents();
 
       setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       lrRadio_.setSelected(orientation_.equals(LR));
       tbRadio_.setSelected(orientation_.equals(TB));

--- a/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewFrame.java
+++ b/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewFrame.java
@@ -86,7 +86,7 @@ public class SplitViewFrame extends JFrame implements ProcessorConfigurator {
 
       initComponents();
 
-      setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
+      super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
 
       lrRadio_.setSelected(orientation_.equals(LR));

--- a/plugins/Tracker/src/main/java/com/imaging100x/tracker/TrackerControl.java
+++ b/plugins/Tracker/src/main/java/com/imaging100x/tracker/TrackerControl.java
@@ -220,8 +220,7 @@ public class TrackerControl extends JFrame {
       setResizable(false);
       getContentPane().setLayout(null);
 
-      super.setLocation(100, 100);
-      super.setSize(412, 346);
+      setBounds(100, 100, 412, 346);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       final JLabel intervalmsLabel = new JLabel();

--- a/plugins/Tracker/src/main/java/com/imaging100x/tracker/TrackerControl.java
+++ b/plugins/Tracker/src/main/java/com/imaging100x/tracker/TrackerControl.java
@@ -220,7 +220,7 @@ public class TrackerControl extends JFrame {
       setResizable(false);
       getContentPane().setLayout(null);
 
-      setBounds(100, 100, 412, 346);
+      super.setBounds(100, 100, 412, 346);
       WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       final JLabel intervalmsLabel = new JLabel();

--- a/plugins/Tracker/src/main/java/com/imaging100x/tracker/TrackerControl.java
+++ b/plugins/Tracker/src/main/java/com/imaging100x/tracker/TrackerControl.java
@@ -39,12 +39,7 @@ import java.io.File;
 import java.util.GregorianCalendar;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.swing.ButtonGroup;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JRadioButton;
-import javax.swing.JTextField;
-import javax.swing.Timer;
+import javax.swing.*;
 import javax.swing.border.BevelBorder;
 
 import mmcorej.MMCoreJ;
@@ -65,11 +60,11 @@ import org.micromanager.UserProfile;
 // should not imitate this practice.
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.MDUtils;
-import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.TextUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 
 
-public class TrackerControl extends MMFrame {
+public class TrackerControl extends JFrame {
    public static final String menuName = "Live Tracking";
    public static final String tooltipDescription =
       "Use image correlation based tracking to countersteer the XY stage";
@@ -224,7 +219,10 @@ public class TrackerControl extends MMFrame {
       setTitle("Live Tracking");
       setResizable(false);
       getContentPane().setLayout(null);
-      loadAndRestorePosition(100, 100, 412, 346);
+
+      super.setLocation(100, 100);
+      super.setSize(412, 346);
+      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
 
       final JLabel intervalmsLabel = new JLabel();
       intervalmsLabel.setText("Interval [ms]");

--- a/plugins/ZProjector/src/main/java/org/micromanager/zprojector/ZProjectorPluginFrame.java
+++ b/plugins/ZProjector/src/main/java/org/micromanager/zprojector/ZProjectorPluginFrame.java
@@ -28,17 +28,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.swing.ButtonGroup;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JFormattedTextField;
-import javax.swing.JLabel;
-import javax.swing.JRadioButton;
-import javax.swing.JSpinner;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.WindowConstants;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.text.DefaultFormatter;
 import net.miginfocom.swing.MigLayout;
@@ -47,15 +37,15 @@ import org.micromanager.data.Coords;
 import org.micromanager.data.DataProvider;
 import org.micromanager.data.Datastore;
 import org.micromanager.display.DisplayWindow;
-import org.micromanager.internal.utils.MMDialog;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
 /**
  *
  * @author nico
  */
-public class ZProjectorPluginFrame extends MMDialog {
+public class ZProjectorPluginFrame extends JDialog {
    private final Studio studio_;
    private final DisplayWindow ourWindow_;
    private final DataProvider ourProvider_;


### PR DESCRIPTION
Delete MMDialog and MMFrame from all involved files except MosaicSequenceFrame and CRISPFrame, because they can't be tested if devices are not available.