### PR TITLE
Studio: Catches profile read exception and attempts to read backup profile.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
+++ b/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
@@ -488,6 +488,15 @@ public final class UserProfileAdmin {
       catch (FileNotFoundException e) { // Not present is equivalent to empty
          return new Profile();
       }
+      catch (IOException e) { // Present but in a bad state.  Try to restore from backup
+         String backup = filename + "~";
+         try {
+            return Profile.fromFilePmap(PropertyMaps.loadJSON(getModernFile(backup)));
+         }
+         catch (IOException ex) { // Not present is equivalent to empty
+            return new Profile();
+         }
+      }
    }
 
    private void writeFile(String filename, Profile profile, boolean ignoreProfileReadOnly) throws IOException {


### PR DESCRIPTION
If that fails too, it creates a new profile.  Avoids previous uncaught exception causing MM failing to start upon borked profile. Underlying cause: creation of borked profile is unclear, but will be hard to figure out.

Closes #1084