### PR TITLE
Studio: Avoid deadlock in animationcontroller when

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/internal/animate/AnimationController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/animate/AnimationController.java
@@ -126,7 +126,7 @@ public final class AnimationController<P> {
    /**
     * Permanently cease all animation and scheduled events.
     */
-   public synchronized void shutdown() {
+   public void shutdown() {
       scheduler_.shutdown();
       stopAnimation();
       try {
@@ -261,10 +261,10 @@ public final class AnimationController<P> {
          newDataPositionExpiredFuture_ = scheduler_.schedule(new Runnable() {
             @Override
             public void run() {
+               if (Thread.interrupted()) {
+                  return; // Canceled
+               }
                synchronized (AnimationController.this) {
-                  if (Thread.interrupted()) {
-                     return; // Canceled
-                  }
                   listeners_.fire().animationNewDataPositionExpired();
                }
             }


### PR DESCRIPTION
closing live window.  Shutting down the animation controller from the
EDT should not lead to deadlock, which it used to when the animation was
running.  I do not see a reason for shutdown to be synchronized, as all the
functions it calls are synchronized.  Possibly setting perfMon_ to null should
be behind a lock.

Closes #1261 