### PR TITLE
Studio: Now restores properties that were stored with property list

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/PositionList.java
+++ b/mmstudio/src/main/java/org/micromanager/PositionList.java
@@ -259,7 +259,15 @@ public class PositionList implements Iterable<MultiStagePosition> {
          return;
       }
       for (PropertyMap mspMap : map.getPropertyMapList(PropertyKey.STAGE_POSITIONS.key())) {
-         positions_.add(MultiStagePosition.fromPropertyMap(mspMap));
+         MultiStagePosition msp = MultiStagePosition.fromPropertyMap(mspMap);
+         if (mspMap.containsKey(PropertyKey.MULTI_STAGE_POSITION__PROPERTIES.key())) {
+            PropertyMap propertyMap = mspMap.getPropertyMap(PropertyKey.MULTI_STAGE_POSITION__PROPERTIES.key(), null);
+            for (String key: propertyMap.keySet()) {
+               String val = propertyMap.getString(key, "");
+               msp.setProperty(key, val);
+            }
+         }
+         positions_.add(msp);
       }
       notifyChangeListeners();
    }


### PR DESCRIPTION
Tested with the following script:

```
import org.micromanager.PositionList;

fileLocation = "C://tmp//poslist";

PositionList posList = mm.positions().getPositionList();

for(pos : posList){
	pos.setProperty("test", pos.getLabel());
}
posList.save (fileLocation);

posList2 = new PositionList();
posList2.load(fileLocation);

for(pos : posList2){
	String[] names = pos.getPropertyNames();
	for (String name : names){
		mm.scripter().message(name+": "+pos.getProperty(name));
	}
}
```

Closes #1160