### PR TITLE
Linux build of PVCAM adapter

### DIFF
--- a/DeviceAdapters/Makefile.am
+++ b/DeviceAdapters/Makefile.am
@@ -39,7 +39,7 @@ if BUILD_OPENCV
    FAKECAMERA = FakeCamera
 endif
 if BUILD_PVCAM
-   PVCAM = PVCAM PrincetonInstruments
+   PVCAM = PVCAM
 endif
 if BUILD_QCAM
    QCAM = QCam

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -536,7 +536,6 @@ m4_define([device_adapter_dirs], [m4_strip([
    Piezosystem_NV40_3
    Piezosystem_dDrive
    PrecisExcite
-   PrincetonInstruments
    Prior
    PriorLegacy
    QCam

--- a/DeviceAdapters/configure.ac
+++ b/DeviceAdapters/configure.ac
@@ -101,23 +101,27 @@ AS_IF([test "x$want_modbus" != xno],
 AM_CONDITIONAL([BUILD_MODBUS], [test "x$use_modbus" = xyes])
 
 
-# Only build PVCAM if header files present.
-AC_MSG_CHECKING(for Pvcam)
-for dir in /usr/include/pvcam /Library/Frameworks/PVCAM.framework/Headers
-do
-   if test -f "$dir/pvcam.h"; then
-      PVCAMINCDIR="$dir"
-      break
-   fi
-done
-AM_CONDITIONAL([BUILD_PVCAM], [test -n "$PVCAMINCDIR"])
+# Only build PVCAM if SDK present.
+AC_MSG_CHECKING(for PVCAM)
+case $host in
+   *linux*) pvcam_arch="$host_cpu" ;;
+   *)       pvcam_arch="" ;;
+esac
+build_pvcam=no
+test "${PVCAM_SDK_PATH:+set}" = set && { test -n "$pvcam_arch" && build_pvcam=yes; }
+AM_CONDITIONAL([BUILD_PVCAM], [test "x$build_pvcam" = xyes])
 AM_COND_IF([BUILD_PVCAM],
 [
    AC_MSG_RESULT([found])
+   PVCAM_INC_DIR="$PVCAM_SDK_PATH/include"
+   PVCAM_LIB_DIR="$PVCAM_SDK_PATH/library/$pvcam_arch"
+   AC_SUBST(PVCAM_INC_DIR)
+   AC_SUBST(PVCAM_LIB_DIR)
 ],
 [
    AC_MSG_RESULT([not found])
 ])
+
 
 # Same for QCam
 AC_MSG_CHECKING(for QCam)
@@ -415,6 +419,7 @@ case $host in
       PVCAMFRAMEWORKS="-lpvcam"
       ;;
 esac
+# PVCAMFRAMEWORKS left on place only for PrincetonInstruments adapter that relies on very old PVCAM version
 AC_SUBST(PVCAMFRAMEWORKS)
 AC_SUBST(SPOTFRAMEWORKS)
 AC_SUBST(SERIALFRAMEWORKS)


### PR DESCRIPTION
This PR changes how is the PVCAM "framework" used by device adapters.

The PVCAM adapter now builds on Linux only if Photometrics PVCAM SDK is installed and `PVCAM_SDK_PATH` env. variable is properly set. The autotools configuration script prepares two new variables (`PVCAM_INC_DIR` and `PVCAM_LIB_DIR`) for PVCAM adapter Makefile. The adapter changes yet to be merged from SVN (rev. 17445).

The PrincetonInstruments adapter is removed from Linux/Mac build because it requires 10+ years old PVCAM that is incompatible with recent Photometrics PVCAM and I didn't find the SDK. The `PVCAMFRAMEWORKS` variable is now used by this adapter only and could be removed completely together with `PrincetonInstruments/Makefile.am` file.