### PR TITLE
Adrresses slowness of display of  datasets > ~10,000 images

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -21,6 +21,8 @@
 package org.micromanager.data.internal;
 
 import com.google.common.eventbus.Subscribe;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import org.micromanager.data.Coords;
 import org.micromanager.data.DataProviderHasNewSummaryMetadataEvent;
@@ -31,7 +33,6 @@ import org.micromanager.data.SummaryMetadata;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -45,11 +46,14 @@ import java.util.List;
  */
 public final class StorageRAM implements RewritableStorage {
    private ConcurrentHashMap<Coords, Image> coordsToImage_;
+   private Set<String> axesInUse_;
    private Coords maxIndex_;
    private SummaryMetadata summaryMetadata_;
+   private Image anyImage_;
 
    public StorageRAM(Datastore store) {
       coordsToImage_ = new ConcurrentHashMap<>();
+      axesInUse_ = new TreeSet<>();
       maxIndex_ = new DefaultCoords.Builder().build();
       summaryMetadata_ = (new DefaultSummaryMetadata.Builder()).build();
       // It is imperative that we be notified of new images before anyone who
@@ -69,6 +73,7 @@ public final class StorageRAM implements RewritableStorage {
       Coords coords = image.getCoords();
       coordsToImage_.put(coords, image);
       for (String axis : coords.getAxes()) {
+         axesInUse_.add(axis);
          if (maxIndex_.getIndex(axis) < coords.getIndex(axis)) {
             // Either this image is further along on this axis, or we have
             // no index for this axis yet.
@@ -95,15 +100,20 @@ public final class StorageRAM implements RewritableStorage {
 
    @Override
    public Image getAnyImage() {
+      if (anyImage_ != null) {
+         return anyImage_;
+      }
       if (coordsToImage_ != null && coordsToImage_.size() > 0) {
+         coordsToImage_.elements().hasMoreElements();
          Coords coords = new ArrayList<>(coordsToImage_.keySet()).get(0);
-         return coordsToImage_.get(coords);
+         anyImage_ = coordsToImage_.get(coords);
+         return anyImage_;
       }
       return null;
    }
 
    @Override
-   public synchronized List<Image> getImagesMatching(Coords coords) {
+   public List<Image> getImagesMatching(Coords coords) {
       if (coordsToImage_ == null) {
          return null;
       }
@@ -124,10 +134,23 @@ public final class StorageRAM implements RewritableStorage {
          return null;
       }
       List<Image> result = new ArrayList<>();
-      for (Image image : coordsToImage_.values()) {
-         Coords imCoord = image.getCoords().copyRemovingAxes(ignoreTheseAxes);
-         if (imCoord.equals(coords)) {
-            result.add (image);
+      // Optimization: traversing large HashMaps is costly, so avoid that when there is no need
+      // without this, there is noticeable slowdown for one axis data > ~10,000 images
+      boolean haveIgnoredAxes = false;
+      for (String axis : ignoreTheseAxes) {
+         if (axesInUse_.contains(axis)) {
+            haveIgnoredAxes = true;
+            continue;
+         }
+      }
+      if (!haveIgnoredAxes) {
+         result.add(coordsToImage_.get(coords));
+      } else {  // could not optimize, traverse our HashMap
+         for (Image image : coordsToImage_.values()) {
+            Coords imCoord = image.getCoords().copyRemovingAxes(ignoreTheseAxes);
+            if (imCoord.equals(coords)) {
+               result.add(image);
+            }
          }
       }
       return result;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -135,7 +135,10 @@ public final class StorageRAM implements RewritableStorage {
       }
       List<Image> result = new ArrayList<>();
       // Optimization: traversing large HashMaps is costly, so avoid that when there is no need
-      // without this, there is noticeable slowdown for one axis data > ~10,000 images
+      // without this, there is noticeable slowdown for one axis data > ~10,000 images.
+      // An alternative optimization approach is to keep collections of coords
+      // for all possible ignoredAxes.  There is more upfront work involved but may be
+      // needed for fast multi-camera imaging.
       boolean haveIgnoredAxes = false;
       for (String axis : ignoreTheseAxes) {
          if (axesInUse_.contains(axis)) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/animate/AnimationController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/animate/AnimationController.java
@@ -211,21 +211,19 @@ public final class AnimationController<P> {
    }
 
    public synchronized void startAnimation() {
-      if (animationEnabled_.get()) {
+      if (animationEnabled_.compareAndSet(true,true)) {
          return;
       }
       startTicks(tickIntervalMs_, tickIntervalMs_);
-      animationEnabled_.set(true);
    }
 
    public synchronized void stopAnimation() {
-      if (!animationEnabled_.get()) {
+      if (animationEnabled_.compareAndSet(false, false)) {
          return;
       }
       if (isTicksScheduled()) {
          stopTicks();
       }
-      animationEnabled_.set(false);
    }
 
    public boolean isAnimating() {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/animate/AnimationController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/animate/AnimationController.java
@@ -126,7 +126,7 @@ public final class AnimationController<P> {
    /**
     * Permanently cease all animation and scheduled events.
     */
-   public void shutdown() {
+   public synchronized void shutdown() {
       scheduler_.shutdown();
       stopAnimation();
       try {
@@ -210,7 +210,7 @@ public final class AnimationController<P> {
       return newPositionFlashDurationMs_;
    }
 
-   public void startAnimation() {
+   public synchronized void startAnimation() {
       if (animationEnabled_.get()) {
          return;
       }
@@ -218,7 +218,7 @@ public final class AnimationController<P> {
       animationEnabled_.set(true);
    }
 
-   public  void stopAnimation() {
+   public synchronized void stopAnimation() {
       if (!animationEnabled_.get()) {
          return;
       }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1561,7 +1561,9 @@ public final class DisplayUIController implements Closeable, WindowListener,
    }
 
    public void paintDidFinish() {
-      perfMon_.sampleTimeInterval("Repaint completed");
+      if (perfMon_ != null) {
+         perfMon_.sampleTimeInterval("Repaint completed");
+      }
 
       // Paints occur both by our requesting a new image to be displayed and
       // for other reasons. To compute the display rate, we want to count only
@@ -1569,19 +1571,23 @@ public final class DisplayUIController implements Closeable, WindowListener,
       boolean countAsNewDisplayedImage =
               repaintScheduledForNewImages_.compareAndSet(true, false);
       if (countAsNewDisplayedImage) {
-         perfMon_.sampleTimeInterval("Repaint counted as new display");
+         if (perfMon_ != null) {
+            perfMon_.sampleTimeInterval("Repaint counted as new display");
+         }
 
          displayIntervalEstimator_.get().sample();
          if (displayController_.isAnimating()) {
             adjustAnimationTickIntervalMs(
                     displayIntervalEstimator_.get().getQuantile(0.5));
          }
-         perfMon_.sample("Display interval 25th percentile",
-                 displayIntervalEstimator_.get().getQuantile(0.25));
-         perfMon_.sample("Display interval 50th percentile",
-                 displayIntervalEstimator_.get().getQuantile(0.5));
-         perfMon_.sample("Display interval 75th percentile",
-                 displayIntervalEstimator_.get().getQuantile(0.75));
+         if (perfMon_ != null) {
+            perfMon_.sample("Display interval 25th percentile",
+                  displayIntervalEstimator_.get().getQuantile(0.25));
+            perfMon_.sample("Display interval 50th percentile",
+                  displayIntervalEstimator_.get().getQuantile(0.5));
+            perfMon_.sample("Display interval 75th percentile",
+                  displayIntervalEstimator_.get().getQuantile(0.75));
+         }
          showFPS();
       }
    }


### PR DESCRIPTION
When acquiring 50,000 images at 5 msec exposures, the display would start off nice and fast, but slow down over time.  This PR addresses that slowness, at least for single channel data.  Most of the gains seem to be made by optimizing the Storage function "getImagesIgnoringAxes".  This function would iterate through all Coords in the dataset, remove the requested axes and check for identity.  This becomes slow with large collections.  By keeping track of the axes in the dataset, and only doing the complete check when the "missing axes" are actually present in the dataset, this bottleneck was removed.  However, this approach does not work when the "missing axes" are present in the dataset (such as in multi-camera datasets), so it will be good to think about alternative optimizations (none of which are pretty).

In addition, some synchronization has been replaced with Atomic Booleans or ConurrentHashMaps, and additions were made so that perfMon can be set to null without crashing the application.

Display now stays fast even when acquiring 50,000 images (single channel) with the demo camera.