### PR TITLE
Position list manager Refactoring.  Pull the PositionListManager implementation out of MMStudio

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/PositionListManager.java
+++ b/mmstudio/src/main/java/org/micromanager/PositionListManager.java
@@ -35,21 +35,20 @@ public interface PositionListManager {
     * Acquisition Protocol, and shown in the PositionListDlg.
     * @param pl PositionList to be made the current one
     */
-   public void setPositionList(PositionList pl);
+   void setPositionList(PositionList pl);
 
    /**
     * Returns a copy of the current PositionList, the one used by the
     * Acquisition Protocol
     * @return copy of the current PositionList
     */
-   public PositionList getPositionList();
+   PositionList getPositionList();
 
    /**
     * Adds the current position to the list (same as pressing the "Mark" button
     * in the XYPositionList with no position selected)
-    * @deprecated since this function completely depends on the PositionListDlg,
-    * at the very least, it will need to know which axes are selected
+    * @deprecated since this function completely depends on the PositionListDlg.
     */
    @Deprecated
-   public void markCurrentPosition();
+   void markCurrentPosition();
 }

--- a/mmstudio/src/main/java/org/micromanager/PositionListManager.java
+++ b/mmstudio/src/main/java/org/micromanager/PositionListManager.java
@@ -32,10 +32,8 @@ package org.micromanager;
 public interface PositionListManager {
    /**
     * Makes this the 'current' PositionList, i.e., the one used by the
-    * Acquisition Protocol.
-    * Replaces the list in the PositionList Window
-    * It will open a position list dialog if it was not already open.
-    * @param pl PosiionLIst to be made the current one
+    * Acquisition Protocol, and shown in the PositionListDlg.
+    * @param pl PositionList to be made the current one
     */
    public void setPositionList(PositionList pl);
 
@@ -47,9 +45,11 @@ public interface PositionListManager {
    public PositionList getPositionList();
 
    /**
-    * Opens the XYPositionList when it is not opened.
     * Adds the current position to the list (same as pressing the "Mark" button
-    * in the XYPositionList)
+    * in the XYPositionList with no position selected)
+    * @deprecated since this function completely depends on the PositionListDlg,
+    * at the very least, it will need to know which axes are selected
     */
+   @Deprecated
    public void markCurrentPosition();
 }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -16,6 +16,7 @@ import org.micromanager.data.Datastore;
 import org.micromanager.data.Pipeline;
 import org.micromanager.data.internal.DefaultDatastore;
 import org.micromanager.events.AcquisitionEndedEvent;
+import org.micromanager.events.NewPositionListEvent;
 import org.micromanager.events.internal.DefaultAcquisitionEndedEvent;
 import org.micromanager.events.internal.DefaultAcquisitionStartedEvent;
 import org.micromanager.events.internal.InternalShutdownCommencingEvent;
@@ -434,6 +435,11 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine {
    @Override
    public void setPositionList(PositionList posList) {
       posList_ = posList;
+   }
+
+   @Subscribe
+   public void OnNewPositionListEvent(NewPositionListEvent newPositionListEvent) {
+      posList_ = newPositionListEvent.getPositionList();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultPositionListManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultPositionListManager.java
@@ -1,14 +1,18 @@
 package org.micromanager.internal;
 
 import org.micromanager.PositionList;
+import org.micromanager.PositionListManager;
+import org.micromanager.Studio;
+import org.micromanager.events.internal.DefaultNewPositionListEvent;
 
-import javax.swing.SwingUtilities;
 
-public final class PositionListManager implements org.micromanager.PositionListManager {
+public final class DefaultPositionListManager implements PositionListManager {
 
    private PositionList posList_;
+   private Studio studio_;
 
-   public PositionListManager() {
+   public DefaultPositionListManager(Studio studio) {
+      studio_ = studio;
       posList_ = new PositionList();
    }
 
@@ -21,6 +25,8 @@ public final class PositionListManager implements org.micromanager.PositionListM
     */
    public void setPositionList(PositionList pl) { // use serialization to clone the PositionList object
       posList_ = pl; // PositionList.newInstance(pl);
+      studio_.events().post(new DefaultNewPositionListEvent(posList_));
+      /*
       SwingUtilities.invokeLater(() -> {
          if (posListDlg_ != null) {
             posListDlg_.setPositionList(posList_);
@@ -32,6 +38,8 @@ public final class PositionListManager implements org.micromanager.PositionListM
             acqControlWin_.updateGUIContents();
          }
       });
+
+       */
    }
 
    /**
@@ -40,20 +48,15 @@ public final class PositionListManager implements org.micromanager.PositionListM
     * @return copy of the current PositionList
     */
    public PositionList getPositionList()  {
-      return posList_;
+      return PositionList.newInstance(posList_);
    }
 
    /**
-    * Opens the XYPositionList when it is not opened.
     * Adds the current position to the list (same as pressing the "Mark" button
-    * in the XYPositionList)
+    * in the XYPositionList with no position selected)
     */
    public void markCurrentPosition() {
-      if (posListDlg_ == null) {
-         showPositionList();
-      }
-      if (posListDlg_ != null) {
-         posListDlg_.markPosition(false);
-      }
+      MMStudio mm = (MMStudio) studio_;
+      mm.markCurrentPosition();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultPositionListManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultPositionListManager.java
@@ -26,20 +26,6 @@ public final class DefaultPositionListManager implements PositionListManager {
    public void setPositionList(PositionList pl) { // use serialization to clone the PositionList object
       posList_ = pl; // PositionList.newInstance(pl);
       studio_.events().post(new DefaultNewPositionListEvent(posList_));
-      /*
-      SwingUtilities.invokeLater(() -> {
-         if (posListDlg_ != null) {
-            posListDlg_.setPositionList(posList_);
-         }
-         if (acqEngine_ != null) {
-            acqEngine_.setPositionList(posList_);
-         }
-         if (acqControlWin_ != null) {
-            acqControlWin_.updateGUIContents();
-         }
-      });
-
-       */
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -124,7 +124,7 @@ import org.micromanager.quickaccess.internal.DefaultQuickAccessManager;
  * Implements the Studio (i.e. primary API) and does various other
  * tasks that should probably be refactored out at some point.
  */
-public final class MMStudio implements Studio, CompatibilityInterface, PositionListManager, Application {
+public final class MMStudio implements Studio, CompatibilityInterface, Application {
 
    private static final long serialVersionUID = 3556500289598574541L;
    
@@ -162,12 +162,12 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    private DefaultEventManager eventManager_;
    private ApplicationSkin daytimeNighttimeManager_;
    private UserProfileManager userProfileManager_;
+   private PositionListManager posListManager_;
    private UiMovesStageManager uiMovesStageManager_;
    
    // MMcore
    private CMMCore core_;
    private AcquisitionWrapperEngine acqEngine_;
-   private PositionList posList_;
    private MMPositionListDlg posListDlg_;
    private boolean isProgramRunning_;
    private boolean configChanged_ = false;
@@ -332,8 +332,8 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
          afMgr_.setAutofocusMethodByName(afDevice);
       }
 
-      posList_ = new PositionList();
-      acqEngine_.setPositionList(posList_);
+      posListManager_ = new DefaultPositionListManager(this);
+      acqEngine_.setPositionList(posListManager_.getPositionList());
 
       
       // Tell Core to start logging
@@ -1004,7 +1004,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
     * Adds the current position to the list (same as pressing the "Mark"
     * button)
     */
-   @Override
+   // @Override
    public void markCurrentPosition() {
       if (posListDlg_ == null) {
          showPositionList();
@@ -1490,8 +1490,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    @Override
    public void showPositionList() {
       if (posListDlg_ == null) {
-         posListDlg_ = new MMPositionListDlg(studio_, posList_, 
-                 acqControlWin_);
+         posListDlg_ = new MMPositionListDlg(studio_, posListManager_.getPositionList());
          posListDlg_.addListeners();
       }
       posListDlg_.setVisible(true);
@@ -1558,28 +1557,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
 
    public void enableRoiButtons(final boolean enabled) {
       frame_.enableRoiButtons(enabled);
-   }
-
-   @Override
-   public void setPositionList(PositionList pl) {
-      // use serialization to clone the PositionList object
-      posList_ = pl; // PositionList.newInstance(pl);
-      SwingUtilities.invokeLater(() -> {
-         if (posListDlg_ != null) {
-            posListDlg_.setPositionList(posList_);
-         }
-         if (acqEngine_ != null) {
-            acqEngine_.setPositionList(posList_);
-         }
-         if (acqControlWin_ != null) {
-            acqControlWin_.updateGUIContents();
-         }
-      });
-   }
-
-   @Override
-   public PositionList getPositionList() {
-      return posList_;
    }
 
    @Override
@@ -1783,7 +1760,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
 
    @Override
    public PositionListManager positions() {
-      return this;
+      return posListManager_;
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/PositionListManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PositionListManager.java
@@ -1,0 +1,59 @@
+package org.micromanager.internal;
+
+import org.micromanager.PositionList;
+
+import javax.swing.SwingUtilities;
+
+public final class PositionListManager implements org.micromanager.PositionListManager {
+
+   private PositionList posList_;
+
+   public PositionListManager() {
+      posList_ = new PositionList();
+   }
+
+   /**
+    * Makes this the 'current' PositionList, i.e., the one used by the
+    * Acquisition Protocol.
+    * Replaces the list in the PositionList Window
+    * It will open a position list dialog if it was not already open.
+    * @param pl PosiionLIst to be made the current one
+    */
+   public void setPositionList(PositionList pl) { // use serialization to clone the PositionList object
+      posList_ = pl; // PositionList.newInstance(pl);
+      SwingUtilities.invokeLater(() -> {
+         if (posListDlg_ != null) {
+            posListDlg_.setPositionList(posList_);
+         }
+         if (acqEngine_ != null) {
+            acqEngine_.setPositionList(posList_);
+         }
+         if (acqControlWin_ != null) {
+            acqControlWin_.updateGUIContents();
+         }
+      });
+   }
+
+   /**
+    * Returns a copy of the current PositionList, the one used by the
+    * Acquisition Protocol
+    * @return copy of the current PositionList
+    */
+   public PositionList getPositionList()  {
+      return posList_;
+   }
+
+   /**
+    * Opens the XYPositionList when it is not opened.
+    * Adds the current position to the list (same as pressing the "Mark" button
+    * in the XYPositionList)
+    */
+   public void markCurrentPosition() {
+      if (posListDlg_ == null) {
+         showPositionList();
+      }
+      if (posListDlg_ != null) {
+         posListDlg_.markPosition(false);
+      }
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -34,6 +34,7 @@ import org.micromanager.display.internal.RememberedSettings;
 import org.micromanager.events.ChannelExposureEvent;
 import org.micromanager.events.ChannelGroupChangedEvent;
 import org.micromanager.events.GUIRefreshEvent;
+import org.micromanager.events.NewPositionListEvent;
 import org.micromanager.events.internal.ChannelColorEvent;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.interfaces.AcqSettingsListener;
@@ -1212,6 +1213,20 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
          savePanel_.repaint();
 
          disableGUItoSettings_ = false;
+      }
+   }
+
+   @Subscribe
+   public void onNewPositionList(NewPositionListEvent newPositionListEvent) {
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            onNewPositionList(newPositionListEvent);
+         } );
+      }
+      else {
+         acqEng_.setPositionList(newPositionListEvent.getPositionList());
+         // update summary
+         summaryTextArea_.setText(acqEng_.getVerboseSummary());
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
@@ -22,7 +22,6 @@ import org.micromanager.PositionList;
 import org.micromanager.Studio;
 import org.micromanager.events.internal.DefaultNewPositionListEvent;
 import org.micromanager.events.internal.InternalShutdownCommencingEvent;
-import org.micromanager.internal.dialogs.AcqControlDlg;
 
 /**
  * The MMPositionListDlg class extends PositionListDlg to be used as the singleton PositionListDlg used in the MMStudio API
@@ -32,12 +31,10 @@ import org.micromanager.internal.dialogs.AcqControlDlg;
  *   3: Save preferences to the MMStudio UserProfile.
  */
 public final class MMPositionListDlg extends PositionListDlg {
-    AcqControlDlg acd_;
-    
-    public MMPositionListDlg(Studio studio, PositionList posList, AcqControlDlg acd) {
+
+    public MMPositionListDlg(Studio studio, PositionList posList) {
         super(studio, posList);
-        acd_ = acd;
-        
+
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent arg0) {
@@ -50,7 +47,6 @@ public final class MMPositionListDlg extends PositionListDlg {
     @Override
     protected void updatePositionData() {
         super.updatePositionData();
-        acd_.updateGUIContents();
         studio_.events().post(new DefaultNewPositionListEvent(getPositionList()));
     }
     

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -349,7 +349,9 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
       removeAllButton.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent arg0) {
-            int ret = JOptionPane.showConfirmDialog(null, "Are you sure you want to erase\nall positions from the position list?", "Clear all positions?", JOptionPane.YES_NO_OPTION);
+            int ret = JOptionPane.showConfirmDialog(PositionListDlg.this,
+                    "Are you sure you want to erase\nall positions from the position list?",
+                    "Clear all positions?", JOptionPane.YES_NO_OPTION);
             if (ret == JOptionPane.YES_OPTION) {
                clearAllPositions();
             }
@@ -516,6 +518,7 @@ public class PositionListDlg extends MMFrame implements MouseListener, ChangeLis
 
    protected void updatePositionData() {
       positionModel_.fireTableDataChanged();
+      updateMarkButtonText();
    }
    
    public void rebuildAxisList() {

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/api/ASIdiSPIMImplementation.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/api/ASIdiSPIMImplementation.java
@@ -272,7 +272,7 @@ public class ASIdiSPIMImplementation implements ASIdiSPIMInterface {
    @Override
    public PositionList getPositionList() throws ASIdiSPIMException, RemoteException {
       try {
-         return getGui().getPositionList();
+         return getGui().positions().getPositionList();
       } catch (Exception ex) {
          throw new ASIdiSPIMException(ex);
       }


### PR DESCRIPTION
Also deprecates the function markCurrentPosition, as it does not seem to belong with PositionListManager.  This should be probably be implemented in a future StageManager.