### PR TITLE
change default branch of mmCoreAndDevice submodule to privateMain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mmCoreAndDevices"]
 	path = mmCoreAndDevices
 	url=https://github.com/micro-manager/mmCoreAndDevices.git
-	branch = main
+	branch = privateMain


### PR DESCRIPTION
This branch will be set via github action to always stay up to date with the `master` branch. This branch is used to easily check out all code, including private repositories.

After checking out this branch all submodules should be available:

To make sure they are all initialized: `git submodule update --init --recursive`
To make sure all submodules are updated to their most recent commit on their default branch: `git submodule update --remote --recursive`