### PR TITLE
Studio-Autofocus: Removed use of AutofocusShouldInitializeEvent. Closes #1011

### DIFF
--- a/autofocus/src/main/java/org/micromanager/autofocus/Autofocus.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/Autofocus.java
@@ -25,8 +25,6 @@
 //CVS:            $Id: MetadataDlg.java 1275 2008-06-03 21:31:24Z nenad $
 package org.micromanager.autofocus;
 
-import com.google.common.eventbus.Subscribe;
-
 import ij.IJ;
 import ij.ImagePlus;
 import ij.gui.ImageWindow;
@@ -43,7 +41,6 @@ import mmcorej.StrVector;
 
 import org.micromanager.AutofocusPlugin;
 import org.micromanager.Studio;
-import org.micromanager.events.AutofocusPluginShouldInitializeEvent;
 import org.micromanager.internal.utils.AutofocusBase;
 import org.micromanager.internal.utils.PropertyItem;
 
@@ -113,10 +110,6 @@ public class Autofocus extends AutofocusBase implements AutofocusPlugin, SciJava
       super.createProperty(KEY_CHANNEL, CHANNEL);
    }
 
-   @Subscribe
-   public void onInitialize(AutofocusPluginShouldInitializeEvent event) {
-      loadSettings();
-   }
 
    @Override
    public void applySettings() {

--- a/autofocus/src/main/java/org/micromanager/autofocus/AutofocusDuo.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/AutofocusDuo.java
@@ -21,7 +21,6 @@
 //
 package org.micromanager.autofocus;
 
-import com.google.common.eventbus.Subscribe;
 
 import ij.IJ;
 import ij.process.ImageProcessor;
@@ -32,7 +31,6 @@ import mmcorej.CMMCore;
 
 import org.micromanager.AutofocusPlugin;
 import org.micromanager.Studio;
-import org.micromanager.events.AutofocusPluginShouldInitializeEvent;
 import org.micromanager.internal.utils.AutofocusBase;
 import org.micromanager.internal.utils.PropertyItem;
 import org.micromanager.internal.utils.ReportingUtils;
@@ -67,11 +65,6 @@ public class AutofocusDuo extends AutofocusBase implements AutofocusPlugin, SciJ
    public AutofocusDuo() {
       super.createProperty(KEY_AUTOFOCUS1, autoFocus1_);
       super.createProperty(KEY_AUTOFOCUS2, autoFocus2_);
-   }
-
-   @Subscribe
-   public void onInitialize(AutofocusPluginShouldInitializeEvent event) {
-      loadSettings();
    }
 
    @Override

--- a/autofocus/src/main/java/org/micromanager/autofocus/AutofocusTB.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/AutofocusTB.java
@@ -1,7 +1,5 @@
 package org.micromanager.autofocus;
 
-import com.google.common.eventbus.Subscribe;
-
 import ij.IJ;
 import ij.ImagePlus;
 import ij.gui.ImageWindow;
@@ -21,7 +19,6 @@ import org.micromanager.internal.utils.AutofocusBase;
 import org.micromanager.internal.utils.PropertyItem;
 
 import mmcorej.CMMCore;
-import org.micromanager.events.AutofocusPluginShouldInitializeEvent;
 
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.SciJavaPlugin;
@@ -121,10 +118,6 @@ public class AutofocusTB extends AutofocusBase implements AutofocusPlugin, SciJa
       super.createProperty(KEY_CHANNEL2, CHANNEL2);
    }
 
-   @Subscribe
-   public void onInitialize(AutofocusPluginShouldInitializeEvent event) {
-      loadSettings();
-   }
 
    @Override
    public void applySettings() {

--- a/autofocus/src/main/java/org/micromanager/autofocus/HardwareFocusExtender.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/HardwareFocusExtender.java
@@ -22,7 +22,6 @@
 //
 package org.micromanager.autofocus;
 
-import com.google.common.eventbus.Subscribe;
 
 import ij.process.ImageProcessor;
 
@@ -32,7 +31,6 @@ import mmcorej.DeviceType;
 import org.micromanager.Studio;
 
 import org.micromanager.AutofocusPlugin;
-import org.micromanager.events.AutofocusPluginShouldInitializeEvent;
 import org.micromanager.internal.utils.AutofocusBase;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.PropertyItem;
@@ -132,11 +130,6 @@ public class HardwareFocusExtender extends AutofocusBase implements AutofocusPlu
       }
 
       return super.getProperties();
-   }
-
-   @Subscribe
-   public void onInitialize(AutofocusPluginShouldInitializeEvent event) {
-      loadSettings();
    }
 
    @Override

--- a/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
@@ -29,8 +29,6 @@
 //CVS:            $Id: MetadataDlg.java 1275 2008-06-03 21:31:24Z nenad $
 package org.micromanager.autofocus;
 
-import com.google.common.eventbus.Subscribe;
-
 import ij.gui.OvalRoi;
 import ij.process.ByteProcessor;
 import ij.process.FloatProcessor;
@@ -59,8 +57,6 @@ import mmcorej.org.json.JSONException;
 
 import org.micromanager.AutofocusPlugin;
 import org.micromanager.Studio;
-import org.micromanager.events.AutofocusPluginShouldInitializeEvent;
-
 import org.micromanager.internal.utils.AutofocusBase;
 import org.micromanager.internal.utils.imageanalysis.ImageUtils;
 import org.micromanager.internal.utils.MDUtils;
@@ -974,11 +970,6 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
    public void setContext(Studio app) {
       studio_ = app;
       studio_.events().registerForEvents(this);
-   }
-
-   @Subscribe
-   public void onInitialize(AutofocusPluginShouldInitializeEvent event) {
-      loadSettings();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/AutofocusManager.java
+++ b/mmstudio/src/main/java/org/micromanager/AutofocusManager.java
@@ -31,7 +31,7 @@ public interface AutofocusManager {
     * Set the current AutofocusPlugin to use for performing autofocus actions.
     * @param plugin AutofocusPlugin to use for autofocus.
     */
-   public void setAutofocusMethod(AutofocusPlugin plugin);
+   void setAutofocusMethod(AutofocusPlugin plugin);
 
    /**
     * Set the current AutofocusPlugin by name. This will throw an
@@ -39,7 +39,7 @@ public interface AutofocusManager {
     * specified name (as per the value returned by its getName() method).
     * @param name Name of autofocus method to use.
     */
-   public void setAutofocusMethodByName(String name);
+   void setAutofocusMethodByName(String name);
 
    /**
     * Return the current AutofocusPlugin being used to run autofocus. It is
@@ -47,7 +47,7 @@ public interface AutofocusManager {
     * autofocus plugin is required, rather than storing its results.
     * @return AutofocusPlugin currently selected.
     */
-   public AutofocusPlugin getAutofocusMethod();
+   AutofocusPlugin getAutofocusMethod();
 
    /**
     * Return a list of the current valid autofocus names, suitable for use in
@@ -56,11 +56,17 @@ public interface AutofocusManager {
     * devices (which are not).
     * @return List of valid autofocus names.
     */
-   public List<String> getAllAutofocusMethods();
+   List<String> getAllAutofocusMethods();
 
    /**
     * Update the list of available autofocus devices by scanning the system
     * for autofocus device adapters and AutofocusPlugins.
     */
-   public void refresh();
+   void refresh();
+
+   /**
+    * Initializes all known autofocus plugins.
+    *
+    */
+    void initialize();
 }

--- a/mmstudio/src/main/java/org/micromanager/AutofocusPlugin.java
+++ b/mmstudio/src/main/java/org/micromanager/AutofocusPlugin.java
@@ -33,14 +33,21 @@ import org.micromanager.internal.utils.PropertyItem;
 public interface AutofocusPlugin extends MMPlugin {
 
    /**
+    * Initializes the plugin.  Can be called multiple times, for instance
+    * after a change in hardware configuration. Conversely, the plugin
+    * can trust that the hardware never changes without a call to this function.
+    */
+   void initialize();
+
+   /**
     * Pushes setting to the hardware or software autofocus
     */
-   public void applySettings();
+   void applySettings();
    
    /**
     * Stores settings
     */
-   public void saveSettings();
+   void saveSettings();
 
    /**
     * Runs a full, one-shot autofocus protocol. Blocks until focusing is
@@ -48,38 +55,38 @@ public interface AutofocusPlugin extends MMPlugin {
     * @return focus score
     * @throws java.lang.Exception
     */
-   public double fullFocus() throws Exception;
+   double fullFocus() throws Exception;
 
    /**
     * Runs a single, incremental focusing step.
     * @return focus score
     * @throws java.lang.Exception
     */
-   public double incrementalFocus() throws Exception;
+    double incrementalFocus() throws Exception;
    
    /**
     * Returns the number of images acquired
     * @return number of images for autofocussing
     */
-   public int getNumberOfImages();
+   int getNumberOfImages();
 
    /**
     * Returns a detailed status of the autofocus plugin/device.
     * @return description of the autofocus Status
     */
-   public String getVerboseStatus();
+   String getVerboseStatus();
 
    /**
     * Returns an array of the properties for this autofocus plugin.
     * @return array with Property descriptors, representing MMCore data
     */
-   public PropertyItem[] getProperties();
+   PropertyItem[] getProperties();
 
    /**
     * Returns an array of the names of properties for this autofocus plugin.
     * @return array with the names of properties for this autofocus plugin
     */
-   public String[] getPropertyNames();
+   String[] getPropertyNames();
 
    /**
     * Returns the name and value of properties for the autofocus plugin.
@@ -87,14 +94,14 @@ public interface AutofocusPlugin extends MMPlugin {
     * @return value for given property
     * @throws java.lang.Exception thrown by MMCore when key is not found.  
     */
-   public PropertyItem getProperty(String key) throws Exception;
+   PropertyItem getProperty(String key) throws Exception;
 
    /**
     * Sets the value of a particular property.
     * @param p 
     * @throws java.lang.Exception
     */
-   public void setProperty(PropertyItem p) throws Exception;
+   void setProperty(PropertyItem p) throws Exception;
 
    /**
     * Gets the value of a named property.
@@ -102,7 +109,7 @@ public interface AutofocusPlugin extends MMPlugin {
     * @return value for the given property
     * @throws java.lang.Exception
     */
-   public String getPropertyValue(String name) throws Exception;
+   String getPropertyValue(String name) throws Exception;
 
    /**
     * Sets the value of a named property.
@@ -110,13 +117,13 @@ public interface AutofocusPlugin extends MMPlugin {
     * @param value PropertyValue
     * @throws java.lang.Exception by MMCore
     */
-   public void setPropertyValue(String name, String value) throws Exception;
+   void setPropertyValue(String name, String value) throws Exception;
 
    /**
     * Returns the current focus "score" (goodness of focus).
     * @return focus score (goodness of focus)
     */
-   public double getCurrentFocusScore();
+   double getCurrentFocusScore();
 
    /**
     * Turns on continuous autofocus. Typically used by hardware autofocus
@@ -124,7 +131,7 @@ public interface AutofocusPlugin extends MMPlugin {
     * @param enable
     * @throws java.lang.Exception
     */
-   public void enableContinuousFocus(boolean enable) throws Exception;
+   void enableContinuousFocus(boolean enable) throws Exception;
 
    /**
     * Returns true if continuous autofocus has been enabled. Typically used
@@ -132,7 +139,7 @@ public interface AutofocusPlugin extends MMPlugin {
     * @return true if enabled
     * @throws java.lang.Exception
     */
-   public boolean isContinuousFocusEnabled() throws Exception;
+   boolean isContinuousFocusEnabled() throws Exception;
 
    /**
     * Returns true if continuous autofocus is currently locked (successfully
@@ -141,12 +148,12 @@ public interface AutofocusPlugin extends MMPlugin {
     * @return true if locked
     * @throws java.lang.Exception thrown by MMCore
     */
-   public boolean isContinuousFocusLocked() throws Exception;
+   boolean isContinuousFocusLocked() throws Exception;
    
    /**
     * Computes a focus score for the given image
     * @param impro
     * @return calculated score
     */
-   public double computeScore(final ImageProcessor impro);
+   double computeScore(final ImageProcessor impro);
 }

--- a/mmstudio/src/main/java/org/micromanager/events/AutofocusPluginShouldInitializeEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/AutofocusPluginShouldInitializeEvent.java
@@ -26,6 +26,8 @@ package org.micromanager.events;
  * The Core is available and the hardware configuration is loaded when this
  * event is received. Note that the autofocus plugin may receive this event
  * multiple times, if the user loads a new hardware configuration.
+ * @deprecated use
  */
+@Deprecated
 public class AutofocusPluginShouldInitializeEvent {
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -72,7 +72,6 @@ import org.micromanager.data.internal.DefaultDataManager;
 import org.micromanager.display.DataViewer;
 import org.micromanager.display.DisplayManager;
 import org.micromanager.display.internal.DefaultDisplayManager;
-import org.micromanager.events.AutofocusPluginShouldInitializeEvent;
 import org.micromanager.events.ChannelExposureEvent;
 import org.micromanager.events.EventManager;
 import org.micromanager.events.ExposureChangedEvent;
@@ -1376,7 +1375,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
                   loadHardwareConfiguration(sysConfigFile_);
             coreCallback_.setIgnoring(false);
             GUIUtils.preventDisplayAdapterChangeExceptions();
-            events().post(new AutofocusPluginShouldInitializeEvent());
+            afMgr_.initialize();
             FileDialogs.storePath(FileDialogs.MM_CONFIG_FILE, new File(sysConfigFile_));
          }
       } catch (final Exception err) {

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -72,6 +72,7 @@ import org.micromanager.data.internal.DefaultDataManager;
 import org.micromanager.display.DataViewer;
 import org.micromanager.display.DisplayManager;
 import org.micromanager.display.internal.DefaultDisplayManager;
+import org.micromanager.events.AutofocusPluginShouldInitializeEvent;
 import org.micromanager.events.ChannelExposureEvent;
 import org.micromanager.events.EventManager;
 import org.micromanager.events.ExposureChangedEvent;
@@ -1376,6 +1377,8 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
             coreCallback_.setIgnoring(false);
             GUIUtils.preventDisplayAdapterChangeExceptions();
             afMgr_.initialize();
+            // in case 3rdparties use this deprecated code:
+            events().post(new AutofocusPluginShouldInitializeEvent());
             FileDialogs.storePath(FileDialogs.MM_CONFIG_FILE, new File(sysConfigFile_));
          }
       } catch (final Exception err) {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusBase.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusBase.java
@@ -167,5 +167,9 @@ public abstract class AutofocusBase implements AutofocusPlugin {
       return false;
    }
 
+   @Override
+   public void initialize() {
+      loadSettings();
+   }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/CoreAutofocus.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/CoreAutofocus.java
@@ -255,4 +255,11 @@ public final class CoreAutofocus implements AutofocusPlugin {
    public String getCopyright() {
       return "University of California, 2015";
    }
+
+   @Override
+   public void initialize() {
+      // not sure what needs to be done here.
+      // This call is mainly to inform software autofocus that the hardware changed,
+      // but we are hardware;)
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/DefaultAutofocusManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/DefaultAutofocusManager.java
@@ -167,4 +167,10 @@ public final class DefaultAutofocusManager implements AutofocusManager {
       }
       return false;
    }
+
+   public void initialize() {
+      for (AutofocusPlugin afPlugin : afs_) {
+         afPlugin.initialize();
+      }
+   }
 }


### PR DESCRIPTION
Adds a function initialize to AutofocusPlugin and AutofocusBase.
Adds a function initialize to the AutofocusManager, which calls the
initialize function in all known autofocusplugins.
MMstudio now calls that initialize function rather than creating
the event.

Also removed public modifier from interfaces that I touched since
those modifiers are not needed.