### PR TITLE
Display settings API change, add function to DisplaySettings.Builder

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.List;
 import org.micromanager.EventPublisher;
 import org.micromanager.PropertyMap;
-import org.micromanager.PropertyMaps;
 import org.micromanager.data.DataProvider;
 import org.micromanager.data.Datastore;
 import org.micromanager.data.Image;
@@ -39,6 +38,7 @@ public interface DisplayManager extends EventPublisher {
     * display the provided Image. The Datastore will use RAM-based storage,
     * and will not be managed by Micro-Manager by default (see the manage()
     * method, below).
+    *
     * @param image The Image to display.
     * @return The Datastore created to hold the Image.
     */
@@ -47,6 +47,7 @@ public interface DisplayManager extends EventPublisher {
    /**
     * Retrieve a DisplaySettings holding the values the user has saved as their
     * default values.
+    *
     * @return The DisplaySettings as of the last time the user clicked the
     *         "Set as default" button in the Settings tab of a DisplayWindow.
     */
@@ -54,6 +55,7 @@ public interface DisplayManager extends EventPublisher {
 
    /**
     * Generate a "blank" DisplaySettings.Builder with all null values.
+    *
     * @return A DisplaySettingsBuilder with no pre-set values.
     * @deprecated - use displaySettingsBuilder() instead
     */
@@ -63,19 +65,22 @@ public interface DisplayManager extends EventPublisher {
    
    /**
     * Generate a "blank" DisplaySettings.Builder with all null values.
+    *
     * @return A DisplaySettingsBuilder with no pre-set values.
     */
    DisplaySettings.Builder displaySettingsBuilder();
    
    /**
-    * Generates a blank channelDisplaySettings Builder with all null values
+    * Generates a blank channelDisplaySettings Builder with all null values.
+    *
     * @return a blank ChannelDisplaySettings Builder
     */
    ChannelDisplaySettings.Builder channelDisplaySettingsBuilder();
    
    
    /**
-    * Generates a blank componentSettings Builder with all null values
+    * Generates a blank componentSettings Builder with all null values.
+    *
     * @return a blank componentSettings builder
     */
    ComponentDisplaySettings.Builder componentDisplaySettingsBuilder();
@@ -84,6 +89,7 @@ public interface DisplayManager extends EventPublisher {
    /**
     * Generate a ContrastSettings object with the provided values. This version
     * of the method is to be used for single-component images.
+    *
     * @param contrastMin The highest pixel intensity corresponding to black.
     * @param contrastMax The lowest pixel intensity corresponding to full
     *        intensity.
@@ -92,7 +98,7 @@ public interface DisplayManager extends EventPublisher {
     *        when the display is showing multiple channels simultaneously.
     * @return a DisplaySettings.ContrastSettings object, whose properties are
     *         all length-1 arrays with the provided values.
-    * @deprecated
+    * @deprecated Use {@link DisplaySettings#getAllChannelSettings()} instead.
     */
    @Deprecated
    DisplaySettings.ContrastSettings getContrastSettings(
@@ -102,6 +108,7 @@ public interface DisplayManager extends EventPublisher {
    /**
     * Generate a ContrastSettings object with the provided values. This version
     * of the method is to be used for multi-component (e.g. RGB) images.
+    *
     * @param contrastMins Array with the highest pixel intensity corresponding 
     *        to black, for each component.
     * @param contrastMaxes Array with the lowest pixel intensity corresponding to full
@@ -120,65 +127,8 @@ public interface DisplayManager extends EventPublisher {
          Boolean isVisible);
 
    /**
-    * Generate a HistogramData object based on the pixels in the provided
-    * Image. HistogramData objects may be used for controlling the histogram(s)
-    * in the Inspector window by posting a NewHistogramsEvent to the display.
-    * @param image The image whose pixel intensities will be examined.
-    * @param component The component of the image (use 0 for grayscale images).
-    * @param binPower The number of bins in the resulting histogram, expressed
-    *        as an exponent for a power of 2. For example, using 8 here will
-    *        result in a histogram with 256 bins. Note: if accurate min/max
-    *        pixel intensities are required, then this must equal the bitDepth
-    *        parameter; see notes on HistogramData.getMinVal() and
-    *        HistogramData.getMaxVal() for more information.
-    * @param bitDepth The range of values accepted by the histogram, expressed
-    *        as a power of 2. For example, using 10 here would result in a
-    *        histogram whose bins accept values from 0 through 1023,
-    *        inclusive. The other statistics provided in the HistogramData are
-    *        not constrained by this value. Note: if this bitDepth parameter
-    *        does not fully encompass the intensities in the image's pixels,
-    *        then an ArrayIndexOutOfBoundsException will be thrown.
-    * @param extremaPercentage The percentage of pixels to ignore when
-    *        calculating the min/max intensities.
-    * @param shouldCalcStdDev If true, the standard deviation will be
-    *        calculated in the resulting HistogramData; otherwise it will be -1
-    * @return a HistogramData derived from the pixels in the image.
-    */
-   //   public HistogramData calculateHistogram(Image image, int component,
-   //         int binPower, int bitDepth, double extremaPercentage,
-   //         boolean shouldCalcStdDev);
-
-   /**
-    * Generate a HistogramData object based on the pixels in the provided
-    * Image. HistogramData objects may be used for controlling the histogram(s)
-    * in the Inspector window by posting a NewHistogramsEvent to the display.
-    * Behaves as calculateHistogram, except that the binPower, bitDepth, and
-    * extremaPercentage parameters will be derived from the provided
-    * DisplaySettings (or the image's native bit depth, if the bitDepthIndex
-    * property of the DisplaySettings has a value of 0).
-    * @param image The image whose pixel intensities will be examined.
-    * @param component The component of the image (use 0 for grayscale images).
-    * @param settings The DisplaySettings to use for extracting other
-    *        histogram calculation values.
-    * @return a HistogramData derived from the pixels in the image.
-    */
-   //   public HistogramData calculateHistogramWithSettings(Image image,
-   //         int component, DisplaySettings settings);
-
-   /**
-    * Send updated histogram information to anyone who is listening for it for
-    * the specified display. This is equivalent to calling
-    * calculateHistogramWithSettings for every component in every image in the
-    * provided list and then posting a NewHistogramsEvent with the resulting
-    * HistogramDatas.
-    * @param images List of images to calculate histograms for.
-    * @param viewer DataViewer that histogram information should be updated for
-    */
-   //   public void updateHistogramDisplays(List<Image> images, DataViewer viewer);
-
-
-   /**
     * Generate a "blank" PropertyMap.PropertyMapBuilder with empty mappings.
+    *
     * @return A PropertyMapBuilder with no pre-set values.
     * @deprecated Use {@link org.micromanager.PropertyMaps#builder()} instead
     */
@@ -187,6 +137,7 @@ public interface DisplayManager extends EventPublisher {
 
    /**
     * Create a new DisplayWindow for the specified DataProvider and return it.
+    *
     * @param dataProvider The DataProvider whose data should be displayed.
     * @return The created DisplayWindow.
     */
@@ -196,6 +147,7 @@ public interface DisplayManager extends EventPublisher {
     * Create a new DisplayWindow for the specified DataProvider and return it.
     * This version allows you to add your own custom controls to the display
     * that will appear underneath the axis scrollbars.
+    *
     * @param dataProvider The DataProvider whose data should be displayed.
     * @param factory A ControlsFactory used to create custom controls for
     *        the DisplayWindow. May be null.
@@ -207,6 +159,7 @@ public interface DisplayManager extends EventPublisher {
    /**
     * Create a new Inspector window that shows information for the specified
     * DataViewer, or for the topmost window if the DataViewer is null.
+    *
     * @param display The DataViewer the inspector should show information on,
     *        or null to show information on the topmost window.
     */
@@ -218,6 +171,7 @@ public interface DisplayManager extends EventPublisher {
     * DisplayWindow is created, but it can be created earlier by calling this
     * method. Note that once the default Inspector has been created, this
     * method will not do anything, even if that Inspector is later closed.
+    *
     * @return true if an inspector window is created, false otherwise.
     */
    @Deprecated
@@ -228,6 +182,7 @@ public interface DisplayManager extends EventPublisher {
     * aware of the viewer, so that it may be used by Micro-Manager's widgets
     * (chiefly, the Inspector Window). Use removeViewer() to remove a viewer
     * that has been added by this method.
+    *
     * @param viewer The new DataViewer that should be tracked.
     */
    void addViewer(DataViewer viewer);
@@ -235,6 +190,7 @@ public interface DisplayManager extends EventPublisher {
    /**
     * Cause Micro-Manager to stop tracking a DataViewer that was previously
     * added with addViewer().
+    *
     * @param viewer The DataViewer that should no longer be tracked.
     * @throws IllegalArgumentException if the viewer is not currently tracked.
     */
@@ -246,9 +202,10 @@ public interface DisplayManager extends EventPublisher {
     * in a separate display settings file; one new DisplayWindow will be
     * created for every entry in that file. If no file is found then a single
     * default DisplayWindow will be created, as per createDisplay() above.
+    *
     * @param store The Datastore to load display settings for.
     * @return The list of DisplayWindows that were created by this method.
-    * @throws java.io.IOException
+    * @throws java.io.IOException Most likely indicating that a file could not be read.
     */
    List<DisplayWindow> loadDisplays(Datastore store) throws IOException;
 
@@ -272,6 +229,7 @@ public interface DisplayManager extends EventPublisher {
     * are not managed, which means you are responsible for ensuring that they
     * are properly closed and saved. DataProvider created by MicroManager itself
     * (e.g. by running an MDA) are automatically managed.
+    *
     * @param store The DataProvider to manage.
     */
    void manage(DataProvider store);
@@ -279,12 +237,14 @@ public interface DisplayManager extends EventPublisher {
    /**
     * Return a list of all DataProviders that MicroManager is managing (see the
     * manage() method for more information).
+    *
     * @return A list of all DataProviders that Micro-Manager is managing.
     */
    List<DataProvider> getManagedDataProviders();
 
    /**
     * Returns true if the DataProvider is being managed by MicroManager.
+    *
     * @param provider The DataProvider whose management status is under question.
     * @return Whether or not Micro-Manager is managing the DataProvider.
     */
@@ -292,6 +252,7 @@ public interface DisplayManager extends EventPublisher {
 
    /**
     * Returns true if the DataProvider is being managed by MicroManager.
+    *
     * @param provider The DataProvider whose management status is under question.
     * @return Whether or not Micro-Manager is managing the DataProvider.
     * @deprecated use {@link #isManaged(DataProvider)} instead
@@ -304,6 +265,7 @@ public interface DisplayManager extends EventPublisher {
    /**
     * Return all associated DisplayWindows for the Datastore. Returns null if
     * the Datastore is not managed.
+    *
     * @param store Datastore of interest to the caller
     * @return A list of all DisplayWindows Micro-Manager knows are associated
     *         with the specified Datastore, or null.
@@ -315,6 +277,7 @@ public interface DisplayManager extends EventPublisher {
    /**
     * Return all associated DisplayWindows for the DataProvider. Returns null if
     * the DataProvider is not managed.
+    *
     * @param dataProvider DataProvider of interest to the caller
     * @return A list of all DisplayWindows Micro-Manager knows are associated
     *         with the specified Datastore, or null.
@@ -334,15 +297,14 @@ public interface DisplayManager extends EventPublisher {
    DisplayWindow getCurrentWindow();
 
    /**
-    * Return the currently active data viewer.
-    *
+    * Returns the currently active data viewer.
     * The active data viewer is the data viewer that last became active among
     * those currently visible. A data viewer may become active because its
     * window became active (if the viewer is windowed), or because the window
     * containing it became active (if the viewer is a subcomponent of a larger
     * window).
     *
-    * @return the active data viewer, or null if no data viewer is registered
+    * @return the active data viewer, or null if no data viewer is registered.
     */
    DataViewer getActiveDataViewer();
 
@@ -350,6 +312,7 @@ public interface DisplayManager extends EventPublisher {
     * Return all active DisplayWindows. Note this is specifically Micro-
     * Manager DisplayWindows; it doesn't include ImageJ's ImageWindows or
     * any other data-representation windows.
+    *
     * @return A list of all DisplayWindows that Micro-Manager knows about.
     */
    List<DisplayWindow> getAllImageWindows();
@@ -358,6 +321,7 @@ public interface DisplayManager extends EventPublisher {
     * Return all DataViewers that Micro-Manager knows about. This includes
     * the results of getAllImageWindows, as well as any extant DataViewers
     * that have been registered with Micro-Manager via the addViewer method.
+    *
     * @return List with all DataViewers that Micro-Manager knows about
     */
    List<DataViewer> getAllDataViewers();
@@ -366,16 +330,18 @@ public interface DisplayManager extends EventPublisher {
     * Display a prompt for the user to save their data. This is the same
     * prompt that is generated when the last DisplayWindow for a managed
     * Datastore is closed.
+    *
     * @param store The Datastore to save.
     * @param display The DisplayWindow over which to show the prompt.
     * @return true if saving was successful or the user explicitly declined
     *         to save; false if the user cancelled or if saving failed.
-    * @throws java.io.IOException
+    * @throws java.io.IOException Can be thrown when file IO causes an exception.
     */
    boolean promptToSave(Datastore store, DisplayWindow display) throws IOException;
 
    /**
     * Provide an ImagceExporter for generating image sequences.
+    *
     * @return an ImageExporter instance.
     */
    ImageExporter createExporter();
@@ -384,6 +350,7 @@ public interface DisplayManager extends EventPublisher {
     * Given a DataProvider, close any open DisplayWindows for that DataProvider.
     * If the DataProvider is managed, then the user may receive a prompt to
     * save their data, which they have the option to cancel.
+    *
     * @param provider DataProvider for which displays should be closed
     * @return True if all windows were closed; false otherwise (e.g. because
     *         the user canceled saving).
@@ -400,6 +367,7 @@ public interface DisplayManager extends EventPublisher {
 
    /**
     * Close all open image windows.
+    *
     * @param shouldPromptToSave If true, then any open windows for Datastores
     *        that have not been saved will show a prompt to save, and if the
     *        user chooses not to save a file, then the process of closing

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -26,13 +26,12 @@ import java.util.List;
 /**
  * This class defines the parameters that control how a given DisplayWindow
  * displays data from the Datastore.
- * It is immutable; construct it with a DisplaySettingsBuilder.
+ * It is immutable; construct it with a DisplaySettings.Builder.
  * You are not expected to implement this interface; it is here to describe how
  * you can interact with DisplaySettings created by Micro-Manager itself. If
- * you need a DisplaySettingsBuilder, you can generate one via the
+ * you need a DisplaySettings.Builder, you can generate one via the
  * DataManager's getDisplaySettingsBuilder() method, or by using the copy()
  * method of an existing DisplaySettings instance.
- *
  * This class uses a Builder pattern. Please see
  * https://micro-manager.org/wiki/Using_Builders
  * for more information.
@@ -41,35 +40,91 @@ public interface DisplaySettings {
 
    interface Builder {
       Builder zoomRatio(double ratio);
+
       Builder playbackFPS(double fps);
 
       /** Color mode or lookup table for displaying the image.
+       *
         * @param mode ColorMode to appply
         * @return Builder 
         */
       Builder colorMode(ColorMode mode);
+
       Builder colorModeComposite();
+
       Builder colorModeGrayscale();
+
       Builder colorModeSingleColor();
+
       Builder colorModeHighlightSaturated();
 
       /** Whether to use the same intensity scaling for every channel.
+       *
         * @param enable flag
         * @return  Builder
         */
       Builder uniformChannelScaling(boolean enable);
+
       /** Whether to continuously apply autoscale.
+       *
         * @param enable flag
         * @return Builder 
         */
       Builder autostretch(boolean enable);
+
       Builder roiAutoscale(boolean enable);
+
       Builder autoscaleIgnoredQuantile(double quantile);
+
       Builder autoscaleIgnoredPercentile(double percentile);
 
+      /**
+       * Increases the number of ChannelDisplaySettings in this Builder to
+       * the given number.  DefaultSettings for each channel will be added.
+       *
+       * @param channel Final number of ChannelDisplaySettings
+       * @return builder instance to enable chaining commands
+       */
       Builder channel(int channel);
+
+      /**
+       * Sets the ChannelDisplaySettings for the given channel.
+       * If the number of ChannelDisplaySettings is smaller than the given channel
+       * number, "missing" channels will be added (using Default Display Settings).
+       *
+       * @param channel Indicates the number of the channel for which to set
+       *                the DisplaySettings
+       * @return builder instance to enable chaining commands
+       */
       Builder channel(int channel, ChannelDisplaySettings settings);
+
+      /**
+       * Replaces ChannelDisplaySettings with those given.
+       * If provided with null or an empty list, current ChannelDisplaySettings
+       * will be removed.
+       *
+       * @param channelSettings iterable with ChannelDisplaySettings to replace the current
+       *                        ones.  Can be empty or null, in which case ChannelDisplaySettings
+       *                        will be removed from this builder.
+       * @return builder instance to enable chaining commands
+       */
+      Builder channels(Iterable<ChannelDisplaySettings> channelSettings);
+
+      /**
+       * Number of ChannelDisplaySettings in this builder.  Not sure why a builder needs this...
+       *
+       * @return Number of ChannelDisplaySettings in this Builder.
+       */
       int getNumberOfChannels();
+
+      /**
+       * Returns the ChannelDisplaySettings for the given channel number.
+       * If this, or any channel with lower number, does not exist, it will be created,
+       * and filled with DefaultChannelDisplaySettings.
+       *
+       * @param channel Number (index) of the requested channel
+       * @return ChannelDisplaySettings for the requested channel.
+       */
       ChannelDisplaySettings getChannelSettings(int channel); // Creates channel if necessary
 
       DisplaySettings build();
@@ -78,7 +133,8 @@ public interface DisplaySettings {
    /**
     * Zoom level expressed as a ratio (i.e. 1.0 denotes that each pixel in the 
     * image occupies 1 pixel on the screen, 0.5 indicates that 4 image pixels
-    * are combined in 1 screen pixel
+    * are combined in 1 screen pixel.
+    *
     * @return Zoom ratio
     */
    double getZoomRatio();
@@ -87,32 +143,37 @@ public interface DisplaySettings {
    double getPlaybackFPS();
    
    /** Color mode or lookup table for displaying the image.
+    *
      * @return  ColorMode used by these DisplaySettings
      */
    ColorMode getColorMode();
    
    /** Whether to use the same intensity scaling for every channel.
+    *
      * @return true if all channels use the same intensity scaling
     */
    boolean isUniformChannelScalingEnabled();
    
    /** Whether to continuously apply autoscale.
+    *
      * @return  true if AutoStretch is enabled
      */
    boolean isAutostretchEnabled();
    
    /**
-    * Whether to only look at the ROI when autoscaling
+    * Whether to only look at the ROI when autoscaling.
+    *
     * @return true if only the ROI should be taken into account when autoscaling
     */
    boolean isROIAutoscaleEnabled();
    
-    /**
+   /**
     * When autoscaling, the minimum value will have this fraction of pixels
     * with lower intensities, and the maximum value will have this fraction
     * of pixels with higher intensities.
+    *
     * @return Number used in Autostretch mode to determine where to set the
-    * white and black points.  Expressed as fraction.
+    *         white and black points.  Expressed as fraction.
     */
    double getAutoscaleIgnoredQuantile();
    
@@ -120,32 +181,41 @@ public interface DisplaySettings {
     * When autoscaling, the minimum value will have this fraction of pixels
     * with lower intensities, and the maximum value will have this fraction
     * of pixels with higher intensities.
+    *
     * @return Number used in Autostretch mode to determine where to set the
-    * white and black points.  Expressed as percentage.
+    *         white and black points.  Expressed as percentage.
     */
    double getAutoscaleIgnoredPercentile();
    
    /**
     * Returns the number of channels in these DisplaySettings
     * Note that this number may be different from the number of the channels 
-    * in the image being shown
-    * @return 
+    * in the image being shown.
+    *
+    * @return number of channels in these DisplaySettings
     */
    int getNumberOfChannels();
    
    
    ChannelDisplaySettings getChannelSettings(int channel);
+
    List<ChannelDisplaySettings> getAllChannelSettings();
 
    // Convenience methods
    List<Color> getAllChannelColors();
+
    Color getChannelColor(int channel);
+
    List<Boolean> getAllChannelVisibilities();
+
    boolean isChannelVisible(int channel);
 
    Builder copyBuilder();
+
    Builder copyBuilderWithChannelSettings(int channel, ChannelDisplaySettings settings);
-   Builder copyBuilderWithComponentSettings(int channel, int component, ComponentDisplaySettings settings);
+
+   Builder copyBuilderWithComponentSettings(
+         int channel, int component, ComponentDisplaySettings settings);
 
 
    // TODO Add static builder() in Java 8
@@ -160,15 +230,17 @@ public interface DisplaySettings {
     * multi-component (e.g. RGB) channels.
     * You can create a new ContrastSettings object via
     * DisplayManager.createContrastSettings().
+    *
     * @deprecated TODO: explain
     */
    @Deprecated
    interface ContrastSettings {
       /**
        * Return the array of minimum contrast settings for all components.
+       *
        * @return array of minimum contrast settings (i.e. the intensity value
-       * in the image that results in black display) for all components. May
-       * be null.
+       *         in the image that results in black display) for all components. May
+       *         be null.
        */
       @Deprecated
       Integer[] getContrastMins();
@@ -178,6 +250,7 @@ public interface DisplaySettings {
        * specified component. If the contrastMins property is not set or is
        * of inadequate length, then the provided default value will be
        * returned instead.
+       *
        * @param component The component index to use. For example, for an
        *        RGB image, a value of 0 would indicate the red component.
        *        For single-component images, use an index of 0.
@@ -190,9 +263,10 @@ public interface DisplaySettings {
 
       /**
        * Return the array of maximum contrast settings for all components.
+       *
        * @return array of maximum contrast settings (i.e. the intensity value
-       * in the image that results in the brightest display value) for all
-       * components. May be null.
+       *         in the image that results in the brightest display value) for all
+       *         components. May be null.
        */
       @Deprecated
       Integer[] getContrastMaxes();
@@ -202,6 +276,7 @@ public interface DisplaySettings {
        * specified component. If the contrastMaxes property is not set or is
        * of inadequate length, then the provided default value will be
        * returned instead.
+       *
        * @param component The component index to use. For example, for an
        *        RGB image, a value of 0 would indicate the red component.
        *        For single-component images, use an index of 0.
@@ -215,6 +290,7 @@ public interface DisplaySettings {
       /**
        * Return the array of gamma settings for all components. Note that
        * multi-component images do not currently make use of the gamma setting.
+       *
        * @return Array of gamma settings for all components. May be null.
        */
       @Deprecated
@@ -225,6 +301,7 @@ public interface DisplaySettings {
        * If the contrastGammas property is not set or is of inadequate length,
        * then the provided default value will be returned instead. Note that
        * multi-component images do not currently make use of the gamma setting.
+       *
        * @param component The component index to use. For example, for an
        *        RGB image, a value of 0 would indicate the red component.
        *        For single-component images, use an index of 0.
@@ -250,6 +327,7 @@ public interface DisplaySettings {
        * otherwise. This is only relevant when the display is showing
        * multiple channels at the same time (i.e. ColorMode is COMPOSITE); in
        * all other modes this value is ignored.
+       *
        * @return Flag indicating whether the channel is currently displayed
        * @deprecated Use isVisible
        */
@@ -262,6 +340,7 @@ public interface DisplaySettings {
        * the contrastMins, contrastMaxes, and contrastGammas attributes. Note
        * that it is still possible for there to be nulls in one of those
        * arrays.
+       *
        * @return The number of components this object has information for.
        */
       @Deprecated
@@ -273,6 +352,7 @@ public interface DisplaySettings {
       /**
        * Construct a DisplaySettings from the DisplaySettingsBuilder. Call
        * this once you are finished setting all DisplaySettings parameters.
+       *
        * @return Build object
        */
       @Override
@@ -284,12 +364,14 @@ public interface DisplaySettings {
       // for information on the meaning of these fields.
       @Deprecated
       DisplaySettingsBuilder channelColors(Color[] channelColors);
+
       /**
        * "Safely" update the channelColors property to include the new
        * provided color at the specified index. If the channelColors
        * property is null or is not large enough to incorporate the specified
        * index, then a new array will be created that is long enough, values
        * will be copied across, and any missing values will be null.
+       *
        * @param newColor New color for the specified channel.
        * @param channelIndex Index into the channelColors array.
        * @return builder to be used to build the new DisplaySettings
@@ -297,8 +379,10 @@ public interface DisplaySettings {
       @Deprecated
       DisplaySettingsBuilder safeUpdateChannelColor(Color newColor,
             int channelIndex);
+
       @Deprecated
       DisplaySettingsBuilder channelContrastSettings(ContrastSettings[] contrastSettings);
+
       /**
        * "Safely" update the contrastSettings property to have the provided
        * ContrastSettings object at the specified index. If the
@@ -306,6 +390,7 @@ public interface DisplaySettings {
        * the specified index, then a new array will be created that is long
        * enough, values will be copied across, and any missing values will be
        * null.
+       *
        * @param newSettings New ContrastSettings for the channel.
        * @param channelIndex Index into the contrastSettings array.
        * @return builder to be used to build the new DisplaySettings
@@ -316,18 +401,25 @@ public interface DisplaySettings {
 
       @Deprecated
       DisplaySettingsBuilder magnification(Double magnification);
+
       @Deprecated
       DisplaySettingsBuilder zoom(Double ratio);
+
       @Deprecated
       DisplaySettingsBuilder animationFPS(Double animationFPS);
+
       @Deprecated
       DisplaySettingsBuilder channelColorMode(ColorMode channelColorMode);
+
       @Deprecated
       DisplaySettingsBuilder shouldSyncChannels(Boolean shouldSyncChannels);
+
       @Deprecated
       DisplaySettingsBuilder shouldAutostretch(Boolean shouldAutostretch);
+
       @Deprecated
       DisplaySettingsBuilder shouldScaleWithROI(Boolean shouldScaleWithROI);
+
       @Deprecated
       DisplaySettingsBuilder extremaPercentage(Double extremaPercentage);
    }
@@ -335,6 +427,7 @@ public interface DisplaySettings {
    /**
     * Generate a new DisplaySettingsBuilder whose values are initialized to be
     * the values of this DisplaySettings.
+    *
     * @return Copy of the DisplaySettingsBuilder
     */
    @Deprecated
@@ -343,6 +436,7 @@ public interface DisplaySettings {
 
    /**
     * The object containing contrast information for each channel.
+    *
     * @return An array of ContrastSettings objects, one per channel. May
     *         potentially be null or of inadequate length.
     */
@@ -354,6 +448,7 @@ public interface DisplaySettings {
     * the contrastSettings property is null, is too small to have a value for
     * the given index, or has a value of null for that index, then the provided
     * default value will be returned instead.
+    *
     * @param index Channel index to get the ContrastSettings for
     * @param defaultVal Default value to return if no contrast setting is
     *        available.
@@ -369,6 +464,7 @@ public interface DisplaySettings {
     * given index, has a value of null for the given index, or has a
     * ContrastSettings object whose contrastMin property is null, then the
     * provided default value will be returned instead.
+    *
     * @param index Channel index to get the contrast min for.
     * @param component Component index to get the contrast min for.
     * @param defaultVal Default value to return if no contrast min is
@@ -385,6 +481,7 @@ public interface DisplaySettings {
     * given index, has a value of null for the given index, or has a
     * ContrastSettings object whose contrastMax property is null, then the
     * provided default value will be returned instead.
+    *
     * @param index Channel index to get the contrast max for.
     * @param component Component index to get the contrast max for.
     * @param defaultVal Default value to return if no contrast max is
@@ -401,6 +498,7 @@ public interface DisplaySettings {
     * given index, has a value of null for the given index, or has a
     * ContrastSettings object whose contrastGamma property is null, then the
     * provided default value will be returned instead.
+    *
     * @param index Channel index to get the contrast gamma for.
     * @param component Component index to get the contrast gamma for.
     * @param defaultVal Default value to return if no contrast gamma is
@@ -416,6 +514,7 @@ public interface DisplaySettings {
     * have a value for the given index, has a value of null for the given
     * index, or has a ContrastSettings object whose isVisible property is null,
     * then the provided default value will be returned instead.
+    *
     * @param index Channel index to get visibility for.
     * @param defaultVal Default value to return if no visibility is available.
     * @return Flag indicating visibility of the specified channel
@@ -452,6 +551,7 @@ public interface DisplaySettings {
 
    /**
     * The index into the "Display mode" control.
+    *
     * @return index into the "Display mode" control
     * @deprecated - use getColorMode() instead
     */
@@ -459,7 +559,8 @@ public interface DisplaySettings {
    ColorMode getChannelColorMode();
 
    /**
-    * Whether histogram settings should be synced across channels
+    * Whether histogram settings should be synced across channels.
+    *
     * @return True if histograms should sync between channels
     */
    @Deprecated

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -30,14 +30,18 @@ import java.util.List;
  * You are not expected to implement this interface; it is here to describe how
  * you can interact with DisplaySettings created by Micro-Manager itself. If
  * you need a DisplaySettings.Builder, you can generate one via the
- * DataManager's getDisplaySettingsBuilder() method, or by using the copy()
- * method of an existing DisplaySettings instance.
+ * {@link org.micromanager.display.DisplayManager} displaySettingsBuilder()
+ * method or by using one of the copy() methods of an existing DisplaySettings instance.
  * This class uses a Builder pattern. Please see
- * https://micro-manager.org/wiki/Using_Builders
- * for more information.
+ * https://micro-manager.org/wiki/Using_Builders for more information.
  */
 public interface DisplaySettings {
 
+   /**
+    * Builder for DisplaySettings.  Get an instance using the
+    * {@link org.micromanager.display.DisplayManager} displaySettingsBuilder()
+    * method or by using one of the copy() methods of an existing DisplaySettings instance.
+    */
    interface Builder {
       Builder zoomRatio(double ratio);
 
@@ -347,6 +351,11 @@ public interface DisplaySettings {
       int getNumComponents();
    }
 
+   /**
+    * Deprecated version of a DisplaySettings Builder.
+    *
+    * @deprecated Use DisplaySettings.Builder instead
+    */
    @Deprecated
    interface DisplaySettingsBuilder extends Builder {
       /**
@@ -522,6 +531,9 @@ public interface DisplaySettings {
    @Deprecated
    Boolean getSafeIsVisible(int index, Boolean defaultVal);
 
+   /**
+    * ColorMode enums.
+    */
    enum ColorMode {
       // TODO Integer indices should be implementation detail of file format
       COLOR(0), COMPOSITE(1), GRAYSCALE(2), HIGHLIGHT_LIMITS(3), FIRE(4),

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -174,7 +174,6 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
    }
    
    @Override
-   @Deprecated
    public DisplaySettings.Builder displaySettingsBuilder() {
       return DefaultDisplaySettings.builder();
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -155,6 +155,15 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       }
 
       @Override
+      public DisplaySettings.Builder channels(Iterable<ChannelDisplaySettings> channelSettings) {
+         channelSettings_.clear();
+         for (ChannelDisplaySettings channelSetting: channelSettings) {
+            channelSettings_.add(channelSetting);
+         }
+         return this;
+      }
+
+      @Override
       public int getNumberOfChannels() {
          return channelSettings_.size();
       }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -43,8 +43,11 @@ import org.micromanager.internal.utils.MDUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
+/**
+ * Implementation of the DisplaySettings interface.
+ */
 public final class DefaultDisplaySettings implements DisplaySettings {
-   private final static String PROFILEKEY = "Default_Display_Settings";
+   private static final String PROFILEKEY = "Default_Display_Settings";
    private final double zoom_;
    private final double fps_;
    private final ColorMode mode_;
@@ -157,7 +160,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       @Override
       public DisplaySettings.Builder channels(Iterable<ChannelDisplaySettings> channelSettings) {
          channelSettings_.clear();
-         for (ChannelDisplaySettings channelSetting: channelSettings) {
+         for (ChannelDisplaySettings channelSetting : channelSettings) {
             channelSettings_.add(channelSetting);
          }
          return this;
@@ -296,6 +299,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
     * Retrieve the display settings that have been saved in the preferences.
     * Note: we explicitly don't cache these settings, to ensure that
     * displays don't end up with copies of the same settings.
+    *
     * @param key String for storing settings under different locations, so
     *        different "types" of displays can have different default settings.
     * @return display settings that were saved in the preferences
@@ -334,7 +338,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
   
    /**
     * Saves these DisplaySettings in the UserProfile. Implementers are free to 
-    * save copies of the settings themselves.  
+    * save copies of the settings themselves.
+    *
     * @param profile Profile to which these settings should be saved
     * @param key Key under which the settings will be stored.
     *             Will be pre-pended with PROFILEKEY
@@ -347,10 +352,11 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    
    /**
     * Retrieve DisplaySettings from the User Profile.
-    * @param profile UserProfile to save these Display Settings to
-    * @param key Key use to retrieve the DisplaySettings
-    *             Will be pre-pended with PROFILEKEY
-    * @return Stored DisplaySettings or null if none found
+    *
+    * @param profile UserProfile to save these Display Settings to.
+    * @param key Key use to retrieve the DisplaySettings.
+    *             Will be pre-pended with PROFILEKEY.
+    * @return Stored DisplaySettings or null if none found.
     */
    public static DisplaySettings restoreFromProfile(UserProfile profile, String key) {
       MutablePropertyMapView mpmv = profile.getSettings(DefaultDisplaySettings.class);
@@ -368,14 +374,15 @@ public final class DefaultDisplaySettings implements DisplaySettings {
     * default value. This is specifically available to allow the Snap/Live
     * Manager to default to grayscale instead of the normal default (returned
     * from getStandardSettings) of composite mode.
+    *
     * @param key Profile key to use, as per [get|set]StandardSettings.
     */
    public static ColorMode getStandardColorMode(String key,
          DisplaySettings.ColorMode defaultVal) {
       UserProfile profile = MMStudio.getInstance().profile();
       key = key + "_";
-      Integer mode = profile.getSettings(DefaultDisplaySettings.class).
-              getInteger(CHANNEL_COLOR_MODE, -1);
+      Integer mode = profile.getSettings(DefaultDisplaySettings.class)
+            .getInteger(CHANNEL_COLOR_MODE, -1);
       if (mode == -1) {
          return defaultVal;
       }
@@ -413,6 +420,9 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       return result;
    }
 
+   /**
+    * Deprecated way of storing default contrast settings.
+    */
    @Deprecated
    public static class DefaultContrastSettings implements DisplaySettings.ContrastSettings {
       Integer[] contrastMins_;
@@ -422,6 +432,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
 
       /**
        * Convenience method for single-component settings.
+       *
        * @param contrastMin - new value for contrastMin
        * @param contrastMax - new value for contrastMax
        * @param gamma - new gamma value
@@ -452,8 +463,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       @Override
       @Deprecated
       public Integer getSafeContrastMin(int component, Integer defaultVal) {
-         if (component < 0 || contrastMins_ == null ||
-               contrastMins_.length <= component) {
+         if (component < 0 || contrastMins_ == null
+               || contrastMins_.length <= component) {
             return defaultVal;
          }
          return contrastMins_[component];
@@ -468,8 +479,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       @Override
       @Deprecated
       public Integer getSafeContrastMax(int component, Integer defaultVal) {
-         if (component < 0 || contrastMaxes_ == null ||
-               contrastMaxes_.length <= component) {
+         if (component < 0 || contrastMaxes_ == null
+               || contrastMaxes_.length <= component) {
             return defaultVal;
          }
          return contrastMaxes_[component];
@@ -483,8 +494,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
 
       @Override
       public Double getSafeContrastGamma(int component, Double defaultVal) {
-         if (component < 0 || gammas_ == null ||
-               gammas_.length <= component) {
+         if (component < 0 || gammas_ == null
+               || gammas_.length <= component) {
             return defaultVal;
          }
          return gammas_[component];
@@ -530,17 +541,17 @@ public final class DefaultDisplaySettings implements DisplaySettings {
          Integer[] altMins = alt.getContrastMins();
          Integer[] altMaxes = alt.getContrastMaxes();
          Double[] altGammas = alt.getContrastGammas();
-         if (((contrastMins_ == null) != (altMins == null)) ||
-               ((contrastMaxes_ == null) != (altMaxes == null)) ||
-               ((gammas_ == null) != (altGammas == null))) {
+         if (((contrastMins_ == null) != (altMins == null))
+               || ((contrastMaxes_ == null) != (altMaxes == null))
+               || ((gammas_ == null) != (altGammas == null))) {
             // Someone's array is null where the other one isn't.
             return false;
          }
-         if ((contrastMins_ != null &&
-               !Arrays.deepEquals(contrastMins_, altMins)) ||
-               (contrastMaxes_ != null &&
-                !Arrays.deepEquals(contrastMaxes_, altMaxes)) ||
-               (gammas_ != null && !Arrays.deepEquals(gammas_, altGammas))) {
+         if ((contrastMins_ != null
+               && !Arrays.deepEquals(contrastMins_, altMins))
+               || (contrastMaxes_ != null
+               && !Arrays.deepEquals(contrastMaxes_, altMaxes))
+               || (gammas_ != null && !Arrays.deepEquals(gammas_, altGammas))) {
             // Arrays contain unequal values.
             return false;
          }
@@ -552,7 +563,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       public String toString() {
          String result = String.format("<ContrastSettings (%d components)", getNumComponents());
          for (int i = 0; i < getNumComponents(); ++i) {
-            result += String.format("(%d, %d @ %.2f)", getSafeContrastMin(i, -1), getSafeContrastMax(i, -1), getSafeContrastGamma(i, -1.0));
+            result += String.format("(%d, %d @ %.2f)", getSafeContrastMin(i, -1),
+                  getSafeContrastMax(i, -1), getSafeContrastGamma(i, -1.0));
          }
          if (isVisible_ != null) {
             result += isVisible_ ? " (visible)" : " (hidden)";
@@ -563,8 +575,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
 
    @Deprecated
    public static class LegacyBuilder extends Builder
-         implements DisplaySettings.DisplaySettingsBuilder
-   {
+         implements DisplaySettings.DisplaySettingsBuilder {
       @Override
       public DefaultDisplaySettings build() {
          return new DefaultDisplaySettings(this);
@@ -576,8 +587,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             if (channelColors[i] == null) {
                continue;
             }
-            channel(i, getChannelSettings(i).copyBuilder().
-                  color(channelColors[i]).build());
+            channel(i, getChannelSettings(i).copyBuilder()
+                  .color(channelColors[i]).build());
          }
          return this;
       }
@@ -585,8 +596,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       @Override
       public DisplaySettingsBuilder safeUpdateChannelColor(Color newColor,
             int channelIndex) {
-         channel(channelIndex, getChannelSettings(channelIndex).copyBuilder().
-               color(newColor).build());
+         channel(channelIndex, getChannelSettings(channelIndex).copyBuilder()
+               .color(newColor).build());
          return this;
       }
 
@@ -616,18 +627,18 @@ public final class DefaultDisplaySettings implements DisplaySettings {
          for (int j = 0; j < legacySettings.getNumComponents(); ++j) {
             ComponentDisplaySettings.Builder componentBuilder =
                   channelSettings.getComponentSettings(j).copyBuilder();
-            if (legacySettings.getContrastMins() != null &&
-                  legacySettings.getContrastMins()[j] != null) {
+            if (legacySettings.getContrastMins() != null
+                  && legacySettings.getContrastMins()[j] != null) {
                componentBuilder = componentBuilder.scalingMinimum(
                      legacySettings.getContrastMins()[j]);
             }
-            if (legacySettings.getContrastMaxes() != null &&
-                  legacySettings.getContrastMaxes()[j] != null) {
+            if (legacySettings.getContrastMaxes() != null
+                  && legacySettings.getContrastMaxes()[j] != null) {
                componentBuilder = componentBuilder.scalingMaximum(
                      legacySettings.getContrastMaxes()[j]);
             }
-            if (legacySettings.getContrastGammas() != null &&
-                  legacySettings.getContrastGammas()[j] != null) {
+            if (legacySettings.getContrastGammas() != null
+                  && legacySettings.getContrastGammas()[j] != null) {
                componentBuilder = componentBuilder.scalingGamma(
                      legacySettings.getContrastGammas()[j]);
             }
@@ -805,9 +816,14 @@ public final class DefaultDisplaySettings implements DisplaySettings {
 
    @Override
    public DisplaySettings.Builder copyBuilder() {
-      DisplaySettings.Builder ret = builder().zoomRatio(zoom_).playbackFPS(fps_).colorMode(mode_).
-            uniformChannelScaling(uniformChannelScaling_).
-            autostretch(autostretch_).roiAutoscale(useROI_).autoscaleIgnoredQuantile(extremaQuantile_);
+      DisplaySettings.Builder ret = builder()
+            .zoomRatio(zoom_)
+            .playbackFPS(fps_)
+            .colorMode(mode_)
+            .uniformChannelScaling(uniformChannelScaling_)
+            .autostretch(autostretch_)
+            .roiAutoscale(useROI_)
+            .autoscaleIgnoredQuantile(extremaQuantile_);
       for (int i = 0; i < getNumberOfChannels(); ++i) {
          ret.channel(i, channelSettings_.get(i));
       }
@@ -816,27 +832,30 @@ public final class DefaultDisplaySettings implements DisplaySettings {
 
    @Override
    public DisplaySettings.Builder copyBuilderWithChannelSettings(int channel,
-         ChannelDisplaySettings settings)
-   {
+         ChannelDisplaySettings settings) {
       return copyBuilder().channel(channel, settings);
    }
 
    @Override
    public DisplaySettings.Builder copyBuilderWithComponentSettings(
-         int channel, int component, ComponentDisplaySettings settings)
-   {
+         int channel, int component, ComponentDisplaySettings settings) {
       return copyBuilder().channel(channel,
-            getChannelSettings(channel).
-                  copyBuilderWithComponentSettings(component, settings).
-                  build());
+            getChannelSettings(channel)
+                  .copyBuilderWithComponentSettings(component, settings)
+                  .build());
    }
 
    @Override
    @Deprecated
    public DisplaySettingsBuilder copy() {
-      DisplaySettings.Builder ret = new LegacyBuilder().zoomRatio(zoom_).playbackFPS(fps_).colorMode(mode_).
-            uniformChannelScaling(uniformChannelScaling_).
-            autostretch(autostretch_).roiAutoscale(useROI_).autoscaleIgnoredQuantile(extremaQuantile_);
+      DisplaySettings.Builder ret = new LegacyBuilder()
+            .zoomRatio(zoom_)
+            .playbackFPS(fps_)
+            .colorMode(mode_)
+            .uniformChannelScaling(uniformChannelScaling_)
+            .autostretch(autostretch_)
+            .roiAutoscale(useROI_)
+            .autoscaleIgnoredQuantile(extremaQuantile_);
       for (int i = 0; i < getNumberOfChannels(); ++i) {
          ret.channel(i, channelSettings_.get(i));
       }
@@ -921,8 +940,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             builder.extremaPercentage(tags.getDouble(EXTREMA_PERCENTAGE));
          }
          return builder.build();
-      }
-      catch (JSONException e) {
+      } catch (JSONException e) {
          ReportingUtils.logError(e, "Couldn't convert JSON into DisplaySettings");
          return null;
       }
@@ -942,8 +960,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
                val = "null";
             }
             result += String.format("\n    %s: %s", field.getName(), val.toString());
-         }
-         catch (IllegalAccessException e) {
+         } catch (IllegalAccessException e) {
             ReportingUtils.logError(e, "Couldn't access field " + field.getName());
          }
       }
@@ -952,8 +969,9 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    /**
-    * Store these displaySettings in a propertyMap
+    * Store these displaySettings in a propertyMap.
     * NS: Should this be in the API?
+    *
     * @return PropertyMap containing these DisplaySettings
     */
    public PropertyMap toPropertyMap() {
@@ -962,24 +980,25 @@ public final class DefaultDisplaySettings implements DisplaySettings {
          channelSettings.add(((DefaultChannelDisplaySettings) cs).toPropertyMap());
       }
       
-      return PropertyMaps.builder().
-            putDouble(PropertyKey.ZOOM_RATIO.key(), zoom_).
-            putDouble(PropertyKey.PLAYBACK_FPS.key(), fps_).
-            putEnumAsString(PropertyKey.COLOR_MODE.key(), mode_).
-            putBoolean(PropertyKey.UNIFORM_CHANNEL_SCALING.key(), uniformChannelScaling_).
-            putBoolean(PropertyKey.AUTOSTRETCH.key(), autostretch_).
-            putBoolean(PropertyKey.ROI_AUTOSCALE.key(), useROI_).
-            putDouble(PropertyKey.AUTOSCALE_IGNORED_QUANTILE.key(), extremaQuantile_).
-            putPropertyMapList(PropertyKey.CHANNEL_SETTINGS.key(), channelSettings).
-            build();
+      return PropertyMaps.builder()
+            .putDouble(PropertyKey.ZOOM_RATIO.key(), zoom_)
+            .putDouble(PropertyKey.PLAYBACK_FPS.key(), fps_)
+            .putEnumAsString(PropertyKey.COLOR_MODE.key(), mode_)
+            .putBoolean(PropertyKey.UNIFORM_CHANNEL_SCALING.key(), uniformChannelScaling_)
+            .putBoolean(PropertyKey.AUTOSTRETCH.key(), autostretch_)
+            .putBoolean(PropertyKey.ROI_AUTOSCALE.key(), useROI_)
+            .putDouble(PropertyKey.AUTOSCALE_IGNORED_QUANTILE.key(), extremaQuantile_)
+            .putPropertyMapList(PropertyKey.CHANNEL_SETTINGS.key(), channelSettings)
+            .build();
    }
    
    /**
-    * Restore DisplaySettings from a PropertyMap
+    * Restore DisplaySettings from a PropertyMap.
     * NS: Should this be in the api?
+    *
     * @param pMap PropertyMap to be restored to DisplaySettings
     * @return restored DisplaySettings.  Any missing component will be replaced 
-    * with the (Builder's) default 
+    *         with the (Builder's) default.
     */
    public static DisplaySettings fromPropertyMap(PropertyMap pMap) {
       DefaultDisplaySettings.Builder ddsb = new DefaultDisplaySettings.Builder();
@@ -1007,14 +1026,16 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             ddsb.roiAutoscale(pMap.getBoolean(PropertyKey.ROI_AUTOSCALE.key(), ddsb.useROI_));
          }
          if (pMap.containsDouble(PropertyKey.AUTOSCALE_IGNORED_QUANTILE.key())) {
-            ddsb.autoscaleIgnoredQuantile(pMap.getDouble(PropertyKey.AUTOSCALE_IGNORED_QUANTILE.key(),
+            ddsb.autoscaleIgnoredQuantile(pMap.getDouble(PropertyKey
+                        .AUTOSCALE_IGNORED_QUANTILE.key(),
                     ddsb.extremaQuantile_));
          }
          if (pMap.containsPropertyMapList(PropertyKey.CHANNEL_SETTINGS.key())) {
             List<PropertyMap> propertyMapList = pMap.getPropertyMapList(
                     PropertyKey.CHANNEL_SETTINGS.key(), new ArrayList<PropertyMap>());
             for (int i = 0; i < propertyMapList.size(); i++) {
-               ddsb.channel(i, DefaultChannelDisplaySettings.fromPropertyMap(propertyMapList.get(i)));
+               ddsb.channel(i, DefaultChannelDisplaySettings
+                     .fromPropertyMap(propertyMapList.get(i)));
             }
          }
       } // note that if PropertyMap was null, the builder will return defaults
@@ -1023,10 +1044,10 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
 
    /**
-    * Extracts DisplaySettings from given File
+    * Extracts DisplaySettings from given File.
     *
-    * @param sourceFile
-    * @return
+    * @param sourceFile file to read settings from.
+    * @return DisplaySettings restored from file.
     */  
    public static DisplaySettings getSavedDisplaySettings(final File sourceFile) {
       if (sourceFile.canRead()) {
@@ -1042,18 +1063,20 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    }
    
    /**
-    * Saves the current displaySettings to the indicated File
-    * DisplaySettings are saves as a JSON encoded PropertyMap
-    * 
+    * Saves the current displaySettings to the indicated File.
+    * DisplaySettings are saved as a JSON encoded PropertyMap.
+    *
     * @param destination File to which these DisplaySettings should be saved
     */
    public void save(File destination) {
       try {
          if (!toPropertyMap().saveJSON(destination, true, false)) {
-            ReportingUtils.logError("Failed to save Display Settings to: " + destination.getPath());
+            ReportingUtils.logError("Failed to save Display Settings to: "
+                  + destination.getPath());
          }
       } catch (IOException ioe) {
-         ReportingUtils.logError(ioe, "Failed to save Display Settings to: " + destination.getPath());
+         ReportingUtils.logError(ioe, "Failed to save Display Settings to: "
+               + destination.getPath());
       }
    }
    
@@ -1061,13 +1084,13 @@ public final class DefaultDisplaySettings implements DisplaySettings {
     * Saves the current displaySettings to a file in the provided path.
     * This file will be named using a common convention (DisplaySettings.json, 
     * defined in PropertyKey.DISPLAY_SETTINGS_FILE_NAME).  
-    * 
+    *
     * @param path path under which to create the DisplaySettings file 
     */
    public void save(String path) {
       // TODO: test for sanity of input path?      
-      File displaySettingsFile = new File(path + 
-               File.separator + PropertyKey.DISPLAY_SETTINGS_FILE_NAME.key() );
+      File displaySettingsFile = new File(path
+            + File.separator + PropertyKey.DISPLAY_SETTINGS_FILE_NAME.key());
       save(displaySettingsFile);
    }
 


### PR DESCRIPTION
To enable setting (and deleting and replacing) all channelDisplaySettings at once.

Failed to replicate the strange bug that I had seen before of multi-camera display appearing with a single camera config file, so did not put the new function in action yet.

Also lots of CheckStyle cleanup, but that should all be inconsequential, other than that the code looks prettier and the Javadoc improved.

Closes #1247.