### PR TITLE
Move ROI functionality from MMStudio to a dedicated ROI manager

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
@@ -1,8 +1,24 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       
+//
+// COPYRIGHT:    University of California, San Francisco, 2014
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+
 package org.micromanager.internal;
 
 import ij.ImagePlus;

--- a/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
@@ -156,7 +156,7 @@ public class MMROIManager {
       studio_.live().setSuspended(false);
    }
    
-   public void setMultiROI(List<Rectangle> rois) throws Exception {
+   private void setMultiROI(List<Rectangle> rois) throws Exception {
       studio_.live().setSuspended(true);
       studio_.core().setMultiROI(rois);
       studio_.cache().refreshValues();

--- a/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
@@ -1,0 +1,171 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.micromanager.internal;
+
+import ij.ImagePlus;
+import ij.WindowManager;
+import ij.gui.Roi;
+import ij.gui.ShapeRoi;
+import java.awt.Rectangle;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JOptionPane;
+import org.micromanager.data.Image;
+import org.micromanager.display.DataViewer;
+import org.micromanager.internal.utils.ReportingUtils;
+
+public class MMROIManager {
+   private final MMStudio studio_;
+   
+   public MMROIManager(MMStudio studio) {
+      studio_ = studio;
+   }
+   
+   public void setROI() {
+      ImagePlus curImage = WindowManager.getCurrentImage();
+      if (curImage == null) {
+         studio_.logs().showError("There is no open image window.");
+         return;
+      }
+
+      Roi roi = curImage.getRoi();
+      if (roi == null) {
+         // Nothing to be done.
+         studio_.logs().showError("There is no selection in the image window.\nUse the ImageJ rectangle tool to draw the ROI.");
+         return;
+      }
+      if (roi.getType() == Roi.RECTANGLE) {
+         try {
+            studio_.app().setROI(updateROI(roi));
+         }
+         catch (Exception e) {
+            // Core failed to set new ROI.
+            studio_.logs().logError(e, "Unable to set new ROI");
+         }
+         return;
+      }
+      // Dealing with multiple ROIs; this may not be supported.
+      try {
+         if (!(roi instanceof ShapeRoi && studio_.core().isMultiROISupported())) {
+            handleError("ROI must be a rectangle.\nUse the ImageJ rectangle tool to draw the ROI.");
+            return;
+         }
+      }
+      catch (Exception e) {
+         handleError("Unable to determine if multiple ROIs is supported");
+         return;
+      }
+      // Generate list of rectangles for the ROIs.
+      ArrayList<Rectangle> rois = new ArrayList<>();
+      for (Roi subRoi : ((ShapeRoi) roi).getRois()) {
+         // HACK: just use the bounding box of each sub-ROI. Determining if
+         // sub-ROIs are rectangles is difficult (they "decompose" to Polygons
+         // once there's more than one at a time, so as far as I can tell we
+         // would have to test each angle of each polygon to see if it's
+         // 90 degrees and has the correct handedness), and this provides a
+         // good- enough solution for now.
+         rois.add(updateROI(subRoi));
+      }
+      try {
+         setMultiROI(rois);
+      }
+      catch (Exception e) {
+         // Core failed to set new ROI.
+         studio_.logs().logError(e, "Unable to set new ROI");
+      }
+   }
+
+   /**
+    * Adjust the provided rectangular ROI based on any current ROI that may be
+    * in use.
+    */
+   private Rectangle updateROI(Roi roi) {
+      Rectangle r = roi.getBounds();
+
+      // If the image has ROI info attached to it, correct for the offsets.
+      // Otherwise, assume the image was taken with the current camera ROI
+      // (which is a horrendously buggy way to do things, but that was the
+      // old behavior and I'm leaving it in case there are cases where it is
+      // necessary).
+      Rectangle originalROI = null;
+
+      DataViewer viewer = studio_.displays().getActiveDataViewer();
+      if (viewer != null) {
+         try {
+            List<Image> images = viewer.getDisplayedImages();
+            // Just take the first one.
+            originalROI = images.get(0).getMetadata().getROI();
+         }
+         catch (IOException e) {
+            ReportingUtils.showError(e, "There was an error determining the selected ROI");
+         }
+      }
+
+      if (originalROI == null) {
+         try {
+            originalROI = studio_.core().getROI();
+         }
+         catch (Exception e) {
+            // Core failed to provide an ROI.
+            studio_.logs().logError(e, "Unable to get core ROI");
+            return null;
+         }
+      }
+
+      r.x += originalROI.x;
+      r.y += originalROI.y;
+      return r;
+   }
+   
+   public void setCenterQuad() {
+      ImagePlus curImage = WindowManager.getCurrentImage();
+      if (curImage == null) {
+         return;
+      }
+
+      Rectangle r = curImage.getProcessor().getRoi();
+      int width = r.width / 2;
+      int height = r.height / 2;
+      int xOffset = r.x + width / 2;
+      int yOffset = r.y + height / 2;
+
+      curImage.setRoi(xOffset, yOffset, width, height);
+      Roi roi = curImage.getRoi();
+      try {
+         studio_.app().setROI(updateROI(roi));
+      }
+      catch (Exception e) {
+         // Core failed to set new ROI.
+         studio_.logs().logError(e, "Unable to set new ROI");
+      }
+   }
+
+   public void clearROI() {
+      studio_.live().setSuspended(true);
+      try {
+         studio_.core().clearROI();
+         studio_.cache().refreshValues();
+
+      } catch (Exception e) {
+         ReportingUtils.showError(e);
+      }
+      studio_.live().setSuspended(false);
+   }
+   
+   public void setMultiROI(List<Rectangle> rois) throws Exception {
+      studio_.live().setSuspended(true);
+      studio_.core().setMultiROI(rois);
+      studio_.cache().refreshValues();
+      studio_.live().setSuspended(false);
+   }
+   
+   private void handleError(String message) {
+      studio_.live().setLiveModeOn(false);
+      JOptionPane.showMessageDialog(studio_.uiManager().frame(), message);
+      studio_.core().logMessage(message);
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -148,8 +148,7 @@ public final class MMStudio implements Studio {
    private ZMQServer zmqServer_;
    private org.micromanager.internal.utils.HotKeys hotKeys_;
 
-   // Our instance
-   // TODO: make this non-static
+   // Our instance TODO: make this non-static
    private static MMStudio studio_;
 
    // Callback
@@ -237,11 +236,9 @@ public final class MMStudio implements Studio {
       try {
          core_ = new CMMCore();
       } catch(UnsatisfiedLinkError ex) {
-         ReportingUtils.showError(ex, 
-               "Failed to load the MMCoreJ_wrap native library");
+         ReportingUtils.showError(ex, "Failed to load the MMCoreJ_wrap native library");
       } catch(NoSuchMethodError ex) {
-         ReportingUtils.showError(ex, 
-               "Incompatible version of MMCoreJ_wrap native library");
+         ReportingUtils.showError(ex, "Incompatible version of MMCoreJ_wrap native library");
       }
       
       // Start up multiple managers.  
@@ -250,19 +247,16 @@ public final class MMStudio implements Studio {
       userProfileManager_ = new UserProfileManager();       
       compatibility_ = new DefaultCompatibilityInterface(studio_);
       
-      // Essential GUI settings in preparation of the intro dialog
-      daytimeNighttimeManager_ = DaytimeNighttime.create(studio_);
+      daytimeNighttimeManager_ = DaytimeNighttime.create(studio_); // Essential GUI settings in preparation of the intro dialog
       defaultApplication_ = new DefaultApplication(studio_, daytimeNighttimeManager_);
       
       // Start loading plugins in the background
       // Note: plugin constructors should not expect a fully constructed Studio!
       pluginManager_ = new DefaultPluginManager(studio_);
       
-      // Lots of places use this. instantiate it first.
-      eventManager_ = new DefaultEventManager();
+      eventManager_ = new DefaultEventManager(); // Lots of places use this. instantiate it first.
 
-      // used by Snap/Live Manager and StageControlFrame
-      uiMovesStageManager_ = new UiMovesStageManager(this);
+      uiMovesStageManager_ = new UiMovesStageManager(this); // used by Snap/Live Manager and StageControlFrame
       events().registerForEvents(uiMovesStageManager_);
       
       snapLiveManager_ = new SnapLiveManager(this, core_);
@@ -273,15 +267,12 @@ public final class MMStudio implements Studio {
       displayManager_ = new DefaultDisplayManager(this);
       albumInstance_ = new DefaultAlbum(studio_);
 
-      // The tools menu depends on the Quick-Access Manager.
-      quickAccess_ = new DefaultQuickAccessManager(studio_);    
+      quickAccess_ = new DefaultQuickAccessManager(studio_); // The tools menu depends on the Quick-Access Manager.
 
       acqEngine_ = new AcquisitionWrapperEngine();
       acqEngine_.setParentGUI(this);
       acqEngine_.setZStageDevice(core_.getFocusDevice());
 
-
-      
       // Load, but do not show, image pipeline panel.
       // Note: pipelineFrame is used in the dataManager, however, pipelineFrame 
       // needs the dataManager.  Let's hope for the best....
@@ -300,12 +291,9 @@ public final class MMStudio implements Studio {
       posListManager_ = new DefaultPositionListManager(this);
       acqEngine_.setPositionList(posListManager_.getPositionList());
 
-      
-      // Tell Core to start logging
-      initializeLogging(core_);
-      
-      // We need to be subscribed to the global event bus for plugin loading
-      events().registerForEvents(this);
+      initializeLogging(core_); // Tell Core to start logging
+ 
+      events().registerForEvents(this); // We need to be subscribed to the global event bus for plugin loading
 
       // Start loading acqEngine in the background
       prepAcquisitionEngine();
@@ -327,11 +315,9 @@ public final class MMStudio implements Studio {
       }
       if (!pluginManager_.isInitializationComplete()) {
          ReportingUtils.logMessage("Warning: Plugin loading did not finish within 15 seconds; continuing anyway");
-      }
-      else {
+      } else {
          ReportingUtils.logMessage("Finished waiting for plugins to load");
       }
-
 
       UserProfileAdmin profileAdmin = userProfileManager_.getAdmin();
       UUID profileUUID = profileAdmin.getUUIDOfDefaultProfile();
@@ -350,51 +336,39 @@ public final class MMStudio implements Studio {
             if (sysConfigFile_ == null) {
                 ReportingUtils.showMessage("A hardware configuration for a profile matching name: " + profileNameAutoStart + " could not be found");
             }
-          }
-          else if (StartupSettings.create(profileAdmin.getNonSavingProfile(profileUUID)).
+          } else if (StartupSettings.create(profileAdmin.getNonSavingProfile(profileUUID)).
                shouldSkipUserInteractionWithSplashScreen()) {
             List<String> recentConfigs = HardwareConfigurationManager.
                   getRecentlyUsedConfigFilesFromProfile(
                         profile());
             sysConfigFile_ = recentConfigs.isEmpty() ? null : recentConfigs.get(0);
-         }
-         else {
+         } else {
             IntroDlg introDlg = new IntroDlg(this, MMVersion.VERSION_STRING);
             if (!introDlg.okChosen()) {
                closeSequence(false);
                return;
             }
-
             profileUUID = introDlg.getSelectedProfileUUID();
             profileAdmin.setCurrentUserProfile(profileUUID);
-
             sysConfigFile_ = introDlg.getSelectedConfigFilePath();
          }
-      }
-      catch (IOException ex) {
-         // TODO We should fall back to virtual profile
-         ReportingUtils.showError(ex, "Error accessing user profiles");
+      } catch (IOException ex) {
+         ReportingUtils.showError(ex, "Error accessing user profiles"); // TODO We should fall back to virtual profile
       }
 
-      // Profile may have been switched in Intro Dialog, so reflect its setting
-      core_.enableDebugLog(OptionsDlg.isDebugLoggingEnabled(studio_));
+      core_.enableDebugLog(OptionsDlg.isDebugLoggingEnabled(studio_));  // Profile may have been switched in Intro Dialog, so reflect its setting
 
       IJVersionCheckDlg.execute(studio_);
 
       org.micromanager.internal.diagnostics.gui.ProblemReportController.startIfInterruptedOnExit();
 
-      // This entity is a class property to avoid garbage collection.
-      coreCallback_ = new CoreEventCallback(studio_, acqEngine_);
+      coreCallback_ = new CoreEventCallback(studio_, acqEngine_);  // This entity is a class property to avoid garbage collection.
 
       // Load hardware configuration
       // Note that this also initializes Autofocus plugins.
-      // TODO: This should probably be run on a background thread, while we set
-      // up GUI elements (but various managers will need to be aware of this)
-      if (sysConfigFile_ != null) {  // we do allow running Micro-Manager without 
-         // a config file!
+      if (sysConfigFile_ != null) {  // we do allow running Micro-Manager without a config file!
          if (!loadSystemConfiguration()) {
-            // TODO Do we still need to turn errors off to prevent spurious error messages?
-            ReportingUtils.showErrorOn(false);
+            ReportingUtils.showErrorOn(false);  // TODO Do we still need to turn errors off to prevent spurious error messages?
          }
       }
 
@@ -404,16 +378,14 @@ public final class MMStudio implements Studio {
          core_.setCircularBufferMemoryFootprint(settings().getCircularBufferSize());
       } catch (Exception ex) {
          ReportingUtils.showError(ex);
-      }
-      
+      }    
       
       // Arrange to log stack traces when the EDT hangs.
       // Use parameters that ensure a stack trace dump within 10 seconds of an
       // EDT hang (and _no_ dump on hangs under 5.5 seconds)
       EDTHangLogger.startDefault(core_, 4500, 1000);
 
-      // Move ImageJ window to place where it last was if possible or else
-      // (150,150) if not
+      // Move ImageJ window to place where it last was if possible or else (150,150) if not
       if (IJ.getInstance() != null) {
          Point ijWinLoc = IJ.getInstance().getLocation();
          if (GUIUtils.getGraphicsConfigurationContaining(ijWinLoc.x, ijWinLoc.y) == null) {
@@ -422,41 +394,29 @@ public final class MMStudio implements Studio {
          }
       }
       
-      // Load (but do no show) the scriptPanel
-      ui_.createScriptPanel();
-      
+      ui_.createScriptPanel();  // Load (but do no show) the scriptPanel
       ui_.createMainWindow(); // Now create and show the main window
 
-      
       cache_ = new MMCache(this, ui_.frame());
 
-
-      // We wait until after showing the main window to enable hot keys
-      hotKeys_ = new HotKeys();
+      hotKeys_ = new HotKeys(); // We wait until after showing the main window to enable hot keys
       hotKeys_.loadSettings(userProfileManager_.getProfile());
 
-
-      // Switch error reporting back on TODO See above where it's turned off
-      ReportingUtils.showErrorOn(true);
+      ReportingUtils.showErrorOn(true); // Switch error reporting back on TODO See above where it's turned off
       
       events().registerForEvents(displayManager_);
       
       // Tell the GUI to reflect the hardware configuration. (The config was
       // loaded before creating the GUI, so we need to reissue the event.)
       events().post(new SystemConfigurationLoadedEvent());
-
       executeStartupScript();
-
       ui_.updateGUI(true);
       
-      // Give plugins a chance to initialize their state
-      events().post(new StartupCompleteEvent());
+      events().post(new StartupCompleteEvent()); // Give plugins a chance to initialize their state
       
-      // start zmq server if so desired
-      if (settings().getShouldRunZMQServer()) {
+      if (settings().getShouldRunZMQServer()) { // start zmq server if so desired
          runZMQServer();
-      }
-      
+      }      
    }
 
    private void initializeLogging(CMMCore core) {
@@ -489,8 +449,7 @@ public final class MMStudio implements Studio {
 
    /**
     * Spawn a new thread to load the acquisition engine jar, because this
-    * takes significant time (TODO: Does it really, not that it is
-    * AOT-compiled?).
+    * takes significant time. Measured as ~1.3 seconds.
     */
    private void prepAcquisitionEngine() {
       acquisitionEngine2010LoadingThread_ = new Thread("Pipeline Class loading thread") {

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -850,19 +850,6 @@ public final class MMStudio implements Studio {
       return true;
    }
 
-   private void saveSettings() {
-      // TODO All of the following should be taken care of by specific modules
-
-      if (ui_.frame() != null) {
-         ui_.frame().savePrefs();
-      }
-
-      // NOTE: do not save auto shutter state
-      if (afMgr_ != null && afMgr_.getAutofocusMethod() != null) {
-         profile().getSettings(MMStudio.class).putString(AUTOFOCUS_DEVICE, afMgr_.getAutofocusMethod().getName());
-      }
-   }
-
    public synchronized boolean closeSequence(boolean quitInitiatedByImageJ) {
       if (!isProgramRunning()) {
          if (core_ != null) {
@@ -890,8 +877,17 @@ public final class MMStudio implements Studio {
       }
 
       isProgramRunning_ = false;
+      
+      //Save settings
+      if (ui_.frame() != null) {
+         ui_.frame().savePrefs();
+      }
 
-      saveSettings();
+      // NOTE: do not save auto shutter state
+      if (afMgr_ != null && afMgr_.getAutofocusMethod() != null) {
+         profile().getSettings(MMStudio.class).putString(AUTOFOCUS_DEVICE, afMgr_.getAutofocusMethod().getName());
+      }
+      
       try {
          ui_.frame().getConfigPad().saveSettings();
          hotKeys_.saveSettings(userProfileManager_.getProfile());

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -489,18 +489,18 @@ public final class MainFrame extends MMFrame {
             "span 2, alignx center, growx, wrap");
       setRoiButton_ = createButton(null, "shape_handles.png",
          "Set Region Of Interest to selected rectangle", () -> {
-            mmStudio_.setROI();
+            mmStudio_.roiManager().setROI();
       });
       roiPanel.add(setRoiButton_, SMALLBUTTON_SIZE);
       centerQuadButton_ = createButton(null, "center_quad.png",
          "Set Region Of Interest to center quad of camera", () -> {
-            mmStudio_.setCenterQuad();
+            mmStudio_.roiManager().setCenterQuad();
       });
       roiPanel.add(centerQuadButton_, SMALLBUTTON_SIZE);
 
       clearRoiButton_ = createButton(null, "arrow_out.png",
          "Reset Region of Interest to full frame", () -> {
-            mmStudio_.clearROI();
+            mmStudio_.roiManager().clearROI();
       });
       roiPanel.add(clearRoiButton_, SMALLBUTTON_SIZE);
 


### PR DESCRIPTION
This PR seeks to more closely align the  `MMStudio` class with the "Single-responsibility principle" by moving public methods used by the `MainFrame` ROI buttons from `MMStudio` to a new class which can be accessed through the new `MMStudio.roiManager()` method.

This PR also makes some formatting changes to the `MMStudio` constructor to make it a bit easier to read by condensing into fewer lines. (I think an 80 character line-length limit is pretty dated at this point) 