### PR TITLE
Projector: log writer no longer issues alerts when log directory is empty.  

### DIFF
--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
@@ -559,8 +559,6 @@ public class ProjectorControlForm extends JFrame {
    private BufferedWriter checkLogFile() {
       if (logFileWriter_ == null || logFile_ == null || !(new File(logFile_)).exists()) {
          if (logDirectoryTextField_.getText().isEmpty()) {
-            studio_.alerts().postAlert("Logging disabled", this.getClass(),
-                  "To enable logging, set the Log Directory");
             return null;
          }
          String currentDate = LOGFILEDATE_FORMATTER.format(new Date());


### PR DESCRIPTION
These alerts caused massive problems when issues
too many times.  That by itself is a problem for another day, but something good to remember.