### PR TITLE
Forbid setting summary metadata after adding images to datastore

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/Datastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Datastore.java
@@ -55,13 +55,14 @@ public interface Datastore extends DataProvider {
 
    /**
     * Set the SummaryMetadata. Posts a NewSummaryMetadataEvent to the event
-    * bus. This method may only be called once for a given Datastore.
+    * bus. This method may only be called once for a given Datastore, and
+    * must be called before adding any images.
     *
     * @param metadata Object representing the summary metadata
     * @throws java.io.IOException if an IO error occurs
     * @throws DatastoreFrozenException if the freeze() method has been called.
     * @throws DatastoreRewriteException if the Datastore already has
-    *         SummaryMetadata.
+    *         SummaryMetadata or already has images.
     */
    void setSummaryMetadata(SummaryMetadata metadata) throws IOException;
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -296,7 +296,7 @@ public class DefaultDatastore implements Datastore {
       if (isFrozen_) {
          throw new DatastoreFrozenException();
       }
-      if (haveSetSummary_) {
+      if (haveSetSummary_ || getNumImages() > 0) {
          throw new DatastoreRewriteException();
       }
       haveSetSummary_ = true;


### PR DESCRIPTION
Resolves #1016. As best as I can tell, there is no existing code that tries to add images before adding metadata.