### PR TITLE
SharpnessPlugin: Do not evaluate images until opened.

### DIFF
--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorController.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/SharpnessInspectorController.java
@@ -50,7 +50,7 @@ public class SharpnessInspectorController extends AbstractInspectorPanelControll
     private final SharpnessInspectorPanel panel_;
     private DataViewer viewer_;
     private final Studio studio_;
-    private boolean autoImageEvaluation_ = true;
+    private boolean autoImageEvaluation_ = false;
     private final SharpnessEvaluator eval_ = new SharpnessEvaluator();
     
     private SharpnessInspectorController(Studio studio) {
@@ -132,7 +132,8 @@ public class SharpnessInspectorController extends AbstractInspectorPanelControll
     
     @Subscribe
     public void onNewImage(DataProviderHasNewImageEvent evt) {
-        ///This is fired because we register for the dataprovider events. Happens each time a new image is available from the provider.
+        // This is fired because we register for the dataprovider events.
+        // Happens each time a new image is available from the provider.
         if (!this.autoImageEvaluation_) {
             return;
         }


### PR DESCRIPTION
Closes #1229.  The plugin had everything build-in to do this correctly, but the flag signaling whether or not to evaluate images was initialized to the wrong value.