### PR TITLE
Fix Call to non-api method of MMStudio in Clojure Acquisition Engine

### DIFF
--- a/acqEngine/src/main/clj/org/micromanager/acq_engine.clj
+++ b/acqEngine/src/main/clj/org/micromanager/acq_engine.clj
@@ -954,7 +954,7 @@
       "IJType" (get-IJ-type depth)
       "KeepShutterOpenChannels" (:keep-shutter-open-channels settings)
       "KeepShutterOpenSlices" (:keep-shutter-open-slices settings)
-      "MicroManagerVersion" (if gui (.getVersion gui) "N/A")
+      "MicroManagerVersion" (if gui (.. gui compat getVersion) "N/A")
       "PixelSize_um" (core getPixelSizeUm)
       "PixelSizeAffine" (core getPixelSizeAffineAsString)
       "PixelType" (get-pixel-type)


### PR DESCRIPTION
After PR #1061 the acquisition engine stopped working since one of the public method of MMStudio that it had been using was no longer present. This PR fixes the clojure code to make the correct call to the equivalent API method.