### PR TITLE
Save/Load overlay settings from user profile

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
@@ -110,36 +110,36 @@ public final class OverlaysInspectorPanelController
    }
 
    private void loadSettings(Iterable<OverlayPlugin> plugins) {
-    //Load the overlays from the profile.
-    List<PropertyMap> settings = profile_.getSettings(this.getClass()).getPropertyMapList(PROPERTYMAPKEY, (PropertyMap[]) null);
-    if (settings == null) {
-        return;
-    }
-    for (PropertyMap pMap : settings) {
-       for (OverlayPlugin p : plugins) { // We must loop through overlay plugins to determine if they are a match for this setting.
-          Overlay o = p.createOverlay();
-          if (pMap.getString(TITLEPMAPKEY, "loadFailed").equals(o.getTitle())) {  // Checking against Overlay 'Title; is the best way we have to link settings with an overlay.
-              PropertyMap config = pMap.getPropertyMap(CONFIGPMAPKEY, null);
-              o.setConfiguration(config);
-              o.setVisible(pMap.getBoolean(VISIBLEPMAPKEY, false));
-              viewer_.addOverlay(o);
-              break;
-          }
-       }
-    }
+      //Load the overlays from the profile.
+      List<PropertyMap> settings = profile_.getSettings(this.getClass()).getPropertyMapList(PROPERTYMAPKEY, (PropertyMap[]) null);
+      if (settings == null) {
+         return;
+      }
+      for (PropertyMap pMap : settings) {
+         for (OverlayPlugin p : plugins) { // We must loop through overlay plugins to determine if they are a match for this setting.
+            Overlay o = p.createOverlay();
+            if (pMap.getString(TITLEPMAPKEY, "loadFailed").equals(o.getTitle())) {  // Checking against Overlay 'Title; is the best way we have to link settings with an overlay.
+               PropertyMap config = pMap.getPropertyMap(CONFIGPMAPKEY, null);
+               o.setConfiguration(config);
+               o.setVisible(pMap.getBoolean(VISIBLEPMAPKEY, false));
+               viewer_.addOverlay(o);
+               break;
+            }
+         }
+      }
    }
    
    private void saveSettings() {
-       List<PropertyMap> configList = new ArrayList<>();
-       for (Overlay o : this.overlays_) {
-           PropertyMap map = new DefaultPropertyMap.Builder()
-                   .putPropertyMap(CONFIGPMAPKEY, o.getConfiguration())
-                   .putBoolean(VISIBLEPMAPKEY, o.isVisible())
-                   .putString(TITLEPMAPKEY, o.getTitle())
-                   .build();
-           configList.add(map);
-       }
-       profile_.getSettings(this.getClass()).putPropertyMapList(PROPERTYMAPKEY, configList);
+      List<PropertyMap> configList = new ArrayList<>();
+      for (Overlay o : this.overlays_) {
+         PropertyMap map = new DefaultPropertyMap.Builder()
+               .putPropertyMap(CONFIGPMAPKEY, o.getConfiguration())
+               .putBoolean(VISIBLEPMAPKEY, o.isVisible())
+               .putString(TITLEPMAPKEY, o.getTitle())
+               .build();
+         configList.add(map);
+      }
+      profile_.getSettings(this.getClass()).putPropertyMapList(PROPERTYMAPKEY, configList);
    }
    
    private void handleAddOverlay(OverlayPlugin plugin) {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
@@ -209,11 +209,11 @@ public final class OverlaysInspectorPanelController
    @Override
    public void detachDataViewer() {
       viewer_.unregisterForEvents(this);
+      for (Overlay o : overlays_) { //We can't manually remove the overlays from `overlays_` we need to allow the `viewer_` to fire off the relevant events so that everything is properly handled.
+         this.handleRemoveOverlay(o);
+      }
       viewer_ = null;
-      configsPanel_.removeAll();
       this.saveSettings();
-      overlays_.clear();
-      configPanelControllers_.clear();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
+++ b/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
@@ -150,7 +150,7 @@ public final class UserProfileAdmin {
      for (IndexEntry entry : getIndex().getEntries()) {
          if (entry.getUUID().equals(uuid)) {
             final String filename = entry.getFilename();
-            profile.toPropertyMap().saveJSON(getModernFile(filename), true, true); //Force write the file even thought the profile may be set to readonly.
+            profile.toPropertyMap().saveJSON(getModernFile(filename), true, true); //Force write the file even though the profile may be set to readonly.
             return;
          }
      }     


### PR DESCRIPTION
This PR changes the way that overlay settings are saved so that they can be successfully reloaded from the user profile. This makes overlays behave like most other aspects of Micro-Manager where preferences are automatically saved and recalled.