### PR TITLE
Makes Annotations work how they presumably were meant to work.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -128,7 +128,8 @@ public final class MMAcquisition extends DataViewerListener {
                store_.setStorage(getAppropriateStorage(studio_, store_, acqPath, true));
             } catch (Exception e) {
                ReportingUtils.showError(e, "Unable to create directory for saving images.");
-               eng.stop(true);
+               eng_.stop(true);
+               return;
             }
          } else {
             store_.setStorage(new StorageRAM(store_));

--- a/mmstudio/src/main/java/org/micromanager/data/Annotation.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Annotation.java
@@ -25,8 +25,7 @@ import org.micromanager.PropertyMap;
 
 /**
  * A Annotation is a container for mutable information that is associated with
- * a Datastore.
- * 
+ * a Datastore. *
  * Annotations are used for attributes like image comments and display settings
  * that may be changed after the Datastore has been frozen.
  */
@@ -34,6 +33,7 @@ public interface Annotation {
    /**
     * Return a PropertyMap of information stored by this Annotation related to
     * the image at the specified coordinates.
+    *
     * @param coords Coordinates of image to get data for.
     * @return PropertyMap of data related to the image, or null if none exists.
     */
@@ -42,6 +42,7 @@ public interface Annotation {
    /**
     * Return a PropertyMap of information stored by the Annotation that is not
     * specific to any one image.
+    *
     * @return PropertyMap of data related to the entire dataset, or null if
     *         none exists.
     */
@@ -50,6 +51,7 @@ public interface Annotation {
    /**
     * Replace the data this Annotation has for the specified Image with the
     * provided PropertyMap.
+    *
     * @param coords Coordinates of image whose data is to be updated.
     * @param newData Updated PropertyMap of data to be stored in the Annotation
     *        that pertains to the image
@@ -59,12 +61,15 @@ public interface Annotation {
    /**
     * Replace the data this Annotation has for the Datastore as a whole with the
     * provided PropertyMap.
+    *
     * @param newData Updated PropertyMap of data to be stored in the Annotation
     *        that is not specific to any one Image.
     */
    void setGeneralAnnotation(PropertyMap newData);
 
    /**
+    * Deprecated function returning tag (which doubles as filename) for this Annotation.
+    *
     * @return the tag for this annotation
     * @deprecated this is an old name for {@link #getTag}
     */
@@ -72,19 +77,21 @@ public interface Annotation {
    String getFilename();
 
    /**
-    * Return this annotation's tag
+    * Return this annotation's tag.
+    *
     * @return the tag for this annotation
     */
    String getTag();
 
    /**
-    * Return the datastore to which this annotation is associated
-    * @return
+    * Return the datastore to which this annotation is associated.
+    *
+    * @return Datastore associated with this annotation.
     */
    Datastore getDatastore();
 
    /**
-    * Commit the changes to this annotation
+    * Commit the changes to this annotation to disk.
     */
    void save() throws IOException;
 }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/CommentsHelper.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/CommentsHelper.java
@@ -29,7 +29,11 @@ import org.micromanager.data.Datastore;
 import org.micromanager.internal.utils.ReportingUtils;
 
 /**
- * A simple helper class to handle access of comments.
+ * Comments are handled separately from SummaryMetadata and Imagemetadata since the
+ * used may change them (add to them) at any point in time.
+ * This class facilitates supporting Comments in the various storage methods.
+ * Note that the design of this class is not final, Annotation should be
+ * part of the API.
  */
 public final class CommentsHelper {
    /** File that comments are saved in. */
@@ -38,8 +42,8 @@ public final class CommentsHelper {
    private static final String COMMENTS_KEY = "comments";
 
    /**
-    * Returns the summary comment for the specified Datastore, or "" if it
-    * does not exist.
+    * Returns the summary comment for the specified Datastore, or en empty string
+    * if no summary comment exists.
     * @param store Datastore from where to retrieve the comment
     * @return comment text
     * @throws java.io.IOException
@@ -53,7 +57,7 @@ public final class CommentsHelper {
 
    /**
     * Write a new summary comment for the given Datastore.
-    * @param store Datastore to whic to add the summary comment
+    * @param store Datastore to which to add the summary comment
     * @param comment text to be added to the metadata
     * @throws java.io.IOException
     */

--- a/mmstudio/src/main/java/org/micromanager/data/internal/CommentsHelper.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/CommentsHelper.java
@@ -132,13 +132,4 @@ public final class CommentsHelper {
       return store.hasAnnotation(COMMENTS_FILE);
    }
 
-   /**
-    * Create a new comments annotation.
-    * @param store
-    * @throws java.io.IOException
-    */
-   public static void createAnnotation(Datastore store) throws IOException {
-      //store.createNewAnnotation(COMMENTS_FILE       // throw new UnsupportedOperationException("TODO");
-      ReportingUtils.logError("TODO: Implement org.micromanager.data.internal.CommentsHelper.createAnnotation");
-   }
 }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/CommentsHelper.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/CommentsHelper.java
@@ -114,6 +114,14 @@ public final class CommentsHelper {
       annotation.save();
    }
 
+   public static void copyComments(Datastore source, Datastore target) throws IOException {
+      Annotation annotation = source.getAnnotation(COMMENTS_FILE);
+      if (target instanceof DefaultDatastore) {
+         DefaultDatastore dTarget = (DefaultDatastore) target;
+         dTarget.setAnnotation(COMMENTS_FILE, annotation);
+      }
+   }
+
    /**
     * Return true if there's a comments annotation.
     * @param store

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
@@ -90,6 +90,9 @@ public final class DefaultAnnotation implements Annotation {
          throw new RuntimeException("Asked to save Annotation when store has no save path");
       }
       File file = getFile(store_, filename_);
+      if (!file.exists()) {
+         file.createNewFile();
+      }
       PropertyMap.Builder builder = PropertyMaps.builder();
       if (generalAnnotation_ != null) {
          builder.putPropertyMap(GENERAL_KEY, generalAnnotation_);
@@ -138,7 +141,7 @@ public final class DefaultAnnotation implements Annotation {
     * @return 
     */
    public static File getFile(Datastore store, String filename) {
-      return new File(store.getSavePath() + "/" + filename);
+      return new File(store.getSavePath() + File.separator + filename);
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
@@ -45,10 +45,18 @@ public final class DefaultAnnotation implements Annotation {
    private HashMap<Coords, PropertyMap> imageAnnotations_ = new HashMap<Coords, PropertyMap>();
    private PropertyMap generalAnnotation_ = PropertyMaps.emptyPropertyMap();
 
+   /**
+    * Annotations are user-provided comments that either pertain to the complete dataset
+    * (Summary comments), or per image.
+    *
+    * @param store Datastore to which this annotation belongs.
+    * @param filename not sure what this filename refers to.
+    * @throws IOException can happen
+    */
    public DefaultAnnotation(Datastore store, String filename) throws IOException {
       store_ = store;
       filename_ = filename;
-      File target = getFile(store, filename);
+      File target = new File(store.getSavePath() + File.separator + filename);
       if (target.exists()) {
          try {
             PropertyMap data = PropertyMaps.loadJSON(new File(target.getAbsolutePath()));
@@ -71,15 +79,14 @@ public final class DefaultAnnotation implements Annotation {
                try {
                   Coords coords = DefaultCoords.fromNormalizedString(def);
                   imageAnnotations_.put(coords, data.getPropertyMap(key, null));
-               }
-               catch (IllegalArgumentException e) {
+               } catch (IllegalArgumentException e) {
                   ReportingUtils.logError("Malformatted coordinate key \"" + def + "\"");
                }
             }
-         }
-         catch (FileNotFoundException e) {
+         } catch (FileNotFoundException e) {
             // This should never happen.
-            ReportingUtils.showError(e, "Unable to load annotation at " + target.getAbsolutePath() + " because it doesn't exist");
+            ReportingUtils.showError(e, "Unable to load annotation at "
+                  + target.getAbsolutePath() + " because it doesn't exist");
          }
       }
    }
@@ -89,7 +96,7 @@ public final class DefaultAnnotation implements Annotation {
       if (store_.getSavePath() == null) {
          throw new RuntimeException("Asked to save Annotation when store has no save path");
       }
-      File file = getFile(store_, filename_);
+      File file = new File(store_.getSavePath() + File.separator + filename_);
       if (!file.exists()) {
          file.createNewFile();
       }
@@ -134,25 +141,15 @@ public final class DefaultAnnotation implements Annotation {
    }
 
    /**
-    * Utility function to get the path at which an Annotation's data should
-    * reside, if it exists.
-    * @param store
-    * @param filename
-    * @return 
-    */
-   public static File getFile(Datastore store, String filename) {
-      return new File(store.getSavePath() + File.separator + filename);
-   }
-
-   /**
     * Return true if there's an existing annotation for this datastore, on
     * disk where the datastore's own data is stored.
-    * @param store
-    * @param filename
-    * @return 
+    *
+    * @param store Datastore to interrogate
+    * @param filename Name of the annotation file
+    * @return True if the annotation file exists, false otherwise
     */
    public static boolean isAnnotationOnDisk(Datastore store, String filename) {
-      return getFile(store, filename).exists();
+      return (new File(store.getSavePath() + File.separator + filename)).exists();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ExecutionException;
 import javax.swing.SwingWorker;
 
 import org.micromanager.Studio;
+import org.micromanager.data.Annotation;
 import org.micromanager.data.Coords;
 import org.micromanager.data.Datastore;
 import org.micromanager.data.Storage;
@@ -156,7 +157,7 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
       duplicate_.freeze();
       duplicate_.close();
       // Save our annotations now.
-      for (DefaultAnnotation annotation : store_.getAnnotations().values()) {
+      for (Annotation annotation : store_.getAnnotations().values()) {
          annotation.save();
       }
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import javax.swing.SwingWorker;
-
 import org.micromanager.Studio;
 import org.micromanager.data.Annotation;
 import org.micromanager.data.Coords;
@@ -15,45 +14,50 @@ import org.micromanager.data.Datastore;
 import org.micromanager.data.Storage;
 import org.micromanager.data.SummaryMetadata;
 import org.micromanager.data.internal.multipagetiff.StorageMultipageTiff;
-import org.micromanager.internal.MMStudio;
 
 /**
- * TODO: Not sure if Swingworker is the best implementation
+ * TODO: Not sure if Swingworker is the best implementation.
  * However, it has nice facilities to give user feedback about progress 
- * of saving (using the setProgress function)
- * 
- * 
+ * of saving (using the setProgress function) *
+ *
  * @author nico
  */
 public class DefaultDataSaver extends SwingWorker<Void, Void> {
-      private final Studio studio;
-      private final DefaultDatastore store_;
-      private final Datastore.SaveMode mode_;
-      private final String path_;
-      private final DefaultDatastore duplicate_;
-      private final Storage saver_;
-      
+   private final Studio studio;
+   private final DefaultDatastore store_;
+   private final String path_;
+   private final DefaultDatastore duplicate_;
+   private final Storage saver_;
+
+   /**
+    * Takes care of most of the dirty work saving data to various targets.
+    *
+    * @param studio The ever present Studio object.
+    * @param store Datastore that is using this Datasaver.
+    * @param mode Mode (currently, RAM, Single TIffs or MultiPage Tiffs).
+    * @param path Path/directory for disk-based storage.
+    * @throws IOException Thrown by disk-based mthods.
+    */
    public DefaultDataSaver(Studio studio,
                            DefaultDatastore store,
                            Datastore.SaveMode mode,
                            String path) throws IOException {
       this.studio = studio;
       store_ = store;
-      mode_ = mode;
       path_ = path;
       
       duplicate_ = new DefaultDatastore(this.studio);
 
-      if (mode_ == Datastore.SaveMode.MULTIPAGE_TIFF) {
+      if (mode == Datastore.SaveMode.MULTIPAGE_TIFF) {
          saver_ = new StorageMultipageTiff(studio.app().getMainWindow(),
                  duplicate_,
                  path_, true, true,
                  StorageMultipageTiff.getShouldSplitPositions());
-      } else if (mode_ == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES) {
+      } else if (mode == Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES) {
          saver_ = new StorageSinglePlaneTiffSeries(duplicate_, path_, true);
       } else {
          throw new IllegalArgumentException("Unrecognized mode parameter "
-                 + mode_);
+                 + mode);
       }
       
    }
@@ -121,19 +125,22 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
                   int t2 = b.getT();
                   if (t1 != t2) {
                      return t1 < t2 ? -1 : 1;
-                  }  break;
+                  }
+                  break;
                case Coords.Z:
                   int z1 = a.getZ();
                   int z2 = b.getZ();
                   if (z1 != z2) {
                      return z1 < z2 ? -1 : 1;
-                  }  break;
+                  }
+                  break;
                case Coords.C:
                   int c1 = a.getChannel();
                   int c2 = b.getChannel();
                   if (c1 != c2) {
                      return c1 < c2 ? -1 : 1;
-                  } break;
+                  }
+                  break;
                default:
                   break;
             }
@@ -170,7 +177,7 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
       try {
          get();
       } catch (ExecutionException | InterruptedException e) {
-          studio.logs().showError(e, "Failed to save to " + path_);
+         studio.logs().showError(e, "Failed to save to " + path_);
       }
       
       studio.alerts().postAlert("Finished saving", this.getClass(), path_);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -401,7 +401,8 @@ public class DefaultDatastore implements Datastore {
             CommentsHelper.copyComments(this, copiedFromStore_);
             CommentsHelper.saveComments(copiedFromStore_);
          } catch (IOException ioe) {
-            ReportingUtils.logError(ioe, "Failed to write comments for " + copiedFromStore_.getName());
+            ReportingUtils.logError(ioe, "Failed to write comments for "
+                  + copiedFromStore_.getName());
          }
       }
       if (storage_ != null) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -81,8 +81,9 @@ public class DefaultDatastore implements Datastore {
    private static final String PREFERRED_SAVE_FORMAT = "default format for saving data";
    
    protected Storage storage_ = null;
+   protected Datastore copiedFromStore_ = null;
    protected String name_ = "Untitled";
-   protected Map<String, DefaultAnnotation> annotations_ = new HashMap<>();
+   protected Map<String, Annotation> annotations_ = new HashMap<>();
    protected PrioritizedEventBus bus_;
    protected boolean isFrozen_ = false;
    protected final Studio studio_;
@@ -107,6 +108,7 @@ public class DefaultDatastore implements Datastore {
     */
    public void copyFrom(Datastore alt, ProgressMonitor monitor)
          throws IOException, UserCancelledException {
+      copiedFromStore_ = alt;
       int imageCount = 0;
       try {
          setSummaryMetadata(alt.getSummaryMetadata());
@@ -130,7 +132,6 @@ public class DefaultDatastore implements Datastore {
          studio_.logs().logError("Inconsistent image coordinates in datastore");
       }
    }
-   
    
    @Override
    public void setName(String name) {
@@ -323,6 +324,10 @@ public class DefaultDatastore implements Datastore {
       return result;
    }
 
+   public void setAnnotation(String tag, Annotation annotation) {
+      annotations_.put(tag, annotation);
+   }
+
    /**
     * Loads annotation from a string and adds to this stores annotations.
     *
@@ -391,6 +396,14 @@ public class DefaultDatastore implements Datastore {
       freeze();
       studio_.events().post(
             new DefaultDatastoreClosingEvent(this));
+      if (copiedFromStore_ != null) {
+         try {
+            CommentsHelper.copyComments(this, copiedFromStore_);
+            CommentsHelper.saveComments(copiedFromStore_);
+         } catch (IOException ioe) {
+            ReportingUtils.logError(ioe, "Failed to write comments for " + copiedFromStore_.getName());
+         }
+      }
       if (storage_ != null) {
          storage_.close();
          // since we call the gc, make sure that storage, which contains the first
@@ -398,7 +411,6 @@ public class DefaultDatastore implements Datastore {
          storage_ = null;
          System.gc();
       }
-      annotations_ = null;
       bus_.shutDown();
    }
 
@@ -497,7 +509,7 @@ public class DefaultDatastore implements Datastore {
       }
    }
    
-   protected Map<String, DefaultAnnotation> getAnnotations() {
+   protected Map<String, Annotation> getAnnotations() {
       return annotations_;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -38,7 +38,6 @@ import org.micromanager.data.SummaryMetadata;
 /**
  * Simple RAM-based storage for Datastores. Methods that interact with the
  * HashMap that is our image storage are synchronized.
- * 
  * TODO: coordsToImage_ can be set to null in the close function
  * if any of the member functions are called after "close", a null pointer exception
  * will follow.  We can either check for null whenever coordsToImage is used,
@@ -52,6 +51,11 @@ public final class StorageRAM implements RewritableStorage {
    private final Set<String> axesInUse_;
    private Image anyImage_;
 
+   /**
+    * Image Data Storage located in RAM.
+    *
+    * @param store Datastore that "owns" this storage.
+    */
    public StorageRAM(Datastore store) {
       coordsToImage_ = new HashMap<>();
       maxIndex_ = new DefaultCoords.Builder().build();
@@ -130,6 +134,18 @@ public final class StorageRAM implements RewritableStorage {
       return results;
    }
 
+   /**
+    * Finds images in this storage that match the given coord, but ignore
+    * the provided axes (i.e., remove those axes from our images, and
+    * then check if the Coord is identical to the one given).
+    *
+    * @param coords coord looking for matching images
+    * @param ignoreTheseAxes Axes to be ignored in the images collection when
+    *                        looking for matches
+    * @return List with Images that have the same coord as the one given
+    *         (except for the axes to be ignored).
+    * @throws IOException Not sure why this is here, should never be thrown.
+    */
    public synchronized List<Image> getImagesIgnoringAxes(Coords coords, String... ignoreTheseAxes)
            throws IOException {
       if (coordsToImage_ == null) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
@@ -218,6 +218,15 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
    public void freeze() {
       closeMetadataStreams();
       isDatasetWritable_ = false;
+      saveComments();
+   }
+
+   private void saveComments() {
+      try {
+         CommentsHelper.saveComments(store_);
+      } catch (IOException ioe) {
+         ReportingUtils.logError(ioe, "Failed to write comments for " + store_.getName());
+      }
    }
 
    @Override
@@ -572,6 +581,7 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
       String time = image.getMetadata().getReceivedTime();
       // TODO: should we log if the date isn't available?
       SummaryMetadata summary = summaryMetadata_;
+      String summaryComment = CommentsHelper.getSummaryComment(store_);
       if (time != null && summary.getStartDate() == null) {
          summary = summary.copyBuilder().startDate(time.split(" ")[0]).build();
       }
@@ -801,6 +811,7 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
 
    @Override
    public void close() {
+      saveComments();
       // We don't maintain any state that needs to be cleaned up.
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -276,7 +276,6 @@ public final class MultipageTiffReader {
          // Already have a comments annotation set up; bail.
          return;
       }
-      boolean didCreate = false;
       ByteBuffer buffer = null;
       try {
          long offset = readOffsetHeaderAndOffset(MultipageTiffWriter.COMMENTS_OFFSET_HEADER, 24);
@@ -292,11 +291,6 @@ public final class MultipageTiffReader {
             if (comments.getString(key).equals("")) {
                continue;
             }
-            if (!didCreate) {
-               // Have at least one comment, so create the annotation.
-               CommentsHelper.createAnnotation(store);
-               didCreate = true;
-            }
             if (key.equals("Summary")) {
                CommentsHelper.setSummaryComment(store, comments.getString(key));
                continue;
@@ -309,9 +303,7 @@ public final class MultipageTiffReader {
             CommentsHelper.setImageComment(store, builder.build(),
                   comments.getString(key));
          }
-         if (didCreate) {
-            CommentsHelper.saveComments(store);
-         }
+         CommentsHelper.saveComments(store);
       }
       catch (JSONException e) {
          ReportingUtils.logError(e, "Unable to generate JSON from buffer " + getString(buffer));

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -551,8 +551,10 @@ public final class MultipageTiffReader {
          raFile_.close();
          raFile_ = null;
       }
-      CommentsHelper.saveComments(masterStorage_.getDatastore());
-      masterStorage_ = null;
+      if (masterStorage_ != null) {
+         CommentsHelper.saveComments(masterStorage_.getDatastore());
+         masterStorage_ = null;
+      }
    }
 
    private long unsignInt(int i) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -19,6 +19,7 @@
 //               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 //
+
 package org.micromanager.data.internal.multipagetiff;
 
 import com.google.common.collect.ImmutableList;
@@ -60,6 +61,9 @@ import org.micromanager.internal.utils.MDUtils;
 import org.micromanager.internal.utils.ProgressBar;
 import org.micromanager.internal.utils.ReportingUtils;
 
+/**
+ * Reads in Multi-page Tiff Data from disk.
+ */
 public final class MultipageTiffReader {
 
    private static final long BIGGEST_INT_BIT = (long) Math.pow(2, 31);
@@ -87,10 +91,11 @@ public final class MultipageTiffReader {
 
    /**
     * This constructor is used for a file that is currently being written.
-    * @param masterStorage
-    * @param summaryMD
-    * @param summaryPmap
-    * @param firstImage
+    *
+    * @param masterStorage Storage entity that will be using this reader
+    * @param summaryMD Summary Metadata
+    * @param summaryPmap unused, delete?
+    * @param firstImage unused, delete?
     */
    public MultipageTiffReader(StorageMultipageTiff masterStorage,
          SummaryMetadata summaryMD, PropertyMap summaryPmap,
@@ -109,7 +114,7 @@ public final class MultipageTiffReader {
    }
 
    /**
-    * This constructor is used for opening datasets that have already been saved
+    * This constructor is used for opening datasets that have already been saved.
     */
    public MultipageTiffReader(StorageMultipageTiff masterStorage, File file)
          throws IOException, InvalidIndexMapException {
@@ -126,8 +131,7 @@ public final class MultipageTiffReader {
 
       try {
          readIndexMap();
-      }
-      catch (IOException e) {
+      } catch (IOException e) {
          // Unlike other IOErrors, this is a potentially recoverable error.
          throw new InvalidIndexMapException(e);
       }
@@ -145,8 +149,7 @@ public final class MultipageTiffReader {
       file_ = file;
       try {
          createFileChannel(true);
-      }
-      catch (Exception ex) {
+      } catch (Exception ex) {
          ReportingUtils.showError(ex, "Cannot open file: " +  file_.getName());
          throw ex instanceof IOException ? (IOException) ex : new IOException(ex);
       }
@@ -156,46 +159,58 @@ public final class MultipageTiffReader {
       fixIndexMap(firstIFD, file.getName());
    }
 
+   /**
+    * Determined if the given directory contains a Micro-Manager Multi-page TIFF
+    * dataset.
+    *
+    * @param directory Where to look
+    * @return True if this is a Micro-Manager Multipage Tiff data set, false otherwise.
+    * @throws IOException when underlying code throws an IOException, or when directory
+    *                      is empty.
+    */
    public static boolean isMMMultipageTiff(String directory) throws IOException {
       File dir = new File(directory);
       File[] children = dir.listFiles();
       if (children == null) {
-         throw new IOException(directory + " does not appear to be a directory; is this a \u00B5Manager dataset?");
+         throw new IOException(directory
+               + " does not appear to be a directory; is this a Micro-Manager dataset?");
       }
       File testFile = null;
       for (File child : children) {
          if (child.isDirectory()) {
             File[] grandchildren = child.listFiles();
             for (File grandchild : grandchildren) {
-               if ( (!grandchild.getName().startsWith("._")) && grandchild.getName().endsWith(".tif")) {
+               if ((!grandchild.getName().startsWith("._")) && grandchild.getName()
+                     .endsWith(".tif")) {
                   testFile = grandchild;
                   break;
                }
             }
-         } else if ( (!child.getName().startsWith("._")) && 
-                 child.getName().endsWith(".tif") || child.getName().endsWith(".TIF")) {
+         } else if ((!child.getName().startsWith("._"))
+               && child.getName().endsWith(".tif") || child.getName().endsWith(".TIF")) {
             testFile = child;
             break;
          }
       }
       if (testFile == null) {
-         throw new IOException("Unable to find any .tif files in " + directory + "; is this a \u00B5Manager dataset?");
+         throw new IOException("Unable to find any .tif files in "
+               + directory + "; is this a Micro-Manager dataset?");
       }
       RandomAccessFile ra;
       try {
-         ra = new RandomAccessFile(testFile,"r");
+         ra = new RandomAccessFile(testFile, "r");
       } catch (FileNotFoundException ex) {
-        ReportingUtils.logError(ex);
-        return false;
+         ReportingUtils.logError(ex);
+         return false;
       }
       FileChannel channel = ra.getChannel();
       ByteBuffer tiffHeader = ByteBuffer.allocate(36);
       ByteOrder bo;
-      channel.read(tiffHeader,0);
+      channel.read(tiffHeader, 0);
       char zeroOne = tiffHeader.getChar(0);
-      if (zeroOne == 0x4949 ) {
+      if (zeroOne == 0x4949) {
          bo = ByteOrder.LITTLE_ENDIAN;
-      } else if (zeroOne == 0x4d4d ) {
+      } else if (zeroOne == 0x4d4d) {
          bo = ByteOrder.BIG_ENDIAN;
       } else {
          throw new IOException("Error reading TIFF header");
@@ -204,35 +219,24 @@ public final class MultipageTiffReader {
       int summaryMDHeader = tiffHeader.getInt(32);
       channel.close();
       ra.close();
-      if (summaryMDHeader == MultipageTiffWriter.SUMMARY_MD_HEADER) {
-         return true;
-      }
-      return false;
+      return summaryMDHeader == MultipageTiffWriter.SUMMARY_MD_HEADER;
    }
 
    public SummaryMetadata getSummaryMetadata() {
       return summaryMetadata_;
    }
 
-   public DefaultImage readImage(Coords coords) throws IOException {
-      if (!coordsToOffset_.containsKey(coords)) {
-         // Coordinates not in our map; maybe the writer hasn't finished
-         // writing it?
-         return null;
-      }
-      if (fileChannel_ == null) {
-         ReportingUtils.logError("Attempted to read image on FileChannel that is null");
-         return null;
-      }
-      long byteOffset = coordsToOffset_.get(coords);
 
-      IFDData data = readIFD(byteOffset);
-      return (DefaultImage) readImage(data);
-   }
 
+   /**
+    * Returns the Coords this reader knows about .
+    *
+    * @return Set of known Coords
+    */
    public Set<Coords> getIndexKeys() {
-      if (coordsToOffset_ == null)
+      if (coordsToOffset_ == null) {
          return null;
+      }
       return coordsToOffset_.keySet();
    }
 
@@ -255,8 +259,8 @@ public final class MultipageTiffReader {
       reader.setLenient(true);
       JsonElement summaryGson = parser.parse(reader);
 
-      imageFormatReadFromSummary_ = NonPropertyMapJSONFormats.imageFormat().
-            fromGson(summaryGson);
+      imageFormatReadFromSummary_ = NonPropertyMapJSONFormats.imageFormat()
+            .fromGson(summaryGson);
       summaryMetadata_ = DefaultSummaryMetadata.fromPropertyMap(
             NonPropertyMapJSONFormats.summaryMetadata().fromGson(summaryGson));
    }
@@ -304,11 +308,9 @@ public final class MultipageTiffReader {
                   comments.getString(key));
          }
          CommentsHelper.saveComments(store);
-      }
-      catch (JSONException e) {
+      } catch (JSONException e) {
          ReportingUtils.logError(e, "Unable to generate JSON from buffer " + getString(buffer));
-      }
-      catch (IOException e) {
+      } catch (IOException e) {
          ReportingUtils.logError(e, "Error reading comments block");
       }
    }
@@ -319,11 +321,13 @@ public final class MultipageTiffReader {
       return buffer;
    }
 
-   private long readOffsetHeaderAndOffset(int offsetHeaderVal, int startOffset) throws IOException  {
-      ByteBuffer buffer1 = readIntoBuffer(startOffset,8);
+   private long readOffsetHeaderAndOffset(int offsetHeaderVal, int startOffset)
+         throws IOException  {
+      ByteBuffer buffer1 = readIntoBuffer(startOffset, 8);
       int offsetHeader = buffer1.getInt(0);
-      if ( offsetHeader != offsetHeaderVal) {
-         throw new IOException("Offset header incorrect, expected: " + offsetHeaderVal +"   found: " + offsetHeader);
+      if (offsetHeader != offsetHeaderVal) {
+         throw new IOException("Offset header incorrect, expected: "
+               + offsetHeaderVal + "   found: " + offsetHeader);
       }
       return unsignInt(buffer1.getInt(4));     
    }
@@ -336,13 +340,13 @@ public final class MultipageTiffReader {
       }
       int numMappings = header.getInt(4);
       coordsToOffset_ = new HashMap<Coords, Long>();
-      ByteBuffer mapBuffer = readIntoBuffer(offset+8, 20*numMappings);     
+      ByteBuffer mapBuffer = readIntoBuffer(offset + 8, 20 * numMappings);
       for (int i = 0; i < numMappings; i++) {
-         int channel = mapBuffer.getInt(i*20);
-         int slice = mapBuffer.getInt(i*20+4);
-         int frame = mapBuffer.getInt(i*20+8);
-         int position = mapBuffer.getInt(i*20+12);
-         long imageOffset = unsignInt(mapBuffer.getInt(i*20+16));
+         int channel = mapBuffer.getInt(i * 20);
+         int slice = mapBuffer.getInt(i * 20 + 4);
+         int frame = mapBuffer.getInt(i * 20 + 8);
+         int position = mapBuffer.getInt(i * 20 + 12);
+         long imageOffset = unsignInt(mapBuffer.getInt(i * 20 + 16));
          if (imageOffset == 0) {
             break; // end of index map reached
          }
@@ -394,6 +398,29 @@ public final class MultipageTiffReader {
       }
    }
 
+   /**
+    * Reads image with given Coords from disk.
+    *
+    * @param coords Coords indicating which image should be retrieved.
+    * @return Image matching Coords
+    * @throws IOException When reading fails
+    */
+   public DefaultImage readImage(Coords coords) throws IOException {
+      if (!coordsToOffset_.containsKey(coords)) {
+         // Coordinates not in our map; maybe the writer hasn't finished
+         // writing it?
+         return null;
+      }
+      if (fileChannel_ == null) {
+         ReportingUtils.logError("Attempted to read image on FileChannel that is null");
+         return null;
+      }
+      long byteOffset = coordsToOffset_.get(coords);
+
+      IFDData data = readIFD(byteOffset);
+      return (DefaultImage) readImage(data);
+   }
+
    private Image readImage(IFDData data) throws IOException {
       ByteBuffer pixelBuffer = ByteBuffer.allocate((int) data.bytesPerImage).order(byteOrder_);
       ByteBuffer mdBuffer = ByteBuffer.allocate((int) data.mdLength).order(byteOrder_);
@@ -407,8 +434,8 @@ public final class MultipageTiffReader {
       JsonElement mdGson = parser.parse(reader);
 
       try {
-         PropertyMap formatPmap = NonPropertyMapJSONFormats.imageFormat().
-                 fromGson(mdGson);
+         PropertyMap formatPmap = NonPropertyMapJSONFormats.imageFormat()
+                 .fromGson(mdGson);
          Coords coords = DefaultCoords.fromPropertyMap(
                  NonPropertyMapJSONFormats.coords().fromGson(mdGson));
          Metadata metadata = DefaultMetadata.fromPropertyMap(
@@ -426,10 +453,10 @@ public final class MultipageTiffReader {
                // TODO We should probably try the IFD before giving up
                throw new IOException("Cannot find image width and height");
             }
-            formatPmap = formatPmap.copyBuilder().
-                    putInteger(PropertyKey.WIDTH.key(), width).
-                    putInteger(PropertyKey.HEIGHT.key(), height).
-                    build();
+            formatPmap = formatPmap.copyBuilder()
+                    .putInteger(PropertyKey.WIDTH.key(), width)
+                    .putInteger(PropertyKey.HEIGHT.key(), height)
+                    .build();
          }
 
          PixelType pixelType = formatPmap.getStringAsEnum(
@@ -490,29 +517,29 @@ public final class MultipageTiffReader {
    private IFDEntry readDirectoryEntry(int offset, ByteBuffer buffer) throws IOException {
       char tag =  buffer.getChar(offset); 
       char type = buffer.getChar(offset + 2);
-      long count = unsignInt( buffer.getInt(offset + 4) );
+      long count = unsignInt(buffer.getInt(offset + 4));
       long value;
-      if ( type == 3 && count == 1) {
+      if (type == 3 && count == 1) {
          value = buffer.getChar(offset + 8);
       } else {
          value = unsignInt(buffer.getInt(offset + 8));
       }
-      return (new IFDEntry(tag,type,count,value));
+      return (new IFDEntry(tag, type, count, value));
    }
 
    //returns byteoffset of first IFD
    private long readHeader() throws IOException {           
       ByteBuffer tiffHeader = ByteBuffer.allocate(8);
-      fileChannel_.read(tiffHeader,0);
+      fileChannel_.read(tiffHeader, 0);
       char zeroOne = tiffHeader.getChar(0);
-      if (zeroOne == 0x4949 ) {
+      if (zeroOne == 0x4949) {
          byteOrder_ = ByteOrder.LITTLE_ENDIAN;
-      } else if (zeroOne == 0x4d4d ) {
+      } else if (zeroOne == 0x4d4d) {
          byteOrder_ = ByteOrder.BIG_ENDIAN;
       } else {
          throw new IOException("Error reading Tiff header");
       }
-      tiffHeader.order( byteOrder_ );  
+      tiffHeader.order(byteOrder_);
       short twoThree = tiffHeader.getShort(2);
       if (twoThree != 42) {
          throw new IOException("Tiff identifier code incorrect");
@@ -529,11 +556,17 @@ public final class MultipageTiffReader {
       }
    }
 
-   private void createFileChannel(boolean isReadWrite) throws FileNotFoundException, IOException {      
+   private void createFileChannel(boolean isReadWrite)
+         throws FileNotFoundException, IOException {
       raFile_ = new RandomAccessFile(file_, isReadWrite ? "rw" : "r");
       fileChannel_ = raFile_.getChannel();
    }
 
+   /**
+    * Closes this MultipageTIffReader. Saves comments.
+    *
+    * @throws IOException Accessing disk can cause these.
+    */
    public void close() throws IOException {
       if (fileChannel_ != null) {
          fileChannel_.close();
@@ -561,17 +594,18 @@ public final class MultipageTiffReader {
    // terminates before properly closing, thereby preventing the multipage tiff
    // writer from putting in the index map, comments, channels, and OME XML in
    // the ImageDescription tag location
-   private void fixIndexMap(long firstIFD, String fileName) throws IOException {
-      long filePosition = firstIFD;
+   private void fixIndexMap(final long firstIFD, final String fileName) throws IOException {
       coordsToOffset_ = new HashMap<Coords, Long>();
       long progBarMax = (fileChannel_.size() / 2L);
       final ProgressBar progressBar = new ProgressBar(null, "Fixing " + fileName, 0, 
               progBarMax >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) progBarMax);
-      progressBar.setRange(0, progBarMax >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) progBarMax);
+      progressBar.setRange(0, progBarMax >= Integer.MAX_VALUE ? Integer.MAX_VALUE
+                                                               : (int) progBarMax);
       progressBar.setProgress(0);
       progressBar.setVisible(true);
       long nextIFDOffsetLocation = 0;
       IFDData data;
+      long filePosition = firstIFD;
       while (filePosition > 0) {
          try {
             data = readIFD(filePosition);
@@ -588,7 +622,7 @@ public final class MultipageTiffReader {
             }
             coordsToOffset_.put(image.getCoords(), filePosition);
 
-            final int progress = (int) (filePosition/2L);
+            final int progress = (int) (filePosition / 2L);
             SwingUtilities.invokeLater(new Runnable() {
                @Override
                public void run() {
@@ -596,7 +630,8 @@ public final class MultipageTiffReader {
                }
             });
 
-            if (data.nextIFD <= filePosition || data.nextIFDOffsetLocation <= nextIFDOffsetLocation ) {
+            if (data.nextIFD <= filePosition
+                  || data.nextIFDOffsetLocation <= nextIFDOffsetLocation) {
                break; //so no recoverable data is ever lost
             }
             filePosition = data.nextIFD;
@@ -623,14 +658,16 @@ public final class MultipageTiffReader {
    }
 
    // TODO: There is a very similar but not identical method in the Writer
-   private int writeDisplaySettings(DisplaySettings settings, long filePosition) throws IOException {
+   private int writeDisplaySettings(DisplaySettings settings, long filePosition)
+         throws IOException {
       String settingsJSON = ((DefaultDisplaySettings) settings).toPropertyMap().toJSON();
-      int numReservedBytes = settingsJSON.length() * MultipageTiffWriter.DISPLAY_SETTINGS_BYTES_PER_CHANNEL;
+      int numReservedBytes = settingsJSON.length()
+            * MultipageTiffWriter.DISPLAY_SETTINGS_BYTES_PER_CHANNEL;
       ByteBuffer header = ByteBuffer.allocate(8).order(MultipageTiffWriter.BYTE_ORDER);
-      ByteBuffer buffer = ByteBuffer.wrap(getBytesFromString(settingsJSON));
       header.putInt(0, MultipageTiffWriter.DISPLAY_SETTINGS_HEADER);
       header.putInt(4, numReservedBytes);
       fileChannel_.write(header, filePosition);
+      ByteBuffer buffer = ByteBuffer.wrap(getBytesFromString(settingsJSON));
       fileChannel_.write(buffer, filePosition + 8);
 
       ByteBuffer offsetHeader = ByteBuffer.allocate(8).order(MultipageTiffWriter.BYTE_ORDER);
@@ -658,7 +695,8 @@ public final class MultipageTiffReader {
          // the extra logging just in case.
          for (String axis : coords.getAxes()) {
             if (!ALLOWED_AXES.contains(axis)) {
-               ReportingUtils.logError("Axis " + axis + " is ignored because it is not one of " + ALLOWED_AXES.toString());
+               ReportingUtils.logError("Axis " + axis
+                     + " is ignored because it is not one of " + ALLOWED_AXES.toString());
             }
          }
          buffer.putInt(4 * position, coordsToOffset_.get(coords).intValue());
@@ -685,15 +723,19 @@ public final class MultipageTiffReader {
 
       @Override
       public String toString() {
-         return String.format("<IFDData offset %d, bytes %d, metadata offset %d, metadata length %d, next %d, next offset %d>",
+         return String.format(
+               "<IFDData offset %d, bytes %d, metadata offset %d, metadata length %d, "
+               + "next %d, next offset %d>",
                pixelOffset, bytesPerImage, mdOffset, mdLength, nextIFD,
                nextIFDOffsetLocation);
       }
    }
 
    private class IFDEntry {
-      public char tag, type;
-      public long count, value;
+      public char tag;
+      public char type;
+      public long count;
+      public long value;
 
       public IFDEntry(char tg, char typ, long cnt, long val) {
          tag = tg;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -551,6 +551,7 @@ public final class MultipageTiffReader {
          raFile_.close();
          raFile_ = null;
       }
+      CommentsHelper.saveComments(masterStorage_.getDatastore());
       masterStorage_ = null;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
@@ -447,6 +447,7 @@ public final class MultipageTiffWriter {
          raFile_ = null;
          masterStorage_ = null;
       });
+      CommentsHelper.saveComments(masterStorage_.getDatastore());
    }
    
    public boolean hasSpaceForFullOMEMetadata(int length) {


### PR DESCRIPTION
Both Single and MultiPageTiff storage now stores Summary and Per Image comments in a file "comments.txt" in the acquisition directory.  Even after opening a file, changes to the comments will be stored in that file.  One possible addition would be to preserve the original comments, but it is already a big step forwards that things actually work.  The code is not easy to understand, and probably could use some structural improvements, but that will happen another time.