### PR TITLE
Fix pymmcore error messages

### DIFF
--- a/MMCorePy_wrap/MMCorePy.i
+++ b/MMCorePy_wrap/MMCorePy.i
@@ -246,13 +246,13 @@ PyObject *setSLMImage_pywrap(const char* slmLabel, char *pixels, int receivedLen
         case MMERR_InvalidStageDevice:
         case MMERR_InvalidStateDevice:
         case MMERR_InvalidXYStageDevice:
+        case MMERR_NoConfigGroup:
+        case MMERR_NoConfiguration:
         case MMERR_PropertyNotInCache:
         case MMERR_SetPropertyFailed:
         case MMERR_UnexpectedDevice:
         case MMERR_UnknownModule:
             SWIG_exception(SWIG_ValueError, e.what());
-        case MMERR_NoConfigGroup:
-        case MMERR_NoConfiguration:
         case MMERR_NullPointerException:
             SWIG_exception(SWIG_NullReferenceError, e.what());
         case MMERR_FileOpenFailed:

--- a/MMCorePy_wrap/MMCorePy.i
+++ b/MMCorePy_wrap/MMCorePy.i
@@ -221,6 +221,8 @@ PyObject *setSLMImage_pywrap(const char* slmLabel, char *pixels, int receivedLen
 %}
 
 // Map Error codes to the appropriate python error type, and populate error message.
+// NOTE: direct use of the %exception directive will not work in most cases because
+// of the way SWIG parses a C++ method with a `throws` specification (used frequently in MM)
 %typemap(throws) CMMError %{
     CMMError e = $1;
     switch (e.getCode())


### PR DESCRIPTION
This fixes https://github.com/micro-manager/pymmcore/issues/15, wherein the message from `CMMCore` exceptions are not making it to the python exception (the code [here](https://github.com/micro-manager/micro-manager/blob/e6203c39e7ac9fd5f94a760cccc2c042115fedb3/MMCorePy_wrap/MMCorePy.i#L223-L255) is supposed to do this, but it doesn't work).  I also made it so that various error codes map to the corresponding python error type (instead of always being a `RuntimeError`).

One issue I ran into here is the use exception specifications in function signatures (with the `throw` keyword, like `bool CMMCore::deviceBusy(const char* label) throw (CMMError)` ... turns out swig [handles this specially](http://www.swig.org/Doc1.3/Typemaps.html#throws_typemap), and the [standard `%exception` directive](http://www.swig.org/Doc4.0/SWIGDocumentation.html#Customization_exception) will not work here.

cc @nicost @marktsuchida 