### PR TITLE
Add comment re MMStudioPlugin not being API

### DIFF
--- a/mmstudio/src/main/java/MMStudioPlugin.java
+++ b/mmstudio/src/main/java/MMStudioPlugin.java
@@ -41,6 +41,8 @@ import org.micromanager.internal.utils.ReportingUtils;
 
 /**
  * ImageJ plugin wrapper for Micro-Manager.
+ *
+ * Note: This class is <i>not</i> part of the MMStudio API.
  */
 public class MMStudioPlugin implements PlugIn, CommandListener {
    volatile static MMStudio studio_;


### PR DESCRIPTION
Closes GH-1010.

Just a comment instead of moving the class to an `internal` package, because it's probably not worth the amount of testing that would be needed, given that the launch mechanism will change as we migrate to the ImageJ2 launcher.