### PR TITLE
Prevent forked repositories from trying to run github actions.

### DIFF
--- a/.github/workflows/updatePrivateMain.yml
+++ b/.github/workflows/updatePrivateMain.yml
@@ -1,12 +1,13 @@
 name: Update privateMain
 
-on:
+on:  # this defines which events trigger a run of this job. In this case a push to the master branch.
   push:
     branches:
       - master
 
 jobs:
   update-privateMain:
+    if: github.repository == 'micro-manager/micro-manager'  # Only run this job if we are on the main repo.
     name: Merge master into privateMain after a new commit
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a check for the repository name so that the action will only run on the main repository.