### PR TITLE
Studio: Storage.geMaxIndex() now return int rather than Integer, Closes #1013.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/Storage.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Storage.java
@@ -97,7 +97,7 @@ public interface Storage {
     * @return Largest stored position along the specified axis or -1 when no images
     * are found on the given axis
     */
-   public Integer getMaxIndex(String axis);
+   public int getMaxIndex(String axis);
 
    /**
     * Return a List of all axis names for Images we know about.

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -121,7 +121,7 @@ public final class StorageRAM implements RewritableStorage {
    }
 
    @Override
-   public Integer getMaxIndex(String axis) {
+   public int getMaxIndex(String axis) {
       return maxIndex_.getIndex(axis);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
@@ -317,7 +317,7 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
    }
 
    @Override
-   public Integer getMaxIndex(String axis) {
+   public int getMaxIndex(String axis) {
       return maxIndices_.getIndex(axis);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -828,7 +828,7 @@ public final class StorageMultipageTiff implements Storage {
    }
 
    @Override
-   public Integer getMaxIndex(String axis) {
+   public int getMaxIndex(String axis) {
       return getMaxIndices().getIndex(axis);
    }
 


### PR DESCRIPTION
All imlementations had int as the underlying type, so null could never
have been returned. Closes #1013 