### PR TITLE
Studio: DisplayController object is now GCd.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -315,6 +315,7 @@ public final class MMAcquisition extends DataViewerListener {
                        studio_.profile(), PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key());
             }
             display_.removeListener(this);
+            display_ = null;
          }
       }
       return result;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -321,6 +321,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
          // TODO DisplayGroupManager.getInstance().removeDisplay(viewer);
       }
       viewers_.removeDataViewer(viewer);
+      haveAutoCreatedInspector_.remove(viewer);
    }
 
    /**
@@ -525,6 +526,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
       DataProvider provider = display.getDataProvider();
       synchronized (this) {
          display.removeListener(this);
+         haveAutoCreatedInspector_.remove(display);
          providerToDisplays_.get(provider).remove(display);
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/AxisLinker.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/AxisLinker.java
@@ -24,7 +24,7 @@ import org.micromanager.display.internal.link.LinkManager;
  * @author mark
  */
 class AxisLinker {
-   private final DisplayController viewer_;
+   private DisplayController viewer_;
    private final String axis_;
    private final AxisLinkAnchor anchor_;
    private final LinkManager linkManager_;
@@ -136,6 +136,7 @@ class AxisLinker {
       if (e.getDataViewer().equals(viewer_)) {
          anchor_.unlink();
          linkManager_.unregisterAnchor(anchor_);
+         viewer_ = null;
       }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -332,8 +332,11 @@ public final class DisplayUIController implements Closeable, WindowListener,
       playbackFpsButton_.removePopupButtonListener((PopupButton button) -> {
          playbackFpsSpinner_.setValue(displayController_.getPlaybackSpeedFps());
       });
-      playbackFpsSpinner_.setModel(null);
       playbackFpsSpinner_ = null;
+      for (MouseListener ml : saveButton_.getMouseListeners()) {
+         saveButton_.removeMouseListener(ml);
+      }
+      saveButton_ = null;
       gearButton_.cleanup();
       gearButton_ = null;
       playbackFpsButton_ = null;
@@ -564,7 +567,8 @@ public final class DisplayUIController implements Closeable, WindowListener,
       tmp2Panel.add(cameraFpsLabel_, new CC());
       panel.add(tmp2Panel, new CC().growX());
 
-      panel.add(new SaveButton(studio_, displayController_));
+      saveButton_ = new SaveButton(studio_, displayController_);
+      panel.add(saveButton_);
       gearButton_ = new GearButton(displayController_, studio_);
       panel.add(gearButton_);
 


### PR DESCRIPTION
Noticed that on short runs many UI elements remain, but these get cleaned up on longer runs.  With DisplayController being released, it is likely that most of its descendants (except the sneaky ones that create backdoor references from plugin to DisplayController) can be left alone.  I will go back in and bring back final objects (and no longer set them to null) wherever possible.  Need this build today though;) 