### PR TITLE
Builder cleanup

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionManager.java
@@ -35,6 +35,19 @@ import org.micromanager.data.SummaryMetadata;
  * or Studio.getAcquisitionManager().
  */
 public interface AcquisitionManager {
+
+   /**
+    * Provides an empty Sequence Settings Builder
+    *
+    */
+   SequenceSettings.Builder getSequenceSettingsBuilder();
+
+   /**
+    * Provides and empty ChannelSpec Builder
+    *
+    */
+   ChannelSpec.Builder getChannelSpecBuilder();
+
    /**
     * Executes Acquisition with settings as in the MDA dialog.
     * Will open the Acquisition Dialog if it is not open yet.
@@ -45,7 +58,7 @@ public interface AcquisitionManager {
     * @return The Datastore containing the images from the acquisition.
     * @throws IllegalThreadStateException if the acquisition is started on the EDT
     */
-   public Datastore runAcquisition() throws IllegalThreadStateException;
+   Datastore runAcquisition() throws IllegalThreadStateException;
 
    /**
     * As runAcquisition, but will return as soon as the acquisition is set up
@@ -54,7 +67,7 @@ public interface AcquisitionManager {
     * @return The Datastore containing the images from the acquisition.
     * @throws IllegalThreadStateException if the acquisition is started on the EDT
     */
-   public Datastore runAcquisitionNonblocking() throws IllegalThreadStateException;
+   Datastore runAcquisitionNonblocking() throws IllegalThreadStateException;
 
    /**
     * Execute an acquisition using the provided SequenceSettings. This function
@@ -68,13 +81,13 @@ public interface AcquisitionManager {
     * @throws IllegalThreadStateException if the acquisition is started on the
     * EDT.
     */
-   public Datastore runAcquisitionWithSettings(SequenceSettings settings,
+   Datastore runAcquisitionWithSettings(SequenceSettings settings,
          boolean shouldBlock) throws IllegalThreadStateException;
 
    /**
     * Halt any ongoing acquisition as soon as possible.
     */
-   public void haltAcquisition();
+   void haltAcquisition();
 
    /**
     * Executes Acquisition with current settings but allows for changing the data path.
@@ -88,7 +101,7 @@ public interface AcquisitionManager {
     * @throws IllegalThreadStateException if the acquisition is started on the
     * EDT.
     */
-   public Datastore runAcquisition(String name, String root) throws IllegalThreadStateException;
+   Datastore runAcquisition(String name, String root) throws IllegalThreadStateException;
 
    /**
     * Load a file containing a SequenceSettings object, and apply the settings
@@ -97,7 +110,7 @@ public interface AcquisitionManager {
     * @param path File path to the SequenceSettings object.
     * @throws IOException if the sequence settings cannot be loaded.
     */
-   public void loadAcquisition(String path) throws IOException;
+   void loadAcquisition(String path) throws IOException;
 
    /**
     * Load a SequenceSettings file and return the SequenceSettings object. The
@@ -105,7 +118,7 @@ public interface AcquisitionManager {
     * @param path File path to the SequenceSettings object.
     * @throws IOException if there was an error reading the file.
     */
-   public SequenceSettings loadSequenceSettings(String path) throws IOException;
+   SequenceSettings loadSequenceSettings(String path) throws IOException;
 
    /**
     * Save the provided SequenceSettings object to disk at the specified path.
@@ -113,7 +126,7 @@ public interface AcquisitionManager {
     * @param path Path to save the SequenceSettings to.
     * @throws IOException if there was an error writing the file to disk.
     */
-   public void saveSequenceSettings(SequenceSettings settings, String path) throws IOException;
+   void saveSequenceSettings(SequenceSettings settings, String path) throws IOException;
 
    /**
     * Returns true when an acquisition is currently running (note: this
@@ -121,19 +134,19 @@ public interface AcquisitionManager {
     * Album" is currently running
     * @return true when an acquisition is currently running
     */
-   public boolean isAcquisitionRunning();
+   boolean isAcquisitionRunning();
 
    /**
     * Pause/Unpause a running acquisition
     * @param state true if paused, false if no longer paused
     */
-   public void setPause(boolean state);
+   void setPause(boolean state);
 
    /**
     * Returns true if the acquisition is currently paused.
     * @return true if paused, false if not paused
     */
-   public boolean isPaused();
+   boolean isPaused();
 
    /**
     * Attach a runnable to the acquisition engine. Each index (f, p, c, s) can
@@ -146,26 +159,26 @@ public interface AcquisitionManager {
     * @param slice 0-based (z) slice number
     * @param runnable code to be run
     */
-   public void attachRunnable(int frame, int position, int channel, int slice,
+   void attachRunnable(int frame, int position, int channel, int slice,
            Runnable runnable);
 
    /**
     * Remove runnables from the acquisition engine
     */
-   public void clearRunnables();
+   void clearRunnables();
 
    /**
     * Return current acquisition settings as shown in the Multi-D Acquisition
     * dialog.
     * @return acquisition settings instance
     */
-   public SequenceSettings getAcquisitionSettings();
+   SequenceSettings getAcquisitionSettings();
 
    /**
     * Apply new acquisition settings
     * @param settings acquisition settings
     */
-   public void setAcquisitionSettings(SequenceSettings settings);
+   void setAcquisitionSettings(SequenceSettings settings);
 
    /**
     * Snap images using the current camera(s) and return them. See also
@@ -176,7 +189,7 @@ public interface AcquisitionManager {
     * (for example, because Live mode is on), or if the current hardware
     * configuration contains no cameras.
     */
-   public List<Image> snap() throws Exception;
+   List<Image> snap() throws Exception;
 
    /**
     * Generate a new SummaryMetadata that contains pre-populated fields based
@@ -185,7 +198,7 @@ public interface AcquisitionManager {
     * computerName.
     * @return A pre-populated SummaryMetadata.
     */
-   public SummaryMetadata generateSummaryMetadata();
+   SummaryMetadata generateSummaryMetadata();
 
    /**
     * Generate a new Metadata that contains pre-populated fields based on the
@@ -210,7 +223,7 @@ public interface AcquisitionManager {
     * @throws Exception If there were any errors communicating with the Core to
     * get required values.
     */
-   public Metadata generateMetadata(Image image, boolean includeHardwareState) throws Exception;
+   Metadata generateMetadata(Image image, boolean includeHardwareState) throws Exception;
 
    /**
     * Test the provided Object, and return true if it corresponds to the
@@ -224,5 +237,5 @@ public interface AcquisitionManager {
     *         was started elsewhere (e.g. by a plugin or other third-party
     *         code).
     */
-   public boolean isOurAcquisition(Object source);
+   boolean isOurAcquisition(Object source);
 }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/ChannelSpec.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/ChannelSpec.java
@@ -31,10 +31,14 @@ import java.awt.Color;
  * MDA (multi-dimensional acquisition). It contains fields corresponding to
  * each of the columns in the Channels section of the MDA dialog. ChannelSpecs
  * are used by the SequenceSettings object to set up channels for acquisitions.
+ *
+ * Maintainer note: This should be an interface, but kept as a class for backward
+ * compatibility.
+ *
  */
 @SuppressWarnings("unused")
-public class ChannelSpec {
-   public static class Builder{
+public final class ChannelSpec {
+   public static final class Builder{
 
       /** Channel group this channel config belongs to **/
       private String channelGroup_ = "";

--- a/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
@@ -35,12 +35,16 @@ import java.util.ArrayList;
  * single acquisition. Various methods of the AcquisitionManager will consume
  * or generate SequenceSettings, and you can create your own to configure your
  * custom acquisitions.
+ *
+ * Maintainer note: This should be an interface, but kept as a class for backward
+ * compatibility.
+ *
  */
-public class SequenceSettings {
+public final class SequenceSettings {
    // version ID for the sequence settings
    public static final double Version = 1.3;
 
-   public static class Builder {
+   public static final class Builder {
       private int numFrames = 1;
       private double intervalMs = 0.0;
       private int displayTimeUnit = 0;  // default to ms to enable import of older settings
@@ -367,55 +371,19 @@ public class SequenceSettings {
     * Create a copy of this SequenceSettings. All parameters will be copied,
     * with new objects being created as necessary (i.e. this is a deep copy).
     * @return Copy of this SequenceSettings.
+    * @deprecated When used correctly, SequenceSettings are immutable.
+    * If you really need a copy, use copyBuilder().build();
     */
+   @Deprecated
    public SequenceSettings copy() {
-      return new SequenceSettings(this);
+      return copyBuilder().build();
    }
 
    /**
     * Default constructor needed since we have a copy constructor
     * @deprecated use Builder instead
     */
-   @Deprecated
-   public SequenceSettings() {
-   }
-
-   /**
-    * copy Constructor provides a deep copy
-    * @param input input that will b deep copied
-    */
-   private SequenceSettings(SequenceSettings input) {
-      cameraTimeout = input.cameraTimeout;
-      channelGroup = input.channelGroup;
-      channels = input.channels == null ? null : new ArrayList<>(input.channels);
-      comment = input.comment;
-      customIntervalsMs = input.customIntervalsMs == null ? null : new ArrayList<>(input.customIntervalsMs);
-      intervalMs = input.intervalMs;
-      displayTimeUnit = input.displayTimeUnit;
-      keepShutterOpenSlices = input.keepShutterOpenSlices;
-      keepShutterOpenChannels = input.keepShutterOpenChannels;
-      numFrames = input.numFrames;
-      prefix = input.prefix;
-      relativeZSlice = input.relativeZSlice;
-      root = input.root;
-      save = input.save;
-      saveMode = input.saveMode;
-      shouldDisplayImages = input.shouldDisplayImages;
-      skipAutofocusCount = input.skipAutofocusCount;
-      slices = input.slices == null ? null : new ArrayList<>(input.slices);
-      slicesFirst = input.slicesFirst;
-      timeFirst = input.timeFirst;
-      useAutofocus = input.useAutofocus;
-      useCustomIntervals = input.useCustomIntervals;
-      usePositionList = input.usePositionList;
-      zReference = input.zReference;
-      useSlices = input.useSlices;
-      useFrames = input.useFrames;
-      useChannels = input.useChannels;
-      sliceZStepUm = input.sliceZStepUm;
-      sliceZBottomUm = input.sliceZBottomUm;
-      sliceZTopUm = input.sliceZTopUm;
-      acqOrderMode = input.acqOrderMode;
+   private SequenceSettings() {
    }
 
    public SequenceSettings.Builder copyBuilder() {return new Builder(this);}

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -38,6 +38,7 @@ import org.micromanager.PropertyMap;
 import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 import org.micromanager.acquisition.AcquisitionManager;
+import org.micromanager.acquisition.ChannelSpec;
 import org.micromanager.acquisition.SequenceSettings;
 import org.micromanager.data.Coords;
 import org.micromanager.data.Datastore;
@@ -66,6 +67,16 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
       studio_ = studio;
       engine_ = engine;
       mdaDialog_ = mdaDialog;
+   }
+
+   @Override
+   public SequenceSettings.Builder getSequenceSettingsBuilder() {
+      return new SequenceSettings.Builder();
+   }
+
+   @Override
+   public ChannelSpec.Builder getChannelSpecBuilder() {
+      return new ChannelSpec.Builder();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -52,7 +52,7 @@ import org.micromanager.internal.dialogs.AcqControlDlg;
 import org.micromanager.internal.utils.MMException;
 
 /**
- * TODO: this class still depends on MMStudio for many things.
+ * TODO: this class still depends on MMStudio for access to its cache.
  */
 public final class DefaultAcquisitionManager implements AcquisitionManager {
    // NOTE: should match the format used by the acquisition engine.

--- a/mmstudio/src/main/java/org/micromanager/data/Coords.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Coords.java
@@ -42,38 +42,38 @@ import java.util.List;
  */
 public interface Coords {
    /** Axis label for the time point (frame) axis. */
-   public static final String TIME_POINT = "time";
+   String TIME_POINT = "time";
 
    /**
     * Same as {@code TIME_POINT} or {@code T}.
     * @deprecated Use discouraged because it reads like a physical time rather
     * than the time point index that it is.
     */
-   @Deprecated public static final String TIME = TIME_POINT;
+   @Deprecated String TIME = TIME_POINT;
 
    /** Axis label for the time point (frame) axis (short form).
     * Same as {@code TIME_POINT}. */
-   public static final String T = TIME_POINT;
+   String T = TIME_POINT;
 
    /** Axis label for the stage position axis. */
-   public static final String STAGE_POSITION = "position";
+   String STAGE_POSITION = "position";
 
    /** Axis label for the stage position axis (short form).
     * Same as {@code STAGE_POSTITION}. */
-   public static final String P = STAGE_POSITION;
+   String P = STAGE_POSITION;
 
    /** Axis label for the Z slice axis. */
-   public static final String Z_SLICE = "z";
+   String Z_SLICE = "z";
 
    /** Axis label for the Z slice axis (short form).
     * Same as {@code Z_SLICE}. */
-   public static final String Z = Z_SLICE;
+  String Z = Z_SLICE;
 
    /** Axis label for the channel axis. */
-   public static final String CHANNEL = "channel";
+   String CHANNEL = "channel";
 
    /** Axis label for the channel axis (short form). Same as {@code CHANNEL}. */
-   public static final String C = CHANNEL;
+   String C = CHANNEL;
 
    interface Builder extends CoordsBuilder {
       @Override Coords build();
@@ -209,7 +209,7 @@ public interface Coords {
     * @return index along {@code axis}, or {@code -1} if {@code axis} does not
     * exist
     */
-   public int getIndex(String axis);
+   int getIndex(String axis);
 
    /**
     * Get the channel index.
@@ -219,14 +219,14 @@ public interface Coords {
     * @return channel index, or {@code -1} if this {@code Coords} doesn't
     * contain a channel index.
     */
-   public int getChannel();
+   int getChannel();
 
    /** 
     * Shorthand for {@link #getChannel() getChannel}.
     * @return channel index, or {@code -1} if this {@code Coords} doesn't
     * contain a channel index.
     */
-   public int getC();
+   int getC();
 
    /**
     * Get the time point (frame) index.
@@ -236,7 +236,7 @@ public interface Coords {
     * @return time point index, or {@code -1} if this {@code Coords} doesn't
     * contain a time point index.
     */
-   public int getTimePoint();
+   int getTimePoint();
 
    /** 
     * Same as {@link #getTimePoint() getTimePoint}.
@@ -244,7 +244,7 @@ public interface Coords {
     * @deprecated Due to looking like the physical time rather than an index. Use {@link #getTimePoint() getTmePoint}
     */
    @Deprecated
-   public int getTime();
+   int getTime();
 
    /** 
     * Shorthand for {@link #getTimePoint() getTimePoint}.
@@ -252,7 +252,7 @@ public interface Coords {
     * @return time point index, or {@code -1} if this {@code Coords} doesn't
     * contain a time point index.
     */
-   public int getT();
+   int getT();
 
    /**
     * Get the Z slice index.
@@ -262,14 +262,14 @@ public interface Coords {
     * @return Z slice index, or {@code -1} if this {@code Coords} doesn't
     * contain a Z slice index.
     */
-   public int getZSlice();
+   int getZSlice();
 
    /** Shorthand for {@link #getZSlice() getZSlice}
     * 
     * @return Z slice index, or {@code -1} if this {@code Coords} doesn't
     * contain a Z slice index.
     */
-   public int getZ();
+   int getZ();
 
    /**
     * Get the stage position index.
@@ -279,37 +279,37 @@ public interface Coords {
     * @return stage position index, or {@code -1} if this {@code Coords}
     * doesn't contain a stage position index.
     */
-   public int getStagePosition();
+   int getStagePosition();
 
    /** Shorthand for {@link #getStagePosition() getStagePosition}.
     * 
     * @return stage position index, or {@code -1} if this {@code Coords}
     * doesn't contain a stage position index.
     */
-   public int getP();
+   int getP();
 
    /**
     * Return all axes that this {@code Coords} has an index for.
     *
     * @return List of all axis
     */
-   public List<String> getAxes();
+   List<String> getAxes();
 
    /**
     * Returns whether this coords has the given axis.
     * @param axis the axis to test for presence
     * @return true if this coords includes {@code axis}
     */
-   public boolean hasAxis(String axis);
+   boolean hasAxis(String axis);
 
-   public boolean hasTimePointAxis();
-   public boolean hasT();
-   public boolean hasStagePositionAxis();
-   public boolean hasP();
-   public boolean hasZSliceAxis();
-   public boolean hasZ();
-   public boolean hasChannelAxis();
-   public boolean hasC();
+   boolean hasTimePointAxis();
+   boolean hasT();
+   boolean hasStagePositionAxis();
+   boolean hasP();
+   boolean hasZSliceAxis();
+   boolean hasZ();
+   boolean hasChannelAxis();
+   boolean hasC();
 
    /**
     * Return true if this instance contains equal indices for every axis in the
@@ -317,8 +317,10 @@ public interface Coords {
     *
     * @param other the instance to compare with
     * @return whether this instance is a superspace coords of {@code other}
+    * @deprecated use equality after removing specific axes instead
     */
-   public boolean isSuperspaceCoordsOf(Coords other);
+   @Deprecated
+   boolean isSuperspaceCoordsOf(Coords other);
 
    /**
     * Return true if the given instance contains equal indices for every axis
@@ -326,35 +328,37 @@ public interface Coords {
     *
     * @param other the instance to compare with
     * @return whether this instance is a subspace coords of {@code other}
+    * @deprecated use equality after removing specific axes instead
     */
-   public boolean isSubspaceCoordsOf(Coords other);
+   @Deprecated
+   boolean isSubspaceCoordsOf(Coords other);
 
    /**
     * @param alt the instance to compare with
     * @return whether this instance is a superspace coords of {@code other}
-    * @deprecated Use the equivalent {@link #isSubspaceCoordsOf(Coords) isSubspaceCoordsOf} instead.
+    * @deprecated Use equality (after removing specific axes) instead
     */
    @Deprecated
-   public boolean matches(Coords alt);
+    boolean matches(Coords alt);
 
    /**
     * Provides a Builder pre-loaded with a copy of this Coords
     * @return copyBuilder
     */
-   public Builder copyBuilder();
+   Builder copyBuilder();
 
    /**
     * @return Builder
     * @deprecated Use {@link #copyBuilder() copyBuilder} instead
     */
    @Deprecated
-   public CoordsBuilder copy();
+   CoordsBuilder copy();
 
 
    /**
     * Removes the axes provided as varargs from this Coord
     * @param axes One or more Strings naming the axes to be removed
-    * @return COpy of this Coords without the listed axes
+    * @return Copy of this Coords without the listed axes
     */
    Coords copyRemovingAxes(String... axes);
 

--- a/mmstudio/src/main/java/org/micromanager/data/DataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/DataManager.java
@@ -38,11 +38,9 @@ public interface DataManager {
    /**
     * Generate a "blank" CoordsBuilder for use in constructing new Coords
     * instances.
-    * @deprecated - Use Coordinates.builder() instead.
     * 
     * @return a CoordsBuilder used to construct new Coords instances.
     */
-   @Deprecated
    Coords.Builder getCoordsBuilder();
 
    /**
@@ -63,6 +61,7 @@ public interface DataManager {
     * @return Coords generated based on the definition string.
     * @throws IllegalArgumentException if the definition string is
     *         malformatted.
+    * @deprecated use of Strings for Coords is discouraged
     */
    @Deprecated
    Coords createCoords(String def) throws IllegalArgumentException;
@@ -347,6 +346,7 @@ public interface DataManager {
     * @return new PropertyMap based on data in the specified file.
     * @throws FileNotFoundException if the path does not point to a file.
     * @throws IOException if there was an error reading the file.
+    * @deprecated
     */
    @Deprecated
    PropertyMap loadPropertyMap(String path) throws FileNotFoundException, IOException;

--- a/mmstudio/src/main/java/org/micromanager/data/NewPipelineEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/data/NewPipelineEvent.java
@@ -25,4 +25,4 @@ package org.micromanager.data;
  * has changed, giving entities that use that pipeline an opportunity to make
  * a new copy of it (by invoking DataManager.copyApplicationPipeline()).
  */
-public class NewPipelineEvent {}
+public interface NewPipelineEvent {}

--- a/mmstudio/src/main/java/org/micromanager/data/Processor.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Processor.java
@@ -24,7 +24,7 @@ package org.micromanager.data;
  * Processors manipulate images before they are added to a Datastore. They
  * are arranged into a sequence by a Pipeline.
  */
-public abstract class Processor {
+public interface Processor {
    /**
     * Update the SummaryMetadata of the Datastore that images will ultimately
     * be stored in. This method will be called at most once, prior to any
@@ -36,7 +36,7 @@ public abstract class Processor {
     *        Processor.
     * @return New SummaryMetadata, modified from the source by the Processor.
     */
-   public SummaryMetadata processSummaryMetadata(SummaryMetadata source) {
+   default SummaryMetadata processSummaryMetadata(SummaryMetadata source) {
       return source;
    }
 
@@ -50,7 +50,7 @@ public abstract class Processor {
     * @param image input Image
     * @param context ProcessorContext to be used to hand the processed image to
     */
-   public abstract void processImage(Image image, ProcessorContext context);
+   void processImage(Image image, ProcessorContext context);
 
    /**
     * Clean up when processing is finished. At this time no more images are
@@ -60,5 +60,5 @@ public abstract class Processor {
     * datastores) then they should be cleaned up at this time.
     * @param context ProcessorContext that can be used to hand images to
     */
-   public void cleanup(ProcessorContext context) {};
+   default void cleanup(ProcessorContext context) {}
 }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultCoords.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultCoords.java
@@ -30,10 +30,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.micromanager.PropertyMap;
 import org.micromanager.PropertyMaps;
 import org.micromanager.data.Coords;
-import static org.micromanager.data.Coords.CHANNEL;
-import static org.micromanager.data.Coords.STAGE_POSITION;
-import static org.micromanager.data.Coords.TIME_POINT;
-import static org.micromanager.data.Coords.Z_SLICE;
 
 
 public final class DefaultCoords implements Coords {
@@ -45,13 +41,13 @@ public final class DefaultCoords implements Coords {
       private final List<Integer> indices_;
 
       public Builder() {
-         axes_ = new ArrayList<String>(5);
-         indices_ = new ArrayList<Integer>(5);
+         axes_ = new ArrayList<>(5);
+         indices_ = new ArrayList<>(5);
       }
 
       private Builder(List<String> axes, List<Integer> indices) {
-         axes_ = new ArrayList<String>(axes);
-         indices_ = new ArrayList<Integer>(indices);
+         axes_ = new ArrayList<>(axes);
+         indices_ = new ArrayList<>(indices);
       }
 
       @Override
@@ -146,7 +142,7 @@ public final class DefaultCoords implements Coords {
 
    @Override
    public List<String> getAxes() {
-      return new ArrayList<String>(axes_);
+      return new ArrayList<>(axes_);
    }
 
    @Override
@@ -164,6 +160,7 @@ public final class DefaultCoords implements Coords {
    @Override public boolean hasC() { return hasChannelAxis(); }
 
    @Override
+   @Deprecated
    public boolean isSuperspaceCoordsOf(Coords other) {
       for (String axis : axes_) {
          // If other doesn't have axis, -1 != this.getIndex(axis)
@@ -175,6 +172,7 @@ public final class DefaultCoords implements Coords {
    }
 
    @Override
+   @Deprecated
    public boolean isSubspaceCoordsOf(Coords other) {
       return other.isSuperspaceCoordsOf(this);
    }
@@ -243,7 +241,7 @@ public final class DefaultCoords implements Coords {
       // Axis order is not considered for equality
       List<String> axes = getAxes();
       Collections.sort(axes);
-      List<Integer> indices = new ArrayList<Integer>(axes.size());
+      List<Integer> indices = new ArrayList<>(axes.size());
       for (String axis : axes) {
          indices.add(getIndex(axis));
       }
@@ -287,6 +285,7 @@ public final class DefaultCoords implements Coords {
    /**
     * Generate a normalized string representation of this Coords, that we can
     * later parse out using {@link #fromNormalizedString}.
+    * @deprecated
     */
    @Deprecated
    public String toNormalizedString() {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -415,7 +415,7 @@ public final class DefaultDataManager implements DataManager {
 
    @Override
    public void notifyPipelineChanged() {
-      studio_.events().post(new NewPipelineEvent());
+      studio_.events().post(new DefaultNewPipelineEvent());
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultNewPipelineEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultNewPipelineEvent.java
@@ -1,0 +1,6 @@
+package org.micromanager.data.internal;
+
+import org.micromanager.data.NewPipelineEvent;
+
+public class DefaultNewPipelineEvent implements NewPipelineEvent {
+}

--- a/mmstudio/src/main/java/org/micromanager/events/ChannelExposureEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/ChannelExposureEvent.java
@@ -24,53 +24,35 @@ package org.micromanager.events;
  * This class signals when the exposure time for one of the channels of the
  * current channel group has been changed.
  */
-public class ChannelExposureEvent {
-   private final double newExposureTime_;
-   private final String channelGroup_;
-   private final String channel_;
-   private final boolean isMainExposureTime_;
+public interface ChannelExposureEvent {
 
-   public ChannelExposureEvent(double newExposureTime, String channelGroup,
-         String channel, boolean isMainExposureTime) {
-      newExposureTime_ = newExposureTime;
-      channelGroup_ = channelGroup;
-      channel_ = channel;
-      isMainExposureTime_ = isMainExposureTime;
-   }
-
-   /**
+    /**
     * Return the new exposure time for the channel.
     */
-   public double getNewExposureTime() {
-      return newExposureTime_;
-   }
+    double getNewExposureTime();
 
    /**
     * Return the name of the channel group in which the modified channel
     * is located.
     */
-   public String getChannelGroup() {
-      return channelGroup_;
-   }
+   String getChannelGroup();
 
    /**
     * Return the channel whose exposure time has changed.
     */
-   public String getChannel() {
-      return channel_;
-   }
+    String getChannel();
 
    /**
     * Returns true if this channel is the currently-active channel (i.e. the
     * one used for snaps and live mode, the one whose exposure time is
     * displayed in the main window).
     */
-   public boolean isMainExposureTime() {
-      return isMainExposureTime_;
-   }
+    boolean isMainExposureTime();
 
+   /**
+    *
+    * @deprecated use {@link #isMainExposureTime()} instead
+    */
    @Deprecated
-   public boolean getIsMainExposureTime() {
-      return isMainExposureTime();
-   }
+    boolean getIsMainExposureTime();
 }

--- a/mmstudio/src/main/java/org/micromanager/events/ConfigGroupChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/ConfigGroupChangedEvent.java
@@ -23,18 +23,9 @@ package org.micromanager.events;
 /**
  * This class signifies when a new value is added to a config group.
  */
-public class ConfigGroupChangedEvent {
-   private final String groupName_;
-   private final String newConfig_;
+public interface ConfigGroupChangedEvent {
 
-   public ConfigGroupChangedEvent(String groupName, String newConfig) {
-      groupName_ = groupName;
-      newConfig_ = newConfig;
-   }
-   public String getNewConfig() {
-      return newConfig_;
-   }
-   public String getGroupName() {
-      return groupName_;
-   }
+   String getNewConfig();
+   String getGroupName();
+
 }

--- a/mmstudio/src/main/java/org/micromanager/events/ExposureChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/ExposureChangedEvent.java
@@ -23,18 +23,8 @@ package org.micromanager.events;
 /**
  * This class signals when the exposure time for a given camera has changed.
  */
-public class ExposureChangedEvent {
-   private final String cameraName_;
-   private final double newExposureTime_;
+public interface ExposureChangedEvent {
 
-   public ExposureChangedEvent(String cameraName, double newExposureTime) {
-      cameraName_ = cameraName;
-      newExposureTime_ = newExposureTime;
-   }
-   public String getCameraName() {
-      return cameraName_;
-   }
-   public double getNewExposureTime() {
-      return newExposureTime_;
-   }
+   String getCameraName();
+   double getNewExposureTime();
 }

--- a/mmstudio/src/main/java/org/micromanager/events/GUIRefreshEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/GUIRefreshEvent.java
@@ -25,4 +25,4 @@ package org.micromanager.events;
  * (e.g. when a "Refresh" button is clicked or when the refreshGUI() method
  * is called in CompatibilityInterface).
  */
-public class GUIRefreshEvent {}
+public interface GUIRefreshEvent {}

--- a/mmstudio/src/main/java/org/micromanager/events/PixelSizeAffineChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/PixelSizeAffineChangedEvent.java
@@ -22,14 +22,8 @@ package org.micromanager.events;
 
 import java.awt.geom.AffineTransform;
 
-public class PixelSizeAffineChangedEvent {
-   private final AffineTransform affine_;
-   
-   public PixelSizeAffineChangedEvent(AffineTransform affine) {
-      affine_ = affine;
-   }
-   
-   public AffineTransform getNewPixelSizeAffine() {
-      return affine_;
-   }
+public interface PixelSizeAffineChangedEvent {
+
+   AffineTransform getNewPixelSizeAffine();
+
 }

--- a/mmstudio/src/main/java/org/micromanager/events/PixelSizeChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/PixelSizeChangedEvent.java
@@ -20,12 +20,8 @@
 
 package org.micromanager.events;
 
-public class PixelSizeChangedEvent {
-   private final double newPixelSizeUm_;
-   public PixelSizeChangedEvent(double newPixelSizeUm) {
-      newPixelSizeUm_ = newPixelSizeUm;
-   }
-   public double getNewPixelSizeUm() {
-      return newPixelSizeUm_;
-   }
+public interface PixelSizeChangedEvent {
+
+   double getNewPixelSizeUm();
+
 }

--- a/mmstudio/src/main/java/org/micromanager/events/PropertiesChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/PropertiesChangedEvent.java
@@ -23,5 +23,5 @@ package org.micromanager.events;
 /**
  * This class signals when any property of the microscope has changed. 
  */
-public class PropertiesChangedEvent {
+public interface PropertiesChangedEvent {
 }

--- a/mmstudio/src/main/java/org/micromanager/events/PropertyChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/PropertyChangedEvent.java
@@ -23,23 +23,25 @@ package org.micromanager.events;
 /**
  * This class provides information when a specific property changes.
  */
-public class PropertyChangedEvent {
-   private final String device_;
-   private final String property_;
-   private final String value_;
-   public PropertyChangedEvent(String device, String property, String value) {
-      device_ = device;
-      property_ = property;
-      value_ = value;
-   }
-   public String getValue() {
-      return value_;
-   }
-   public String getProperty() {
-      return property_;
-   }
-   public String getDevice() {
-      return device_;
-   }
+public interface PropertyChangedEvent {
+
+   /**
+    * Device to which the changed property belongs
+    * @return Device to which the changed property belongs
+    */
+   String getDevice();
+
+   /**
+    *
+    * @return new value of the property
+    */
+   String getValue();
+
+   /**
+    *
+    * @return Property name (key)
+    */
+   String getProperty();
+
 }
 

--- a/mmstudio/src/main/java/org/micromanager/events/SLMExposureChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/SLMExposureChangedEvent.java
@@ -21,20 +21,19 @@
 package org.micromanager.events;
 
 /**
- * This class signals when the exposure time for a given camera has changed.
+ * This interface signals when the exposure time for a given camera has changed.
  */
-public class SLMExposureChangedEvent {
-   private final String deviceName_;
-   private final double newExposureTime_;
+public interface SLMExposureChangedEvent {
 
-   public SLMExposureChangedEvent(String deviceName, double newExposureTime) {
-      deviceName_ = deviceName;
-      newExposureTime_ = newExposureTime;
-   }
-   public String getDeviceName() {
-      return deviceName_;
-   }
-   public double getNewExposureTime() {
-      return newExposureTime_;
-   }
+   /**
+    * Name of the (SLM) device for which exposure changed
+    * @return Name of the (SLM) device for which exposure changed
+    */
+   String getDeviceName();
+
+   /**
+    *
+    * @return new exposure time of thr (SLM) device
+    */
+   double getNewExposureTime();
 }

--- a/mmstudio/src/main/java/org/micromanager/events/ShutdownCommencingEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/ShutdownCommencingEvent.java
@@ -30,25 +30,24 @@ package org.micromanager.events;
  * calling {@link #isCanceled()}. If the shutdown has been canceled, the
  * event must be ignored.
  */
-public class ShutdownCommencingEvent {
-   private boolean isCanceled_ = false;
-
+public interface ShutdownCommencingEvent {
    /**
     * Cancel shutdown.
     */
-   public void cancelShutdown() {
-      isCanceled_ = true;
-   }
+   void cancelShutdown();
 
    /**
     * Return whether or not shutdown has been canceled.
+    * @return true when shutdown was canceled
     */
-   public boolean isCanceled() {
-      return isCanceled_;
-   }
+   boolean isCanceled();
 
+
+   /**
+    *
+    * @return true when shutdown was canceled
+    * @deprecated use {@link #isCanceled()} instead
+    */
    @Deprecated
-   public boolean getIsCancelled() {
-      return isCanceled();
-   }
+   boolean getIsCancelled();
 }

--- a/mmstudio/src/main/java/org/micromanager/events/StagePositionChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/StagePositionChangedEvent.java
@@ -23,26 +23,19 @@ package org.micromanager.events;
 /**
  * This class signals when a single-axis drive has moved. 
  */
-public class StagePositionChangedEvent {
-   private final String deviceName_;
-   private final double pos_;
+public interface StagePositionChangedEvent {
 
-   public StagePositionChangedEvent(String deviceName, double pos) {
-      deviceName_ = deviceName;
-      pos_ = pos;
-   }
+
    /**
-    * The new (current) position of the stage
-    * @return 
+    * T
+    * @return he new (current) position of the stage
     */
-   public double getPos() {
-      return pos_;
-   }
+   double getPos();
+
    /**
     * Name of the stage that moved
-    * @return 
+    * @return Name of the stage that moved
     */
-   public String getDeviceName() {
-      return deviceName_;
-   }
+   String getDeviceName();
+
 }

--- a/mmstudio/src/main/java/org/micromanager/events/StartupCompleteEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/StartupCompleteEvent.java
@@ -23,5 +23,5 @@ package org.micromanager.events;
 /**
  * This event signifies that the system is done starting up.
  */
-public class StartupCompleteEvent {
+public interface StartupCompleteEvent {
 }

--- a/mmstudio/src/main/java/org/micromanager/events/SystemConfigurationLoadedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/SystemConfigurationLoadedEvent.java
@@ -21,7 +21,7 @@
 package org.micromanager.events;
 
 /**
- * This class signals when a configuration file is loaded. 
+ * This interface signals when a configuration file is loaded.
  */
-public class SystemConfigurationLoadedEvent {
+public interface SystemConfigurationLoadedEvent {
 }

--- a/mmstudio/src/main/java/org/micromanager/events/XYStagePositionChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/XYStagePositionChangedEvent.java
@@ -23,24 +23,25 @@ package org.micromanager.events;
 /**
  * This class signals when any XY stage is moved.
  */
-public class XYStagePositionChangedEvent {
-   private final String deviceName_;
-   private final double xPos_;
-   private final double yPos_;
+public interface XYStagePositionChangedEvent {
 
-   public XYStagePositionChangedEvent(String deviceName, 
-         double xPos, double yPos) {
-      deviceName_ = deviceName;
-      xPos_ = xPos;
-      yPos_ = yPos;
-   }
-   public double getXPos() {
-      return xPos_;
-   }
-   public double getYPos() {
-      return yPos_;
-   }
-   public String getDeviceName() {
-      return deviceName_;
-   }
+
+   /**
+    * Name of the (XYStage) device that change position
+    * @return Name of the (XYStage) device that changed position
+    */
+   String getDeviceName();
+
+   /**
+    *
+    * @return New X position of the stage in microns
+    */
+   double getXPos();
+
+   /**
+    *
+    * @return New Y position of the stage in microns
+    */
+   double getYPos();
+
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
@@ -21,23 +21,13 @@
 
 package org.micromanager.events.internal;
 
-import java.awt.geom.AffineTransform;
-import javax.swing.SwingUtilities;
 import mmcorej.CMMCore;
 import mmcorej.MMEventCallback;
 import org.micromanager.Studio;
 import org.micromanager.acquisition.internal.AcquisitionWrapperEngine;
-import org.micromanager.events.ChannelGroupChangedEvent;
-import org.micromanager.events.ConfigGroupChangedEvent;
-import org.micromanager.events.ExposureChangedEvent;
-import org.micromanager.events.PixelSizeAffineChangedEvent;
-import org.micromanager.events.PixelSizeChangedEvent;
-import org.micromanager.events.PropertiesChangedEvent;
-import org.micromanager.events.PropertyChangedEvent;
-import org.micromanager.events.SLMExposureChangedEvent;
-import org.micromanager.events.StagePositionChangedEvent;
-import org.micromanager.events.SystemConfigurationLoadedEvent;
-import org.micromanager.events.XYStagePositionChangedEvent;
+
+import javax.swing.SwingUtilities;
+import java.awt.geom.AffineTransform;
 
 /**
  * Callback to update Java layer when a change happens in the MMCore. This
@@ -72,7 +62,7 @@ public final class CoreEventCallback extends MMEventCallback {
          core_.updateSystemStateCache();
          // see OnPropertyChanged for reasons to run this on the EDT
          SwingUtilities.invokeLater(() ->  studio_.events().post(
-                    new PropertiesChangedEvent()));
+                    new DefaultPropertiesChangedEvent()));
       }
    }
 
@@ -88,7 +78,7 @@ public final class CoreEventCallback extends MMEventCallback {
       // in further callbacks, always run this through invokeLater,
       // (see https://github.com/micro-manager/micro-manager/issues/498)
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new PropertyChangedEvent(deviceName, propName, propValue)));
+              new DefaultPropertyChangedEvent(deviceName, propName, propValue)));
    }
 
    @Override
@@ -101,21 +91,21 @@ public final class CoreEventCallback extends MMEventCallback {
    public void onConfigGroupChanged(String groupName, String newConfig) {
       // see OnPropertyChanged for reasons to run this on the EDT
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new ConfigGroupChangedEvent(groupName, newConfig)));
+              new DefaultConfigGroupChangedEvent(groupName, newConfig)));
    }
 
    @Override
    public void onSystemConfigurationLoaded() {
       // see OnPropertyChanged for reasons to run this on the EDT
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new SystemConfigurationLoadedEvent()));
+              new DefaultSystemConfigurationLoadedEvent()));
    }
 
    @Override
    public void onPixelSizeChanged(double newPixelSizeUm) {
       // see OnPropertyChanged for reasons to run this on the EDT
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new PixelSizeChangedEvent(newPixelSizeUm)));
+              new DefaultPixelSizeChangedEvent(newPixelSizeUm)));
    }
    
    @Override
@@ -125,35 +115,35 @@ public final class CoreEventCallback extends MMEventCallback {
       AffineTransform newPixelSizeAffine = new AffineTransform(flatMatrix);
       // see OnPropertyChanged for reasons to run this on the EDT
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new PixelSizeAffineChangedEvent(newPixelSizeAffine)));
+              new DefaultPixelSizeAffineChangedEvent(newPixelSizeAffine)));
    }
 
    @Override
    public void onStagePositionChanged(String deviceName, double pos) {
       // see OnPropertyChanged for reasons to run this on the EDT
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new StagePositionChangedEvent(deviceName, pos)));
+              new DefaultStagePositionChangedEvent(deviceName, pos)));
    }
 
    @Override
    public void onXYStagePositionChanged(String deviceName, double xPos, double yPos) {
       // see OnPropertyChanged for reasons to run this on the EDT
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new XYStagePositionChangedEvent(deviceName, xPos, yPos)));
+              new DefaultXYStagePositionChangedEvent(deviceName, xPos, yPos)));
    }
 
    @Override
    public void onExposureChanged(String deviceName, double exposure) {
       // see OnPropertyChanged for reasons to run this on the EDT
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new ExposureChangedEvent(deviceName, exposure)));
+              new DefaultExposureChangedEvent(deviceName, exposure)));
    }
 
    @Override
    public void onSLMExposureChanged(String deviceName, double exposure) {
       // see OnPropertyChanged for reasons to run this on the EDT
       SwingUtilities.invokeLater(() -> studio_.events().post(
-              new SLMExposureChangedEvent(deviceName, exposure)));
+              new DefaultSLMExposureChangedEvent(deviceName, exposure)));
    }
 
    public void setIgnoring(boolean isIgnoring) {

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultChannelExposureEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultChannelExposureEvent.java
@@ -1,0 +1,52 @@
+package org.micromanager.events.internal;
+
+public class DefaultChannelExposureEvent {
+   private final double newExposureTime_;
+   private final String channelGroup_;
+   private final String channel_;
+   private final boolean isMainExposureTime_;
+
+   public DefaultChannelExposureEvent(double newExposureTime, String channelGroup,
+                               String channel, boolean isMainExposureTime) {
+      newExposureTime_ = newExposureTime;
+      channelGroup_ = channelGroup;
+      channel_ = channel;
+      isMainExposureTime_ = isMainExposureTime;
+   }
+
+   /**
+    * Return the new exposure time for the channel.
+    */
+   public double getNewExposureTime() {
+      return newExposureTime_;
+   }
+
+   /**
+    * Return the name of the channel group in which the modified channel
+    * is located.
+    */
+   public String getChannelGroup() {
+      return channelGroup_;
+   }
+
+   /**
+    * Return the channel whose exposure time has changed.
+    */
+   public String getChannel() {
+      return channel_;
+   }
+
+   /**
+    * Returns true if this channel is the currently-active channel (i.e. the
+    * one used for snaps and live mode, the one whose exposure time is
+    * displayed in the main window).
+    */
+   public boolean isMainExposureTime() {
+      return isMainExposureTime_;
+   }
+
+   @Deprecated
+   public boolean getIsMainExposureTime() {
+      return isMainExposureTime();
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultConfigGroupChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultConfigGroupChangedEvent.java
@@ -1,0 +1,20 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.ConfigGroupChangedEvent;
+
+public class DefaultConfigGroupChangedEvent implements ConfigGroupChangedEvent {
+      private final String groupName_;
+      private final String newConfig_;
+
+      public DefaultConfigGroupChangedEvent(String groupName, String newConfig) {
+         groupName_ = groupName;
+         newConfig_ = newConfig;
+      }
+      public String getNewConfig() {
+         return newConfig_;
+      }
+      public String getGroupName() {
+         return groupName_;
+      }
+}
+

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultExposureChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultExposureChangedEvent.java
@@ -1,0 +1,19 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.ExposureChangedEvent;
+
+public class DefaultExposureChangedEvent implements ExposureChangedEvent {
+      private final String cameraName_;
+      private final double newExposureTime_;
+
+      public DefaultExposureChangedEvent(String cameraName, double newExposureTime) {
+         cameraName_ = cameraName;
+         newExposureTime_ = newExposureTime;
+      }
+      public String getCameraName() {
+         return cameraName_;
+      }
+      public double getNewExposureTime() {
+         return newExposureTime_;
+      }
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultGUIRefreshEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultGUIRefreshEvent.java
@@ -1,0 +1,6 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.GUIRefreshEvent;
+
+public class DefaultGUIRefreshEvent implements GUIRefreshEvent {
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPixelSizeAffineChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPixelSizeAffineChangedEvent.java
@@ -1,0 +1,16 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.PixelSizeAffineChangedEvent;
+import java.awt.geom.AffineTransform;
+
+public class DefaultPixelSizeAffineChangedEvent implements PixelSizeAffineChangedEvent {
+   private final AffineTransform affine_;
+
+   public DefaultPixelSizeAffineChangedEvent(AffineTransform affine) {
+      affine_ = affine;
+   }
+
+   public AffineTransform getNewPixelSizeAffine() {
+      return affine_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPixelSizeChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPixelSizeChangedEvent.java
@@ -1,0 +1,13 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.PixelSizeChangedEvent;
+
+public class DefaultPixelSizeChangedEvent implements PixelSizeChangedEvent {
+   private final double newPixelSizeUm_;
+   public DefaultPixelSizeChangedEvent (double newPixelSizeUm) {
+      newPixelSizeUm_ = newPixelSizeUm;
+   }
+   public double getNewPixelSizeUm() {
+      return newPixelSizeUm_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPropertiesChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPropertiesChangedEvent.java
@@ -1,0 +1,6 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.PropertiesChangedEvent;
+
+public class DefaultPropertiesChangedEvent implements PropertiesChangedEvent {
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPropertyChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPropertyChangedEvent.java
@@ -1,0 +1,25 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.PropertyChangedEvent;
+
+public class DefaultPropertyChangedEvent implements PropertyChangedEvent {
+
+   private final String device_;
+   private final String property_;
+   private final String value_;
+
+   public DefaultPropertyChangedEvent(String device, String property, String value) {
+      device_ = device;
+      property_ = property;
+      value_ = value;
+   }
+   public String getValue() {
+      return value_;
+   }
+   public String getProperty() {
+      return property_;
+   }
+   public String getDevice() {
+      return device_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultSLMExposureChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultSLMExposureChangedEvent.java
@@ -1,0 +1,20 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.SLMExposureChangedEvent;
+
+
+public class DefaultSLMExposureChangedEvent implements SLMExposureChangedEvent {
+   private final String deviceName_;
+   private final double newExposureTime_;
+
+   public DefaultSLMExposureChangedEvent (String deviceName, double newExposureTime) {
+      deviceName_ = deviceName;
+      newExposureTime_ = newExposureTime;
+   }
+   public String getDeviceName() {
+      return deviceName_;
+   }
+   public double getNewExposureTime() {
+      return newExposureTime_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultShutdownCommencingEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultShutdownCommencingEvent.java
@@ -1,0 +1,26 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.ShutdownCommencingEvent;
+
+public class DefaultShutdownCommencingEvent implements ShutdownCommencingEvent {
+   private boolean isCanceled_ = false;
+
+   /**
+    * Cancel shutdown.
+    */
+   public void cancelShutdown() {
+      isCanceled_ = true;
+   }
+
+   /**
+    * Return whether or not shutdown has been canceled.
+    */
+   public boolean isCanceled() {
+      return isCanceled_;
+   }
+
+   @Deprecated
+   public boolean getIsCancelled() {
+      return isCanceled();
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultStagePositionChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultStagePositionChangedEvent.java
@@ -1,0 +1,32 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.StagePositionChangedEvent;
+
+public class DefaultStagePositionChangedEvent implements StagePositionChangedEvent {
+   private final String deviceName_;
+   private final double pos_;
+
+   public DefaultStagePositionChangedEvent(String deviceName, double pos) {
+      deviceName_ = deviceName;
+      pos_ = pos;
+   }
+
+   /**
+    * The new (current) position of the stage
+    * @return The new (current) position of the stage
+    */
+
+   public double getPos() {
+         return pos_;
+      }
+
+
+   /**
+    * Name of the stage that moved
+    * @return Name of the stage that moved
+    */
+   public String getDeviceName() {
+         return deviceName_;
+      }
+
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultStartupCompleteEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultStartupCompleteEvent.java
@@ -1,0 +1,6 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.StartupCompleteEvent;
+
+public class DefaultStartupCompleteEvent implements StartupCompleteEvent {
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultSystemConfigurationLoadedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultSystemConfigurationLoadedEvent.java
@@ -1,0 +1,7 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.SystemConfigurationLoadedEvent;
+
+public class DefaultSystemConfigurationLoadedEvent  implements
+        SystemConfigurationLoadedEvent {
+}

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultXYStagePositionChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultXYStagePositionChangedEvent.java
@@ -1,0 +1,25 @@
+package org.micromanager.events.internal;
+
+import org.micromanager.events.XYStagePositionChangedEvent;
+
+public class DefaultXYStagePositionChangedEvent implements XYStagePositionChangedEvent {
+   private final String deviceName_;
+   private final double xPos_;
+   private final double yPos_;
+
+   public DefaultXYStagePositionChangedEvent(String deviceName,
+                                      double xPos, double yPos) {
+      deviceName_ = deviceName;
+      xPos_ = xPos;
+      yPos_ = yPos;
+   }
+   public double getXPos() {
+      return xPos_;
+   }
+   public double getYPos() {
+      return yPos_;
+   }
+   public String getDeviceName() {
+      return deviceName_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
@@ -38,6 +38,7 @@ import org.micromanager.Application;
 import org.micromanager.ApplicationSkin;
 import org.micromanager.Studio;
 import org.micromanager.events.ChannelExposureEvent;
+import org.micromanager.events.internal.DefaultChannelExposureEvent;
 import org.micromanager.internal.hcwizard.MMConfigFileException;
 import org.micromanager.internal.hcwizard.MicroscopeModel;
 import org.micromanager.internal.utils.DefaultAutofocusManager;
@@ -116,7 +117,7 @@ public class DefaultApplication implements Application {
       double exposure;
       try {
          exposure = studio_.core().getExposure();
-         studio_.events().post(new ChannelExposureEvent(exposure,
+         studio_.events().post(new DefaultChannelExposureEvent(exposure,
                   channelGroup, channel, true));
       }
       catch (Exception e) {
@@ -156,9 +157,9 @@ public class DefaultApplication implements Application {
     * Acquires its info from the preferences
     * Same thing is used in MDA window, but this class keeps its own copy
     * 
-    * @param channelGroup
-    * @param channel - 
-    * @param defaultExp - default value
+    * @param channelGroup Core-channelgroup
+    * @param channel - specific channel of interest
+    * @param defaultExp - default exposure
     * @return exposure time
     */
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -23,18 +23,6 @@ import ij.IJ;
 import ij.ImageJ;
 import ij.WindowManager;
 import ij.gui.Toolbar;
-import java.awt.Point;
-import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URISyntaxException;
-import java.net.UnknownHostException;
-import java.util.*;
-import java.util.function.Function;
-import javax.swing.JOptionPane;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 import mmcorej.CMMCore;
 import mmcorej.MMCoreJ;
 import org.micromanager.Album;
@@ -64,10 +52,11 @@ import org.micromanager.events.EventManager;
 import org.micromanager.events.ExposureChangedEvent;
 import org.micromanager.events.PropertiesChangedEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
-import org.micromanager.events.StartupCompleteEvent;
-import org.micromanager.events.SystemConfigurationLoadedEvent;
 import org.micromanager.events.internal.CoreEventCallback;
 import org.micromanager.events.internal.DefaultEventManager;
+import org.micromanager.events.internal.DefaultShutdownCommencingEvent;
+import org.micromanager.events.internal.DefaultStartupCompleteEvent;
+import org.micromanager.events.internal.DefaultSystemConfigurationLoadedEvent;
 import org.micromanager.events.internal.InternalShutdownCommencingEvent;
 import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
 import org.micromanager.internal.diagnostics.EDTHangLogger;
@@ -83,9 +72,9 @@ import org.micromanager.internal.pluginmanagement.DefaultPluginManager;
 import org.micromanager.internal.script.ScriptPanel;
 import org.micromanager.internal.utils.DaytimeNighttime;
 import org.micromanager.internal.utils.DefaultAutofocusManager;
-import org.micromanager.internal.utils.HotKeys;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.GUIUtils;
+import org.micromanager.internal.utils.HotKeys;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.internal.utils.UIMonitor;
 import org.micromanager.internal.utils.WaitDialog;
@@ -94,6 +83,23 @@ import org.micromanager.profile.internal.UserProfileAdmin;
 import org.micromanager.profile.internal.gui.HardwareConfigurationManager;
 import org.micromanager.quickaccess.QuickAccessManager;
 import org.micromanager.quickaccess.internal.DefaultQuickAccessManager;
+
+import javax.swing.JOptionPane;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import java.awt.Point;
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
 
 
 /*
@@ -405,11 +411,11 @@ public final class MMStudio implements Studio {
       
       // Tell the GUI to reflect the hardware configuration. (The config was
       // loaded before creating the GUI, so we need to reissue the event.)
-      events().post(new SystemConfigurationLoadedEvent());
+      events().post(new DefaultSystemConfigurationLoadedEvent());
       executeStartupScript();
       ui_.updateGUI(true);
       
-      events().post(new StartupCompleteEvent()); // Give plugins a chance to initialize their state
+      events().post(new DefaultStartupCompleteEvent()); // Give plugins a chance to initialize their state
       
       if (settings().getShouldRunZMQServer()) { // start zmq server if so desired
          runZMQServer();
@@ -679,7 +685,7 @@ public final class MMStudio implements Studio {
          // Shutdown cancelled by user.
          return false;
       }
-      ShutdownCommencingEvent externalEvent = new ShutdownCommencingEvent();
+      ShutdownCommencingEvent externalEvent = new DefaultShutdownCommencingEvent();
       events().post(externalEvent);
       if (externalEvent.isCanceled()) {
          // Shutdown cancelled by user.

--- a/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
@@ -28,6 +28,7 @@ import javax.swing.ToolTipManager;
 import mmcorej.MMCoreJ;
 import org.micromanager.PositionList;
 import org.micromanager.events.GUIRefreshEvent;
+import org.micromanager.events.internal.DefaultGUIRefreshEvent;
 import org.micromanager.internal.dialogs.AcqControlDlg;
 import org.micromanager.internal.dialogs.CalibrationListDlg;
 import org.micromanager.internal.menus.MMMenuBar;
@@ -256,7 +257,7 @@ public class MMUIManager {
          ReportingUtils.logError(e);
       }
       frame_.setConfigText(studio_.getSysConfigFile());
-      studio_.events().post(new GUIRefreshEvent());
+      studio_.events().post(new DefaultGUIRefreshEvent());
    }
    
    public void configureBinningCombo() throws Exception {

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
@@ -6,7 +6,7 @@ import javax.swing.JOptionPane;
 import com.google.common.util.concurrent.AtomicDouble;
 import mmcorej.MMCoreJ;
 import org.micromanager.Studio;
-import org.micromanager.events.XYStagePositionChangedEvent;
+import org.micromanager.events.internal.DefaultXYStagePositionChangedEvent;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 
@@ -257,7 +257,7 @@ public class XYNavigator {
 					double[] ys = new double[1];
 					studio_.core().getXYPosition(xyStage_, xs, ys);
 					studio_.events().post(
-							new XYStagePositionChangedEvent(xyStage_, xs[0], ys[0]));
+							new DefaultXYStagePositionChangedEvent(xyStage_, xs[0], ys[0]));
 				}
 			} catch (Exception ex) {
 				ReportingUtils.logError(ex.getMessage());

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/ZNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/ZNavigator.java
@@ -3,7 +3,7 @@ package org.micromanager.internal.navigation;
 
 import com.google.common.util.concurrent.AtomicDouble;
 import org.micromanager.Studio;
-import org.micromanager.events.StagePositionChangedEvent;
+import org.micromanager.events.internal.DefaultStagePositionChangedEvent;
 import org.micromanager.internal.utils.ReportingUtils;
 
 import java.util.HashMap;
@@ -69,7 +69,7 @@ public class ZNavigator {
                studio_.core().waitForDevice(stage_);
                double z = studio_.core().getPosition(stage_);
                studio_.events().post(
-                       new StagePositionChangedEvent(stage_, z));
+                       new DefaultStagePositionChangedEvent(stage_, z));
             }
          } catch (Exception ex) {
             ReportingUtils.showError(ex);

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
@@ -22,6 +22,7 @@ import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
 import org.micromanager.data.NewPipelineEvent;
 import org.micromanager.data.ProcessorFactory;
+import org.micromanager.data.internal.DefaultNewPipelineEvent;
 import org.micromanager.internal.MMStudio;
 
 // TODO: currently we redraw the entire table any time it changes, rather than
@@ -77,7 +78,7 @@ public final class PipelineTableModel extends AbstractTableModel {
    @Override
    public void fireTableDataChanged() {
       super.fireTableDataChanged();
-      MMStudio.getInstance().events().post(new NewPipelineEvent());
+      MMStudio.getInstance().events().post(new DefaultNewPipelineEvent());
    }
 
    /**

--- a/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombiner.java
+++ b/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombiner.java
@@ -17,7 +17,7 @@ import org.micromanager.data.Processor;
 import org.micromanager.data.ProcessorContext;
 import org.micromanager.data.SummaryMetadata;
 
-public class FrameCombiner extends Processor {
+public class FrameCombiner implements Processor {
 
    private final Studio studio_;
    private final LogManager log_;

--- a/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperProcessor.java
+++ b/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperProcessor.java
@@ -33,7 +33,7 @@ import org.micromanager.PropertyMaps;
 import org.micromanager.Studio;
 
 
-public class FlipperProcessor extends Processor {
+public class FlipperProcessor implements Processor {
 
    // Valid rotation values.
    public static final int R0 = 0;

--- a/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ShadingProcessor.java
+++ b/plugins/MultiChannelShading/src/main/java/org/micromanager/multichannelshading/ShadingProcessor.java
@@ -60,7 +60,7 @@ import org.micromanager.data.internal.DefaultImage;
  *
  * @author nico, modified for MM2.0 by Chris Weisiger
  */
-public class ShadingProcessor extends Processor {
+public class ShadingProcessor implements Processor {
 
    private final Studio studio_;
    private final String channelGroup_;

--- a/plugins/PipelineSaver/src/main/java/org/micromanager/pipelinesaver/SaverProcessor.java
+++ b/plugins/PipelineSaver/src/main/java/org/micromanager/pipelinesaver/SaverProcessor.java
@@ -31,7 +31,7 @@ import org.micromanager.data.Processor;
 import org.micromanager.data.ProcessorContext;
 import org.micromanager.Studio;
 
-public class SaverProcessor extends Processor {
+public class SaverProcessor implements Processor {
    private Studio studio_;
    private Datastore store_;
    private final String format_;

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingProcessor.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingProcessor.java
@@ -55,7 +55,7 @@ import org.micromanager.internal.utils.NumberUtils;
  *
  * @author nico, heavily updated by Chris Weisiger
  */
-public class RatioImagingProcessor extends Processor {
+public class RatioImagingProcessor implements Processor {
 
    private final Studio studio_;
    private final PropertyMap settings_;

--- a/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewProcessor.java
+++ b/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewProcessor.java
@@ -42,7 +42,7 @@ import org.micromanager.Studio;
  *
  * @author nico, heavily updated by Chris Weisiger
  */
-public class SplitViewProcessor extends Processor {
+public class SplitViewProcessor implements Processor {
 
    private final Studio studio_;
    private String orientation_ = SplitViewFrame.LR;


### PR DESCRIPTION
Closes #1021 with the exception of issue #1012 mentioned in there.

Note this causes binary incompatibility with existing plugins (that expect classes rather than interfaces.  Recompiling those plugins (no code change needed) fixes that.  Alternative (deprecating and renaming these events) would be ugly.  