### PR TITLE
Studio: Avoid deadlock that occurs in rare circustances.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -178,8 +178,8 @@ public final class SnapLiveManager extends DataViewerListener
          else {
             stopLiveMode();
          }
-         mmStudio_.events().post(new DefaultLiveModeEvent(isLiveOn_));
       }
+      mmStudio_.events().post(new DefaultLiveModeEvent(isLiveOn_));
    }
 
    /**


### PR DESCRIPTION
This changes moves the callback signaling the new state of the shutter out of the lock.  I can not think of a reason that it should be inside the lock, and there are documented cases (https://forum.image.sc/t/occasional-crashes-when-starting-acquisition/46305/2) where this causes a deadlock involving the AWT.