### PR TITLE
Fix Issue with MMPositionListDlg - PositionListDlg distinction

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
@@ -40,8 +40,6 @@ import org.micromanager.Studio;
 import org.micromanager.events.ChannelExposureEvent;
 import org.micromanager.internal.hcwizard.MMConfigFileException;
 import org.micromanager.internal.hcwizard.MicroscopeModel;
-import org.micromanager.internal.positionlist.MMPositionListDlg;
-import org.micromanager.internal.positionlist.PositionListDlg;
 import org.micromanager.internal.utils.DefaultAutofocusManager;
 import org.micromanager.internal.utils.ReportingUtils;
 

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultPositionListManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultPositionListManager.java
@@ -23,8 +23,9 @@ public final class DefaultPositionListManager implements PositionListManager {
     * It will open a position list dialog if it was not already open.
     * @param pl PosiionLIst to be made the current one
     */
+   @Override
    public void setPositionList(PositionList pl) { // use serialization to clone the PositionList object
-      posList_ = pl; // PositionList.newInstance(pl);
+      posList_ = pl;
       studio_.events().post(new DefaultNewPositionListEvent(posList_));
    }
 
@@ -33,6 +34,7 @@ public final class DefaultPositionListManager implements PositionListManager {
     * Acquisition Protocol
     * @return copy of the current PositionList
     */
+   @Override
    public PositionList getPositionList()  {
       return PositionList.newInstance(posList_);
    }
@@ -41,6 +43,7 @@ public final class DefaultPositionListManager implements PositionListManager {
     * Adds the current position to the list (same as pressing the "Mark" button
     * in the XYPositionList with no position selected)
     */
+   @Override
    public void markCurrentPosition() {
       MMStudio mm = (MMStudio) studio_;
       mm.uiManager().markCurrentPosition();

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/MMPositionListDlg.java
@@ -20,6 +20,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import org.micromanager.PositionList;
 import org.micromanager.Studio;
+import org.micromanager.events.NewPositionListEvent;
 import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 
 /**
@@ -58,11 +59,19 @@ public final class MMPositionListDlg extends PositionListDlg {
             axisCol0Width);
    }
     
-    @Subscribe
+   @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
       if (!event.isCanceled()) {
          saveDims();
          dispose();
       }
    }   
+   
+   @Subscribe
+   public void onNewPositionList(NewPositionListEvent nple) {
+       PositionList pl = nple.getPositionList();
+       if (this.getPositionList() != pl) { // Without this check we will enter an infinite loop.
+            this.setPositionList(nple.getPositionList());
+       }
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -154,7 +154,7 @@ public class PositionListDlg extends JFrame implements MouseListener, ChangeList
          }
       };
       posTable_.setFont(arialSmallFont_);
-      positionModel_ = new PositionTableModel(studio_);
+      positionModel_ = new PositionTableModel();
       positionModel_.setData(posList);
       posTable_.setModel(positionModel_);
       scrollPane.setViewportView(posTable_);

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -747,11 +747,6 @@ public class PositionListDlg extends JFrame implements MouseListener, ChangeList
       });
    }
 
-   @Subscribe
-   public void onNewPositionList(NewPositionListEvent nple) {
-      positionModel_.setData(nple.getPositionList());
-      positionModel_.fireTableDataChanged();
-   }
 
    /**
     * Update display of the current stage position.

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -510,7 +510,7 @@ public class PositionListDlg extends JFrame implements MouseListener, ChangeList
    }
 
    protected void updatePositionData() {
-      // positionModel_.fireTableDataChanged();
+      positionModel_.fireTableDataChanged();
       updateMarkButtonText();
    }
    

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionTableModel.java
@@ -24,8 +24,6 @@ import javax.swing.table.AbstractTableModel;
 import org.micromanager.MultiStagePosition;
 import org.micromanager.PositionList;
 import org.micromanager.StagePosition;
-import org.micromanager.Studio;
-import org.micromanager.events.internal.DefaultNewPositionListEvent;
 
 class PositionTableModel extends AbstractTableModel {
    private static final long serialVersionUID = 1L;
@@ -33,13 +31,8 @@ class PositionTableModel extends AbstractTableModel {
          "Label",
          "Position [um]"
    };
-   private Studio studio_;
    private PositionList posList_;
    private MultiStagePosition curMsp_;
-
-   public PositionTableModel(Studio studio) {
-      studio_ = studio;
-   }
 
    public void setData(PositionList pl) {
       posList_ = pl;


### PR DESCRIPTION
This PR:
 - Fixes an issue where an update to the position list of the singleton `MMPositionListDlg` would result in updating the position list of all instances of `PositionListDlg`
 - Fixes an issue where updates to the position list of an instance of `PositionListDlg` would not be reflected in the UI until the user pressed the `Refresh` button.
 - Removes some unused references to Studio and some unused imports.