### PR TITLE
relax naming checks

### DIFF
--- a/buildscripts/codestyle/readme.md
+++ b/buildscripts/codestyle/readme.md
@@ -6,5 +6,6 @@ The following changes have been made to the original https://github.com/checksty
  - All properties under the "Indentation" module have been changed to be multiples of 3 rather than multiples of 2.
  - Member variable names are permitted to end with an underscore
  - Parameter names, member names, and many other name types are allowed to have only a single lowercase letter at the beginning, i.e. `xLabel`
+ - All-caps abbreviations are allowed. For example, `refreshGUI` is fine and doesn't need to be changed to `refreshGui`
  
  Information about these properties can be found here: https://checkstyle.sourceforge.io/config_misc.html

--- a/buildscripts/codestyle/readme.md
+++ b/buildscripts/codestyle/readme.md
@@ -4,5 +4,7 @@ original Google rules to match the rules specfied at https://micro-manager.org/w
 
 The following changes have been made to the original https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml :
  - All properties under the "Indentation" module have been changed to be multiples of 3 rather than multiples of 2.
+ - Member variable names are permitted to end with an underscore
+ - Parameter names, member names, and many other name types are allowed to have only a single lowercase letter at the beginning, i.e. `xLabel`
  
  Information about these properties can be found here: https://checkstyle.sourceforge.io/config_misc.html

--- a/buildscripts/codestyle/sun_checks.xml
+++ b/buildscripts/codestyle/sun_checks.xml
@@ -255,6 +255,7 @@
       <property name="arrayInitIndent" value="3"/>
     </module>
     <module name="AbbreviationAsWordInName">
+	  <property name="severity" value="ignore"/>
       <property name="ignoreFinal" value="false"/>
       <property name="allowedAbbreviationLength" value="0"/>
       <property name="tokens"

--- a/buildscripts/codestyle/sun_checks.xml
+++ b/buildscripts/codestyle/sun_checks.xml
@@ -33,6 +33,7 @@
            default="checkstyle-suppressions.xml" />
     <property name="optional" value="true"/>
   </module>
+	
 
   <!-- Checks for whitespace                               -->
   <!-- See http://checkstyle.org/config_whitespace.html -->
@@ -180,32 +181,32 @@
              value="Type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="MemberName">
-      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*(_)?$"/>
       <message key="name.invalidPattern"
              value="Member name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LambdaParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LocalVariableName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="PatternVariableName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
     </module>


### PR DESCRIPTION
The checkstyle rules are loosened in the following ways:
 - Member variable names are permitted to end with an underscore
 - Parameter names, member names, and many other name types are allowed to have only a single lowercase letter at the beginning, i.e. `xLabel`
 - All-caps abbreviations are allowed. For example, `refreshGUI` is fine and doesn't need to be changed to `refreshGui`