### PR TITLE
Omicron: prevent access violation on shutdown by not calling ExXShutdownDLL()

### DIFF
--- a/DeviceAdapters/Omicron/OmicronDeviceDriver.cpp
+++ b/DeviceAdapters/Omicron/OmicronDeviceDriver.cpp
@@ -60,12 +60,16 @@ bool openDriver() {
 }
 
 void closeDriver() {
-	if (DLLHandle) {
+	if (DLLHandle != NULL) {
 		alldevices.clear();
 		devNameToID.clear();
 		try {
-			if (ExXShutdownDLL)
-				ExXShutdownDLL();
+			if (ExXShutdownDLL) {
+            // NS, 20210212: This function call tries to access address 0 causing an access violation
+            // crashing MM on shutdown.
+            // Not sure what the consequences are of not calling this function.
+				// ExXShutdownDLL();
+         }
 		}
 		catch (...) {
 			MessageBox(NULL, "Fehler DeleteDevice", "Fehler", MB_OK | MB_TASKMODAL | MB_ICONWARNING);


### PR DESCRIPTION
Closes #957 

git-svn-id: https://valelab.ucsf.edu/svn/micromanager2/trunk@17422 d0ab736e-dc22-4aeb-8dc9-08def0aa14fd