### PR TITLE
fix references to 3rdparty public

### DIFF
--- a/DeviceAdapters/KuriosLCTF/KuriosLCTF.vcxproj
+++ b/DeviceAdapters/KuriosLCTF/KuriosLCTF.vcxproj
@@ -91,26 +91,26 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;KURIOSLCTF_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>../../../3rdpartypublic/Kurios/Kurios-C++SDKv1.6.2;$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)/Kurios/Kurios-C++SDKv1.6.2;$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>KURIOS_COMMAND_LIB_win32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>../../../3rdpartypublic/Kurios/Kurios-C++SDKv1.6.2;$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)/Kurios/Kurios-C++SDKv1.6.2;$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;KURIOSLCTF_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../3rdpartypublic/Kurios/Kurios-C++SDKv1.6.2;$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)/Kurios/Kurios-C++SDKv1.6.2;$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>../../../3rdpartypublic/Kurios/Kurios-C++SDKv1.6.2;$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)/Kurios/Kurios-C++SDKv1.6.2;$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>KURIOS_COMMAND_LIB_win64.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -122,14 +122,14 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;KURIOSLCTF_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../3rdpartypublic/Kurios/Kurios-C++SDKv1.6.2;$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)/Kurios/Kurios-C++SDKv1.6.2;$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>../../../3rdpartypublic/Kurios/Kurios-C++SDKv1.6.2;$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)/Kurios/Kurios-C++SDKv1.6.2;$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>KURIOS_COMMAND_LIB_win32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -141,14 +141,14 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;KURIOSLCTF_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../3rdpartypublic/Kurios/Kurios-C++SDKv1.6.2;$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)/Kurios/Kurios-C++SDKv1.6.2;$(MM_MMDEVICE_INCLUDEDIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>../../../3rdpartypublic/Kurios/Kurios-C++SDKv1.6.2;$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)/Kurios/Kurios-C++SDKv1.6.2;$(MM_BOOST_LIBDIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>KURIOS_COMMAND_LIB_win64.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/DeviceAdapters/PVCAM/PVCAMIncludes.h
+++ b/DeviceAdapters/PVCAM/PVCAMIncludes.h
@@ -3,8 +3,8 @@
 
 #ifdef WIN32
 #pragma warning(push)
-#include "../../../3rdpartypublic/Photometrics/PVCAM/SDK/Headers/master.h"
-#include "../../../3rdpartypublic/Photometrics/PVCAM/SDK/Headers/pvcam.h"
+#include "$(MM_3RDPARTYPUBLIC)/Photometrics/PVCAM/SDK/Headers/master.h"
+#include "$(MM_3RDPARTYPUBLIC)/Photometrics/PVCAM/SDK/Headers/pvcam.h"
 #pragma warning(pop)
 #endif
 

--- a/DeviceAdapters/Ximea/XIMEACamera.vcxproj
+++ b/DeviceAdapters/Ximea/XIMEACamera.vcxproj
@@ -84,7 +84,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\3rdpartypublic\pugixml\pugixml-1.8\src;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\src;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -104,7 +104,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\3rdpartypublic\pugixml\pugixml-1.8\src;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\src;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -113,7 +113,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>xiapi64.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\3rdpartypublic\pugixml\pugixml-1.8\build-vs2010\x64;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\bin\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\build-vs2010\x64;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\bin\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -121,7 +121,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\..\..\3rdpartypublic\pugixml\pugixml-1.8\src;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\src;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
@@ -142,7 +142,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\..\..\3rdpartypublic\pugixml\pugixml-1.8\src;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\src;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;MODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
@@ -150,19 +150,19 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>xiapi64.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\3rdpartypublic\pugixml\pugixml-1.8\build-vs2010\x64;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\bin\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\build-vs2010\x64;..\..\..\3rdparty\Ximea\API-Windows-4.21.2.0-beta\bin\x64\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\3rdpartypublic\pugixml\pugixml-1.8\src\pugixml.cpp" />
+    <ClCompile Include="$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\src\pugixml.cpp" />
     <ClCompile Include="xiApiPlus\xiAPIplus_core.cpp" />
     <ClCompile Include="XIMEACamera.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\3rdpartypublic\pugixml\pugixml-1.8\src\pugixml.hpp" />
+    <ClInclude Include="$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\src\pugixml.hpp" />
     <ClInclude Include="xiApiPlus\xiapiplus.h" />
     <ClInclude Include="XIMEACamera.h" />
   </ItemGroup>

--- a/DeviceAdapters/Ximea/XIMEACamera.vcxproj.filters
+++ b/DeviceAdapters/Ximea/XIMEACamera.vcxproj.filters
@@ -27,7 +27,7 @@
     <ClCompile Include="xiApiPlus\xiAPIplus_core.cpp">
       <Filter>Source Files\xiApiPlus</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\3rdpartypublic\pugixml\pugixml-1.8\src\pugixml.cpp">
+    <ClCompile Include="$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\src\pugixml.cpp">
       <Filter>Source Files\pugixml</Filter>
     </ClCompile>
   </ItemGroup>
@@ -38,7 +38,7 @@
     <ClInclude Include="xiApiPlus\xiapiplus.h">
       <Filter>Source Files\xiApiPlus</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\3rdpartypublic\pugixml\pugixml-1.8\src\pugixml.hpp">
+    <ClInclude Include="$(MM_3RDPARTYPUBLIC)\pugixml\pugixml-1.8\src\pugixml.hpp">
       <Filter>Source Files\pugixml</Filter>
     </ClInclude>
   </ItemGroup>

--- a/buildscripts/ivysettings.xml
+++ b/buildscripts/ivysettings.xml
@@ -11,11 +11,11 @@
       <ibiblio name ="bintray-micro-manager" m2compatible="true" root="https://dl.bintray.com/micro-manager/micro-manager"/>
 
 		<filesystem name="thirdpartypublic">
-			<artifact pattern="${ivy.settings.dir}/../../3rdpartypublic/classext/[artifact].[ext]"/>
+			<artifact pattern="${mm.thirdpartypublic}/classext/[artifact].[ext]"/>
 		</filesystem>
 
       <filesystem name="thirdpartypublic3d"><!-- jogl/gluegen jars need separate handling-->
-			<artifact pattern="${ivy.settings.dir}/../../3rdpartypublic/javalib3d/[artifact]-[revision].[ext]"/>
+			<artifact pattern="${mm.thirdpartypublic}/javalib3d/[artifact]-[revision].[ext]"/>
 		</filesystem>
 
 		<filesystem name="thirdpartynonfree">


### PR DESCRIPTION
This PR fixes various parts of the codebase that assume the 3rdPartyPublic repository is located at "../3rdPartyPublic" rather than using the Ant and VS environment variables.

This will make is easier to rename or move the public repository in the future.