### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ To get the complete source code follow these instructions:
 
 1. Clone the repository: `git clone https://github.com/micro-manager/micro-manager.git`
 2. Move Git bash into the repository: `cd micro-manager`
-3. Make sure any submodules are also cloned: `git submodule update --init --recursive`
+3. Make sure any submodules are also cloned: `git submodule update --init --recursive --remote`  
+For more information about working with Git submodules click [here](https://git-scm.com/book/en/v2/Git-Tools-Submodules).  
 
 If you are working only with the source code that is publicly available then that's all. Some vendors do not allow us to make public device adapters written for their equipment.  If you are part of the micro-manager group, you can get access to these "secret" device adapters by:
 
 1. Move Git bash into the `mmCoreAndDevices` submodule: `cd mmCoreAndDevices`
 2. Change to the "privateMain" branch: `git checkout privateMain`
-3. "privateMain" has a submodule that main does not. Make sure that any new submodules are in a consistent state: `git submodule update --init --recursive --remote`
+3. "privateMain" has a submodule that main does not. Make sure that any new submodules are in a consistent state: `git submodule update --init --recursive --remote`  
 For more information about working with Git submodules click [here](https://git-scm.com/book/en/v2/Git-Tools-Submodules). 
 
 


### PR DESCRIPTION
Fix the description of how to clone submodules. `--remote` was mentioned near the bottom of the readme but was left out from the top section. Until a better option that using the `--remote` option is implemented this will make the readme more accurate.