### PR TITLE
AcqDialog implementation fixes

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -241,7 +241,7 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
          return;
       }
       engine_.setSequenceSettings(ss);
-      mdaDialog_.updateGUIContents();
+      mdaDialog_.updateGUIBlocking();
    }
 
    @Override


### PR DESCRIPTION
Adds a function AcqDialog.updateGUIBlocking, that is now called by acquisitionManager.setAcquisitionSettings().  This assures that the acquisition settings are actually set when this function returns.  Previously, rare bugs where see when running a script with the sequence:
```
mm.acquisitions().set_acquisition_settings(ssb.build())
mm.acquisitions().run_acquisition_nonblocking()
```
I expect this update (only to the implementation of the API function acquisitions().setAcquisitionSettings()) to fix this problem.