### PR TITLE
Delegate functionality from MMStudio to helper classes.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -277,12 +277,12 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
       Metadata.Builder result = image.getMetadata().copyBuilderWithNewUUID()
          .camera(camera)
          .receivedTime(DATE_FORMATTER.format(new Date()))
-         .pixelSizeUm(mmstudio.cache().getCachedPixelSizeUm())
-         .pixelSizeAffine(mmstudio.cache().getCachedPixelSizeAffine())
-         .xPositionUm(mmstudio.cache().getCachedXPosition())
-         .yPositionUm(mmstudio.cache().getCachedYPosition())
-         .zPositionUm(mmstudio.cache().getCachedZPosition())
-         .bitDepth(mmstudio.cache().getCachedBitDepth());
+         .pixelSizeUm(mmstudio.cache().getPixelSizeUm())
+         .pixelSizeAffine(mmstudio.cache().getPixelSizeAffine())
+         .xPositionUm(mmstudio.cache().getStageX())
+         .yPositionUm(mmstudio.cache().getStageY())
+         .zPositionUm(mmstudio.cache().getStageZ())
+         .bitDepth(mmstudio.cache().getImageBitDepth());
 
       try {
          String binning = studio_.core().getPropertyFromCache(

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -277,12 +277,12 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
       Metadata.Builder result = image.getMetadata().copyBuilderWithNewUUID()
          .camera(camera)
          .receivedTime(DATE_FORMATTER.format(new Date()))
-         .pixelSizeUm(mmstudio.getCachedPixelSizeUm())
-         .pixelSizeAffine(mmstudio.getCachedPixelSizeAffine())
-         .xPositionUm(mmstudio.getCachedXPosition())
-         .yPositionUm(mmstudio.getCachedYPosition())
-         .zPositionUm(mmstudio.getCachedZPosition())
-         .bitDepth(mmstudio.getCachedBitDepth());
+         .pixelSizeUm(mmstudio.cache().getCachedPixelSizeUm())
+         .pixelSizeAffine(mmstudio.cache().getCachedPixelSizeAffine())
+         .xPositionUm(mmstudio.cache().getCachedXPosition())
+         .yPositionUm(mmstudio.cache().getCachedYPosition())
+         .zPositionUm(mmstudio.cache().getCachedZPosition())
+         .bitDepth(mmstudio.cache().getCachedBitDepth());
 
       try {
          String binning = studio_.core().getPropertyFromCache(

--- a/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
@@ -37,20 +37,20 @@ import org.micromanager.internal.utils.TextUtils;
  * Simple class used to cache information that doesn't change very often.
  */
 public class MMCache {
-   static public long width_;
-   static public long height_;
-   static public long bytesPerPixel_;
-   static public long imageBitDepth_;
-   static public double pixSizeUm_;
-   static public AffineTransform affineTransform_;
-   static public double zPos_;
-   static public double x_;
-   static public double y_;
+   private long width_;
+   private long height_;
+   private long bytesPerPixel_;
+   private long imageBitDepth_;
+   private double pixSizeUm_;
+   private AffineTransform affineTransform_;
+   private double zPos_;
+   private double x_;
+   private double y_;
 
-   static public String cameraLabel_ = "";
-   static public String shutterLabel_ = "";
-   static public String xyStageLabel_ = "";
-   static public String zStageLabel_ = "";
+   private String cameraLabel_ = "";
+   private String shutterLabel_ = "";
+   private String xyStageLabel_ = "";
+   private String zStageLabel_ = "";
 
    static private CMMCore core_;
    static private MainFrame frame_;
@@ -195,5 +195,21 @@ public class MMCache {
    
    public AffineTransform getPixelSizeAffine() {
       return affineTransform_;
+   }
+   
+   public String getCameraLabel() {
+      return cameraLabel_;
+   }
+   
+   public String getZStageLabel() {
+      return zStageLabel_;
+   }
+   
+   public String getXYStageLabel() {
+      return xyStageLabel_;
+   }
+   
+   public String getShutterLabel() {
+      return shutterLabel_;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
@@ -35,9 +35,8 @@ import org.micromanager.internal.utils.TextUtils;
 
 /**
  * Simple class used to cache information that doesn't change very often.
- * TODO: rename this.
  */
-class StaticInfo {
+public class MMCache {
    static public long width_;
    static public long height_;
    static public long bytesPerPixel_;
@@ -57,9 +56,10 @@ class StaticInfo {
    static private MainFrame frame_;
 
    @SuppressWarnings("LeakingThisInConstructor")
-   public StaticInfo(Studio studio, MainFrame frame) {
+   public MMCache(Studio studio, MainFrame frame) {
       core_ = studio.core();
       frame_ = frame;
+      studio.events().registerForEvents(this);
    }
 
    public void updateXYPos(double x, double y) {
@@ -72,7 +72,7 @@ class StaticInfo {
       y_ += y;
       updateInfoDisplay();
    }
-   public void getNewXYStagePosition() {
+   public void updateXYStagePosition() {
       double[] x = new double[1];
       double[] y = new double[1];
       try {

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -476,7 +476,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
       // Now create and show the main window
       mmMenuBar_ = MMMenuBar.createMenuBar(studio_);
       frame_ = new MainFrame(this, core_);
-      cache_ = new MMCache();
+      cache_ = new MMCache(this, frame_);
       frame_.toFront();
       frame_.setVisible(true);
       ReportingUtils.SetContainingFrame(frame_);
@@ -864,13 +864,13 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
             live().setSuspended(false);
             return;
          }
-         if (core_.getProperty(StaticInfo.cameraLabel_,
+         if (core_.getProperty(MMCache.cameraLabel_,
                  MMCoreJ.getG_Keyword_Binning()).equals(mode)) {
             // No change in binning mode.
             live().setSuspended(false);
             return;
          }
-         core_.setProperty(StaticInfo.cameraLabel_, MMCoreJ.getG_Keyword_Binning(), mode);
+         core_.setProperty(MMCache.cameraLabel_, MMCoreJ.getG_Keyword_Binning(), mode);
          cache().refreshValues();
       } catch (Exception e) {
          ReportingUtils.showError(e);
@@ -979,7 +979,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
    // //////////////////////////////////////////////////////////////////////////
 
    private boolean isCameraAvailable() {
-      return StaticInfo.cameraLabel_.length() > 0;
+      return MMCache.cameraLabel_.length() > 0;
    }
 
    /**
@@ -1028,8 +1028,8 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
    }
 
    private void configureBinningCombo() throws Exception {
-      if (StaticInfo.cameraLabel_.length() > 0) {
-         frame_.configureBinningComboForCamera(StaticInfo.cameraLabel_);
+      if (MMCache.cameraLabel_.length() > 0) {
+         frame_.configureBinningComboForCamera(MMCache.cameraLabel_);
       }
    }
 
@@ -1044,7 +1044,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
          if (cache() != null) {
             cache().refreshValues();
             if (acqEngine_ != null) {
-               acqEngine_.setZStageDevice(StaticInfo.zStageLabel_);  
+               acqEngine_.setZStageDevice(MMCache.zStageLabel_);  
             }
          }
 
@@ -1070,7 +1070,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
 
    @Subscribe
    public void onExposureChanged(ExposureChangedEvent event) {
-      if (event.getCameraName().equals(StaticInfo.cameraLabel_)) {
+      if (event.getCameraName().equals(MMCache.cameraLabel_)) {
          frame_.setDisplayedExposureTime(event.getNewExposureTime());
       }
    }
@@ -1095,8 +1095,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
             double exp = core_.getExposure();
             frame_.setDisplayedExposureTime(exp);
             configureBinningCombo();
-            String binSize;
-            binSize = core_.getPropertyFromCache(StaticInfo.cameraLabel_, MMCoreJ.getG_Keyword_Binning());
+            String binSize = core_.getPropertyFromCache(MMCache.cameraLabel_, MMCoreJ.getG_Keyword_Binning());
             frame_.setBinSize(binSize);
          }
 
@@ -1835,61 +1834,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
    
    public MMSettings settings() {
       return settings_;
-   }
-
-   public class MMCache {
-      private final StaticInfo staticInfo_ = new StaticInfo(studio_, frame_);
-      
-      public MMCache() {
-               events().registerForEvents(staticInfo_);
-      }
-      
-      public double getCachedXPosition() {
-         return staticInfo_.getStageX();
-      }
-
-      public double getCachedYPosition() {
-         return staticInfo_.getStageY();
-      }
-
-      public double getCachedZPosition() {
-         return staticInfo_.getStageZ();
-      }
-
-      public int getCachedBitDepth() {
-         return staticInfo_.getImageBitDepth();
-      }
-
-      public double getCachedPixelSizeUm() {
-         return staticInfo_.getPixelSizeUm();
-      }
-
-      public AffineTransform getCachedPixelSizeAffine() {
-         return staticInfo_.getPixelSizeAffine();
-      }
-      
-      public void refreshValues() {
-         staticInfo_.refreshValues();
-      }
-      
-      public void updateXYPos(double x, double y) {
-         staticInfo_.updateXYPos(x, y);
-      }
-      
-      public void updateXYPosRelative(double x, double y) {
-         staticInfo_.updateXYPosRelative(x, y);
-      }
-
-      public void updateZPos(double z) {
-         staticInfo_.updateZPos(z);
-      }
-      public void updateZPosRelative(double z) {
-         staticInfo_.updateZPosRelative(z);
-      }
-
-      public void updateXYStagePosition() {
-         staticInfo_.getNewXYStagePosition();
-      }
    }
 
    public class MMSettings {

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -167,7 +167,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
    
    // Local Classes
    private final MMSettings settings_ = new MMSettings();
-   private final MMCache cache_ = new MMCache();
+   private MMCache cache_;
    
    
    // MMcore
@@ -197,9 +197,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
 
    private Thread acquisitionEngine2010LoadingThread_ = null;
    private Class<?> acquisitionEngine2010Class_ = null;
-   private IAcquisitionEngine2010 acquisitionEngine2010_ = null;
-   private StaticInfo staticInfo_;
-   
+   private IAcquisitionEngine2010 acquisitionEngine2010_ = null;   
    
    /**
     * Main procedure for stand alone operation.
@@ -478,8 +476,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
       // Now create and show the main window
       mmMenuBar_ = MMMenuBar.createMenuBar(studio_);
       frame_ = new MainFrame(this, core_);
-      staticInfo_ = new StaticInfo(studio_, frame_);
-      events().registerForEvents(staticInfo_);
+      cache_ = new MMCache();
       frame_.toFront();
       frame_.setVisible(true);
       ReportingUtils.SetContainingFrame(frame_);
@@ -763,7 +760,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
       live().setSuspended(true);
       try {
          core_.clearROI();
-         staticInfo_.refreshValues();
+         cache().refreshValues();
 
       } catch (Exception e) {
          ReportingUtils.showError(e);
@@ -874,7 +871,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
             return;
          }
          core_.setProperty(StaticInfo.cameraLabel_, MMCoreJ.getG_Keyword_Binning(), mode);
-         staticInfo_.refreshValues();
+         cache().refreshValues();
       } catch (Exception e) {
          ReportingUtils.showError(e);
       }
@@ -963,24 +960,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
       return pipelineFrame_;
    }
 
-   public void updateXYPos(double x, double y) {
-      staticInfo_.updateXYPos(x, y);
-   }
-   public void updateXYPosRelative(double x, double y) {
-      staticInfo_.updateXYPosRelative(x, y);
-   }
-
-   public void updateZPos(double z) {
-      staticInfo_.updateZPos(z);
-   }
-   public void updateZPosRelative(double z) {
-      staticInfo_.updateZPosRelative(z);
-   }
-
-   public void updateXYStagePosition() {
-      staticInfo_.getNewXYStagePosition();
-   }
-
    public void updateCenterAndDragListener(boolean isEnabled) {
       isClickToMoveEnabled_ = isEnabled;
       if (isEnabled) {
@@ -1062,8 +1041,8 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
    // SystemConfigurationLoaded itself and handle its own updates.
    public void initializeGUI() {
       try {
-         if (staticInfo_ != null) {
-            staticInfo_.refreshValues();
+         if (cache() != null) {
+            cache().refreshValues();
             if (acqEngine_ != null) {
                acqEngine_.setZStageDevice(StaticInfo.zStageLabel_);  
             }
@@ -1104,7 +1083,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
       ReportingUtils.logMessage("Updating GUI; config pad = " +
             updateConfigPadStructure + "; from cache = " + fromCache);
       try {
-         staticInfo_.refreshValues();
+         cache().refreshValues();
          afMgr_.refresh();
 
          if (!fromCache) { // The rest of this function uses the cached property values. If `fromCache` is false, start by updating all properties in the cache.
@@ -1605,14 +1584,15 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
    public void setROI(Rectangle r) throws Exception {
       live().setSuspended(true);
       core_.setROI(r.x, r.y, r.width, r.height);
-      staticInfo_.refreshValues();
+      cache().refreshValues();
+      cache().refreshValues();
       live().setSuspended(false);
    }
 
    public void setMultiROI(List<Rectangle> rois) throws Exception {
       live().setSuspended(true);
       core_.setMultiROI(rois);
-      staticInfo_.refreshValues();
+      cache().refreshValues();
       live().setSuspended(false);
    }
 
@@ -1858,6 +1838,12 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
    }
 
    public class MMCache {
+      private final StaticInfo staticInfo_ = new StaticInfo(studio_, frame_);
+      
+      public MMCache() {
+               events().registerForEvents(staticInfo_);
+      }
+      
       public double getCachedXPosition() {
          return staticInfo_.getStageX();
       }
@@ -1880,6 +1866,29 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
 
       public AffineTransform getCachedPixelSizeAffine() {
          return staticInfo_.getPixelSizeAffine();
+      }
+      
+      public void refreshValues() {
+         staticInfo_.refreshValues();
+      }
+      
+      public void updateXYPos(double x, double y) {
+         staticInfo_.updateXYPos(x, y);
+      }
+      
+      public void updateXYPosRelative(double x, double y) {
+         staticInfo_.updateXYPosRelative(x, y);
+      }
+
+      public void updateZPos(double z) {
+         staticInfo_.updateZPos(z);
+      }
+      public void updateZPosRelative(double z) {
+         staticInfo_.updateZPosRelative(z);
+      }
+
+      public void updateXYStagePosition() {
+         staticInfo_.getNewXYStagePosition();
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -767,13 +767,13 @@ public final class MMStudio implements Studio {
             live().setSuspended(false);
             return;
          }
-         if (core_.getProperty(MMCache.cameraLabel_,
+         if (core_.getProperty(cache().getCameraLabel(),
                  MMCoreJ.getG_Keyword_Binning()).equals(mode)) {
             // No change in binning mode.
             live().setSuspended(false);
             return;
          }
-         core_.setProperty(MMCache.cameraLabel_, MMCoreJ.getG_Keyword_Binning(), mode);
+         core_.setProperty(cache().getCameraLabel(), MMCoreJ.getG_Keyword_Binning(), mode);
          cache().refreshValues();
       } catch (Exception e) {
          ReportingUtils.showError(e);
@@ -882,7 +882,7 @@ public final class MMStudio implements Studio {
    // //////////////////////////////////////////////////////////////////////////
 
    private boolean isCameraAvailable() {
-      return MMCache.cameraLabel_.length() > 0;
+      return cache().getCameraLabel().length() > 0;
    }
 
    /**
@@ -902,8 +902,8 @@ public final class MMStudio implements Studio {
    }
 
    private void configureBinningCombo() throws Exception {
-      if (MMCache.cameraLabel_.length() > 0) {
-         frame_.configureBinningComboForCamera(MMCache.cameraLabel_);
+      if (isCameraAvailable()) {
+         frame_.configureBinningComboForCamera(cache().getCameraLabel());
       }
    }
 
@@ -918,7 +918,7 @@ public final class MMStudio implements Studio {
          if (cache() != null) {
             cache().refreshValues();
             if (acqEngine_ != null) {
-               acqEngine_.setZStageDevice(MMCache.zStageLabel_);  
+               acqEngine_.setZStageDevice(cache().getZStageLabel());  
             }
          }
 
@@ -944,7 +944,7 @@ public final class MMStudio implements Studio {
 
    @Subscribe
    public void onExposureChanged(ExposureChangedEvent event) {
-      if (event.getCameraName().equals(MMCache.cameraLabel_)) {
+      if (event.getCameraName().equals(cache().getCameraLabel())) {
          frame_.setDisplayedExposureTime(event.getNewExposureTime());
       }
    }
@@ -969,7 +969,7 @@ public final class MMStudio implements Studio {
             double exp = core_.getExposure();
             frame_.setDisplayedExposureTime(exp);
             configureBinningCombo();
-            String binSize = core_.getPropertyFromCache(MMCache.cameraLabel_, MMCoreJ.getG_Keyword_Binning());
+            String binSize = core_.getPropertyFromCache(cache().getCameraLabel(), MMCoreJ.getG_Keyword_Binning());
             frame_.setBinSize(binSize);
          }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1847,6 +1847,15 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
       transform.getMatrix(params);
       profile().getSettings(MMStudio.class).putDoubleList(AFFINE_TRANSFORM + config, params);
    }
+   
+   
+   public MMCache cache() {
+      return cache_;
+   }
+   
+   public MMSettings settings() {
+      return settings_;
+   }
 
    public class MMCache {
       public double getCachedXPosition() {
@@ -1872,10 +1881,6 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
       public AffineTransform getCachedPixelSizeAffine() {
          return staticInfo_.getPixelSizeAffine();
       }
-   }
-
-   public MMCache cache() {
-      return cache_;
    }
 
    public class MMSettings {
@@ -1921,8 +1926,5 @@ public final class MMStudio implements Studio, CompatibilityInterface, Applicati
                CIRCULAR_BUFFER_SIZE, newSize);
       }
    }
-   
-   public MMSettings settings() {
-      return settings_;
-   }
+ 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -123,11 +123,6 @@ public final class MMStudio implements Studio {
    private static final String AUTOFOCUS_DEVICE = "autofocus_device";
    private static final int TOOLTIP_DISPLAY_DURATION_MILLISECONDS = 15000;
    private static final int TOOLTIP_DISPLAY_INITIAL_DELAY_MILLISECONDS = 2000;
-   // Note that this property is set by one of the launcher scripts.
-   private static final String SHOULD_DELETE_OLD_CORE_LOGS = "whether or not to delete old MMCore log files";
-   private static final String SHOULD_RUN_ZMQ_SERVER = "run ZQM server";
-   private static final String CORE_LOG_LIFETIME_DAYS = "how many days to keep MMCore log files, before they get deleted";
-   private static final String CIRCULAR_BUFFER_SIZE = "size, in megabytes of the circular buffer used to temporarily store images before they are written to disk";
 
    // GUI components
    private boolean wasStartedAsImageJPlugin_;
@@ -1566,6 +1561,11 @@ public final class MMStudio implements Studio {
    }
 
    public class MMSettings {
+      private static final String SHOULD_DELETE_OLD_CORE_LOGS = "whether or not to delete old MMCore log files";
+      private static final String SHOULD_RUN_ZMQ_SERVER = "run ZQM server";
+      private static final String CORE_LOG_LIFETIME_DAYS = "how many days to keep MMCore log files, before they get deleted";
+      private static final String CIRCULAR_BUFFER_SIZE = "size, in megabytes of the circular buffer used to temporarily store images before they are written to disk";
+
       public boolean getShouldDeleteOldCoreLogs() {
          return profile().getSettings(MMStudio.class).getBoolean(
                SHOULD_DELETE_OLD_CORE_LOGS, false);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/OptionsDlg.java
@@ -139,13 +139,13 @@ public final class OptionsDlg extends MMDialog {
 
       final JCheckBox deleteLogCheckBox = new JCheckBox();
       deleteLogCheckBox.setText("Delete log files after");
-      deleteLogCheckBox.setSelected(mmStudio_.getShouldDeleteOldCoreLogs());
+      deleteLogCheckBox.setSelected(mmStudio_.settings().getShouldDeleteOldCoreLogs());
       deleteLogCheckBox.addActionListener((ActionEvent e) -> {
-         mmStudio_.setShouldDeleteOldCoreLogs(deleteLogCheckBox.isSelected());
+         mmStudio_.settings().setShouldDeleteOldCoreLogs(deleteLogCheckBox.isSelected());
       });
 
       logDeleteDaysField_ =
-         new JTextField(Integer.toString(mmStudio_.getCoreLogLifetimeDays()), 2);
+         new JTextField(Integer.toString(mmStudio_.settings().getCoreLogLifetimeDays()), 2);
 
       final JButton deleteLogFilesButton = new JButton();
       deleteLogFilesButton.setText("Delete Log Files Now");
@@ -200,7 +200,7 @@ public final class OptionsDlg extends MMDialog {
       });
 
       bufSizeField_ = new JTextField(
-            Integer.toString(mmStudio_.getCircularBufferSize()), 5);
+            Integer.toString(mmStudio_.settings().getCircularBufferSize()), 5);
 
       String[] options = new String[SkinMode.values().length];
       for (int i = 0; i < SkinMode.values().length; ++i) {
@@ -257,14 +257,14 @@ public final class OptionsDlg extends MMDialog {
       
       final JCheckBox runServer = new JCheckBox();
       runServer.setText("Run server on port " + ZMQSocketWrapper.DEFAULT_MASTER_PORT_NUMBER);
-      runServer.setSelected(mmStudio.getShouldRunZMQServer());
+      runServer.setSelected(mmStudio.settings().getShouldRunZMQServer());
       runServer.addActionListener((ActionEvent arg0) ->  {
          if (runServer.isSelected()) {
             mmStudio_.runZMQServer();
          } else {
             mmStudio_.stopZMQServer();
          }
-         mmStudio_.setShouldRunZMQServer(runServer.isSelected());         
+         mmStudio_.settings().setShouldRunZMQServer(runServer.isSelected());         
       });
 
       final JButton closeButton = new JButton();
@@ -348,8 +348,8 @@ public final class OptionsDlg extends MMDialog {
          return;
       }
 
-      mmStudio_.setCircularBufferSize(seqBufSize);
-      mmStudio_.setCoreLogLifetimeDays(deleteLogDays);
+      mmStudio_.settings().setCircularBufferSize(seqBufSize);
+      mmStudio_.settings().setCoreLogLifetimeDays(deleteLogDays);
 
       ScriptPanel.setStartupScript(mmStudio_, startupScriptFile_.getText());
       mmStudio_.app().makeActive();

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
@@ -105,15 +105,15 @@ public final class ToolsMenu {
 
       GUIUtils.addMenuItem(toolsMenu_, "Options...",
               "Set a variety of Micro-Manager configuration options", () -> {
-                 final int oldBufsize = mmStudio_.getCircularBufferSize();
+                 final int oldBufsize = mmStudio_.settings().getCircularBufferSize();
 
                  OptionsDlg dlg = new OptionsDlg(core_, mmStudio_);
                  dlg.setVisible(true);
                  // adjust memory footprint if necessary
-                 if (oldBufsize != mmStudio_.getCircularBufferSize()) {
+                 if (oldBufsize != mmStudio_.settings().getCircularBufferSize()) {
                     try {
                        core_.setCircularBufferMemoryFootprint(
-                               mmStudio_.getCircularBufferSize());
+                               mmStudio_.settings().getCircularBufferSize());
                     } catch (Exception exc) {
                        ReportingUtils.showError(exc);
                     }


### PR DESCRIPTION
This PR introduces two new classes which take over functionality that was previously performed directly by MMStudio. There should be no changes to the functionality of Micro-Manager, the goal of this PR is just to make MMStudio more organized and readable.

`MMCache` is essentially just a rename of the `StaticInfo` class and replaces these public methods of `MMStudio`:
```updateXYPos
updateXYPosRelative
updateZPos
updateZPosRelative
updateXYStagePosition
getCachedXPosition
getCachedYPosition
getCachedZPosition
getCachedBitDepth
getCachedPixelSizeUm
getCachedPixelSizeAffine
```

The `MMSettings` class is currently an internal class of `MMStudio` and is responsible for setting and retrieving top-level application preferences and replaces these public methods of `MMStudio`:
```
getShouldDeleteOldCoreLogs
setShouldDeleteOldCoreLogs
getShouldRunZMQServer
setShouldRunZMQServer
getCoreLogLifetimeDays
setCoreLogLifetimeDays
getCircularBufferSize
setCircularBufferSize
```

These two classes can be accessed from an instance of MMStudio using the `cache()` and `settings()` methods.