### PR TITLE
No longer keeps thousands of threads running.  Fix several deadlocks in EDT

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -375,6 +375,7 @@ public class DefaultDatastore implements Datastore {
          storage_.close();
          System.gc();
       }
+      bus_.shutDown();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -45,7 +45,6 @@ import org.micromanager.data.Coords;
 import org.micromanager.data.DataProvider;
 import org.micromanager.data.Datastore;
 import org.micromanager.data.Image;
-import org.micromanager.data.ImagesDifferInSizeException;
 import org.micromanager.data.Storage;
 import org.micromanager.data.SummaryMetadata;
 import org.micromanager.data.internal.DefaultCoords;
@@ -61,6 +60,7 @@ import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.data.DataProviderHasNewSummaryMetadataEvent;
 import org.micromanager.display.DataViewer;
 import org.micromanager.display.DisplaySettings;
+import org.micromanager.internal.utils.ThreadFactoryFactory;
 
 
 /**
@@ -403,8 +403,9 @@ public final class StorageMultipageTiff implements Storage {
       // initialize writing executor
       if (writingExecutor_ == null) {
          writingExecutor_ = new ThreadPoolExecutor(1, 1, 0,
-               TimeUnit.NANOSECONDS,
-               new LinkedBlockingQueue<java.lang.Runnable>());
+                 TimeUnit.NANOSECONDS,
+                 new LinkedBlockingQueue<java.lang.Runnable>(),
+                 ThreadFactoryFactory.createThreadFactory("StorageMultiPageTiff"));
       }
       int fileSetIndex = 0;
       if (splitByXYPosition_) {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/metadata/PlaneMetadataInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/metadata/PlaneMetadataInspectorPanelController.java
@@ -38,6 +38,7 @@ import org.micromanager.display.DataViewer;
 import org.micromanager.display.inspector.AbstractInspectorPanelController;
 import org.micromanager.internal.utils.CoalescentEDTRunnablePool;
 import org.micromanager.internal.utils.CoalescentEDTRunnablePool.CoalescentRunnable;
+import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.internal.utils.ThreadFactoryFactory;
 import org.micromanager.display.DisplayDidShowImageEvent;
 
@@ -171,8 +172,8 @@ public final class PlaneMetadataInspectorPanelController extends AbstractInspect
       try {
           images = viewer_.getDisplayedImages();
       }
-      catch (IOException e) {
-         // TODO Show error
+      catch (IOException | NullPointerException e) {
+         ReportingUtils.logError("Exception in PlaneMetadataInspectorPanelController");
          return;
       }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -59,6 +59,7 @@ import javax.swing.JToggleButton;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import net.miginfocom.layout.CC;
@@ -1097,17 +1098,36 @@ public final class DisplayUIController implements Closeable, WindowListener,
    }
 
    void setPlaybackFpsIndicator(double fps) {
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            playbackFpsButton_.setText(String.format("Playback: %.1f fps", fps));
+         });
+         return;
+      }
       playbackFpsButton_.setText(String.format("Playback: %.1f fps", fps));
    }
 
    void setNewImageIndicator(boolean show) {
       // NS: I am not sure what this means to the user in the snap/live window,
       // and it takes up space, so don't show in preview windows
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            newImageIndicator_.setVisible(show && !isPreview_);
+         });
+         return;
+      }
       newImageIndicator_.setVisible(show && !isPreview_);
    }
 
    private void updateAxisPositionIndicator(final String axis, 
            final int position, final int length) {
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            updateAxisPositionIndicator(axis, position, length);
+         });
+         return;
+      }
+
       int checkedLength = length;
       if (checkedLength < 0) {
          int axisIndex = displayedAxes_.indexOf(axis);

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -408,6 +408,13 @@ public final class MainFrame extends JFrame {
 
    @Subscribe
    public void onAlertUpdated(AlertUpdatedEvent event) {
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            onAlertUpdated(event);
+         });
+         return;
+      }
+
       displayedAlert_ = event.getAlert();
       String title = displayedAlert_.getTitle();
       String text = displayedAlert_.getText();

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
@@ -9,6 +9,7 @@ import org.micromanager.Studio;
 import org.micromanager.events.internal.DefaultXYStagePositionChangedEvent;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.ThreadFactoryFactory;
 
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
@@ -229,7 +230,8 @@ public class XYNavigator {
 
 		public XYStageTask(String xyStage) {
 			xyStage_ = xyStage;
-			executorService_ = Executors.newSingleThreadExecutor();
+			executorService_ = Executors.newSingleThreadExecutor(
+					ThreadFactoryFactory.createThreadFactory("XYNavigator-" + xyStage ));
 		}
 
 		/**

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/ZNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/ZNavigator.java
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.AtomicDouble;
 import org.micromanager.Studio;
 import org.micromanager.events.internal.DefaultStagePositionChangedEvent;
 import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.ThreadFactoryFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +47,8 @@ public class ZNavigator {
       public ZStageTask(String stage) {
          stage_ = stage;
          moveMemory_ = new AtomicDouble(0.0);
-         executorService_ = Executors.newSingleThreadExecutor();
+         executorService_ = Executors.newSingleThreadExecutor(
+                 ThreadFactoryFactory.createThreadFactory("ZNavigator-" + stage ));
       }
 
       public void setPosition(double pos) {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ProgressBar.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ProgressBar.java
@@ -29,6 +29,7 @@ import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
+import javax.swing.SwingUtilities;
 
 
 public final class ProgressBar extends JPanel {
@@ -38,7 +39,9 @@ public final class ProgressBar extends JPanel {
    private final JProgressBar progressBar;
    private final JFrame frame;
 
+   @MustCallOnEDT
    public ProgressBar (Component parent, String windowName, int start, int end) {
+
       super(new BorderLayout());
       
       frame = new JFrame(windowName);
@@ -61,6 +64,12 @@ public final class ProgressBar extends JPanel {
    }
 
    public void setProgress(int progress) {
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            setProgress(progress);
+         });
+         return;
+      }
       if (!frame.isVisible()) {
          if (System.currentTimeMillis() - startTimeMs > delayTimeMs) {
             frame.setVisible(true);


### PR DESCRIPTION
This PR names all threads running in threadpools.  Naming showed that the ThreadPools produced by the PrioritizedEventBus were not removed.  This PR shuts down that ThreadPool when it is not longer needed.

In addition, several deadlocks were observed that could be avoided by executing display related code on the EDT.