### PR TITLE
Make  `MMStudio.updateGUI` more efficient

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1102,30 +1102,26 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
          staticInfo_.refreshValues();
          afMgr_.refresh();
 
+         if (!fromCache) { // The rest of this function uses the cached property values. If `fromCache` is false, start by updating all properties in the cache.
+            core_.updateSystemStateCache();
+         }
+         
          // camera settings
          if (isCameraAvailable()) {
             double exp = core_.getExposure();
             frame_.setDisplayedExposureTime(exp);
             configureBinningCombo();
             String binSize;
-            if (fromCache) {
-               binSize = core_.getPropertyFromCache(StaticInfo.cameraLabel_, MMCoreJ.getG_Keyword_Binning());
-            } else {
-               binSize = core_.getProperty(StaticInfo.cameraLabel_, MMCoreJ.getG_Keyword_Binning());
-            }
+            binSize = core_.getPropertyFromCache(StaticInfo.cameraLabel_, MMCoreJ.getG_Keyword_Binning());
             frame_.setBinSize(binSize);
          }
 
          frame_.updateAutofocusButtons(afMgr_.getAutofocusMethod() != null);
-
+         
          ConfigGroupPad pad = frame_.getConfigPad();
          // state devices
          if (updateConfigPadStructure && (pad != null)) {
-            pad.refreshStructure(fromCache);
-            // Needed to update read-only properties.  May slow things down...
-            if (!fromCache) {
-               core_.updateSystemStateCache();
-            }
+            pad.refreshStructure(true);
          }
 
          // update Channel menus in Multi-dimensional acquisition dialog
@@ -1136,7 +1132,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
             calibrationListDlg_.refreshCalibrations();
          }
          if (propertyBrowser_ != null) {
-            propertyBrowser_.refresh(fromCache);
+            propertyBrowser_.refresh(true);
          }
 
          ReportingUtils.logMessage("Finished updating GUI");


### PR DESCRIPTION

Working with the "Device Property Browser" can be extremely slow for configurations with many properties. In my case I am seeing delays of ~6 seconds.  This is because after each adjustment of a property, the `MMStudio.updateGUI()` method is called with `fromCache` set to `false`, meaning that the value of every property must be requested from the hardware.

Upon inspection of debug log files it can be seen that many properties are requested twice or in some cases three times. This is because the property values are requested once from a call to `core_.updateSystemStateCache()` and may then be requested again from a call to `pad.refreshStructure(fromCache)` and then again with a call to `propertyBrowser_.refresh(fromCache)`

This pull request changes the implementation of `updateGUI` so that when it is called with `fromCache = false` it will make the call to `core_.updateSystemStateCache()` but will then rely only on the cache, ensuring that each property is only requested once.