### PR TITLE
Add `getByteArray` to `Image`

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/Image.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Image.java
@@ -243,4 +243,12 @@ public interface Image {
     */
    Object getRawPixelsForComponent(int component);
 
+   /**
+    * Regardless of the the value of {@code #getBytesPerPixel} return an array of bytes containing
+    * raw data for the image. Useful for doing low-level handling of raw image data.
+    *
+    * @return The byte array containing raw data for this image.
+    */
+   byte[] getByteArray();
+
 }

--- a/mmstudio/src/main/java/org/micromanager/data/Image.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Image.java
@@ -245,9 +245,10 @@ public interface Image {
 
    /**
     * Regardless of the the value of {@code #getBytesPerPixel} return an array of bytes containing
-    * raw data for the image. Useful for doing low-level handling of raw image data.
+    * raw data for the image. Useful for doing low-level handling of raw image data. The returned
+    * array is a copy of the original data.
     *
-    * @return The byte array containing raw data for this image.
+    * @return The byte array containing a copy of the raw data for this image.
     */
    byte[] getByteArray();
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -70,25 +70,33 @@ public final class BufferTools {
       return null;
    }
 
-   public static byte[] getByteArray(Buffer rawPixels_) {
-      if (rawPixels_ instanceof IntBuffer) {
-         IntBuffer buf = (IntBuffer) rawPixels_;
-         ByteBuffer bb = ByteBuffer.allocate(rawPixels_.remaining() * 4);
+   /**
+    *  Convert a buffer to an array of `byte` regardless of the underlying data type of the buffer
+    *  Useful for low-level data manipulation and for efficiently streaming data over a socket.
+    *  
+    * @param rawPixels A buffer of pixel data. IntBuffer, ShortBuffer, and ByteBuffer are currently
+    *                   supported.
+    * @return An array of `byte` containing the raw data of the rawPixels buffer.
+    */
+   public static byte[] getByteArray(Buffer rawPixels) {
+      if (rawPixels instanceof IntBuffer) {
+         IntBuffer buf = (IntBuffer) rawPixels;
+         ByteBuffer bb = ByteBuffer.allocate(rawPixels.remaining() * 4);
          while (buf.hasRemaining()) {
             bb.putInt(buf.get());
          }
          buf.rewind();
          return bb.array();
-      } else if (rawPixels_ instanceof ShortBuffer) {
-         ShortBuffer buf = (ShortBuffer) rawPixels_;
-         ByteBuffer bb = ByteBuffer.allocate(rawPixels_.remaining() * 2);
+      } else if (rawPixels instanceof ShortBuffer) {
+         ShortBuffer buf = (ShortBuffer) rawPixels;
+         ByteBuffer bb = ByteBuffer.allocate(rawPixels.remaining() * 2);
          while (buf.hasRemaining()) {
             bb.putShort(buf.get());
          }
          buf.rewind();
          return bb.array();
-      } else if (rawPixels_ instanceof ByteBuffer) {
-         return ((ByteBuffer) rawPixels_).array();
+      } else if (rawPixels instanceof ByteBuffer) {
+         return ((ByteBuffer) rawPixels).array();
       } else {
          throw new RuntimeException(("Unhandled Case."));
       }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -1,6 +1,7 @@
 
 package org.micromanager.data.internal;
 
+import java.util.Arrays;
 import org.micromanager.internal.utils.ReportingUtils;
 
 import java.io.UnsupportedEncodingException;
@@ -72,11 +73,12 @@ public final class BufferTools {
 
    /**
     *  Convert a buffer to an array of `byte` regardless of the underlying data type of the buffer
-    *  Useful for low-level data manipulation and for efficiently streaming data over a socket.
+    *  Useful for low-level data manipulation and for efficiently streaming data over a socket. The
+    *  returned buffer is a copy of the original data.
     *  
     * @param rawPixels A buffer of pixel data. IntBuffer, ShortBuffer, and ByteBuffer are currently
     *                   supported.
-    * @return An array of `byte` containing the raw data of the rawPixels buffer.
+    * @return An array of `byte` containing a copy of the raw data of the rawPixels buffer.
     */
    public static byte[] getByteArray(Buffer rawPixels) {
       if (rawPixels instanceof IntBuffer) {
@@ -86,7 +88,8 @@ public final class BufferTools {
             bb.putInt(buf.get());
          }
          buf.rewind();
-         return bb.array();
+         byte[] arr = bb.array();
+         return Arrays.copyOf(arr, arr.length);
       } else if (rawPixels instanceof ShortBuffer) {
          ShortBuffer buf = (ShortBuffer) rawPixels;
          ByteBuffer bb = ByteBuffer.allocate(rawPixels.remaining() * 2);
@@ -94,9 +97,11 @@ public final class BufferTools {
             bb.putShort(buf.get());
          }
          buf.rewind();
-         return bb.array();
+         byte[] arr = bb.array();
+         return Arrays.copyOf(arr, arr.length);
       } else if (rawPixels instanceof ByteBuffer) {
-         return ((ByteBuffer) rawPixels).array();
+         byte[] arr = ((ByteBuffer) rawPixels).array();
+         return Arrays.copyOf(arr, arr.length);
       } else {
          throw new RuntimeException(("Unhandled Case."));
       }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -69,6 +69,30 @@ public final class BufferTools {
       }
       return null;
    }
+
+   public static byte[] getByteArray(Buffer rawPixels_) {
+      if (rawPixels_ instanceof IntBuffer) {
+         IntBuffer buf = (IntBuffer) rawPixels_;
+         ByteBuffer bb = ByteBuffer.allocate(rawPixels_.remaining() * 4);
+         while (buf.hasRemaining()) {
+            bb.putInt(buf.get());
+         }
+         buf.rewind();
+         return bb.array();
+      } else if (rawPixels_ instanceof ShortBuffer) {
+         ShortBuffer buf = (ShortBuffer) rawPixels_;
+         ByteBuffer bb = ByteBuffer.allocate(rawPixels_.remaining() * 2);
+         while (buf.hasRemaining()) {
+            bb.putShort(buf.get());
+         }
+         buf.rewind();
+         return bb.array();
+      } else if (rawPixels_ instanceof ByteBuffer) {
+         return ((ByteBuffer) rawPixels_).array();
+      } else {
+         throw new RuntimeException(("Unhandled Case."));
+      }
+   }
    
    public static Buffer directBufferFromArray(Object primitiveArray) {
       if (primitiveArray instanceof byte[]) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
@@ -286,6 +286,11 @@ public final class DefaultImage implements Image {
    }
 
    @Override
+   public byte[] getByteArray() {
+      return BufferTools.getByteArray(rawPixels_);
+   }
+
+   @Override
    public Object getRawPixelsCopy() {
       Object original = getRawPixels();
       Object copy;


### PR DESCRIPTION
This PR adds a method to `Image` that returns a `byte[]` array of the raw pixel data regardless of the pixel data type.

I use this method to efficiently transfer image data to Python using Py4J. More information [here](https://www.py4j.org/advanced_topics.html#byte-array-byte). A similar approach may be useful to Pycro-Manager if not already implemented.

This method could also be useful for other low-level processing of raw data.

The primary implementation is added to `BufferTools` which `DefaultImage` then calls upon.