### PR TITLE
Sharpness Inspector Plugin

### DIFF
--- a/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
@@ -40,7 +40,7 @@ import mmcorej.TaggedImage;
 import org.micromanager.AutofocusPlugin;
 import org.micromanager.Studio;
 import org.micromanager.autofocus.internal.oughtafocus.BrentFocuser;
-import org.micromanager.autofocus.internal.oughtafocus.ImgSharpnessAnalysis;
+import org.micromanager.imageprocessing.ImgSharpnessAnalysis;
 import org.micromanager.internal.utils.AutofocusBase;
 import org.micromanager.internal.utils.imageanalysis.ImageUtils;
 import org.micromanager.internal.utils.MMException;

--- a/libraries/ImageProcessing/src/main/java/org/micromanager/imageprocessing/FHT_NoScaling.java
+++ b/libraries/ImageProcessing/src/main/java/org/micromanager/imageprocessing/FHT_NoScaling.java
@@ -27,7 +27,7 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
 //CVS:            $Id: MetadataDlg.java 1275 2008-06-03 21:31:24Z nenad $
-package org.micromanager.autofocus.internal.oughtafocus;
+package org.micromanager.imageprocessing;
 
 import ij.process.ByteProcessor;
 import ij.process.FloatProcessor;

--- a/libraries/ImageProcessing/src/main/java/org/micromanager/imageprocessing/ImgSharpnessAnalysis.java
+++ b/libraries/ImageProcessing/src/main/java/org/micromanager/imageprocessing/ImgSharpnessAnalysis.java
@@ -28,7 +28,7 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
 //CVS:            $Id: MetadataDlg.java 1275 2008-06-03 21:31:24Z nenad $
-package org.micromanager.autofocus.internal.oughtafocus;
+package org.micromanager.imageprocessing;
 
 import ij.gui.OvalRoi;
 import ij.process.ImageProcessor;

--- a/plugins/SharpnessInspector/build.xml
+++ b/plugins/SharpnessInspector/build.xml
@@ -1,0 +1,4 @@
+<!-- Build file used to compile Emu with Micro-Manager -->
+<project name="SharpnessInspector" basedir="." default="jar">
+	<import file="../javapluginbuild.xml"/>
+</project>

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessEvaluator.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessEvaluator.java
@@ -22,7 +22,7 @@ package org.micromanager.sharpnessinspector;
 
 import ij.process.ImageProcessor;
 import java.awt.Rectangle;
-import org.micromanager.autofocus.internal.oughtafocus.ImgSharpnessAnalysis;
+import org.micromanager.imageprocessing.ImgSharpnessAnalysis;
 import org.micromanager.data.Image;
 import org.micromanager.internal.MMStudio;
 

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessEvaluator.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessEvaluator.java
@@ -1,0 +1,80 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       PWS Plugin
+//
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Nick Anthony, 2021
+//
+// COPYRIGHT:    Northwestern University, 2021
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+package edu.bpl.imgSharpnessPlugin;
+
+import ij.process.ImageProcessor;
+import java.awt.Rectangle;
+import org.micromanager.autofocus.internal.oughtafocus.ImgSharpnessAnalysis;
+import org.micromanager.data.Image;
+import org.micromanager.internal.MMStudio;
+
+/**
+ *
+ * @author Nick Anthony
+ */
+public class SharpnessEvaluator {
+    private final ImgSharpnessAnalysis anl = new ImgSharpnessAnalysis();
+    private ImgSharpnessAnalysis.Method method_ = ImgSharpnessAnalysis.Method.Redondo; // In my experience Redondo works much better than other methods.
+    
+    public void setMethod(ImgSharpnessAnalysis.Method method) {
+        method_ = method;
+        anl.setComputationMethod(ImgSharpnessAnalysis.Method.valueOf(method.name()));
+    }
+    
+    public ImgSharpnessAnalysis.Method getMethod() {
+       return method_;
+    }
+    
+    public double evaluate(Image img, Rectangle r) {
+        ImageProcessor proc = MMStudio.getInstance().data().getImageJConverter().createProcessor(img);
+        proc.setRoi(r);
+        proc = proc.crop();
+        return anl.compute(proc);
+    }
+    
+    /* Before using the ImgSharpnessAnalysis we used to do it ourselves here
+    private double evaluateGradient(Image img, Rectangle r) {
+        GrayF32 im = new GrayF32(r.width, r.height);
+        for (int i=0; i<r.width; i++) {
+            for (int j=0; j<r.height; j++) {
+                long intensity = img.getIntensityAt(r.x + i, r.y + j);
+                im.set(i, j, (int) intensity);
+            }
+        }
+        GrayF32 blurred = BlurImageOps.gaussian(im, null, -1, 3, null);
+        PixelMath.divide(blurred, ImageStatistics.mean(blurred), blurred); //Normalize?
+        GrayF32 dx = new GrayF32(im.width, im.height);
+        GrayF32 dy = new GrayF32(im.width, im.height);
+        GImageDerivativeOps.gradient(DerivativeType.THREE, blurred, dx, dy, BorderType.EXTENDED);
+        //Calculate magnitude of the gradient
+        PixelMath.pow2(dx, dx);
+        PixelMath.pow2(dy, dy);
+        GrayF32 mag = new GrayF32(dx.width, dx.height);
+        PixelMath.add(dx, dy, mag);
+        PixelMath.sqrt(mag, mag);
+        float[] arr = mag.getData();
+        double[] dubArr = new double[arr.length];
+        for (int i = 0; i < arr.length; i++) { // must convert from float[] to double[]
+            dubArr[i] = arr[i];
+        }
+        return new Percentile().evaluate(dubArr, 95);
+    } */
+}

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessEvaluator.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessEvaluator.java
@@ -18,7 +18,7 @@
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
-package edu.bpl.imgSharpnessPlugin;
+package org.micromanager.sharpnessinspector;
 
 import ij.process.ImageProcessor;
 import java.awt.Rectangle;

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorController.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorController.java
@@ -1,0 +1,243 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       PWS Plugin
+//
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Nick Anthony, 2021
+//
+// COPYRIGHT:    Northwestern University, 2021
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+package edu.bpl.imgSharpnessPlugin;
+
+import edu.bpl.imgSharpnessPlugin.ui.SharpnessInspectorPanel;
+
+import com.google.common.base.Preconditions;
+import com.google.common.eventbus.Subscribe;
+import ij.gui.Roi;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import javax.swing.JPanel;
+import javax.swing.SwingWorker;
+import org.micromanager.Studio;
+import org.micromanager.autofocus.internal.oughtafocus.ImgSharpnessAnalysis;
+import org.micromanager.data.DataProviderHasNewImageEvent;
+import org.micromanager.data.Image;
+import org.micromanager.data.internal.DefaultImage;
+import org.micromanager.display.DataViewer;
+import org.micromanager.display.DisplayWindow;
+import org.micromanager.display.inspector.AbstractInspectorPanelController;
+import org.micromanager.display.inspector.internal.panels.intensity.ImageStatsPublisher;
+import org.micromanager.events.StagePositionChangedEvent;
+import org.micromanager.internal.utils.MustCallOnEDT;
+
+/**
+ *
+ * @author Nick Anthony
+ */
+public class SharpnessInspectorController extends AbstractInspectorPanelController {
+    private static boolean expanded_ = false;  //For some reason a whole new instance of this class is created each time we switch display viewers. Having this variable static allows it's value to stay unchanged between instances.
+    private final SharpnessInspectorPanel panel_;
+    private DataViewer viewer_;
+    private final Studio studio_;
+    private boolean autoImageEvaluation_ = true;
+    private final SharpnessEvaluator eval_ = new SharpnessEvaluator();
+    
+    private SharpnessInspectorController(Studio studio) {
+        studio_ = studio;
+        studio_.events().registerForEvents(this);
+        panel_ = new SharpnessInspectorPanel();
+        
+        panel_.setEvaluationMethod(eval_.getMethod());
+        panel_.addPropertyChangeListener("evalMethod", (evt) -> {
+           eval_.setMethod((ImgSharpnessAnalysis.Method) evt.getNewValue());
+        });
+        
+        panel_.addScanRequestedListener((evt) -> {
+            SwingWorker worker = new SwingWorker() {
+                @Override
+                protected Object doInBackground() throws Exception {
+                    SharpnessInspectorController.this.beginScan(evt.intervalUm(), evt.rangeUm());
+                    return null;
+                }
+            };
+            worker.execute();
+        });
+        
+    }
+    
+    public static SharpnessInspectorController create(Studio studio) {
+        return new SharpnessInspectorController(studio);
+    }
+
+    @Override
+    public String getTitle() {
+       return "Image Sharpness";
+    }
+
+    @Override
+    public JPanel getPanel() {
+       return panel_;
+    }
+
+    @Override
+    @MustCallOnEDT
+    public void attachDataViewer(DataViewer viewer) {
+       Preconditions.checkNotNull(viewer);
+       if (!(viewer instanceof ImageStatsPublisher)) {
+          throw new IllegalArgumentException("Programming error");
+       }
+       detachDataViewer();
+       viewer_ = viewer;
+       viewer.registerForEvents(this);
+       viewer.getDataProvider().registerForEvents(this);
+    }
+
+    @Override
+    @MustCallOnEDT
+    public void detachDataViewer() {
+       if (viewer_ == null) {
+          return;
+       }
+       viewer_.getDataProvider().unregisterForEvents(this);
+       viewer_.unregisterForEvents(this);
+       viewer_ = null;
+    }
+
+    @Override
+    public boolean isVerticallyResizableByUser() {
+       return true;
+    }
+
+    @Override
+    public void setExpanded(boolean status) {
+       expanded_ = status;
+       autoImageEvaluation_ = status; // If the UI is collapsed there is no reason to process images.
+    }
+
+    @Override
+    public boolean initiallyExpand() {
+       return expanded_;
+    }
+    
+    @Subscribe
+    public void onNewImage(DataProviderHasNewImageEvent evt) {
+        ///This is fired because we register for the dataprovider events. Happens each time a new image is available from the provider.
+        if (!this.autoImageEvaluation_) {
+            return;
+        }
+        DefaultImage img = (DefaultImage) evt.getImage();
+        Roi roi;
+        try {
+            roi = ((DisplayWindow) viewer_).getImagePlus().getRoi();
+        } catch (RuntimeException rte) { // Sometimes when the display window is just getting initialized this occurs due to a nullpointer in trying to get the ImagePlus
+           return;
+        }
+        if (roi == null || !roi.isArea()) {
+            this.panel_.setRoiSelected(false);
+            return;
+        }
+        this.panel_.setRoiSelected(true);
+        Rectangle r = roi.getBounds();
+        if (r.width < 5 || r.height < 5) {
+            return; //Rectangle must be larger than the kernel used to calculate gradient which is 1x3
+        }
+        double grad = eval_.evaluate(img, r);
+        double z = img.getMetadata().getZPositionUm();
+        this.panel_.setValue(z, System.currentTimeMillis(), grad);
+    }
+    
+    @Subscribe
+    public void onZPosChanged(StagePositionChangedEvent evt) { //TODO Many z stages don't fire this. use polling instead
+        if (!studio_.core().getFocusDevice().equals(evt.getDeviceName())) {
+            return; //Stage device names don't match. We only want to use the default focus device.
+        }
+        this.panel_.setZPos(evt.getPos());
+    }
+    
+    private void beginScan(double intervalUm, double rangeUm) {
+        this.panel_.clearData();
+        this.panel_.setPlotMode(PlotMode.Z);
+        this.autoImageEvaluation_ = false;
+        
+        if (studio_.live().getIsLiveModeOn()) {
+            studio_.live().setLiveMode(false);
+        }
+        
+        Roi roi = ((DisplayWindow) viewer_).getImagePlus().getRoi();
+        Rectangle r;
+        if (roi == null || !roi.isArea()) {
+            r = new Rectangle(  // use full image fov
+                    ((DisplayWindow) viewer_).getImagePlus().getWidth(),
+                    ((DisplayWindow) viewer_).getImagePlus().getHeight());
+        } else {
+            r = roi.getBounds();
+            //Rectangle must be larger than the kernel used to calculate gradient which is 1x3
+            if (r.width < 5) {
+                r.setSize(5, r.height);
+            } if (r.height < 5) {
+                r.setSize(r.width, 5);
+            }
+        }
+        try {
+            long numSteps = Math.round(rangeUm / intervalUm);
+            double startingPos = studio_.core().getPosition();
+            studio_.core().setRelativePosition(-(rangeUm/2.0)); // Move down by half of the range so that the scan is centered at the starting point.
+            while (studio_.core().deviceBusy(studio_.core().getFocusDevice())) { // make sure we moved
+                Thread.sleep(50);
+            }
+            for (int i=0; i<numSteps; i++) {
+                studio_.core().setRelativePosition(intervalUm);
+                while (studio_.core().deviceBusy(studio_.core().getFocusDevice())) { // make sure we moved
+                    Thread.sleep(50);
+                }
+                
+                Image img = studio_.live().snap(true).get(0);
+                double sharpness = eval_.evaluate(img, r);
+                
+                double pos = studio_.core().getPosition();
+                panel_.setValue(pos, System.currentTimeMillis(), sharpness);
+            }
+            studio_.core().setPosition(startingPos);
+        } catch (Exception e) {
+            studio_.logs().showError(e);
+        } finally {
+            this.autoImageEvaluation_ = true;
+        }
+    }
+
+   public static class RequestScanEvent extends ActionEvent {
+       private final double interval;
+       private final double range;
+
+       public RequestScanEvent(Object source, double intervalUm, double rangeUm) {
+           super(source, 0, "startScan");
+           interval = intervalUm;
+           range = rangeUm;
+       }
+
+       public double intervalUm() { return interval; }
+       public double rangeUm() { return range; }
+   }
+
+
+   public interface RequestScanListener {
+       public void actionPerformed(RequestScanEvent evt);
+   }
+   
+   public static enum PlotMode {
+      Time,
+      Z;
+   }
+   
+}

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorController.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorController.java
@@ -20,7 +20,7 @@
 //
 package org.micromanager.sharpnessinspector;
 
-import edu.bpl.imgSharpnessPlugin.ui.SharpnessInspectorPanel;
+import org.micromanager.sharpnessinspector.ui.SharpnessInspectorPanel;
 
 import com.google.common.base.Preconditions;
 import com.google.common.eventbus.Subscribe;
@@ -30,7 +30,7 @@ import java.awt.event.ActionEvent;
 import javax.swing.JPanel;
 import javax.swing.SwingWorker;
 import org.micromanager.Studio;
-import org.micromanager.autofocus.internal.oughtafocus.ImgSharpnessAnalysis;
+import org.micromanager.imageprocessing.ImgSharpnessAnalysis;
 import org.micromanager.data.DataProviderHasNewImageEvent;
 import org.micromanager.data.Image;
 import org.micromanager.data.internal.DefaultImage;

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorController.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorController.java
@@ -18,7 +18,7 @@
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
-package edu.bpl.imgSharpnessPlugin;
+package org.micromanager.sharpnessinspector;
 
 import edu.bpl.imgSharpnessPlugin.ui.SharpnessInspectorPanel;
 

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorPlugin.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorPlugin.java
@@ -33,7 +33,7 @@ import org.scijava.plugin.Plugin;
  * @author Nick Anthony
  */
 @Plugin(type = InspectorPanelPlugin.class,
-    priority = Priority.VERY_HIGH,
+    priority = Priority.NORMAL,
     name = "Focus Sharpness",
     description = "View quantitative image sharpness.")
 public class SharpnessInspectorPlugin implements InspectorPanelPlugin {

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorPlugin.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorPlugin.java
@@ -18,7 +18,7 @@
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
-package edu.bpl.imgSharpnessPlugin;
+package org.micromanager.sharpnessinspector;
 
 import org.micromanager.Studio;
 import org.micromanager.display.DataViewer;

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorPlugin.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorPlugin.java
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       ImgSharpnessPlugin
+//
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Nick Anthony, 2021
+//
+// COPYRIGHT:    Northwestern University, 2021
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+package edu.bpl.imgSharpnessPlugin;
+
+import org.micromanager.Studio;
+import org.micromanager.display.DataViewer;
+import org.micromanager.display.inspector.InspectorPanelController;
+import org.micromanager.display.inspector.InspectorPanelPlugin;
+import org.micromanager.display.inspector.internal.panels.intensity.ImageStatsPublisher;
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ *
+ * @author Nick Anthony
+ */
+@Plugin(type = InspectorPanelPlugin.class,
+    priority = Priority.VERY_HIGH,
+    name = "Focus Sharpness",
+    description = "View quantitative image sharpness.")
+public class SharpnessInspectorPlugin implements InspectorPanelPlugin {
+    @Override
+    public boolean isApplicableToDataViewer(DataViewer viewer) {
+        return viewer.getDataProvider() != null && viewer instanceof ImageStatsPublisher;
+    }
+
+    @Override
+    public InspectorPanelController createPanelController(Studio studio) {
+        return SharpnessInspectorController.create(studio);
+    }
+    
+    public static String README = "This plugin provides a real-time plot of image sharpness. Simply click and drag on an image display to select an ROI and the plugin will begin evaluating the sharpness "
+            + "of the image within the ROI using the selected method. Sharpness is evaluated using the same code that is used by the OughtaFocus plugin, for more information about the various evaluation"
+            + " methods please view the documentation for the OughtaFocus autofocus plugin.";
+}

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/JFreeTextOverlay.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/JFreeTextOverlay.java
@@ -18,7 +18,7 @@
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
-package edu.bpl.imgSharpnessPlugin.ui;
+package org.micromanager.sharpnessinspector.ui;
 
 import java.awt.Font;
 import java.awt.FontMetrics;

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/JFreeTextOverlay.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/JFreeTextOverlay.java
@@ -1,0 +1,69 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       PWS Plugin
+//
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Nick Anthony, 2021
+//
+// COPYRIGHT:    Northwestern University, 2021
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+package edu.bpl.imgSharpnessPlugin.ui;
+
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.panel.AbstractOverlay;
+import org.jfree.chart.panel.Overlay;
+
+
+/**
+ * A Text overlay for a JFreeChart
+ * @author nick
+ */
+class JFreeTextOverlay extends AbstractOverlay implements Overlay {
+    private String _text;
+    private boolean _vis = true;
+    private final Font _font = new Font("arial", Font.BOLD, 15);
+    
+    public JFreeTextOverlay(String text) {
+        this._text = text;
+    }
+    
+    public void setVisible(boolean visible) {
+        this._vis = visible;
+    }
+    
+    public boolean isVisible() {
+        return this._vis;
+    }
+    
+    @Override
+    public void paintOverlay(Graphics2D g2, ChartPanel chartPanel) {
+        if (this._vis) {
+            Shape savedClip = g2.getClip();
+            Rectangle2D dataArea = chartPanel.getScreenDataArea();
+            g2.clip(dataArea);
+            g2.setFont(this._font);
+            FontMetrics metrics = g2.getFontMetrics();
+            int h = metrics.getHeight();
+            int w = metrics.stringWidth(_text);
+            g2.drawString(this._text, (int) Math.round(dataArea.getCenterX() - (w / 2)), (int) Math.round(dataArea.getCenterY() - (h / 2)));
+            
+            g2.setClip(savedClip);  
+        }
+    }
+}

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
@@ -20,9 +20,8 @@
 //
 package org.micromanager.sharpnessinspector.ui;
 
-import edu.bpl.imgSharpnessPlugin.SharpnessInspectorController;
-import edu.bpl.imgSharpnessPlugin.SharpnessInspectorPlugin;
-import edu.bpl.pwsplugin.UI.utils.ImprovedComponents;
+import org.micromanager.sharpnessinspector.SharpnessInspectorController;
+import org.micromanager.sharpnessinspector.SharpnessInspectorPlugin;
 import java.awt.Color;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -33,6 +32,7 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
+import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -45,7 +45,7 @@ import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
-import org.micromanager.autofocus.internal.oughtafocus.ImgSharpnessAnalysis;
+import org.micromanager.imageprocessing.ImgSharpnessAnalysis;
 /**
  *
  * @author nick
@@ -243,8 +243,8 @@ public class SharpnessInspectorPanel extends JPanel {
     }
         
     private class ScanDialog extends JDialog {
-        private final ImprovedComponents.FormattedTextField interval = new ImprovedComponents.FormattedTextField(NumberFormat.getNumberInstance());
-        private final ImprovedComponents.FormattedTextField range = new ImprovedComponents.FormattedTextField(NumberFormat.getNumberInstance());
+        private final JFormattedTextField interval = new JFormattedTextField(NumberFormat.getNumberInstance());
+        private final JFormattedTextField range = new JFormattedTextField(NumberFormat.getNumberInstance());
         private final JButton startButton = new JButton("Start");
 
         public ScanDialog() {

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
@@ -18,7 +18,7 @@
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
-package edu.bpl.imgSharpnessPlugin.ui;
+package org.micromanager.sharpnessinspector.ui;
 
 import edu.bpl.imgSharpnessPlugin.SharpnessInspectorController;
 import edu.bpl.imgSharpnessPlugin.SharpnessInspectorPlugin;

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
@@ -1,0 +1,282 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       PWS Plugin
+//
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Nick Anthony, 2021
+//
+// COPYRIGHT:    Northwestern University, 2021
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+package edu.bpl.imgSharpnessPlugin.ui;
+
+import edu.bpl.imgSharpnessPlugin.SharpnessInspectorController;
+import edu.bpl.imgSharpnessPlugin.SharpnessInspectorPlugin;
+import edu.bpl.pwsplugin.UI.utils.ImprovedComponents;
+import java.awt.Color;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import net.miginfocom.swing.MigLayout;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+import org.micromanager.autofocus.internal.oughtafocus.ImgSharpnessAnalysis;
+/**
+ *
+ * @author nick
+ */
+public class SharpnessInspectorPanel extends JPanel {
+    
+    private final static String SERIES_NAME = "DATA";
+
+    private final JFreeChart zChart = ChartFactory.createXYLineChart(
+            null, //title
+            "Z", // xlabel
+            "Gradient", // ylabel
+            new XYSeriesCollection(new XYSeries(SERIES_NAME, true, false)),
+            PlotOrientation.VERTICAL,
+            false, // legend
+            false, //tooltips
+            false //urls
+    );
+    
+    private final JFreeChart tChart = ChartFactory.createXYLineChart(
+                null, //title
+            "Time", // xlabel
+            "Gradient", // ylabel
+            new XYSeriesCollection(new XYSeries(SERIES_NAME, true, false)),
+            PlotOrientation.VERTICAL,
+            false, // legend
+            false, //tooltips
+            false //urls
+    );
+
+    private final ChartPanel chartPanel = new ChartPanel(
+        tChart,
+        200, // int width,
+        200, // int height,
+        100, // int minimumDrawWidth,
+        100, // int minimumDrawHeight,
+        10000, // int maximumDrawWidth,
+        10000, // int maximumDrawHeight,
+        true, // boolean useBuffer,
+        true, // boolean properties,
+        true, // boolean copy,
+        true, // boolean save,
+        true, // boolean print,
+        true, // boolean zoom,
+        true // boolean tooltips
+    );
+        
+    private final JButton resetButton = new JButton("Reset Plot");
+    private final JButton scanButton = new JButton("Scan...");
+
+    private final List<SharpnessInspectorController.RequestScanListener> scanRequestedListeners = new ArrayList<>();
+    private final ScanDialog scanDlg = new ScanDialog();
+    private final JComboBox<SharpnessInspectorController.PlotMode> plotModeBox = new JComboBox<>(new DefaultComboBoxModel<>(SharpnessInspectorController.PlotMode.values()));
+    private final JComboBox<ImgSharpnessAnalysis.Method> evaluationMode = new JComboBox<>(new DefaultComboBoxModel<>(ImgSharpnessAnalysis.Method.values()));
+    private final JFreeTextOverlay noRoiOverlay = new JFreeTextOverlay("No Roi Drawn");
+    
+    private final XYSeries zDataSeries = ((XYSeriesCollection) zChart.getXYPlot().getDataset()).getSeries(SERIES_NAME);
+    private final XYSeries tDataSeries = ((XYSeriesCollection) tChart.getXYPlot().getDataset()).getSeries(SERIES_NAME);
+
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    
+    public SharpnessInspectorPanel() {
+        super(new MigLayout("fill, nogrid"));
+                
+        resetButton.addActionListener((evt) -> {
+            this.clearData();
+        });
+        
+        scanButton.addActionListener((evt) -> {
+            this.scanDlg.setVisible(true);
+        });
+        
+        this.zChart.getXYPlot().setDomainCrosshairVisible(true); // A crosshair overlay to display the current z position.
+        this.zChart.getXYPlot().setDomainCrosshairPaint(new Color(0, 0, 0)); // black crosshair
+        this.zChart.getXYPlot().setRangeCrosshairVisible(true); // A crosshair overlay to display the current sharpness.
+        this.zChart.getXYPlot().setRangeCrosshairPaint(new Color(0, 0, 0)); // black crosshair
+        this.tChart.getXYPlot().getDomainAxis().setTickLabelsVisible(false); // hide the values for `time`
+        this.chartPanel.addOverlay(noRoiOverlay); // An overlay that tells the user that there needs to be a roi selected.
+        this.chartPanel.setPopupMenu(null); // disable the right-click menu
+        this.chartPanel.setDomainZoomable(false); // disale zooming by click-drag
+        this.chartPanel.setRangeZoomable(false);
+        
+        //make plot background transparent
+        Color trans = new Color(0xFF, 0xFF, 0xFF, 0);
+        zChart.setBackgroundPaint(trans);
+        zChart.getXYPlot().setBackgroundPaint(trans);
+        ((NumberAxis) zChart.getXYPlot().getRangeAxis()).setAutoRangeIncludesZero(false);  //Don't always include 0 in the vertical autoranging.
+        tChart.setBackgroundPaint(trans);
+        tChart.getXYPlot().setBackgroundPaint(trans);
+        ((NumberAxis) tChart.getXYPlot().getRangeAxis()).setAutoRangeIncludesZero(false);  //Don't always include 0 in the vertical autoranging.
+        
+        this.plotModeBox.addItemListener((evt) -> {
+            SharpnessInspectorController.PlotMode mode = (SharpnessInspectorController.PlotMode) this.plotModeBox.getSelectedItem();
+            this.setPlotMode(mode);         
+        });
+        
+        evaluationMode.addActionListener((evt) -> {
+           this.pcs.firePropertyChange("evalMethod", null, (ImgSharpnessAnalysis.Method) evaluationMode.getSelectedItem());
+        });
+        
+        JButton infoButton = new JButton("?");
+        infoButton.addActionListener((evt) -> {
+            JOptionPane.showMessageDialog(infoButton,
+                    "<html><body><p style='width: 200px;'>" + SharpnessInspectorPlugin.README +" </p></body></html>",  // Wrapping in HTML for word wrapping.
+                    "Plugin Information",
+                    JOptionPane.INFORMATION_MESSAGE);
+        });
+        
+        super.add(chartPanel, "wrap, spanx, grow, pushy");
+        super.add(scanButton);
+        super.add(resetButton);
+        super.add(new JLabel("X axis:"));
+        super.add(plotModeBox, "wrap");
+        super.add(new JLabel("Method:"));
+        super.add(evaluationMode);
+        super.add(infoButton);
+    }
+    
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.addPropertyChangeListener(listener);
+    }
+    
+    @Override
+    public void addPropertyChangeListener(String property, PropertyChangeListener listener) {
+        this.pcs.addPropertyChangeListener(property, listener);
+    }
+    
+    public void setValue(double z, double time, double sharpness) {
+        //Add an XY value to the plot. if the x value already exists the old value will be replaced.
+        this.zDataSeries.addOrUpdate(z, sharpness);
+        this.zChart.getXYPlot().setRangeCrosshairValue(sharpness); //Set the vertical crosshair to the current sharpness value.
+        this.setZPos(z);
+        
+        //Find the index associated with data that is more than `timeLimit` seconds old and delete it.
+        double timeLimit = 30;
+        int i;
+        for (i=0; i<tDataSeries.getItemCount(); i++) {
+            Double t = (Double) tDataSeries.getX(i);
+            if (((time - t) / 1000) < timeLimit) {
+                break;
+            }
+        }
+        if (i == tDataSeries.getItemCount()) {
+            tDataSeries.clear();
+        } else if (i > 0) {
+            tDataSeries.delete(0, i);
+        }
+        this.tDataSeries.addOrUpdate(time, sharpness);
+    }
+    
+    public void setZPos(double z) {
+        //Set the currect z position for the cursor to be set to.
+        this.zChart.getXYPlot().setDomainCrosshairValue(z);
+    }
+    
+    public void clearData() {
+        this.zDataSeries.clear();
+        this.tDataSeries.clear();
+    }
+    
+    public void setRoiSelected(boolean hasRoi) {
+        //If there is no roi selected use this method to make an overlay visible that tells this to the user.
+        if (!hasRoi) {
+            if (!this.noRoiOverlay.isVisible()) {
+                this.noRoiOverlay.setVisible(true);
+                this.repaint(); // Make sure the change in visibility is rendered.
+            }
+        } else {
+            if (this.noRoiOverlay.isVisible()) {
+                this.noRoiOverlay.setVisible(false);
+                this.repaint(); // Make sure the change in visibility is rendered.
+            }
+        }
+    }
+    
+    public void addScanRequestedListener(SharpnessInspectorController.RequestScanListener listener) {
+        //Add a listener that will be fired when the `scan` button is pressed.
+        this.scanRequestedListeners.add(listener);
+    }
+
+    public void setPlotMode(SharpnessInspectorController.PlotMode mode) {
+        switch (mode) {
+            case Time:
+                this.chartPanel.setChart(tChart);
+                break;
+            case Z:
+                this.chartPanel.setChart(zChart);
+                break;
+        }
+        if (plotModeBox.getSelectedItem() != mode) {
+            plotModeBox.setSelectedItem(mode);
+        }
+        this.pcs.firePropertyChange("plotMode", null, mode);
+    }
+        
+    private class ScanDialog extends JDialog {
+        private final ImprovedComponents.FormattedTextField interval = new ImprovedComponents.FormattedTextField(NumberFormat.getNumberInstance());
+        private final ImprovedComponents.FormattedTextField range = new ImprovedComponents.FormattedTextField(NumberFormat.getNumberInstance());
+        private final JButton startButton = new JButton("Start");
+
+        public ScanDialog() {
+            super(SwingUtilities.getWindowAncestor(SharpnessInspectorPanel.this));
+            this.setLayout(new MigLayout());
+            this.setLocationRelativeTo(SharpnessInspectorPanel.this);
+            this.setTitle("Scan Parameters");
+
+            
+            this.interval.setColumns(5);
+            this.interval.setValue(0.1);
+            this.range.setColumns(5);
+            this.range.setValue(5);
+            
+            this.startButton.addActionListener((evt) -> {
+                SharpnessInspectorController.RequestScanEvent event = new SharpnessInspectorController.RequestScanEvent(this, ((Number) interval.getValue()).doubleValue(), ((Number) range.getValue()).doubleValue());
+                for (SharpnessInspectorController.RequestScanListener listener : SharpnessInspectorPanel.this.scanRequestedListeners) {
+                    listener.actionPerformed(event);
+                }
+                this.setVisible(false);
+            });
+
+            this.add(new JLabel("Interval (um):"));
+            this.add(interval, "wrap");
+            this.add(new JLabel("Range (um):"));
+            this.add(range, "wrap");
+            this.add(startButton, "spanx, align center");
+            this.pack();
+        }
+    }
+    
+    public void setEvaluationMethod(ImgSharpnessAnalysis.Method method) {
+        evaluationMode.setSelectedItem(method);
+    }
+}

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
@@ -57,7 +57,7 @@ public class SharpnessInspectorPanel extends JPanel {
     private final JFreeChart zChart = ChartFactory.createXYLineChart(
             null, //title
             "Z", // xlabel
-            "Gradient", // ylabel
+            "Sharpness (A.U.)", // ylabel
             new XYSeriesCollection(new XYSeries(SERIES_NAME, true, false)),
             PlotOrientation.VERTICAL,
             false, // legend
@@ -68,7 +68,7 @@ public class SharpnessInspectorPanel extends JPanel {
     private final JFreeChart tChart = ChartFactory.createXYLineChart(
                 null, //title
             "Time", // xlabel
-            "Gradient", // ylabel
+            "Sharpness (A.U.)", // ylabel
             new XYSeriesCollection(new XYSeries(SERIES_NAME, true, false)),
             PlotOrientation.VERTICAL,
             false, // legend


### PR DESCRIPTION
This PR adds an inspector plugin called "Image Sharpness" which provides a real-time plot of image sharpness within an ROI. The x axis can be set to `Time` or to `Z` in which case the current Z position of the default Z stage is used. This only works well if the ZStage provides consistent updates of it's position.

In addition to real-time analysis of the image you can use the `Scan` button to sweep through a range of Z positions and plot the sharpness as a function of Z.

The methods of evaluating sharpness are the same as those used by the OughtaFocus Plugin. In order to facilitate this, the sharpness analysis code previously found in `org.micromanager.autofocus.internal.oughtafocus` is now in the libraries folder and ends up in `org.micromanager.imageprocessing`.

Known issue: The axis labels and tick marks of the plot are black and cannot be seen in the `Night` color scheme.