### PR TITLE
Deprecate methods named "getIsX" and "setIsX"

### DIFF
--- a/acqEngine/src/main/clj/org/micromanager/acq_engine.clj
+++ b/acqEngine/src/main/clj/org/micromanager/acq_engine.clj
@@ -564,14 +564,14 @@
      (when (and gui
                 (< 1000 delta)
                 (@state :live-mode-on)
-                (not (.getIsLiveModeOn (.live gui))))
+                (not (.isLiveModeOn (.live gui))))
       (.setLiveMode (.live gui) true))
     (when (pos? delta)
       (interruptible-sleep delta))
     (await-resume)
     (when gui
-      (swap! state assoc :live-mode-on (.getIsLiveModeOn (.live gui)))
-      (when (.getIsLiveModeOn (.live gui))
+      (swap! state assoc :live-mode-on (.isLiveModeOn (.live gui)))
+      (when (.isLiveModeOn (.live gui))
         (.setLiveMode (.live gui) false)))
     (let [now (jvm-time-ms)
           wake-time (if (> now (+ target-time 10)) now target-time)]

--- a/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
@@ -189,7 +189,7 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
       applySettings();
       Rectangle oldROI = studio_.core().getROI();
       CMMCore core = studio_.getCMMCore();
-      liveModeOn_ = studio_.live().getIsLiveModeOn();
+      liveModeOn_ = studio_.live().isLiveModeOn();
 
       //ReportingUtils.logMessage("Original ROI: " + oldROI);
       int w = (int) (oldROI.width * cropFactor);

--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
@@ -460,7 +460,7 @@ public class ProjectorControlForm extends MMFrame {
               dme.getEvent().isShiftDown() && 
               dme.getEvent().getButton() == 1) {
          // System.out.println("" + dme.getEvent().getID()+ " " + dme.getEvent().paramString());
-         if (studio_.acquisitions().isAcquisitionRunning() || studio_.live().getIsLiveModeOn()) {
+         if (studio_.acquisitions().isAcquisitionRunning() || studio_.live().isLiveModeOn()) {
             Point2D p2D = dme.getCenterLocation();
             addPointToPointAndShootQueue(p2D);
          }

--- a/mmstudio/src/main/java/MMStudioPlugin.java
+++ b/mmstudio/src/main/java/MMStudioPlugin.java
@@ -56,7 +56,7 @@ public class MMStudioPlugin implements PlugIn, CommandListener {
          @Override
          public void run() {
             try {
-               if (studio_ == null || !studio_.getIsProgramRunning()) {
+               if (studio_ == null || !studio_.isProgramRunning()) {
                   // OS-specific stuff
                   // TODO Why here and not in MMStudio?
                   if (JavaUtils.isMac()) {

--- a/mmstudio/src/main/java/org/micromanager/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/SnapLiveManager.java
@@ -68,10 +68,15 @@ public interface SnapLiveManager {
     * Turns live mode on or off. This will post an
     * org.micromanager.events.LiveModeEvent on the global application event
     * bus.
-    * @param isOn If true, then live mode will be activated; otherwise it will
+    * @param on If true, then live mode will be activated; otherwise it will
     *        be halted.
     */
-   public void setLiveMode(boolean isOn);
+   void setLiveModeOn(boolean on);
+
+   @Deprecated
+   default void setLiveMode(boolean on) {
+      setLiveModeOn(on);
+   }
 
    /**
     * Temporarily halt live mode, or re-start it after a temporary halt. This

--- a/mmstudio/src/main/java/org/micromanager/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/SnapLiveManager.java
@@ -51,10 +51,18 @@ public interface SnapLiveManager {
    public List<Image> snap(boolean shouldDisplay);
 
    /**
-    * Indicates if live mode is currently running.
+    * Returns whether live mode is on.
+    *
+    * If live mode is on but suspended, this method returns <code>true</code>.
+    *
     * @return true iff live mode is on.
     */
-   public boolean getIsLiveModeOn();
+   boolean isLiveModeOn();
+
+   @Deprecated
+   default boolean getIsLiveModeOn() {
+      return isLiveModeOn();
+   }
 
    /**
     * Turns live mode on or off. This will post an
@@ -70,7 +78,7 @@ public interface SnapLiveManager {
     * is useful for actions that cannot be performed while live mode is
     * running (such as changing many camera settings), so that live mode can
     * be re-started once the action is complete. Instead of calling
-    * getIsLiveModeOn(), stopping it if necessary, and then re-starting it if
+    * isLiveModeOn(), stopping it if necessary, and then re-starting it if
     * it was on, you can instead blindly do:
     * - setSuspended(true);
     * - do something that can't run when live mode is on;

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -802,7 +802,7 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
 
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
-      if (!event.getIsCancelled() && isAcquisitionRunning()) {
+      if (!event.isCanceled() && isAcquisitionRunning()) {
          int result = JOptionPane.showConfirmDialog(null,
                "Acquisition in progress. Are you sure you want to exit and discard all data?",
                "Micro-Manager", JOptionPane.YES_NO_OPTION,

--- a/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/internal/AlertsWindow.java
@@ -256,7 +256,7 @@ public final class AlertsWindow extends MMFrame {
    
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
-      if (!event.getIsCancelled()) {
+      if (!event.isCanceled()) {
         dispose();
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/data/Pipeline.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Pipeline.java
@@ -100,7 +100,12 @@ public interface Pipeline {
     * modes. See DataManager.createPipeline() for more information.
     * @return True if the Pipeline is synchronous, False otherwise.
     */
-   public boolean getIsSynchronous();
+   boolean isSynchronous();
+
+   @Deprecated
+   default boolean getIsSynchronous() {
+      return isSynchronous();
+   }
 
    /**
     * Halt image processing, so that the Pipeline will not produce any more

--- a/mmstudio/src/main/java/org/micromanager/data/internal/pipeline/DefaultPipeline.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/pipeline/DefaultPipeline.java
@@ -119,7 +119,7 @@ public final class DefaultPipeline implements Pipeline {
    }
 
    @Override
-   public boolean getIsSynchronous() {
+   public boolean isSynchronous() {
       return isSynchronous_;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
@@ -279,10 +279,15 @@ public interface DisplayManager extends EventPublisher {
 
    /**
     * Returns true if the DataProvider is being managed by MicroManager.
-    * @param store The DataProvider whose management status is under question.
+    * @param provider The DataProvider whose management status is under question.
     * @return Whether or not Micro-Manager is managing the DataProvider.
     */
-   boolean getIsManaged(DataProvider store);
+   boolean isManaged(DataProvider provider);
+
+   @Deprecated
+   default boolean getIsManaged(DataProvider provider) {
+      return isManaged(provider);
+   }
 
    /**
     * Return all associated DisplayWindows for the Datastore. Returns null if

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -160,7 +160,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
       // If shutdown is already cancelled, don't do anything.
-      if (!event.getIsCancelled() && !closeAllDisplayWindows(true)) {
+      if (!event.isCanceled() && !closeAllDisplayWindows(true)) {
          event.cancelShutdown();
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -130,7 +130,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    }
 
    @Override
-   public synchronized boolean getIsManaged(DataProvider provider) {
+   public synchronized boolean isManaged(DataProvider provider) {
       return providerToDisplays_.containsKey(provider);
    }
 
@@ -309,7 +309,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
 
       DataProvider store = viewer.getDataProvider();
       synchronized (this) {
-         if (getIsManaged(store) && viewer instanceof DisplayWindow) {
+         if (isManaged(store) && viewer instanceof DisplayWindow) {
             DisplayWindow display = (DisplayWindow) viewer;
             providerToDisplays_.get(store).add(display);
             display.addListener(this, 100);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -536,7 +536,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             return false;
          }
          // All arrays have same contents or are both null.
-         return (isVisible_ != alt.getIsVisible());
+         return (isVisible_ != alt.isVisible());
       }
 
       @Override
@@ -624,8 +624,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             }
             channelBuilder.component(j, componentBuilder.build());
          }
-         if (legacySettings.getIsVisible() != null) {
-            channelBuilder.visible(legacySettings.getIsVisible());
+         if (legacySettings.isVisible() != null) {
+            channelBuilder.visible(legacySettings.isVisible());
          }
          channel(channelIndex, channelBuilder.build());
          return this;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -2055,7 +2055,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
    @Subscribe
    public void onLiveModeEvent(LiveModeEvent liveModeEvent) {
       // Used to reset counters for camera fps measurements
-      if (liveModeEvent.getIsOn()) {
+      if (liveModeEvent.isOn()) {
          nrLiveFramesReceived_ = 0;
          lastImageNumber_ = 0;
          durationMs_ = 0.0;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
@@ -23,8 +23,7 @@
 package org.micromanager.display.internal.gearmenu;
 
 import com.bulenkov.iconloader.IconLoader;
-import ij.CompositeImage;
-import ij.ImagePlus;
+
 import java.awt.Color;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
@@ -264,7 +263,7 @@ public final class ExportMovieDlg extends MMDialog {
       JLabel help = new JLabel("<html><body>Export a series of images from your dataset. The images will be exactly as currently<br>drawn on your display, including histogram scaling, zoom, overlays, etc. Note that<br>this does not preserve the raw data, nor any metadata.</body></html>");
       contentsPanel_.add(help, "align center");
 
-      if (getIsComposite()) {
+      if (isComposite()) {
          contentsPanel_.add(new JLabel("<html><body>The \"channel\" axis is unavailable as the display is in composite mode.</body></html>"),
                "align center");
       }
@@ -488,7 +487,7 @@ public final class ExportMovieDlg extends MMDialog {
    /**
     * Returns true if the display mode is composite.
     */
-   private boolean getIsComposite() {
+   private boolean isComposite() {
       return display_.getDisplaySettings().getColorMode() ==
               DisplaySettings.ColorMode.COMPOSITE;
    }
@@ -503,7 +502,7 @@ public final class ExportMovieDlg extends MMDialog {
       for (String axis : provider_.getAxes()) {
          // Channel axis is only available when in non-composite display modes.
          if (provider_.getMaxIndices().getIndex(axis) > 0 &&
-               (!axis.equals(Coords.CHANNEL) || !getIsComposite())) {
+               (!axis.equals(Coords.CHANNEL) || !isComposite())) {
             result.add(axis);
          }
       }

--- a/mmstudio/src/main/java/org/micromanager/events/ChannelExposureEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/ChannelExposureEvent.java
@@ -65,7 +65,12 @@ public class ChannelExposureEvent {
     * one used for snaps and live mode, the one whose exposure time is
     * displayed in the main window).
     */
-   public boolean getIsMainExposureTime() {
+   public boolean isMainExposureTime() {
       return isMainExposureTime_;
+   }
+
+   @Deprecated
+   public boolean getIsMainExposureTime() {
+      return isMainExposureTime();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/LiveModeEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/LiveModeEvent.java
@@ -29,5 +29,10 @@ public interface LiveModeEvent {
     * @return True if live mode has been turned on, false if it has been turned
     *         off.
     */
-   public boolean getIsOn();
+   boolean isOn();
+
+   @Deprecated
+   default boolean getIsOn() {
+      return isOn();
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/ShutdownCommencingEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/ShutdownCommencingEvent.java
@@ -26,19 +26,24 @@ package org.micromanager.events;
  * that data can be saved or other similarly-critical decisions).
  */
 public class ShutdownCommencingEvent {
-   private boolean isCancelled_ = false;
+   private boolean isCanceled_ = false;
 
    /**
     * Cancel shutdown.
     */
    public void cancelShutdown() {
-      isCancelled_ = true;
+      isCanceled_ = true;
    }
 
    /**
-    * Return whether or not shutdown has been cancelled.
+    * Return whether or not shutdown has been canceled.
     */
+   public boolean isCanceled() {
+      return isCanceled_;
+   }
+
+   @Deprecated
    public boolean getIsCancelled() {
-      return isCancelled_;
+      return isCanceled();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultLiveModeEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultLiveModeEvent.java
@@ -30,7 +30,7 @@ public final class DefaultLiveModeEvent implements LiveModeEvent {
    }
 
    @Override
-   public boolean getIsOn() {
+   public boolean isOn() {
       return isOn_;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/InternalShutdownCommencingEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/InternalShutdownCommencingEvent.java
@@ -26,19 +26,19 @@ package org.micromanager.events.internal;
  * API; it's only intended for internal use.
  */
 public final class InternalShutdownCommencingEvent {
-   private boolean isCancelled_ = false;
+   private boolean isCanceled_ = false;
 
    /**
     * Cancel shutdown.
     */
    public void cancelShutdown() {
-      isCancelled_ = true;
+      isCanceled_ = true;
    }
 
    /**
-    * Return whether or not shutdown has been cancelled.
+    * Return whether or not shutdown has been canceled.
     */
-   public boolean getIsCancelled() {
-      return isCancelled_;
+   public boolean isCanceled() {
+      return isCanceled_;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/MouseMovesStageStateChangeEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/MouseMovesStageStateChangeEvent.java
@@ -11,7 +11,7 @@ public final class MouseMovesStageStateChangeEvent {
       isEnabled_ = isEnabled;
    }
 
-   public boolean getIsEnabled() {
+   public boolean isEnabled() {
       return isEnabled_;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1258,7 +1258,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       }
       ShutdownCommencingEvent externalEvent = new ShutdownCommencingEvent();
       events().post(externalEvent);
-      if (externalEvent.getIsCancelled()) {
+      if (externalEvent.isCanceled()) {
          // Shutdown cancelled by user.
          return false;
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1502,7 +1502,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       frame_.setConfigSaveButtonStatus(configChanged_);
    }
 
-   public boolean getIsConfigChanged() {
+   public boolean hasConfigChanged() {
       return configChanged_;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -545,7 +545,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    }
 
    private void handleError(String message) {
-      live().setLiveMode(false);
+      live().setLiveModeOn(false);
       JOptionPane.showMessageDialog(frame_, message);
       core_.logMessage(message);
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.net.UnknownHostException;
 import java.util.*;
 import java.util.function.Function;
@@ -1254,7 +1252,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       // one that's accessible in the API.
       InternalShutdownCommencingEvent internalEvent = new InternalShutdownCommencingEvent();
       events().post(internalEvent);
-      if (internalEvent.getIsCancelled()) {
+      if (internalEvent.isCanceled()) {
          // Shutdown cancelled by user.
          return false;
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -985,7 +985,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       events().post(new MouseMovesStageStateChangeEvent(isEnabled));
    }
 
-   public boolean getIsClickToMoveEnabled() {
+   public boolean isClickToMoveEnabled() {
       return isClickToMoveEnabled_;
    }
    

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -416,7 +416,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       }
 
       // Profile may have been switched in Intro Dialog, so reflect its setting
-      core_.enableDebugLog(OptionsDlg.getIsDebugLogEnabled(studio_));
+      core_.enableDebugLog(OptionsDlg.isDebugLoggingEnabled(studio_));
 
       IJVersionCheckDlg.execute(studio_);
 
@@ -510,7 +510,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
 
    private void initializeLogging(CMMCore core) {
       core.enableStderrLog(true);
-      core.enableDebugLog(OptionsDlg.getIsDebugLogEnabled(studio_));
+      core.enableDebugLog(OptionsDlg.isDebugLoggingEnabled(studio_));
       ReportingUtils.setCore(core);
 
       // Set up logging to CoreLog file
@@ -533,7 +533,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       // Although our general rule is to perform identical logging regardless
       // of the current log level, we make an exception for UIMonitor, which we
       // enable only when debug logging is turned on (from the GUI).
-      UIMonitor.enable(OptionsDlg.getIsDebugLogEnabled(studio_));
+      UIMonitor.enable(OptionsDlg.isDebugLoggingEnabled(studio_));
    }
   
    public void showPipelineFrame() {

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1242,7 +1242,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    }
 
    public synchronized boolean closeSequence(boolean quitInitiatedByImageJ) {
-      if (!getIsProgramRunning()) {
+      if (!isProgramRunning()) {
          if (core_ != null) {
             core_.logMessage("MMStudio::closeSequence called while isProgramRunning_ is false");
          }
@@ -1318,7 +1318,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
       return true;
    }
 
-   public boolean getIsProgramRunning() {
+   public boolean isProgramRunning() {
       return isProgramRunning_;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -678,7 +678,7 @@ public final class MainFrame extends MMFrame {
 
    @Subscribe
    public void onMouseMovesStage(MouseMovesStageStateChangeEvent event) {
-      setHandMovesButton(event.getIsEnabled());
+      setHandMovesButton(event.isEnabled());
    }
 
    private void setHandMovesButton(boolean state) {

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -690,7 +690,7 @@ public final class MainFrame extends MMFrame {
 
    @Subscribe
    public void onChannelExposure(ChannelExposureEvent event) {
-      if (event.getIsMainExposureTime()) {
+      if (event.isMainExposureTime()) {
          setDisplayedExposureTime(event.getNewExposureTime());
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -447,7 +447,7 @@ public final class SnapLiveManager extends DataViewerListener
    }
 
    @Override
-   public boolean getIsLiveModeOn() {
+   public boolean isLiveModeOn() {
       return isLiveOn_;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -164,7 +164,7 @@ public final class SnapLiveManager extends DataViewerListener
    }
 
    @Override
-   public void setLiveMode(boolean isOn) {
+   public void setLiveModeOn(boolean isOn) {
       synchronized(liveModeLock_) {
          if (isLiveOn_ == isOn) {
             return;
@@ -238,7 +238,7 @@ public final class SnapLiveManager extends DataViewerListener
          ReportingUtils.showError(e, "Couldn't start live mode sequence acquisition");
          // Give up on starting live mode.
          amStartingSequenceAcquisition_ = false;
-         setLiveMode(false);
+         setLiveModeOn(false);
          return;
       }
 
@@ -869,7 +869,7 @@ public final class SnapLiveManager extends DataViewerListener
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
       if (!event.isCanceled()) {
-         setLiveMode(false);
+         setLiveModeOn(false);
       }
    }
 
@@ -884,7 +884,7 @@ public final class SnapLiveManager extends DataViewerListener
    public boolean canCloseViewer(DataViewer viewer) {
       if (viewer instanceof DisplayWindow && viewer.equals(display_)) {
          saveDisplaySettings();
-         setLiveMode(false);
+         setLiveModeOn(false);
       }
       return true;
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -523,7 +523,7 @@ public final class SnapLiveManager extends DataViewerListener
    @Subscribe
    public void onMouseMovesStageStateChange(MouseMovesStageStateChangeEvent e) {
       if (display_ != null) {
-         if (e.getIsEnabled()) {
+         if (e.isEnabled()) {
             uiMovesStageManager_.activate(display_);
          } else {
             uiMovesStageManager_.deActivate(display_);

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -868,7 +868,7 @@ public final class SnapLiveManager extends DataViewerListener
 
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
-      if (!event.getIsCancelled()) {
+      if (!event.isCanceled()) {
          setLiveMode(false);
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
@@ -356,7 +356,7 @@ public final class CalibrationListDlg extends MMDialog {
          if (studio_ != null && !disposed_) {
             studio_.events().unregisterForEvents(this);
             MMStudio mmStudio = (MMStudio) studio_;
-            if (mmStudio.getIsConfigChanged()) {
+            if (mmStudio.hasConfigChanged()) {
                Object[] options = {"Yes", "No"};
                int userFeedback = JOptionPane.showOptionDialog(null,
                        "Save Changed Pixel Configuration?", "Micro-Manager",

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -97,10 +97,10 @@ public final class OptionsDlg extends MMDialog {
       final JCheckBox debugLogEnabledCheckBox = new JCheckBox();
       debugLogEnabledCheckBox.setText("Enable debug logging");
       debugLogEnabledCheckBox.setToolTipText("Enable verbose logging for troubleshooting and debugging");
-      debugLogEnabledCheckBox.setSelected(getIsDebugLogEnabled(mmStudio_));
+      debugLogEnabledCheckBox.setSelected(isDebugLoggingEnabled(mmStudio_));
       debugLogEnabledCheckBox.addActionListener((final ActionEvent e) -> {
          boolean isEnabled = debugLogEnabledCheckBox.isSelected();
-         setIsDebugLogEnabled(mmStudio_, isEnabled);
+         setDebugLoggingEnabled(mmStudio_, isEnabled);
          core_.enableDebugLog(isEnabled);
          UIMonitor.enable(isEnabled);
       });
@@ -356,12 +356,12 @@ public final class OptionsDlg extends MMDialog {
       dispose();
    }
 
-   public static boolean getIsDebugLogEnabled(Studio studio) {
+   public static boolean isDebugLoggingEnabled(Studio studio) {
       return studio.profile().getSettings(OptionsDlg.class).getBoolean(
             IS_DEBUG_LOG_ENABLED, false);
    }
 
-   public static void setIsDebugLogEnabled(Studio studio, boolean isEnabled) {
+   public static void setDebugLoggingEnabled(Studio studio, boolean isEnabled) {
       studio.profile().getSettings(OptionsDlg.class).putBoolean(
             IS_DEBUG_LOG_ENABLED, isEnabled);
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -833,7 +833,7 @@ public final class StageControlFrame extends MMFrame {
       
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
-      if (!event.getIsCancelled()) {
+      if (!event.isCanceled()) {
          this.dispose();
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
@@ -132,7 +132,7 @@ public final class ConfigMenu {
          return;
       }
       
-      if (mmStudio_.getIsConfigChanged()) {
+      if (mmStudio_.hasConfigChanged()) {
          Object[] options = {"Yes", "No"};
          int n = JOptionPane.showOptionDialog(null,
                  "Save Hardware Configuration?", "Micro-Manager",

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
@@ -181,10 +181,10 @@ public final class ToolsMenu {
 
    @Subscribe
    public void onMouseMovesStage(MouseMovesStageStateChangeEvent event) {
-      String icon = event.getIsEnabled() ? "move_hand_on.png" : "move_hand.png";
+      String icon = event.isEnabled() ? "move_hand_on.png" : "move_hand.png";
       centerAndDragMenuItem_.setIcon(IconLoader.getIcon(
               "/org/micromanager/icons/" + icon));
-      centerAndDragMenuItem_.setSelected(event.getIsEnabled());
+      centerAndDragMenuItem_.setSelected(event.isEnabled());
    }
 
    public boolean getMouseMovesStage() {

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ConfiguratorWrapper.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/ConfiguratorWrapper.java
@@ -59,19 +59,19 @@ public final class ConfiguratorWrapper {
       return name_;
    }
 
-   public boolean getIsEnabled() {
+   public boolean isEnabled() {
       return isEnabled_;
    }
 
-   public boolean getIsEnabledInLive() {
+   public boolean isEnabledInLive() {
       return isEnabledInLive_;
    }
 
-   public void setIsEnabled(boolean isEnabled) {
+   public void setEnabled(boolean isEnabled) {
       isEnabled_ = isEnabled;
    }
 
-   public void setIsEnabledInLive(boolean isEnabled) {
+   public void setEnabledInLive(boolean isEnabled) {
       isEnabledInLive_ = isEnabled;
    }
 
@@ -112,13 +112,13 @@ public final class ConfiguratorWrapper {
          ProcessorConfigurator configurator = plugin.createConfigurator(settings);
          ConfiguratorWrapper result = new ConfiguratorWrapper(plugin,
                configurator, json.getString("name"));
-         result.setIsEnabled(json.getBoolean("isEnabled"));
+         result.setEnabled(json.getBoolean("isEnabled"));
          // This flag was added later.
          if (json.has("isEnabledInLive")) {
-            result.setIsEnabledInLive(json.getBoolean("isEnabledInLive"));
+            result.setEnabledInLive(json.getBoolean("isEnabledInLive"));
          }
          else {
-            result.setIsEnabledInLive(result.getIsEnabled());
+            result.setEnabledInLive(result.isEnabled());
          }
          return result;
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
@@ -21,7 +21,6 @@ import javax.swing.table.AbstractTableModel;
 import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
 import org.micromanager.data.NewPipelineEvent;
-import org.micromanager.data.ProcessorConfigurator;
 import org.micromanager.data.ProcessorFactory;
 import org.micromanager.internal.MMStudio;
 
@@ -110,8 +109,8 @@ public final class PipelineTableModel extends AbstractTableModel {
    public List<ConfiguratorWrapper> getEnabledConfigurators(boolean isLiveMode) {
       ArrayList<ConfiguratorWrapper> result = new ArrayList<ConfiguratorWrapper>();
       for (ConfiguratorWrapper config : pipelineConfigs_) {
-         if ((isLiveMode && config.getIsEnabledInLive()) ||
-               (!isLiveMode && config.getIsEnabled())) {
+         if ((isLiveMode && config.isEnabledInLive()) ||
+               (!isLiveMode && config.isEnabled())) {
             result.add(config);
          }
       }
@@ -175,9 +174,9 @@ public final class PipelineTableModel extends AbstractTableModel {
    public Object getValueAt(int row, int column) {
       switch (column) {
          case ENABLED_COLUMN:
-            return pipelineConfigs_.get(row).getIsEnabled();
+            return pipelineConfigs_.get(row).isEnabled();
          case ENABLED_LIVE_COLUMN:
-            return pipelineConfigs_.get(row).getIsEnabledInLive();
+            return pipelineConfigs_.get(row).isEnabledInLive();
          case NAME_COLUMN:
             return pipelineConfigs_.get(row).getName();
          case CONFIGURE_COLUMN:
@@ -189,11 +188,11 @@ public final class PipelineTableModel extends AbstractTableModel {
    @Override
    public void setValueAt(Object value, int row, int column) {
       if (column == ENABLED_COLUMN) {
-         pipelineConfigs_.get(row).setIsEnabled((Boolean) value);
+         pipelineConfigs_.get(row).setEnabled((Boolean) value);
          fireTableDataChanged();
       }
       else if (column == ENABLED_LIVE_COLUMN) {
-         pipelineConfigs_.get(row).setIsEnabledInLive((Boolean) value);
+         pipelineConfigs_.get(row).setEnabledInLive((Boolean) value);
          fireTableDataChanged();
       }
    }
@@ -232,7 +231,7 @@ public final class PipelineTableModel extends AbstractTableModel {
       for (String configString : serializedConfigs) {
          ConfiguratorWrapper config = ConfiguratorWrapper.fromString(
                configString, studio);
-         if (config.getIsEnabled()) {
+         if (config.isEnabled()) {
             didUpdate = true;
          }
          pipelineConfigs_.add(config);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
@@ -65,7 +65,7 @@ public final class MMPositionListDlg extends PositionListDlg {
     
     @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
-      if (!event.getIsCancelled()) {
+      if (!event.isCanceled()) {
          saveDims();
          dispose();
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeyAction.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeyAction.java
@@ -45,7 +45,7 @@ public final class HotKeyAction {
                   studio_.live().snap(true);
                   return true;
                case TOGGLELIVE:
-                  snapLiveManager_.setLiveMode(!snapLiveManager_.isLiveModeOn());
+                  snapLiveManager_.setLiveModeOn(!snapLiveManager_.isLiveModeOn());
                   return true;
                case TOGGLESHUTTER:
                   try {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeyAction.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/HotKeyAction.java
@@ -45,7 +45,7 @@ public final class HotKeyAction {
                   studio_.live().snap(true);
                   return true;
                case TOGGLELIVE:
-                  snapLiveManager_.setLiveMode(!snapLiveManager_.getIsLiveModeOn());
+                  snapLiveManager_.setLiveMode(!snapLiveManager_.isLiveModeOn());
                   return true;
                case TOGGLESHUTTER:
                   try {

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/QuickAccessFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/QuickAccessFrame.java
@@ -43,9 +43,6 @@ import java.util.HashSet;
 import javax.swing.BorderFactory;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -55,12 +52,7 @@ import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
+
 import net.miginfocom.swing.MigLayout;
 import mmcorej.org.json.JSONArray;
 import mmcorej.org.json.JSONException;
@@ -71,7 +63,6 @@ import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.quickaccess.QuickAccessPlugin;
 import org.micromanager.quickaccess.WidgetPlugin;
-import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 
 /**
  * This class shows the Quick Access Window for frequently-used controls.
@@ -862,7 +853,7 @@ public final class QuickAccessFrame extends JFrame {
 
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
-      if (!event.getIsCancelled()) {
+      if (!event.isCanceled()) {
          dispose();
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/LiveButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/LiveButton.java
@@ -101,7 +101,7 @@ public final class LiveButton extends WidgetPlugin implements SciJavaPlugin {
       result.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            studio_.live().setLiveMode(!studio_.live().isLiveModeOn());
+            studio_.live().setLiveModeOn(!studio_.live().isLiveModeOn());
          }
       });
       result.setFont(GUIUtils.buttonFont);

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/LiveButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/LiveButton.java
@@ -112,7 +112,7 @@ public final class LiveButton extends WidgetPlugin implements SciJavaPlugin {
       HierarchyListener wrapper = new HierarchyListener() {
          @Subscribe
          public void onLiveMode(LiveModeEvent event) {
-            boolean isOn = event.getIsOn();
+            boolean isOn = event.isOn();
             result.setIcon(IconLoader.getIcon(
                   isOn ? "/org/micromanager/icons/cancel.png" :
                   "/org/micromanager/icons/camera_go.png"));

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/LiveButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/LiveButton.java
@@ -101,7 +101,7 @@ public final class LiveButton extends WidgetPlugin implements SciJavaPlugin {
       result.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            studio_.live().setLiveMode(!studio_.live().getIsLiveModeOn());
+            studio_.live().setLiveMode(!studio_.live().isLiveModeOn());
          }
       });
       result.setFont(GUIUtils.buttonFont);
@@ -136,7 +136,7 @@ public final class LiveButton extends WidgetPlugin implements SciJavaPlugin {
             }
          }
       };
-      result.setIcon(studio_.live().getIsLiveModeOn() ?
+      result.setIcon(studio_.live().isLiveModeOn() ?
             IconLoader.getIcon("/org/micromanager/icons/cancel.png") :
             IconLoader.getIcon("/org/micromanager/icons/camera_go.png"));
       result.addHierarchyListener(wrapper);

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/SnapButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/SnapButton.java
@@ -103,7 +103,7 @@ public final class SnapButton extends WidgetPlugin implements SciJavaPlugin {
             studio_.live().snap(true);
          }
       });
-      result.setEnabled(!studio_.live().getIsLiveModeOn());
+      result.setEnabled(!studio_.live().isLiveModeOn());
       // This is a little convoluted: we need to change the snap button's
       // state depending on if live mode is active or not, which requires an
       // event subscription. We need to clean up that subscription when the

--- a/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/SnapButton.java
+++ b/mmstudio/src/main/java/org/micromanager/quickaccess/internal/controls/SnapButton.java
@@ -111,7 +111,7 @@ public final class SnapButton extends WidgetPlugin implements SciJavaPlugin {
       HierarchyListener subscriber = new HierarchyListener() {
          @Subscribe
          public void onLiveMode(LiveModeEvent event) {
-            result.setEnabled(!event.getIsOn());
+            result.setEnabled(!event.isOn());
          }
 
          @Override

--- a/mmstudio/src/test/java/org/micromanager/data/internal/VersionCompatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/VersionCompatTest.java
@@ -41,7 +41,7 @@ import java.util.UUID;
 
 /**
  * This class tests that we properly transfer data between versions
- * (1.4 -> 2.0). It relies on an acquisition that was run immediately after
+ * (1.4 to 2.0). It relies on an acquisition that was run immediately after
  * startup using the 1.4.23 MDA interface with the following parameters:
  * - 64x64 DemoCamera
  * - 2 timepoints 5000ms apart

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIMFrame.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIMFrame.java
@@ -149,7 +149,7 @@ public class ASIdiSPIMFrame extends SPIMFrame  {
       controller_ = new ControllerUtils(gui_, props_, prefs_, devices_, positions_);
       
       // make sure Live mode is turned off 
-      gui_.live().setLiveMode(false);
+      gui_.live().setLiveModeOn(false);
  
       // create the panels themselves
       // in some cases dependencies create required ordering

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIMFrame.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/ASIdiSPIMFrame.java
@@ -429,7 +429,7 @@ public class ASIdiSPIMFrame extends SPIMFrame  {
   
    @Subscribe
    public void liveModeEnabled(LiveModeEvent liveEvent) {
-      if (liveEvent.getIsOn()) {
+      if (liveEvent.isOn()) {
          piezoSleepPreventer_.start();
       } else {
          piezoSleepPreventer_.stop();

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/AcquisitionPanel.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/AcquisitionPanel.java
@@ -1784,7 +1784,7 @@ public class AcquisitionPanel extends ListeningJPanel implements DevicesListener
         boolean liveModeOriginally = gui_.live().isLiveModeOn();
 
         if (liveModeOriginally) {
-            gui_.live().setLiveMode(false);
+            gui_.live().setLiveModeOn(false);
         }
 
         // make sure slice timings are up to date
@@ -3050,7 +3050,7 @@ public class AcquisitionPanel extends ListeningJPanel implements DevicesListener
         } catch (Exception ex) {
             MyDialogUtils.showError("Could not restore camera after acquisition");
         }
-        gui_.live().setLiveMode(liveModeOriginally);
+        gui_.live().setLiveModeOn(liveModeOriginally);
 
         if (nonfatalError) {
             MyDialogUtils.showError("Missed some images during acquisition, see core log for details");

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/AcquisitionPanel.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/AcquisitionPanel.java
@@ -1781,7 +1781,7 @@ public class AcquisitionPanel extends ListeningJPanel implements DevicesListener
             return false;
         }
 
-        boolean liveModeOriginally = gui_.live().getIsLiveModeOn();
+        boolean liveModeOriginally = gui_.live().isLiveModeOn();
 
         if (liveModeOriginally) {
             gui_.live().setLiveMode(false);

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/CameraSubPanel.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/CameraSubPanel.java
@@ -153,12 +153,12 @@ public final class CameraSubPanel extends ListeningJPanel  {
       toggleButtonLive_.setMargin(new Insets(2, 15, 2, 15));
       toggleButtonLive_.setIconTextGap(6);
       toggleButtonLive_.setToolTipText("Continuous live view");
-      setLiveButtonAppearance(gui_.live().getIsLiveModeOn());
+      setLiveButtonAppearance(gui_.live().isLiveModeOn());
       toggleButtonLive_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            setLiveButtonAppearance(!gui_.live().getIsLiveModeOn());
-            gui_.live().setLiveMode(!gui_.live().getIsLiveModeOn());
+            setLiveButtonAppearance(!gui_.live().isLiveModeOn());
+            gui_.live().setLiveMode(!gui_.live().isLiveModeOn());
          }
       });
       super.add(toggleButtonLive_, "center, width " + columnWidth + "px, span 2");

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/CameraSubPanel.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/CameraSubPanel.java
@@ -158,7 +158,7 @@ public final class CameraSubPanel extends ListeningJPanel  {
          @Override
          public void actionPerformed(ActionEvent e) {
             setLiveButtonAppearance(!gui_.live().isLiveModeOn());
-            gui_.live().setLiveMode(!gui_.live().isLiveModeOn());
+            gui_.live().setLiveModeOn(!gui_.live().isLiveModeOn());
          }
       });
       super.add(toggleButtonLive_, "center, width " + columnWidth + "px, span 2");

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/NavigationPanel.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/NavigationPanel.java
@@ -609,6 +609,6 @@ public class NavigationPanel extends ListeningJPanel  {
    
    @Subscribe
    public void liveModeEnabled(LiveModeEvent liveEvent) {
-      cameraPanel_.liveModeEnabled(liveEvent.getIsOn());
+      cameraPanel_.liveModeEnabled(liveEvent.isOn());
    } 
 }

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/SetupPanel.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/SetupPanel.java
@@ -1158,7 +1158,7 @@ public final class SetupPanel extends ListeningJPanel {
    
    @Subscribe
    public void liveModeEnabled(LiveModeEvent liveEvent) {
-      cameraPanel_.liveModeEnabled(liveEvent.getIsOn());
+      cameraPanel_.liveModeEnabled(liveEvent.isOn());
    }
 
 }

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/data/Cameras.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/data/Cameras.java
@@ -168,7 +168,7 @@ public class Cameras {
       String mmDevice = devices_.getMMDevice(key);
       if (mmDevice != null) {
          try {
-            final boolean liveEnabled = gui_.live().getIsLiveModeOn();
+            final boolean liveEnabled = gui_.live().isLiveModeOn();
             if (liveEnabled) {
                gui_.live().setLiveMode(false);
             }
@@ -790,7 +790,7 @@ public class Cameras {
     */
    public void setCameraROI(Devices.Keys camKey, Rectangle roi) {
       try {
-         final boolean liveEnabled = gui_.live().getIsLiveModeOn();
+         final boolean liveEnabled = gui_.live().isLiveModeOn();
          if (liveEnabled) {
             gui_.live().setLiveMode(false);
          }

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/data/Cameras.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/data/Cameras.java
@@ -170,14 +170,14 @@ public class Cameras {
          try {
             final boolean liveEnabled = gui_.live().isLiveModeOn();
             if (liveEnabled) {
-               gui_.live().setLiveMode(false);
+               gui_.live().setLiveModeOn(false);
             }
             currentCameraKey_ = key;
             core_.setCameraDevice(mmDevice);
             setShutterForCamera(key); 
             gui_.app().refreshGUIFromCache();
             if (liveEnabled) {
-               gui_.live().setLiveMode(true);
+               gui_.live().setLiveModeOn(true);
             }
          } catch (Exception ex) {
             MyDialogUtils.showError("Failed to set Core Camera property");
@@ -792,11 +792,11 @@ public class Cameras {
       try {
          final boolean liveEnabled = gui_.live().isLiveModeOn();
          if (liveEnabled) {
-            gui_.live().setLiveMode(false);
+            gui_.live().setLiveModeOn(false);
          }
          core_.setROI(devices_.getMMDevice(camKey), roi.x, roi.y, roi.width, roi.height);
          if (liveEnabled) {
-            gui_.live().setLiveMode(true);
+            gui_.live().setLiveModeOn(true);
          }
       }
       catch (Exception ex) {

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/AutofocusUtils.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/AutofocusUtils.java
@@ -313,7 +313,7 @@ public class AutofocusUtils {
             boolean focusSuccess = false; 
 
             try {
-               liveModeOriginally = gui_.live().getIsLiveModeOn();
+               liveModeOriginally = gui_.live().isLiveModeOn();
                if (liveModeOriginally) {
                   gui_.live().setLiveMode(false);
                   gui_.core().waitForDevice(originalCamera);

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/AutofocusUtils.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/AutofocusUtils.java
@@ -315,7 +315,7 @@ public class AutofocusUtils {
             try {
                liveModeOriginally = gui_.live().isLiveModeOn();
                if (liveModeOriginally) {
-                  gui_.live().setLiveMode(false);
+                  gui_.live().setLiveModeOn(false);
                   gui_.core().waitForDevice(originalCamera);
                }
                
@@ -587,7 +587,7 @@ public class AutofocusUtils {
                   if (liveModeOriginally) {
                      gui_.core().waitForDevice(camera);
                      gui_.core().waitForDevice(originalCamera);
-                     gui_.live().setLiveMode(true);
+                     gui_.live().setLiveModeOn(true);
                   }
 
                } catch (Exception ex) {

--- a/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombiner.java
+++ b/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombiner.java
@@ -67,7 +67,7 @@ public class FrameCombiner extends Processor {
          return;
       }
       // when live mode is on and user selected to do z proejct => do nothing
-      if (studio_.live().getIsLiveModeOn()
+      if (studio_.live().isLiveModeOn()
               && processorDimension_.equals(FrameCombinerPlugin.PROCESSOR_DIMENSION_Z)) {
          context.outputImage(image);
          return;
@@ -96,7 +96,7 @@ public class FrameCombiner extends Processor {
 
          // Check whether this combinations of coords are allowed to be processed
          boolean processCombinations = true;
-         if (channelsToAvoid_.contains(coords.getChannel()) && !studio_.live().getIsLiveModeOn()) {
+         if (channelsToAvoid_.contains(coords.getChannel()) && !studio_.live().isLiveModeOn()) {
             processCombinations = false;
          }
 

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/HCSPlugin.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/HCSPlugin.java
@@ -86,7 +86,7 @@ public class HCSPlugin implements MenuPlugin, SciJavaPlugin {
    @Subscribe
    public void closeRequested( ShutdownCommencingEvent sce){
       if (frame_ != null) {
-         if (!sce.getIsCancelled()) {
+         if (!sce.isCanceled()) {
             frame_.dispose();
          }
       }

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/uielements/ScrollBarAnimateIcon.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/uielements/ScrollBarAnimateIcon.java
@@ -79,7 +79,7 @@ public class ScrollBarAnimateIcon extends JButton {
          @Override
          public void mousePressed(MouseEvent e) {
             parent_.toggleAnimation(axis_);
-            setIsAnimated(!isAnimated_);
+            setAnimated(!isAnimated_);
          }
       });
    }
@@ -107,12 +107,12 @@ public class ScrollBarAnimateIcon extends JButton {
       g2d.drawString(label_, 20, 13);
    }
 
-   public void setIsAnimated(boolean isAnimated) {
+   public void setAnimated(boolean isAnimated) {
       isAnimated_ = isAnimated;
       curIcon_ = isAnimated_ ? PAUSE_ICON : PLAY_ICON;
    }
 
-   public boolean getIsAnimated() {
+   public boolean isAnimated() {
       return isAnimated_;
    }
 

--- a/plugins/RTIntensities/src/main/java/org/micromanager/plugins/rtintensities/RTIntensitiesFrame.java
+++ b/plugins/RTIntensities/src/main/java/org/micromanager/plugins/rtintensities/RTIntensitiesFrame.java
@@ -235,7 +235,7 @@ public class RTIntensitiesFrame extends JFrame {
    	if (! autoStart_  || manager_ == null) {
    		return;
    	}
-   	if (!event.getIsOn()) {
+   	if (!event.isOn()) {
    		return;
    	}
       DataViewer viewer = studio_.displays().getActiveDataViewer();

--- a/plugins/SlideExplorer/src/main/java/org/micromanager/slideexplorer/Hub.java
+++ b/plugins/SlideExplorer/src/main/java/org/micromanager/slideexplorer/Hub.java
@@ -697,7 +697,7 @@ public class Hub {
          Point mapPosition = coords_.tileToMap(tileIndex);
 
          if (!cache_.hasImage(tileIndex)) {
-            studio_.getSnapLiveManager().setLiveMode(false);
+            studio_.getSnapLiveManager().setLiveModeOn(false);
             final ImageProcessor img = controller_.grabImageAtMapPosition(mapPosition);
             cache_.addImage(tileIndex, img);
          }


### PR DESCRIPTION
Closes GH-1014.

This PR also renames internal methods, to reduce noise. Except for method names in `TaggedSpotsProtos`, which have not been touched here.