### PR TITLE
Make all Builders uniform

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/Application.java
+++ b/mmstudio/src/main/java/org/micromanager/Application.java
@@ -41,7 +41,7 @@ public interface Application {
     * poll each device in the system for its current state, which may take
     * significant time. Compare refreshGUIFromCache().
     */
-   public void refreshGUI();
+   void refreshGUI();
 
    /**
     * Updates the GUI so that its state reflects the current state of the
@@ -49,14 +49,14 @@ public interface Application {
     * pull values from the Core's System State Cache, which is fast but may not
     * necessarily reflect the actual state of hardware.
     */
-   public void refreshGUIFromCache();
+   void refreshGUIFromCache();
 
    /**
     * Set the exposure time for the current channel (if any). Equivalent to
     * updating the exposure time field in the main window.
     * @param exposureMs Exposure time, in milliseconds.
     */
-   public void setExposure(double exposureMs);
+   void setExposure(double exposureMs);
 
    /**
     * Updates the exposure time associated with the given preset. If the
@@ -68,7 +68,7 @@ public interface Application {
     *        channel that should be updated.
     * @param exposure New exposure time to set.
     */
-   public void setChannelExposureTime(String channelGroup, String channel,
+   void setChannelExposureTime(String channelGroup, String channel,
            double exposure);
 
    /**
@@ -80,7 +80,7 @@ public interface Application {
     * @param defaultExp Default value to return if no exposure time is found.
     * @return Exposure time for the channel, or the provided default value.
     */
-   public double getChannelExposureTime(String channelGroup, String channel,
+   double getChannelExposureTime(String channelGroup, String channel,
            double defaultExp);
 
    /**
@@ -93,18 +93,18 @@ public interface Application {
     * @throws IOException If shouldOverwrite is false and there is already a
     *         file at the chosen path.
     */
-   public void saveConfigPresets(String path, boolean allowOverwrite) throws IOException;
+   void saveConfigPresets(String path, boolean allowOverwrite) throws IOException;
 
    /**
     * Pop up the dialog used to configure the autofocus settings for the
     * current autofocus device.
     */
-   public void showAutofocusDialog();
+   void showAutofocusDialog();
 
    /**
     * Display the position list dialog.
     */
-   public void showPositionList();
+   void showPositionList();
 
    /**
     * Set the default camera's ROI -- a convenience function. Will stop and
@@ -113,12 +113,12 @@ public interface Application {
     * @param rect Rectangle defining the ROI
     * @throws Exception if there is an error in the Core when setting the ROI
     */
-   public void setROI(Rectangle rect) throws Exception;
+   void setROI(Rectangle rect) throws Exception;
 
    /**
     * Move the main Micro-Manager window to the top of the user interface.
     */
-   public void makeActive();
+   void makeActive();
 
    /**
     * Provide access to the main window of the program. This is largely
@@ -126,19 +126,19 @@ public interface Application {
     * to the main window.
     * @return the main Window
     */
-   public JFrame getMainWindow();
+   JFrame getMainWindow();
 
    /**
     * Provides access to the application skin API for determining colors for
     * various GUI components.
     * @return ApplicationSkin instance.
     */
-   public ApplicationSkin skin();
+   ApplicationSkin skin();
 
    /**
     * Provides access to the application skin API for determining colors for
     * various GUI components. Identical to skin() except in name.
     * @return ApplicationSkin instance.
     */
-   public ApplicationSkin getApplicationSkin();
+   ApplicationSkin getApplicationSkin();
 }

--- a/mmstudio/src/main/java/org/micromanager/ApplicationSkin.java
+++ b/mmstudio/src/main/java/org/micromanager/ApplicationSkin.java
@@ -41,7 +41,7 @@ public interface ApplicationSkin {
    /**
     * Available skins used by the application.
     */
-   public enum SkinMode {
+   enum SkinMode {
       DAY("Day"), 
       NIGHT("Night");
       private final String desc_;
@@ -80,43 +80,43 @@ public interface ApplicationSkin {
     * application-wide event bus.
     * @param mode The mode to use.
     */
-   public void setSkin(SkinMode mode);
+   void setSkin(SkinMode mode);
 
    /**
     * @return the current Micro-Manager skin.
     */
-   public SkinMode getSkin();
+   SkinMode getSkin();
 
    /**
     * Return the current background color for normal GUI elements.
     * @return current background color
     */
-   public Color getBackgroundColor();
+   Color getBackgroundColor();
 
    /**
     * Return the current "lighter" background color for highlighted or
     * otherwise differentiated GUI elements.
     * @return light background color
     */
-   public Color getLightBackgroundColor();
+   Color getLightBackgroundColor();
 
    /**
     * Return the current "disabled" background color.
     * @return "disabled" background color
     */
-   public Color getDisabledBackgroundColor();
+   Color getDisabledBackgroundColor();
 
    /**
     * Return the current color for enabled text.
     * @return current color for enabled text
     */
-   public Color getEnabledTextColor();
+   Color getEnabledTextColor();
 
    /**
     * Return the current color for disabled text.
     * @return current color for disabled text.
     */
-   public Color getDisabledTextColor();
+   Color getDisabledTextColor();
    
    /**
     * If the specified mode is not currently active, then we switch to that
@@ -124,10 +124,10 @@ public interface ApplicationSkin {
     * with a nonstandard look-and-feel.
     * @param mode SkinMode to switch to (but without updating the UI)
     */
-   public void suspendToMode(SkinMode mode);
+   void suspendToMode(SkinMode mode);
    
    /**
     * Restores the mode that was active before suspendToMode was called.
     */
-   public void resume();
+   void resume();
 }

--- a/mmstudio/src/main/java/org/micromanager/PropertyManager.java
+++ b/mmstudio/src/main/java/org/micromanager/PropertyManager.java
@@ -1,0 +1,47 @@
+package org.micromanager;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Provides access to PropertyMaps.  And instance of this interface is obtained
+ * through Studio.properties() and Studio.propertyManager();
+ */
+public interface PropertyManager {
+
+   /**
+    * Provides an easy way for a script to obtain a PropertyMap Builder
+    * @return PropertyMap Builder
+    */
+   PropertyMap.Builder propertyMapBuilder();
+
+   /**
+    * Returns an empty property map.
+    * @return empty property map
+    */
+   PropertyMap emptyPropertyMap();
+
+   /**
+    * Creates a property map from its JSON-serialized form.
+    * JSON format is described in {@link org.micromanager.internal.propertymap.PropertyMapJSONSerializer}
+    * @param json json formatted String to be converted into a PropertyMap
+    * @return PropertyMap result from conversion
+    * @throws IOException if {@code json} is invalid JSON or if it does not
+    * represent a valid property map
+    */
+   PropertyMap fromJSON(String json) throws IOException;
+
+   /**
+    * Create a property map from its JSON-serialized form stored in a file.
+    *
+    * JSON format is described in {@link org.micromanager.internal.propertymap.PropertyMapJSONSerializer}
+    * @param file File containing JSON serialized Properties.
+    * @return PropertyMap resulting from conversion fo JSON in file.
+    * @throws IOException if there was a problem reading {@code file} or if the
+    * file contained invalid JSON or if the JSON did not represent a valid
+    * property map
+    * @throws java.io.FileNotFoundException this subclass of {@code IOException}
+    * is thrown if {@code file} does not exist
+    */
+   PropertyMap loadJSON(File file) throws IOException;
+}

--- a/mmstudio/src/main/java/org/micromanager/PropertyMap.java
+++ b/mmstudio/src/main/java/org/micromanager/PropertyMap.java
@@ -83,7 +83,7 @@ public interface PropertyMap {
     * This is only used for interchange purposes, for example when performing
     * bulk operations on property maps.
     */
-   public interface OpaqueValue {
+   interface OpaqueValue {
       /**
        * 
        * @return 

--- a/mmstudio/src/main/java/org/micromanager/PropertyMaps.java
+++ b/mmstudio/src/main/java/org/micromanager/PropertyMaps.java
@@ -48,8 +48,8 @@ public final class PropertyMaps {
 
    /**
     * Create a property map from its JSON-serialized form.
-    * @param json
-    * @return
+    * @param json json formatted String to be converted into a PropertyMap
+    * @return PropertyMap result from conversion
     * @throws IOException if {@code json} is invalid JSON or if it does not
     * represent a valid property map
     */

--- a/mmstudio/src/main/java/org/micromanager/Studio.java
+++ b/mmstudio/src/main/java/org/micromanager/Studio.java
@@ -43,7 +43,7 @@ public interface Studio {
     * implicit, temporary image storage datastore.
     * @return An implementation of the Album API.
     */
-   public Album album();
+   Album album();
 
    /**
     * Provides access to and control of the contents of the Album, the
@@ -51,42 +51,42 @@ public interface Studio {
     * in name.
     * @return An implementation of the Album API.
     */
-   public Album getAlbum();
+   Album getAlbum();
 
    /**
     * Provides access to the compatibility layer that exposes some old 1.4
     * API methods.
     * @return An implementation of the compatibility API.
     */
-   public CompatibilityInterface compat();
+   CompatibilityInterface compat();
 
    /**
     * Provides access to the compatibility layer that exposes some old 1.4
     * API methods. Identical to compat() in all but name.
     * @return An implementation of the compatibility API.
     */
-   public CompatibilityInterface getCompatibilityInterface();
+   CompatibilityInterface getCompatibilityInterface();
 
    /**
     * Provides access to Micro-Manager's logging functions, like logError(),
     * showMessage(), etc.
     * @return Access to Micro-Manager's logging interface.
     */
-   public LogManager logs();
+   LogManager logs();
 
    /**
     * Provides access to Micro-Manager's logging functions, like logError(),
     * showMessage(), etc. Identical to logs() except in name.
     * @return Access to Micro-Manager's logging interface.
     */
-   public LogManager getLogManager();
+   LogManager getLogManager();
 
    /**
     * Provide access to the AcquisitionManager, for running data acquisition
     * using the Micro-Manager acquisition engine.
     * @return AcquisitionManager
     */
-   public AcquisitionManager acquisitions();
+   AcquisitionManager acquisitions();
 
    /**
     * Provide access to the AcquisitionManager, for running data acquisition
@@ -94,14 +94,14 @@ public interface Studio {
     * except in name.
     * @return AcquisitionManager
     */
-   public AcquisitionManager getAcquisitionManager();
+   AcquisitionManager getAcquisitionManager();
 
    /**
     * Provide access to the AlertManager, for creating low-profile, non-
     * interrupting alerts in the user interface.
     * @return AlertManager
     */
-   public AlertManager alerts();
+   AlertManager alerts();
 
    /**
     * Provide access to the AlertManager, for creating low-profile, non-
@@ -109,62 +109,62 @@ public interface Studio {
     * in name.
     * @return AlertManager
     */
-   public AlertManager getAlertManager();
+   AlertManager getAlertManager();
 
    /**
     * Provide access to the AutofocusManager, for performing autofocus
     * operations.
     * @return AutofocusManager
     */
-   public AutofocusManager getAutofocusManager();
+   AutofocusManager getAutofocusManager();
 
    /**
     * Provides access to the Core and its functionality.
     * @return Micro-Manager core object. 
     */
-   public CMMCore core();
+   CMMCore core();
 
    /**
     * Provides access to the Core and its functionality. Identical to core()
     * except in name.
     * @return Micro-Manager core object. 
     */
-   public CMMCore getCMMCore();
+   CMMCore getCMMCore();
 
    /**
     * Provide access to the DataManager instance for accessing Micro-Manager
     * data constructs.
     * @return DataManager instance
     */
-   public DataManager data();
+   DataManager data();
 
    /**
     * Provide access to the DataManager instance for accessing Micro-Manager
     * data constructs. Identical to data() except in name.
     * @return DataManager instance
     */
-   public DataManager getDataManager();
+   DataManager getDataManager();
 
    /**
     * Provides access to the DisplayManager instance for accessing
     * Micro-Manager display constructs.
     * @return DisplayManager instance
     */
-   public DisplayManager displays();
+   DisplayManager displays();
 
    /**
     * Provides access to the DisplayManager instance for accessing
     * Micro-Manager display constructs. Identical to displays() except in name.
     * @return DisplayManager instance
     */
-   public DisplayManager getDisplayManager();
+   DisplayManager getDisplayManager();
 
    /**
     * Provides access to the EventManager instance for subscribing to and
     * posting events on the application-wide EventBus.
     * @return EventManager instance
     */
-   public EventManager events();
+   EventManager events();
 
    /**
     * Provides access to the EventManager instance for subscribing to and
@@ -172,114 +172,114 @@ public interface Studio {
     * except in name.
     * @return EventManager instance
     */
-   public EventManager getEventManager();
+   EventManager getEventManager();
 
    /**
     * Provides access to some utility methods for use in the Beanshell
     * scripting panel.
     * @return ScriptController instance.
     */
-   public ScriptController scripter();
+   ScriptController scripter();
 
    /**
     * Provides access to some utility methods for use in the Beanshell
     * scripting panel. Identical to scripter() except in name.
     * @return ScriptController instance.
     */
-   public ScriptController getScriptController();
+   ScriptController getScriptController();
 
    /**
     * Provides access to the Snap/Live display and associated logic.
     * @return SnapLiveManager instance.
     */
-   public SnapLiveManager live();
+   SnapLiveManager live();
 
    /**
     * Provides access to the Snap/Live display and associated logic. Identical
     * to live() except in name.
     * @return SnapLiveManager instance. 
     */
-   public SnapLiveManager getSnapLiveManager();
+   SnapLiveManager getSnapLiveManager();
 
    /**
     * Provides access to the UserProfile instance for accessing per-user
     * profiles.
     * @return UserProfile instance
     */
-   public UserProfile profile();
+   UserProfile profile();
 
    /**
     * Provides access to the UserProfile instance for accessing per-user
     * profiles. Identical to profile() except in name.
     * @return UserProfile instance
     */
-   public UserProfile getUserProfile();
+   UserProfile getUserProfile();
 
    /**
     * Provides access to the PluginManager for accessing plugin instances.
     * @return PluginManager instance.
     */
-   public PluginManager plugins();
+   PluginManager plugins();
 
    /**
     * Provides access to the PluginManager for accessing plugin instances.
     * Identical to plugins() except in name.
     * @return PluginManager instance.
     */
-   public PluginManager getPluginManager();
+   PluginManager getPluginManager();
 
    /**
     * Provides access to the PositionListManager for interacting with the
     * Stage Position List.
     * @return PositionListManager instance.
     */
-   public PositionListManager positions();
+   PositionListManager positions();
 
    /**
     * Provides access to the PositionListManager for interacting with the
     * Stage Position List. Identical to positions() except in name.
     * @return PositionListManager instance.
     */
-   public PositionListManager getPositionListManager();
+   PositionListManager getPositionListManager();
 
    /**
     * Provides access to the QuickAccessManager for accessing the Quick-Access
     * Panel system.
     * @return QuickAccessManager instance.
     */
-   public QuickAccessManager quickAccess();
+   QuickAccessManager quickAccess();
 
    /**
     * Provides access to the QuickAccessManager for accessing the Quick-Access
     * Panel system. Identical to quickAccess() except in name.
     * @return QuickAccessManager instance.
     */
-   public QuickAccessManager getQuickAccessManager();
+   QuickAccessManager getQuickAccessManager();
 
    /**
     * Provides access to the ShutterManager for controlling the shutter state.
     * @return ShutterManager instance.
     */
-   public ShutterManager shutter();
+   ShutterManager shutter();
 
    /**
     * Provides access to the ShutterManager for controlling the shutter state.
     * Identical to shutter() except in name.
     * @return ShutterManager instance.
     */
-   public ShutterManager getShutterManager();
+   ShutterManager getShutterManager();
 
    /**
     * Provides access to the application API for controlling and updating the
     * GUI.
     * @return Application instance.
     */
-   public Application app();
+   Application app();
 
    /**
     * Provides access to the application API for controlling and updating the
     * GUI. Identical to app() except in name.
     * @return Application instance.
     */
-   public Application getApplication();
+   Application getApplication();
 }

--- a/mmstudio/src/main/java/org/micromanager/Studio.java
+++ b/mmstudio/src/main/java/org/micromanager/Studio.java
@@ -282,4 +282,18 @@ public interface Studio {
     * @return Application instance.
     */
    Application getApplication();
+
+   /**
+    * Provides access to the PropertyManagerAPI.  Provides access to the
+    * PropertyMap.Builder
+    * @return PropertyManager instance
+    */
+   PropertyManager properties();
+
+   /**
+    * Provides access to the PropertyManagerAPI.  Provides access to the
+    * PropertyMap.Builder
+    * @return PropertyManager instance
+    */
+   PropertyManager getPropertyManager();
 }

--- a/mmstudio/src/main/java/org/micromanager/UserProfile.java
+++ b/mmstudio/src/main/java/org/micromanager/UserProfile.java
@@ -46,7 +46,7 @@ public interface UserProfile {
     * Return the name of this profile as displayed to the user
     * @return the profile name
     */
-   public String getProfileName();
+   String getProfileName();
 
    /**
     * Get an interface to save and retrieve settings.
@@ -56,76 +56,76 @@ public interface UserProfile {
     * @param owner the class that "owns" the settings
     * @return an object allowing settings to be set and retrieved
     */
-   public MutablePropertyMapView getSettings(Class<?> owner);
+   MutablePropertyMapView getSettings(Class<?> owner);
 
    /**
     * Reset this user profile, deleting all settings.
     * <p>
     * Do not confuse with {@code getSettings(owner).clear()}!
     */
-   public void clearSettingsForAllClasses();
+   void clearSettingsForAllClasses();
 
 
    // Old methods with weird types
 
    /** @deprecated use {@code getSettings(c).getString(key, fallback)} instead */
    @Deprecated
-   public String getString(Class<?> c, String key, String fallback);
+   String getString(Class<?> c, String key, String fallback);
    /** @deprecated use {@code getSettings(c).getStringList(key, fallback)} instead */
    @Deprecated
-   public String[] getStringArray(Class<?> c, String key, String[] fallback);
+   String[] getStringArray(Class<?> c, String key, String[] fallback);
    /** @deprecated use {@code getSettings(c).putString(key, value)} instead */
    @Deprecated
-   public void setString(Class<?> c, String key, String value);
+   void setString(Class<?> c, String key, String value);
    /** @deprecated use {@code getSettings(c).putStringList(key, value)} instead */
    @Deprecated
-   public void setStringArray(Class<?> c, String key, String[] value);
+   void setStringArray(Class<?> c, String key, String[] value);
    /** @deprecated use {@code getSettings(c).getInteger(key, fallback)} instead */
    @Deprecated
-   public Integer getInt(Class<?> c, String key, Integer fallback);
+   Integer getInt(Class<?> c, String key, Integer fallback);
    /** @deprecated use {@code getSettings(c).getIntegerList(key, fallback)} instead */
    @Deprecated
-   public Integer[] getIntArray(Class<?> c, String key, Integer[] fallback);
+   Integer[] getIntArray(Class<?> c, String key, Integer[] fallback);
    /** @deprecated use {@code getSettings(c).putInteger(key, value)} instead */
    @Deprecated
-   public void setInt(Class<?> c, String key, Integer value);
+   void setInt(Class<?> c, String key, Integer value);
    /** @deprecated use {@code getSettings(c).putIntegerList(key, value)} instead */
    @Deprecated
-   public void setIntArray(Class<?> c, String key, Integer[] value);
+   void setIntArray(Class<?> c, String key, Integer[] value);
    /** @deprecated use {@code getSettings(c).getLong(key, fallback)} instead */
    @Deprecated
-   public Long getLong(Class<?> c, String key, Long fallback);
+   Long getLong(Class<?> c, String key, Long fallback);
    /** @deprecated use {@code getSettings(c).getLongList(key, fallback)} instead */
    @Deprecated
-   public Long[] getLongArray(Class<?> c, String key, Long[] fallback);
+   Long[] getLongArray(Class<?> c, String key, Long[] fallback);
    /** @deprecated use {@code getSettings(c).putLong(key, value)} instead */
    @Deprecated
-   public void setLong(Class<?> c, String key, Long value);
+   void setLong(Class<?> c, String key, Long value);
    /** @deprecated use {@code getSettings(c).putLongList(key, value)} instead */
    @Deprecated
-   public void setLongArray(Class<?> c, String key, Long[] value);
+   void setLongArray(Class<?> c, String key, Long[] value);
    /** @deprecated use {@code getSettings(c).getDouble(key, fallback)} instead */
    @Deprecated
-   public Double getDouble(Class<?> c, String key, Double fallback);
+   Double getDouble(Class<?> c, String key, Double fallback);
    /** @deprecated use {@code getSettings(c).getDoubleList(key, fallback)} instead */
    @Deprecated
-   public Double[] getDoubleArray(Class<?> c, String key, Double[] fallback);
+   Double[] getDoubleArray(Class<?> c, String key, Double[] fallback);
    /** @deprecated use {@code getSettings(c).putDouble(key, value)} instead */
    @Deprecated
-   public void setDouble(Class<?> c, String key, Double value);
+   void setDouble(Class<?> c, String key, Double value);
    /** @deprecated use {@code getSettings(c).putDoubleList(key, value)} instead */
    @Deprecated
-   public void setDoubleArray(Class<?> c, String key, Double[] value);
+   void setDoubleArray(Class<?> c, String key, Double[] value);
    /** @deprecated use {@code getSettings(c).getBoolean(key, fallback)} instead */
    @Deprecated
-   public Boolean getBoolean(Class<?> c, String key, Boolean fallback);
+   Boolean getBoolean(Class<?> c, String key, Boolean fallback);
    /** @deprecated use {@code getSettings(c).getBooleanList(key, fallback)} instead */
    @Deprecated
-   public Boolean[] getBooleanArray(Class<?> c, String key, Boolean[] fallback);
+   Boolean[] getBooleanArray(Class<?> c, String key, Boolean[] fallback);
    /** @deprecated use {@code getSettings(c).putBoolean(key, value)} instead */
    @Deprecated
-   public void setBoolean(Class<?> c, String key, Boolean value);
+   void setBoolean(Class<?> c, String key, Boolean value);
    /** @deprecated use {@code getSettings(c).putBooleanList(key, value)} instead */
    @Deprecated
-   public void setBooleanArray(Class<?> c, String key, Boolean[] value);
+   void setBooleanArray(Class<?> c, String key, Boolean[] value);
 }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionManager.java
@@ -40,13 +40,13 @@ public interface AcquisitionManager {
     * Provides an empty Sequence Settings Builder
     *
     */
-   SequenceSettings.Builder getSequenceSettingsBuilder();
+   SequenceSettings.Builder sequenceSettingsBuilder();
 
    /**
     * Provides and empty ChannelSpec Builder
     *
     */
-   ChannelSpec.Builder getChannelSpecBuilder();
+   ChannelSpec.Builder channelSpecBuilder();
 
    /**
     * Executes Acquisition with settings as in the MDA dialog.

--- a/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
@@ -383,6 +383,7 @@ public final class SequenceSettings {
     * Default constructor needed since we have a copy constructor
     * @deprecated use Builder instead
     */
+   @Deprecated
    private SequenceSettings() {
    }
 
@@ -414,7 +415,7 @@ public final class SequenceSettings {
    /**
     * Time intervals between the starts of time points in milliseconds
     */
-   public ArrayList<Double> customIntervalsMs() { return customIntervalsMs; };
+   public ArrayList<Double> customIntervalsMs() { return customIntervalsMs; }
    /**
     * LIst with channel definitions to be used in the acquisition
     * @return LIst with channel definitions to be used in the acquisition

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -70,12 +70,12 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
    }
 
    @Override
-   public SequenceSettings.Builder getSequenceSettingsBuilder() {
+   public SequenceSettings.Builder sequenceSettingsBuilder() {
       return new SequenceSettings.Builder();
    }
 
    @Override
-   public ChannelSpec.Builder getChannelSpecBuilder() {
+   public ChannelSpec.Builder channelSpecBuilder() {
       return new ChannelSpec.Builder();
    }
 
@@ -183,16 +183,9 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
    @Override
    public void saveSequenceSettings(SequenceSettings settings, String path) throws IOException {
       File file = new File(path);
-      FileWriter writer = null;
-      try {
-         writer = new FileWriter(file);
+      try (FileWriter writer = new FileWriter(file)) {
          writer.write(SequenceSettings.toJSONStream(settings));
          writer.close();
-      }
-      finally {
-         if (writer != null) {
-            writer.close();
-         }
       }
    }
 
@@ -251,7 +244,7 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
          throw new RuntimeException("No camera configured.");
       }
       core.snapImage();
-      ArrayList<Image> result = new ArrayList<Image>();
+      ArrayList<Image> result = new ArrayList<>();
       for (int c = 0; c < core.getNumberOfCameraChannels(); ++c) {
          TaggedImage tagged = core.getTaggedImage(c);
          Image temp = new DefaultImage(tagged);

--- a/mmstudio/src/main/java/org/micromanager/alerts/Alert.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/Alert.java
@@ -32,10 +32,10 @@ public interface Alert {
     * been dismissed (either via their dismiss() method or by the user
     * closing them) are no longer usable.
     */
-   public boolean isUsable();
+   boolean isUsable();
 
    /**
     * Dismiss the Alert, causing it to no longer be visible to the user.
     */
-   public void dismiss();
+   void dismiss();
 }

--- a/mmstudio/src/main/java/org/micromanager/alerts/AlertManager.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/AlertManager.java
@@ -49,7 +49,7 @@ public interface AlertManager {
     * @return Either a newly-created Alert, or the Alert that already existed,
     *         to which this new alert text was added.
     */
-   public Alert postAlert(String title, Class<?> group, String text);
+   Alert postAlert(String title, Class<?> group, String text);
 
    /**
     * Create a UpdatableAlert. UpdatableAlerts can have their contents changed
@@ -61,7 +61,7 @@ public interface AlertManager {
     * @param text Initial text to display to the user.
     * @return Newly-created UpdatableAlert
     */
-   public UpdatableAlert postUpdatableAlert(String title, String text);
+   UpdatableAlert postUpdatableAlert(String title, String text);
 
    /**
     * Create an alert containing the provided special contents. If there is
@@ -79,5 +79,5 @@ public interface AlertManager {
     * @param contents Contents to be inserted into the alert dialog.
     * @return Newly-created Alert
     */
-   public UpdatableAlert postCustomAlert(String title, JComponent contents);
+   UpdatableAlert postCustomAlert(String title, JComponent contents);
 }

--- a/mmstudio/src/main/java/org/micromanager/alerts/UpdatableAlert.java
+++ b/mmstudio/src/main/java/org/micromanager/alerts/UpdatableAlert.java
@@ -41,11 +41,11 @@ public interface UpdatableAlert extends Alert {
     * directly.
     * @param text New text of alert.
     */
-   public void setText(String text);
+   void setText(String text);
 
    /**
     * Returns the current text of the alert.
     * @return Current text of the alert.
     */
-   public String getText();
+   String getText();
 }

--- a/mmstudio/src/main/java/org/micromanager/data/DataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/DataManager.java
@@ -22,25 +22,38 @@ package org.micromanager.data;
 
 import java.awt.Component;
 import java.awt.Window;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import mmcorej.TaggedImage;
 import mmcorej.org.json.JSONException;
 import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
 
 /**
  * This class provides general utility functions for working with
  * Micro-Manager data. You can access it via ScriptInterface's data() method
- * (for example, "mm.data().getCoordsBuilder()").
+ * (for example, "mm.data().cordsBuilder()").
  */
 public interface DataManager {
+
+   /**
+    * Generate a "blank" CoordsBuilder for use in constructing new Coords
+    * instances.
+    *
+    * @return a CoordsBuilder used to construct new Coords instances.
+    */
+   Coords.Builder coordsBuilder();
+
    /**
     * Generate a "blank" CoordsBuilder for use in constructing new Coords
     * instances.
     * 
     * @return a CoordsBuilder used to construct new Coords instances.
+    * @deprecated Use {@link #coordsBuilder()} instead
     */
+   @Deprecated
    Coords.Builder getCoordsBuilder();
 
    /**
@@ -57,6 +70,7 @@ public interface DataManager {
     * underscores. For example, "filter2_pos" is a valid axis, but
     * "1filter-pos" is not, because it starts with a number, and because it
     * contains a "-" which is not a legal character.
+    *
     * @param def Normalized coordinate definition string.
     * @return Coords generated based on the definition string.
     * @throws IllegalArgumentException if the definition string is
@@ -321,8 +335,27 @@ public interface DataManager {
     * Generate a "blank" MetadataBuilder for use in constructing new
     * Metadata instances.
     * @return a MetadataBuilder for creating new Metadata instances.
+    * @deprecated Use {@link #metadataBuilder()} instead
     */
+   @Deprecated
    Metadata.Builder getMetadataBuilder();
+
+   /**
+    * Generate a "blank" MetadataBuilder for use in constructing new
+    * Metadata instances.
+    * @return a MetadataBuilder for creating new Metadata instances.
+    */
+   Metadata.Builder metadataBuilder();
+
+   /**
+    * Generate a "blank" SummaryMetadataBuilder for use in constructing new
+    * SummaryMetadata instances.
+    * @return a SummaryMetadataBuilder for creating new SummaryMetadata
+    *         instances.
+    * @deprecated Use {@link #summaryMetadataBuilder()} instead
+    */
+   @Deprecated
+   SummaryMetadata.Builder getSummaryMetadataBuilder();
 
    /**
     * Generate a "blank" SummaryMetadataBuilder for use in constructing new
@@ -330,7 +363,7 @@ public interface DataManager {
     * @return a SummaryMetadataBuilder for creating new SummaryMetadata
     *         instances.
     */
-   SummaryMetadata.Builder getSummaryMetadataBuilder();
+   SummaryMetadata.Builder summaryMetadataBuilder();
 
    /**
     * Generate a "blank" PropertyMap.Builder with all null values.
@@ -346,7 +379,7 @@ public interface DataManager {
     * @return new PropertyMap based on data in the specified file.
     * @throws FileNotFoundException if the path does not point to a file.
     * @throws IOException if there was an error reading the file.
-    * @deprecated
+    * @deprecated use {@link PropertyMaps#loadJSON(File)} instead
     */
    @Deprecated
    PropertyMap loadPropertyMap(String path) throws FileNotFoundException, IOException;

--- a/mmstudio/src/main/java/org/micromanager/data/Datastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Datastore.java
@@ -42,7 +42,7 @@ public interface Datastore extends DataProvider {
     * bus.
     *
     * @param image Micro-Manager Image object
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurs
     * @throws DatastoreFrozenException if the freeze() method has been called.
     * @throws DatastoreRewriteException if an Image with the same coordinates
     *         already exists in the Datastore.
@@ -58,7 +58,7 @@ public interface Datastore extends DataProvider {
     * bus. This method may only be called once for a given Datastore.
     *
     * @param metadata Object representing the summary metadata
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurs
     * @throws DatastoreFrozenException if the freeze() method has been called.
     * @throws DatastoreRewriteException if the Datastore already has
     *         SummaryMetadata.
@@ -70,22 +70,22 @@ public interface Datastore extends DataProvider {
     *
     * @param tag the tag for the annotation
     * @return true if the annotation exists; false otherwise
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurs
     */
    boolean hasAnnotation(String tag) throws IOException;
 
    /**
     * Get an annotation, creating it if it doesn't exist
-    * @param tag
-    * @return
-    * @throws java.io.IOException
+    * @param tag tag for the annotation
+    * @return Annotation for th given tag
+    * @throws java.io.IOException if an IO error occurs
     */
    Annotation getAnnotation(String tag) throws IOException;
 
    /**
     * Freeze this Datastore so it cannot be further modified.
     * 
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurs
     */
    void freeze() throws IOException;
 
@@ -122,7 +122,8 @@ public interface Datastore extends DataProvider {
     * @param parent Window  on top of which to display the dialog prompt;
     *        may be null.
     * @return true if data was saved; false if user canceled
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurs
+    * @deprecated Use {@link #save(Component, boolean)} instead
     */
    @Deprecated
    boolean save(Component parent) throws IOException;
@@ -136,7 +137,7 @@ public interface Datastore extends DataProvider {
     * @param blocking if true will return after saving, otherwise will return quickly
     *       and continue saving on another thread
     * @return Path chosen by user to save the data, null if dialog was canceled
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurs
     */
    String save(Component parent, boolean blocking) throws IOException;
 
@@ -148,7 +149,7 @@ public interface Datastore extends DataProvider {
     * @param mode File format to save to
     * @param path File path used to save the data
     * 
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurs
     */
    void save(SaveMode mode, String path) throws IOException;
    
@@ -159,13 +160,13 @@ public interface Datastore extends DataProvider {
     * @param path File path used to save the data
     * @param blocking when true, will block while saving data, otherwise will return
     *                   immediately
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurs
     */
    void save(SaveMode mode, String path, boolean blocking) throws IOException;
    
    /**
     * Sets the name of the Datastore.  Posts a DatastoreNewNameEvent
-    * @param name 
+    * @param name new name of the Datastore
     */
    void setName(String name);
 }

--- a/mmstudio/src/main/java/org/micromanager/data/RewritableDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/RewritableDatastore.java
@@ -67,7 +67,7 @@ public interface RewritableDatastore extends Datastore {
     * event bus. Throws an IllegalArgumentException if the provided coordinates
     * do not correspond to any image in the Datastore.
     * @param coords Coordinates of the image to remove.
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurred.
     * @throws IllegalArgumentException if the coords do not match any image.
     */
    void deleteImage(Coords coords) throws IOException;
@@ -84,7 +84,7 @@ public interface RewritableDatastore extends Datastore {
     * This method may potentially remove no images.
     * @param coords Potentially-underspecified coordinates of the image(s) to
     *        remove.
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurred.
     */
    void deleteImagesMatching(Coords coords) throws IOException;
 
@@ -92,7 +92,7 @@ public interface RewritableDatastore extends Datastore {
     * Delete all images from the Datastore. An ImageDeletedEvent will be
     * published on the Datastore's event bus for each image, as will a
     * DatastoreClearedEvent.
-    * @throws java.io.IOException
+    * @throws java.io.IOException if an IO error occurred.
     */
    void deleteAllImages() throws IOException;
 }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -20,14 +20,6 @@
 
 package org.micromanager.data.internal;
 
-import java.awt.Component;
-import java.awt.Window;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import javax.swing.JOptionPane;
-import javax.swing.ProgressMonitor;
 import mmcorej.TaggedImage;
 import mmcorej.org.json.JSONException;
 import org.micromanager.PropertyMap;
@@ -38,7 +30,6 @@ import org.micromanager.data.Datastore;
 import org.micromanager.data.Image;
 import org.micromanager.data.ImageJConverter;
 import org.micromanager.data.Metadata;
-import org.micromanager.data.NewPipelineEvent;
 import org.micromanager.data.Pipeline;
 import org.micromanager.data.Processor;
 import org.micromanager.data.ProcessorConfigurator;
@@ -54,6 +45,15 @@ import org.micromanager.internal.UserCancelledException;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.JavaUtils;
 import org.micromanager.internal.utils.ReportingUtils;
+
+import javax.swing.JOptionPane;
+import javax.swing.ProgressMonitor;
+import java.awt.Component;
+import java.awt.Window;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This implementation of the DataManager interface provides general utility
@@ -73,9 +73,14 @@ public final class DefaultDataManager implements DataManager {
    }
 
    @Override
+   public Coords.Builder coordsBuilder() {
+      return new DefaultCoords.Builder();
+   }
+
+   @Override
    @Deprecated
    public Coords.Builder getCoordsBuilder() {
-      return new DefaultCoords.Builder();
+      return coordsBuilder();
    }
 
    @Override
@@ -305,12 +310,24 @@ public final class DefaultDataManager implements DataManager {
    }
 
    @Override
+   @Deprecated
    public Metadata.Builder getMetadataBuilder() {
+      return metadataBuilder();
+   }
+
+   @Override
+   public Metadata.Builder metadataBuilder() {
       return new DefaultMetadata.Builder();
    }
 
    @Override
+   @Deprecated
    public SummaryMetadata.Builder getSummaryMetadataBuilder() {
+      return summaryMetadataBuilder();
+   }
+
+   @Override
+   public SummaryMetadata.Builder summaryMetadataBuilder() {
       return new DefaultSummaryMetadata.Builder();
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
@@ -12,7 +12,7 @@ import java.util.List;
  * @author mark
  */
 public interface ChannelDisplaySettings {
-   public interface Builder {
+   interface Builder {
       Builder color(Color color);
       Builder colorWhite();
       Builder colorColorBlindFriendly(int number);

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultPropertyManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultPropertyManager.java
@@ -1,0 +1,63 @@
+package org.micromanager.internal;
+
+import org.micromanager.PropertyManager;
+import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
+import org.micromanager.internal.propertymap.DefaultPropertyMap;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class DefaultPropertyManager implements PropertyManager {
+   /**
+    * Provides an easy way for a script to obtain a PropertyMap Builder
+    *
+    * @return PropertyMap Builder
+    */
+   @Override
+   public PropertyMap.Builder propertyMapBuilder() {
+      return DefaultPropertyMap.builder();
+   }
+
+   /**
+    * Returns an empty property map.
+    *
+    * @return empty property map
+    */
+   @Override
+   public PropertyMap emptyPropertyMap() {
+      return PropertyMaps.emptyPropertyMap();
+   }
+
+   /**
+    * Creates a property map from its JSON-serialized form.
+    * JSON format is described in {@link org.micromanager.internal.propertymap.PropertyMapJSONSerializer}
+    * @param json json formatted String to be converted into a PropertyMap
+    * @return PropertyMap result from conversion
+    * @throws IOException if {@code json} is invalid JSON or if it does not
+    * represent a valid property map
+    */
+   @Override
+   public PropertyMap fromJSON(String json) throws IOException {
+      return PropertyMaps.fromJSON(json);
+   }
+
+   /**
+    * Create a property map from its JSON-serialized form stored in a file.
+    *
+    * JSON format is described in {@link org.micromanager.internal.propertymap.PropertyMapJSONSerializer}
+    * @param file File containing JSON serialized Properties.
+    * @return PropertyMap resulting from conversion fo JSON in file.
+    * @throws IOException if there was a problem reading {@code file} or if the
+    * file contained invalid JSON or if the JSON did not represent a valid
+    * property map
+    * @throws java.io.FileNotFoundException this subclass of {@code IOException}
+    * is thrown if {@code file} does not exist
+    */
+   @Override
+   public PropertyMap loadJSON(File file) throws IOException {
+      return PropertyMaps.loadJSON(file);
+   }
+
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -33,6 +33,7 @@ import org.micromanager.CompatibilityInterface;
 import org.micromanager.LogManager;
 import org.micromanager.PluginManager;
 import org.micromanager.PositionListManager;
+import org.micromanager.PropertyManager;
 import org.micromanager.ScriptController;
 import org.micromanager.ShutterManager;
 import org.micromanager.Studio;
@@ -135,6 +136,7 @@ public final class MMStudio implements Studio {
    private UiMovesStageManager uiMovesStageManager_;
    private DefaultApplication defaultApplication_;
    private DefaultCompatibilityInterface compatibility_;
+   private PropertyManager propertyManager_;
    
    // Local Classes
    private final MMSettings settings_ = new MMSettings();
@@ -295,6 +297,8 @@ public final class MMStudio implements Studio {
 
       posListManager_ = new DefaultPositionListManager(this);
       acqEngine_.setPositionList(posListManager_.getPositionList());
+
+      propertyManager_ = new DefaultPropertyManager();
 
       initializeLogging(core_); // Tell Core to start logging
  
@@ -1088,6 +1092,18 @@ public final class MMStudio implements Studio {
    public AlertManager getAlertManager() {
       return alerts();
    }
+
+   @Override
+   public PropertyManager getPropertyManager() {
+      return propertyManager_;
+   }
+
+   @Override
+   public PropertyManager properties() {
+      return propertyManager_;
+   }
+
+
 
    public UiMovesStageManager getUiMovesStageManager () {
       return uiMovesStageManager_;

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/AcquisitionPanel.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/AcquisitionPanel.java
@@ -2463,7 +2463,7 @@ public class AcquisitionPanel extends ListeningJPanel implements DevicesListener
                 if (acqNum > 0) {
                     name += "_" + acqNum;
                 }
-                SummaryMetadata.Builder smb = gui_.data().getSummaryMetadataBuilder();
+                SummaryMetadata.Builder smb = gui_.data().summaryMetadataBuilder();
                 smb = smb.channelNames(channelNames_).
                         channelGroup(multiChannelPanel_.getChannelGroup()).
                         zStepUm((double) acqSettings.stepSizeUm).
@@ -3166,7 +3166,7 @@ public class AcquisitionPanel extends ListeningJPanel implements DevicesListener
      * @param position - position at which to insert image
      * @param ms - Time stamp to be added to the image metadata
      * @param taggedImg - image + metadata to be added
-     * @throws org.json.JSONException
+     * @throws mmcorej.org.json.JSONException
      * @throws org.micromanager.data.DatastoreFrozenException
      * @throws org.micromanager.data.DatastoreRewriteException
      */

--- a/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/AutofocusUtils.java
+++ b/plugins/ASIdiSPIM/src/main/java/org/micromanager/asidispim/utils/AutofocusUtils.java
@@ -346,7 +346,7 @@ public class AutofocusUtils {
                   DisplaySettings.Builder dsb = ourWindow_.getDisplaySettings().copyBuilder();
                   ourWindow_.setDisplaySettings(dsb.colorModeGrayscale().
                           build());
-                  SummaryMetadata.Builder smb = gui_.data().getSummaryMetadataBuilder();
+                  SummaryMetadata.Builder smb = gui_.data().summaryMetadataBuilder();
                   Coords dim = Coordinates.builder().z(nrImages).
                           channel(1).stagePosition(1).t(1).build();
                   store.setSummaryMetadata(smb.intendedDimensions(dim).build());

--- a/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperConfigurator.java
+++ b/plugins/ImageFlipper/src/main/java/org/micromanager/imageflipper/FlipperConfigurator.java
@@ -297,7 +297,7 @@ public class FlipperConfigurator extends JFrame implements ProcessorConfigurator
 
       Image testImage = studio_.data().ij().createImage(proc,
             Coordinates.builder().build(),
-            studio_.data().getMetadataBuilder().build());
+            studio_.data().metadataBuilder().build());
       testImage = FlipperProcessor.transformImage(studio_, testImage,
             getMirror(), getRotate());
       exampleImageTarget_.setIcon(

--- a/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsExecutor.java
+++ b/plugins/PTCTools/src/main/java/org/micromanager/ptctools/PtcToolsExecutor.java
@@ -118,7 +118,7 @@ public class PtcToolsExecutor extends Thread  {
 
          // temporary store to hold images while calculating mean and stdDev
          Datastore store = studio_.data().createRAMDatastore();
-         final SummaryMetadata.Builder smb = studio_.data().getSummaryMetadataBuilder();
+         final SummaryMetadata.Builder smb = studio_.data().summaryMetadataBuilder();
          final Coords.Builder cb = Coordinates.builder();
          Coords coords = cb.c(1).p(1).
                  t(nrFrames).z(1).build();


### PR DESCRIPTION
Closes #1019

Only thing missing is access function for PropertyMaps.Builder().  I am not sure where that function should be.  The only logical place is the Studio interface itself. Suggestions?

PropertyMaps is a bit chaotic with the Builder extending a deprecated interface. Would be nice to clean this all up after the release.