### PR TITLE
Reduce redundant function calls.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -777,7 +777,7 @@ public final class MMStudio implements Studio {
 
    @Subscribe
    public void onPropertiesChanged(PropertiesChangedEvent event) {
-      ui_.updateGUI(true);
+      ui_.updateGUI(true, true);
    }
 
    @Subscribe

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -199,7 +199,6 @@ public final class PropertyEditor extends MMFrame {
             setValueInCore(item,value);
          }
          core_.updateSystemStateCache();
-         refresh(true);
          studio_.app().refreshGUIFromCache();
          fireTableCellUpdated(row, col);
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -162,15 +162,6 @@ public final class PropertyEditor extends MMFrame {
    }
 
    @Subscribe
-   public void onPropertiesChanged(PropertiesChangedEvent event) {
-      // avoid re-executing a refresh because of callbacks while we are
-      // updating
-      if (!data_.updating()) {
-         refresh(false);
-      }
-   }
-
-   @Subscribe
    public void onPropertyChanged(PropertyChangedEvent event) {
       String device = event.getDevice();
       String property = event.getProperty();


### PR DESCRIPTION
This PR contains 3 independent changes that all have to do with avoiding duplicate calls certain functions. Each of the 3 changes are contained in their own commit so it is easy to view each one separately.

1: The `MMStudio.onPropertiesChanged` event handler initiates a refresh of the GUI which involved updating the property cache. However, `CoreEventCallback.onPropertiesChanged` already updates the property cache, there is no reason to do it twice.

2: The `PropertyEditor.onPropertiesChanged` event handler calls `PropertyEditor.refresh` . However,  `MMStudio.onPropertiesChanged` also indirectly calls `PropertyEditor.refresh` through a call to `refreshGUI`. There is no reason to refresh the Property Editor twice.

3: `PropertyEditor.setValueAt` calls `PropertyEditor.refresh` and then immediately calls `studio_.app().refreshGUIFromCache` which results in a second call to `PropertyEditor.refresh`. There is no reason to refresh the Property Editor twice.