### PR TITLE
Improve inspector panel and overlay settings.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/inspector/AbstractInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/AbstractInspectorPanelController.java
@@ -95,7 +95,7 @@ public abstract class AbstractInspectorPanelController
    public abstract void attachDataViewer(DataViewer viewer);
 
    /**
-    * Detach from any currently attached data viewer.
+    * Detach from any currently attached data viewer. This method should not throw an exception if a viewer is not yet attached.
     */
    @Override
    public abstract void detachDataViewer();

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
@@ -52,7 +52,6 @@ import org.micromanager.display.internal.event.DataViewerDidBecomeVisibleEvent;
 import org.micromanager.display.internal.event.DataViewerWillCloseEvent;
 import org.micromanager.display.internal.event.InspectorDidCloseEvent;
 import org.micromanager.internal.utils.EventBusExceptionLogger;
-import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.WindowPositioning;
 import org.scijava.plugin.Plugin;

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
@@ -314,24 +314,6 @@ public final class InspectorController
       updateDataViewerChooserImpl(viewers);
    }
 
-   private void showPanelsForDataViewer(DataViewer viewer) {
-      //Detach all controllers from the current viewer.
-      for (SectionInfo sectionInfo : sections_) {
-         sectionInfo.inspectorPanelController_.detachDataViewer();
-      }
-      
-      if (viewer != null && !viewer.isClosed()) {
-         for (SectionInfo secInfo : sections_) {
-            if (secInfo.plugin_.isApplicableToDataViewer(viewer)) {
-               secInfo.inspectorSectionController_.setEnabled(true);
-               secInfo.inspectorPanelController_.attachDataViewer(viewer);
-            } else {
-               secInfo.inspectorSectionController_.setEnabled(false);
-            }
-         }
-      }
-   }
-
    void inspectorSectionWillChangeHeight(InspectorSectionController section) {
    }
 
@@ -452,14 +434,25 @@ public final class InspectorController
       }
       if (viewer != viewer_) {
          frame_.setTitle(String.format("Inspect \"%s\"", viewer.getName()));
-         showPanelsForDataViewer(viewer);
+         
+         for (SectionInfo secInfo : sections_) { // attach each individual section to the viewer.
+            if (secInfo.plugin_.isApplicableToDataViewer(viewer)) {
+               secInfo.inspectorSectionController_.setEnabled(true);
+               secInfo.inspectorPanelController_.attachDataViewer(viewer);
+            } else {
+               secInfo.inspectorSectionController_.setEnabled(false);
+            }
+         }
+         
          viewer_ = viewer;
       }
    }
 
    private void detachFromDataViewer() {
       frame_.setTitle(String.format("Inspector: No Image"));
-      showPanelsForDataViewer(null);
+      for (SectionInfo sectionInfo : sections_) { //Detach all controllers from the current viewer.
+         sectionInfo.inspectorPanelController_.detachDataViewer();
+      }
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
@@ -188,14 +188,49 @@ public final class InspectorController
             JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
       scrollPane_.setBorder(BorderFactory.createEmptyBorder());
 
+      // Initialize Sections
+      List<InspectorPanelPlugin> plugins = new ArrayList<InspectorPanelPlugin>(
+      studio_.plugins().getInspectorPlugins().values());
+      Collections.sort(plugins, new Comparator<InspectorPanelPlugin>() {
+         @Override
+         public int compare(InspectorPanelPlugin o1, InspectorPanelPlugin o2) {
+            Plugin p1 = o1.getClass().getAnnotation(Plugin.class);
+            Plugin p2 = o2.getClass().getAnnotation(Plugin.class);
+            return -Double.compare(p1.priority(), p2.priority());
+         }
+      });
+      for (InspectorPanelPlugin plugin : plugins) {
+         InspectorPanelController panelController = plugin.createPanelController(studio_);
+         InspectorSectionController section = InspectorSectionController.create(this, panelController);
+         panelController.addInspectorPanelListener(section);
+         SectionInfo secInfo = new SectionInfo(panelController, section, plugin);
+         sections_.add(secInfo);
+      }
+      
+      sectionsPane_ = VerticalMultiSplitPane.create(sections_.size(), true);
+      for (int i = 0; i < sections_.size(); ++i) {
+         InspectorSectionController sectionController = 
+                 sections_.get(i).inspectorSectionController_;
+         sectionsPane_.setComponentAtIndex(i,
+               sectionController.getSectionPanel());
+         sectionsPane_.setComponentResizeEnabled(i,
+               sectionController.isVerticallyResizableByUser() &&
+               sectionController.isExpanded());
+      }
+      scrollPane_.setViewportView(sectionsPane_);
+      
       frame_.add(headerPanel_, new CC().growX().pushX().wrap());
       frame_.add(scrollPane_, new CC().grow().push().wrap());
 
       frame_.pack();
 
-      // The frame's minimum size will need to be updated when there are panels
-      // inserted, but for now the packed size is the minimum.
-      frame_.setMinimumSize(frame_.getPreferredSize());
+      WindowPositioning.setUpBoundsMemory(frame_, InspectorController.class, null);
+
+      frame_.setMinimumSize(new Dimension(frame_.getPreferredSize().width + 16,
+            frame_.getMinimumSize().height));
+      frame_.setSize(
+            Math.max(frame_.getWidth(), frame_.getMinimumSize().width),
+            frame_.getHeight());
    }
 
    @Override
@@ -281,74 +316,21 @@ public final class InspectorController
    }
 
    private void showPanelsForDataViewer(DataViewer viewer) {
-      // TODO We need to store and reuse panels, because their height should
-      // not change when we reattach to another image.
-      // TODO Also each panel needs to detach from previous viewer
-
-
+      //Detach all controllers from the current viewer.
       for (SectionInfo sectionInfo : sections_) {
          sectionInfo.inspectorPanelController_.detachDataViewer();
       }
-      sections_.clear();
       
       if (viewer != null && !viewer.isClosed()) {
-         List<InspectorPanelPlugin> plugins = new ArrayList<InspectorPanelPlugin>(
-               studio_.plugins().getInspectorPlugins().values());
-         Collections.sort(plugins, new Comparator<InspectorPanelPlugin>() {
-            @Override
-            public int compare(InspectorPanelPlugin o1, InspectorPanelPlugin o2) {
-               Plugin p1 = o1.getClass().getAnnotation(Plugin.class);
-               Plugin p2 = o2.getClass().getAnnotation(Plugin.class);
-               return -Double.compare(p1.priority(), p2.priority());
-            }
-         });
-
-         // This feels like a ball of tangled up wire:
-         for (InspectorPanelPlugin plugin : plugins) {
-            if (plugin.isApplicableToDataViewer(viewer)) {
-               SectionInfo locatedSection = null;
-               for (SectionInfo si : sections_) {
-                     if (si.plugin_.equals(plugin)) {
-                        locatedSection = si;
-                  }
-               }
-               if (locatedSection == null) {
-                  InspectorPanelController panelController
-                          = plugin.createPanelController(studio_);
-                  InspectorSectionController section
-                          = InspectorSectionController.create(this, panelController);
-                  panelController.addInspectorPanelListener(section);
-                  locatedSection = new SectionInfo(panelController, section, plugin);
-               }
-               locatedSection.inspectorPanelController_.attachDataViewer(viewer);
-               sections_.add(locatedSection);
+         for (SectionInfo secInfo : sections_) {
+            if (secInfo.plugin_.isApplicableToDataViewer(viewer)) {
+               secInfo.inspectorSectionController_.setEnabled(true);
+               secInfo.inspectorPanelController_.attachDataViewer(viewer);
+            } else {
+               secInfo.inspectorSectionController_.setEnabled(false);
             }
          }
       }
-
-
-      sectionsPane_ = VerticalMultiSplitPane.create(sections_.size(), true);
-      for (int i = 0; i < sections_.size(); ++i) {
-         InspectorSectionController sectionController = 
-                 sections_.get(i).inspectorSectionController_;
-         sectionsPane_.setComponentAtIndex(i,
-               sectionController.getSectionPanel());
-         sectionsPane_.setComponentResizeEnabled(i,
-               sectionController.isVerticallyResizableByUser() &&
-               sectionController.isExpanded());
-      }
-      scrollPane_.setViewportView(sectionsPane_);
-
-      GraphicsConfiguration config = GUIUtils.getGraphicsConfigurationContaining(1, 1);
-      // TODO Set initial (factory default) position of frame
-      WindowPositioning.setUpBoundsMemory(frame_, InspectorController.class, null);
-      // TODO Attach MM menus to frame
-
-      frame_.setMinimumSize(new Dimension(frame_.getPreferredSize().width + 16,
-            frame_.getMinimumSize().height));
-      frame_.setSize(
-            Math.max(frame_.getWidth(), frame_.getMinimumSize().width),
-            frame_.getHeight());
    }
 
    void inspectorSectionWillChangeHeight(InspectorSectionController section) {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorSectionController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorSectionController.java
@@ -44,6 +44,7 @@ final class InspectorSectionController implements InspectorPanelListener {
    private final JPanel headerPanel_;
    private final JLabel headerLabel_;
    private final PopupButton gearButton_;
+   private boolean mouseClickenabled_ = true;
 
    public static InspectorSectionController create(
          InspectorController inspectorController,
@@ -93,7 +94,9 @@ final class InspectorSectionController implements InspectorPanelListener {
       headerPanel_.addMouseListener(new MouseAdapter() {
          @Override
          public void mouseClicked(MouseEvent e) {
-            setExpanded(!isExpanded());
+            if (mouseClickenabled_) {
+               setExpanded(!isExpanded());
+            }
          }
       });
 
@@ -164,5 +167,21 @@ final class InspectorSectionController implements InspectorPanelListener {
    @Override
    public void inspectorPanelDidChangeTitle(InspectorPanelController controller) {
       headerLabel_.setText(controller.getTitle());
+   }
+   
+   public void setEnabled(boolean enabled) {
+      // When the section is disabled it will collapse and will not be able to be expanded.
+      if (enabled) {
+         mouseClickenabled_ = true;
+         headerLabel_.setEnabled(true);
+      } else {
+         this.setExpanded(false);
+         mouseClickenabled_ = false; 
+         headerLabel_.setEnabled(false);
+      }
+   }
+   
+   public boolean isEnabled() {
+      return this.headerPanel_.isEnabled();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/comments/CommentsInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/comments/CommentsInspectorPanelController.java
@@ -130,21 +130,22 @@ public final class CommentsInspectorPanelController
 
    @Override
    public void detachDataViewer() {
-      Preconditions.checkState(viewer_ != null);
-      savePlaneComments();
-      saveSummaryComments();
-      viewer_.unregisterForEvents(this);
-      viewer_ = null;
-      programmaticallySettingText_ = true;
-      try {
-         summaryTextArea_.setText(null);
-         planeTextArea_.setText(null);
+      if (viewer_ != null) {
+         savePlaneComments();
+         saveSummaryComments();
+         viewer_.unregisterForEvents(this);
+         viewer_ = null;
+         programmaticallySettingText_ = true;
+         try {
+            summaryTextArea_.setText(null);
+            planeTextArea_.setText(null);
+         }
+         finally {
+            programmaticallySettingText_ = false;
+         }
+         summaryTextArea_.setEnabled(false);
+         planeTextArea_.setEnabled(false);
       }
-      finally {
-         programmaticallySettingText_ = false;
-      }
-      summaryTextArea_.setEnabled(false);
-      planeTextArea_.setEnabled(false);
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
@@ -195,9 +195,6 @@ public final class OverlaysInspectorPanelController
       Preconditions.checkArgument(viewer instanceof DisplayWindow);
       viewer_ = (DisplayWindow) viewer;
       viewer_.registerForEvents(this);
-      for (Overlay overlay : viewer_.getOverlays()) {
-         addConfigPanel(overlay);
-      }
       loadSettings(plugins_);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
@@ -208,7 +208,8 @@ public final class OverlaysInspectorPanelController
       if (viewer_ != null) {
          saveSettings(viewer_);
          viewer_.unregisterForEvents(this); // Do this before `handleRemoveOverlay` is called so that we don't get concurrent modification of the `overlays_` list due to events.
-         for (Overlay o : overlays_) { //We can't manually remove the overlays from `overlays_` we need to allow the `viewer_` to fire off the relevant events so that everything is properly handled.
+         List<Overlay> overlays = new ArrayList<>(overlays_);  // We iterate over a copy of the overlays_ list to avoid causing a ConcurrentModificationException by removing items from the list while iterating.
+         for (Overlay o : overlays) { //We can't manually remove the overlays from `overlays_` we need to allow the `viewer_` to fire off the relevant events so that everything is properly handled.
             this.handleRemoveOverlay(o);
             this.removeConfigPanel(o);
          }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
@@ -59,23 +59,23 @@ public final class OverlaysInspectorPanelController
          new ArrayList<>();
 
    private DisplayWindow viewer_;
-
+   private final List<OverlayPlugin> plugins_;
    public static OverlaysInspectorPanelController create(Studio studio) {
       return new OverlaysInspectorPanelController(studio);
    }
 
    private OverlaysInspectorPanelController(Studio studio) {
       profile_ = studio.profile();
-      final List<OverlayPlugin> plugins = new ArrayList<>(
+      plugins_ = new ArrayList<>(
             studio.plugins().getOverlayPlugins().values());
-      Collections.sort(plugins, (OverlayPlugin o1, OverlayPlugin o2) -> {
+      Collections.sort(plugins_, (OverlayPlugin o1, OverlayPlugin o2) -> {
          Plugin p1 = o1.getClass().getAnnotation(Plugin.class);
          Plugin p2 = o2.getClass().getAnnotation(Plugin.class);
          return -Double.compare(p1.priority(), p2.priority());
       });
 
       addOverlayMenu_ = new JPopupMenu();
-      for (final OverlayPlugin plugin : plugins) {
+      for (final OverlayPlugin plugin : plugins_) {
          String name = plugin.getClass().getAnnotation(Plugin.class).name();
          JMenuItem item = new JMenuItem(name);
          item.addActionListener((ActionEvent e) -> {
@@ -102,11 +102,6 @@ public final class OverlaysInspectorPanelController
             new CC().gapBefore("push").gapAfter("rel").
                   gapY("rel", "rel").
                   height("pref:pref:pref"));
-      
-       SwingUtilities.invokeLater(() -> {
-           loadSettings(plugins); // This prevents a weird error due to loading before the UI is complete.
-       });
-
    }
 
    private void loadSettings(Iterable<OverlayPlugin> plugins) {
@@ -200,10 +195,10 @@ public final class OverlaysInspectorPanelController
       Preconditions.checkArgument(viewer instanceof DisplayWindow);
       viewer_ = (DisplayWindow) viewer;
       viewer_.registerForEvents(this);
-
       for (Overlay overlay : viewer_.getOverlays()) {
          addConfigPanel(overlay);
       }
+      loadSettings(plugins_);
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
@@ -105,7 +105,6 @@ public final class OverlaysInspectorPanelController
 
    private void loadSettings(DisplayWindow viewer) {
       //Load the overlays from the profile.
-      System.out.println("Load");
       String providerName = viewer.getDataProvider().getName();
       List<PropertyMap> settings = profile_.getSettings(this.getClass()).getPropertyMapList(providerName, (PropertyMap[]) null);
       if (settings == null) {
@@ -126,7 +125,6 @@ public final class OverlaysInspectorPanelController
    }
    
    private void saveSettings(DisplayWindow viewer) {
-      System.out.println("Save");
       List<PropertyMap> configList = new ArrayList<>();
       for (Overlay o : this.overlays_) {
          PropertyMap map = new DefaultPropertyMap.Builder()
@@ -194,7 +192,6 @@ public final class OverlaysInspectorPanelController
 
    @Override
    public void attachDataViewer(DataViewer viewer) {
-      System.out.println("Attach");
       Preconditions.checkState(viewer_ == null);
       Preconditions.checkArgument(viewer instanceof DisplayWindow);
       viewer_ = (DisplayWindow) viewer;
@@ -204,15 +201,13 @@ public final class OverlaysInspectorPanelController
 
    @Override
    public void detachDataViewer() {
-      System.out.println("Detach");
       if (viewer_ != null) {
          saveSettings(viewer_);
-         viewer_.unregisterForEvents(this); // Do this before `handleRemoveOverlay` is called so that we don't get concurrent modification of the `overlays_` list due to events.
          List<Overlay> overlays = new ArrayList<>(overlays_);  // We iterate over a copy of the overlays_ list to avoid causing a ConcurrentModificationException by removing items from the list while iterating.
          for (Overlay o : overlays) { //We can't manually remove the overlays from `overlays_` we need to allow the `viewer_` to fire off the relevant events so that everything is properly handled.
-            this.handleRemoveOverlay(o);
-            this.removeConfigPanel(o);
+            this.handleRemoveOverlay(o);  // The viewer will fire an event that will also remove the UI components from the inspector.
          }
+         viewer_.unregisterForEvents(this);
          viewer_ = null;
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/overlays/OverlaysInspectorPanelController.java
@@ -208,12 +208,14 @@ public final class OverlaysInspectorPanelController
 
    @Override
    public void detachDataViewer() {
-      viewer_.unregisterForEvents(this);
-      for (Overlay o : overlays_) { //We can't manually remove the overlays from `overlays_` we need to allow the `viewer_` to fire off the relevant events so that everything is properly handled.
-         this.handleRemoveOverlay(o);
+      if (viewer_ != null) {
+         viewer_.unregisterForEvents(this);
+         for (Overlay o : overlays_) { //We can't manually remove the overlays from `overlays_` we need to allow the `viewer_` to fire off the relevant events so that everything is properly handled.
+            this.handleRemoveOverlay(o);
+         }
+         viewer_ = null;
+         this.saveSettings();
       }
-      viewer_ = null;
-      this.saveSettings();
    }
 
    @Override


### PR DESCRIPTION
This PR makes the following changes:

1: Previously all UI content of the `Inspector` panel would be removed and completely reconstructed each time the `Inspector` was  attached to a new `DataViewer`. This led to some confusing behavior where code in the `detachDataViewer` method of `AbstractInspectorPanelController` implementations would be ineffective since a completely new instance of every `InspectorPanelController` was being created for every new attachment event. Now each `InspectorPanelController` is only constructed once during the construction of a new `Inspector` panel. The only notable difference to a user is that the `Inspector` panel will now show a section for every available `InspectorPanelController` even if  `InspectorPanelPlugin.isApplicableToDataViewer` returns `false`. However, the panel will be collapsed and disabled in this case.

2: The `detachDataViewer` method of each `InspectorPanelController` was being called multiple times for each attachment to a new `DataViewer`. The code has been simplified so that it is now called only once.

3: Overlay settings are now saved and loaded based on the name of the `DataProvider` attached to the `DataViewer`. This means that settings for a "Preview" window will be separate from overlay settings for an "Album" window, etc.