### PR TITLE
Give IntroDlg it's own taskbar entry

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
@@ -96,9 +96,10 @@ public final class IntroDlg extends JDialog {
     * @param versionStr 
     */
    public IntroDlg(Studio studio, String versionStr) {
-      super((Window) null); // Passing null here causes
+      super((Window) null); // Passing null here causes the dialog to have an invisible parent frame that shows up in the task bar.
       super.setIconImage(Toolkit.getDefaultToolkit().getImage(
-            getClass().getResource("/org/micromanager/icons/microscope.gif")));      // Select a plugin to use to customize the dialog.
+            getClass().getResource("/org/micromanager/icons/microscope.gif")));
+      // Select a plugin to use to customize the dialog.
       Map<String, IntroPlugin> plugins = studio == null ?
             Collections.<String, IntroPlugin>emptyMap() :
             studio.plugins().getIntroPlugins();

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
@@ -30,6 +30,8 @@ import java.awt.Font;
 import java.awt.GraphicsConfiguration;
 import java.awt.Insets;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
@@ -94,7 +96,9 @@ public final class IntroDlg extends JDialog {
     * @param versionStr 
     */
    public IntroDlg(Studio studio, String versionStr) {
-      // Select a plugin to use to customize the dialog.
+      super((Window) null); // Passing null here causes
+      super.setIconImage(Toolkit.getDefaultToolkit().getImage(
+            getClass().getResource("/org/micromanager/icons/microscope.gif")));      // Select a plugin to use to customize the dialog.
       Map<String, IntroPlugin> plugins = studio == null ?
             Collections.<String, IntroPlugin>emptyMap() :
             studio.plugins().getIntroPlugins();


### PR DESCRIPTION
The introduction dialog currently acts as an ownerless JDialog. In some cases where there are many windows open the intro dialog will end up behind a bunch of other windows and since it doesn't have it's own entry on the Windows taskbar it can be a pain to bring it to the front.

This PR simple calls the JDialog constructor with a `null` owner in order to more properly implement an ownerless dialog. See the constructor documentation for more information: https://docs.oracle.com/javase/7/docs/api/javax/swing/JDialog.html

It also sets the Micro-Manager icon as the dialog's icon in the task bar.