### PR TITLE
StageControl plugin new features

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -35,7 +35,18 @@ import java.text.ParseException;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
-
+import javax.swing.BorderFactory;
+import javax.swing.ButtonGroup;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import mmcorej.CMMCore;
 import mmcorej.DeviceType;
 import mmcorej.StrVector;
@@ -52,28 +63,14 @@ import org.micromanager.internal.utils.TextUtils;
 import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
 
-import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JFormattedTextField;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-
-
 /**
- *
- * @author nico
- * @author Jon
- *
+ * Generated the stage control UI.  The ugly window with lots of arrows.
  * TODO: The XYZKeyListener now gets the active z Stage and the amount each
  * keypress should move each stage from this dialog.  The Dialog should also
  * show which keys do what, and possibly provide the option to change these keys.
+ *
+ * @author Nico Stuurman
+ * @author Jon Daniels
  */
 public final class StageControlFrame extends JFrame {
    private final Studio studio_;
@@ -89,12 +86,20 @@ public final class StageControlFrame extends JFrame {
       "SMALLMOVEMENT", "MEDIUMMOVEMENT", "LARGEMOVEMENT"
    };
    public static final String[] Y_MOVEMENTS = new String[] {
-           "SMALLMOVEMENT_Y", "MEDIUMMOVEMENT_Y", "LARGEMOVEMENT_Y"
+         "SMALLMOVEMENT_Y", "MEDIUMMOVEMENT_Y", "LARGEMOVEMENT_Y"
    };
-   public static final String SMALL_MOVEMENT_Z = "SMALLMOVEMENTZ"; // used both by individual ZPanels (with id) and in general
+
+   // used both by individual ZPanels (with id) and in general
+   public static final String SMALL_MOVEMENT_Z = "SMALLMOVEMENTZ";
+
    public static final String MEDIUM_MOVEMENT_Z = "MEDIUMMOVEMENTZ";
-   public static final String SELECTED_Z_DRIVE = "SELECTED_Z_DRIVE"; // used to keep track of the "active" Z Drive
-   private static final String CURRENT_Z_DRIVE = "CURRENTZDRIVE"; // used by Drive selection combo boxes
+
+   // used to keep track of the "active" Z Drive
+   public static final String SELECTED_Z_DRIVE = "SELECTED_Z_DRIVE";
+
+   // used by Drive selection combo boxes
+   private static final String CURRENT_Z_DRIVE = "CURRENTZDRIVE";
+
    private static final String REFRESH = "REFRESH";
    private static final String NR_Z_PANELS = "NRZPANELS";
 
@@ -103,31 +108,38 @@ public final class StageControlFrame extends JFrame {
    private JPanel errorPanel_;
    private JPanel xyPanel_;
    private JLabel xyPositionLabel_;
-   private JPanel[] zPanel_ = new JPanel[MAX_NUM_Z_PANELS];
-   private JComboBox<String>[] zDriveSelect_ = new JComboBox[MAX_NUM_Z_PANELS];
-   private JRadioButton[] zDriveActiveButtons_ = new JRadioButton[MAX_NUM_Z_PANELS];
-   private ButtonGroup zDriveActiveGroup_ = new ButtonGroup();
+   private final JPanel[] zPanel_ = new JPanel[MAX_NUM_Z_PANELS];
+   private final JComboBox<String>[] zDriveSelect_ = new JComboBox[MAX_NUM_Z_PANELS];
+   private final JRadioButton[] zDriveActiveButtons_ = new JRadioButton[MAX_NUM_Z_PANELS];
+   private final ButtonGroup zDriveActiveGroup_ = new ButtonGroup();
 
-   private JLabel[] zPositionLabel_ = new JLabel[MAX_NUM_Z_PANELS];
+   private final JLabel[] zPositionLabel_ = new JLabel[MAX_NUM_Z_PANELS];
    private JPanel settingsPanel_;
    private JCheckBox enableRefreshCB_;
    private Timer timer_ = null;
    // Ordered small, medium, large.
-   private JFormattedTextField[] xStepTexts_ = new JFormattedTextField[] {
+   private final JFormattedTextField[] xStepTexts_ = new JFormattedTextField[] {
       new JFormattedTextField(NumberFormat.getNumberInstance()),
       new JFormattedTextField(NumberFormat.getNumberInstance()),
       new JFormattedTextField(NumberFormat.getNumberInstance())
    };
-   private JFormattedTextField[] yStepTexts_ = new JFormattedTextField[] {
-           new JFormattedTextField(NumberFormat.getNumberInstance()),
-           new JFormattedTextField(NumberFormat.getNumberInstance()),
-           new JFormattedTextField(NumberFormat.getNumberInstance())
+   private final JFormattedTextField[] yStepTexts_ = new JFormattedTextField[] {
+      new JFormattedTextField(NumberFormat.getNumberInstance()),
+      new JFormattedTextField(NumberFormat.getNumberInstance()),
+      new JFormattedTextField(NumberFormat.getNumberInstance())
    };
-   private JFormattedTextField[] zStepTextsSmall_ = new JFormattedTextField[MAX_NUM_Z_PANELS];
-   private JFormattedTextField[] zStepTextsMedium_ = new JFormattedTextField[MAX_NUM_Z_PANELS];
-   private JButton[] plusButtons_ = new JButton[MAX_NUM_Z_PANELS];
-   private JButton[] minusButtons_ = new JButton[MAX_NUM_Z_PANELS];
+   private final JFormattedTextField[] zStepTextsSmall_ =
+         new JFormattedTextField[MAX_NUM_Z_PANELS];
+   private final JFormattedTextField[] zStepTextsMedium_ =
+         new JFormattedTextField[MAX_NUM_Z_PANELS];
+   private final JButton[] plusButtons_ = new JButton[MAX_NUM_Z_PANELS];
+   private final JButton[] minusButtons_ = new JButton[MAX_NUM_Z_PANELS];
 
+   /**
+    * Shows the stage control UI.  Creates it if necessary.
+    *
+    * @param studio The Micro-Manager API that gives access to everything.
+    */
    public static void showStageControl(Studio studio) {
       if (staticFrame_ == null) {
          staticFrame_ = new StageControlFrame(studio);
@@ -139,11 +151,12 @@ public final class StageControlFrame extends JFrame {
 
 
    /**
-    * Creates new form StageControlFrame
-    * @param gui the MM api
+    * Constructs a form StageControlFrame.
+    *
+    * @param studio the MM api
     */
-   public StageControlFrame(Studio gui) {
-      studio_ = gui;
+   public StageControlFrame(Studio studio) {
+      studio_ = studio;
       core_ = studio_.getCMMCore();
       settings_ = studio_.profile().getSettings(StageControlFrame.class);
       uiMovesStageManager_ = ((MMStudio) studio_).getUiMovesStageManager(); // TODO: add to API?
@@ -178,7 +191,7 @@ public final class StageControlFrame extends JFrame {
          final int j = i;
          xStepSizes[i] = settings_.getDouble(X_MOVEMENTS[i], xStepSizes[i]);
          xStepTexts_[i].setText(
-                 NumberUtils.doubleToDisplayString(xStepSizes[i]) );
+                 NumberUtils.doubleToDisplayString(xStepSizes[i]));
          xStepTexts_[i].addPropertyChangeListener("value", new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent evt) {
@@ -192,21 +205,23 @@ public final class StageControlFrame extends JFrame {
                               // not removing listener shows the dialog multiple times
                               xStepTexts_[j].removePropertyChangeListener(this);
                               xStepTexts_[j].setText(NumberUtils.doubleToDisplayString(Math.min(
-                                      settings_.getDouble(X_MOVEMENTS[j], xStepSizes[j]), pixelSize * nrPixelsX)));
+                                      settings_.getDouble(X_MOVEMENTS[j], xStepSizes[j]),
+                                      pixelSize * nrPixelsX)));
                               xStepTexts_[j].addPropertyChangeListener(this);
                               return;
                            }
                         }
                         settings_.putDouble(X_MOVEMENTS[j], xStep);
-                      }
+                     }
                   }
                } catch (ParseException pex) {
+                  studio_.logs().logError("Error parsing number in StageControlForm");
                }
             }
          });
          yStepSizes[i] = settings_.getDouble(Y_MOVEMENTS[i], yStepSizes[i]);
          yStepTexts_[i].setText(
-                 NumberUtils.doubleToDisplayString(yStepSizes[i]) );
+                 NumberUtils.doubleToDisplayString(yStepSizes[i]));
          yStepTexts_[i].addPropertyChangeListener("value", new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent evt) {
@@ -220,7 +235,8 @@ public final class StageControlFrame extends JFrame {
                               // not removing listener shows the dialog multiple times
                               yStepTexts_[j].removePropertyChangeListener(this);
                               yStepTexts_[j].setText(NumberUtils.doubleToDisplayString(Math.min(
-                                      settings_.getDouble(Y_MOVEMENTS[j], yStepSizes[j]), pixelSize * nrPixelsY)));
+                                      settings_.getDouble(Y_MOVEMENTS[j], yStepSizes[j]),
+                                      pixelSize * nrPixelsY)));
                               yStepTexts_[j].addPropertyChangeListener(this);
                               return;
                            }
@@ -229,6 +245,7 @@ public final class StageControlFrame extends JFrame {
                      }
                   }
                } catch (ParseException pex) {
+                  studio_.logs().logError("Error parsing number in StageControlForm");
                }
             }
          });
@@ -243,7 +260,8 @@ public final class StageControlFrame extends JFrame {
       // set panels visible depending on what drives are actually present
       xyPanel_.setVisible(haveXY);
       zPanel_[0].setVisible(haveZ);
-      final String sysConfigFile = ((MMStudio) studio_).getSysConfigFile();  // TODO add method to API
+      // TODO: add method to API
+      final String sysConfigFile = ((MMStudio) studio_).getSysConfigFile();
       final String key = NR_Z_PANELS + sysConfigFile;
       int nrZPanels = settings_.getInteger(key, nrZDrives);
       // mailing list report 12/31/2019 encounters nrZPanels == 0, workaround:
@@ -251,7 +269,7 @@ public final class StageControlFrame extends JFrame {
          nrZPanels = 1;
       }
       settings_.putInteger(key, nrZPanels);
-      for (int idx=1; idx<MAX_NUM_Z_PANELS; ++idx) {
+      for (int idx = 1; idx < MAX_NUM_Z_PANELS; ++idx) {
          zPanel_[idx].setVisible(idx < nrZPanels);
       }
       errorPanel_.setVisible(!haveXY && !haveZ);
@@ -294,16 +312,22 @@ public final class StageControlFrame extends JFrame {
             }
 
             // select correct drive, which will grab the correct step sizes via listeners
-            DefaultComboBoxModel<String> model = (DefaultComboBoxModel<String>) zDriveSelect_[idx].getModel();
+            DefaultComboBoxModel<String> model =
+                  (DefaultComboBoxModel<String>) zDriveSelect_[idx].getModel();
             // first attempt to find drive we previously used, then use the drives in order
-            int cbIndex = model.getIndexOf(settings_.getString(CURRENT_Z_DRIVE + idx, ""));  // returns -1 if not found
+            int cbIndex = model.getIndexOf(settings_.getString(
+                  CURRENT_Z_DRIVE + idx, ""));  // returns -1 if not found
             if (cbIndex < 0) {
-               cbIndex = model.getIndexOf((idx < nrZDrives) ? zDrives.get(idx) : "");  // returns -1 if not found
+               // returns -1 if not found
+               cbIndex = model.getIndexOf((idx < nrZDrives) ? zDrives.get(idx) : "");
             }
             if (cbIndex < 0) {
                cbIndex = 0;
             }
-            zDriveSelect_[idx].setSelectedIndex(-1);  // needed to make sure setSelectedIndex fires an ItemListener for index 0
+
+            // needed to make sure setSelectedIndex fires an ItemListener for index 0
+            zDriveSelect_[idx].setSelectedIndex(-1);
+
             zDriveSelect_[idx].setSelectedIndex(cbIndex);
             if (Objects.equals(zDriveSelect_[idx].getSelectedItem(),
                     settings_.getString(SELECTED_Z_DRIVE, " "))) {
@@ -322,7 +346,7 @@ public final class StageControlFrame extends JFrame {
          
          // make sure not to underflow/overflow with plus/minus buttons
          minusButtons_[0].setEnabled(false);
-         plusButtons_[MAX_NUM_Z_PANELS-1].setEnabled(false);
+         plusButtons_[MAX_NUM_Z_PANELS - 1].setEnabled(false);
       }
 
       this.addMouseListener(new MouseAdapter() {
@@ -335,6 +359,7 @@ public final class StageControlFrame extends JFrame {
                   settings_.putDouble(Y_MOVEMENTS[i],
                           NumberUtils.displayStringToDouble(yStepTexts_[i].getText()));
                } catch (ParseException pex) {
+                  studio_.logs().logError("Error parsing number in Stage Control Form");
                }
             }
          }
@@ -364,7 +389,7 @@ public final class StageControlFrame extends JFrame {
       // Vertically align Z panel with XY panel. createZPanel() also makes
       // several assumptions about the layout of the XY panel so that its
       // components are nicely vertically aligned.
-      for (int idx=0; idx<MAX_NUM_Z_PANELS; ++idx) {
+      for (int idx = 0; idx < MAX_NUM_Z_PANELS; ++idx) {
          zPanel_[idx] = createZPanel(idx);
          add(zPanel_[idx], "aligny top, gapleft 20, hidemode 3");
       }
@@ -406,8 +431,8 @@ public final class StageControlFrame extends JFrame {
          // "Right" and "Down" buttons are ordered differently; in any case,
          // the largest-step button is furthest from the center.
          final int stepIndex = (i <= 5) ? (2 - (i % 3)) : (i % 3);
-         String path = "/org/micromanager/icons/stagecontrol/arrowhead-" +
-            stepSizes[stepIndex] + directions[i / 3];
+         String path = "/org/micromanager/icons/stagecontrol/arrowhead-"
+               + stepSizes[stepIndex] + directions[i / 3];
          final JButton button = new JButton(IconLoader.getIcon(path + ".png"));
          // This copy can be referred to in the action listener.
          final int index = i;
@@ -431,6 +456,8 @@ public final class StageControlFrame extends JFrame {
                case 3:
                   dy = 1;
                   break;
+               default:
+                  break;
             }
             try {
                double increment =
@@ -440,8 +467,7 @@ public final class StageControlFrame extends JFrame {
                           NumberUtils.displayStringToDouble((yStepTexts_[stepIndex].getText()));
                }
                setRelativeXYStagePosition(dx * increment, dy * increment);
-            }
-            catch (ParseException ex) {
+            } catch (ParseException ex) {
                JOptionPane.showMessageDialog(theWindow, "XY Step size is not a number");
             }
          });
@@ -450,17 +476,14 @@ public final class StageControlFrame extends JFrame {
          if (i < 3 || i > 8) {
             // Up or down button.
             constraint = "span, alignx center, wrap";
-         }
-         else if (i == 3) {
+         } else if (i == 3) {
             // First horizontal button
             constraint = "split, span";
-         }
-         else if (i == 6) {
+         } else if (i == 6) {
             // Fourth horizontal button (start of the "right" buttons); add
             // a gap to the left.
             constraint = "gapleft 30";
-         }
-         else if (i == 8) {
+         } else if (i == 8) {
             // Last horizontal button.
             constraint = "wrap";
          }
@@ -481,8 +504,8 @@ public final class StageControlFrame extends JFrame {
       String[] labels = new String[] {"1 pixel", "0.1 field", "1 field"};
       for (int i = 0; i < 3; ++i) {
          JLabel indicator = new JLabel(IconLoader.getIcon(
-                  "/org/micromanager/icons/stagecontrol/arrowhead-" +
-                  stepSizes[i] + "r.png"));
+                  "/org/micromanager/icons/stagecontrol/arrowhead-"
+                        + stepSizes[i] + "r.png"));
          // HACK: make it smaller so the gap between rows is smaller.
          result.add(indicator, "height 20!, split, span");
          // This copy can be referred to in the action listener.
@@ -519,7 +542,7 @@ public final class StageControlFrame extends JFrame {
     */
    private JPanel createZPanel(final int idx) {
       final JFrame theWindow = this;
-      JPanel result = new JPanel(new MigLayout("insets 0, gap 0, flowy"));
+      final JPanel result = new JPanel(new MigLayout("insets 0, gap 0, flowy"));
       // result.add(new JLabel("Z Stage", JLabel.CENTER), "growx, alignx center");
       zDriveSelect_[idx] = new JComboBox<>();
       zDriveActiveButtons_[idx] = new JRadioButton();
@@ -540,7 +563,8 @@ public final class StageControlFrame extends JFrame {
       //   one type of listener on the combo-box (there are also ItemListeners for step size fields)
       zDriveSelect_[idx].addItemListener((ItemEvent e) -> {
          if (e.getStateChange() == ItemEvent.SELECTED) {
-            settings_.putString(CURRENT_Z_DRIVE + idx, zDriveSelect_[idx].getSelectedItem().toString());
+            settings_.putString(CURRENT_Z_DRIVE + idx,
+                  zDriveSelect_[idx].getSelectedItem().toString());
             try {
                getZPosLabelFromCore(idx);
             } catch (Exception ex) {
@@ -552,8 +576,10 @@ public final class StageControlFrame extends JFrame {
       // HACK: this defined height for the buttons matches the height of one
       // of the chevron buttons, and helps to align components between the XY
       // and Z panels.
-      result.add(zDriveSelect_[idx], "height 22!, gaptop 4, gapbottom 4, hidemode 0, growx");
-      result.add(zDriveActiveButtons_[idx], "height 22!, gaptop 4, gapbottom 4, hidemode 0, alignx center");
+      result.add(zDriveSelect_[idx],
+            "height 22!, gaptop 4, gapbottom 4, hidemode 0, growx");
+      result.add(zDriveActiveButtons_[idx],
+            "height 22!, gaptop 4, gapbottom 4, hidemode 0, alignx center");
 
       // Create buttons for stepping up/down.
       // Icon name prefix: double, single, single, double
@@ -561,8 +587,8 @@ public final class StageControlFrame extends JFrame {
       // Icon name component: up, up, down, down
       String[] directions = new String[] {"u", "u", "d", "d"};
       for (int i = 0; i < 4; ++i) {
-         String path = "/org/micromanager/icons/stagecontrol/arrowhead-" +
-                  prefixes[i] + directions[i];
+         String path = "/org/micromanager/icons/stagecontrol/arrowhead-"
+               + prefixes[i] + directions[i];
          JButton button = new JButton(IconLoader.getIcon(path + ".png"));
          button.setBorder(null);
          button.setBorderPainted(false);
@@ -573,12 +599,11 @@ public final class StageControlFrame extends JFrame {
          button.addActionListener((ActionEvent e) -> {
             int dz = (index < 2) ? 1 : -1;
             double stepSize;
-            JFormattedTextField text = (index == 0 || index == 3) ? 
-                    zStepTextsMedium_[idx] : zStepTextsSmall_[idx];
+            JFormattedTextField text = (index == 0 || index == 3)
+                  ? zStepTextsMedium_[idx] : zStepTextsSmall_[idx];
             try {
                stepSize = NumberUtils.displayStringToDouble(text.getText());
-            }
-            catch (ParseException ex) {
+            } catch (ParseException ex) {
                JOptionPane.showMessageDialog(theWindow, "Z-step value is not a number");
                return;
             }
@@ -606,14 +631,16 @@ public final class StageControlFrame extends JFrame {
       // controls in the XY panel.
       zStepTextsSmall_[idx] = StageControlFrame.createDoubleEntryFieldFromCombo(
               settings_, zDriveSelect_[idx], SMALL_MOVEMENT_Z, 1.1);
-      result.add(new JLabel(IconLoader.getIcon("/org/micromanager/icons/stagecontrol/arrowhead-sr.png")),
+      result.add(new JLabel(IconLoader.getIcon(
+            "/org/micromanager/icons/stagecontrol/arrowhead-sr.png")),
             "height 20!, span, split 3, flowx");
       result.add(zStepTextsSmall_[idx], "height 20!, width 50");
       result.add(new JLabel("\u00b5m"), "height 20!");
 
       zStepTextsMedium_[idx] = StageControlFrame.createDoubleEntryFieldFromCombo(
               settings_, zDriveSelect_[idx], MEDIUM_MOVEMENT_Z, 11.1);
-      result.add(new JLabel(IconLoader.getIcon("/org/micromanager/icons/stagecontrol/arrowhead-dr.png")),
+      result.add(new JLabel(IconLoader.getIcon(
+            "/org/micromanager/icons/stagecontrol/arrowhead-dr.png")),
             "span, split 3, flowx");
       result.add(zStepTextsMedium_[idx], "height 20!, width 50");
       result.add(new JLabel("\u00b5m"), "height 20!");
@@ -623,7 +650,7 @@ public final class StageControlFrame extends JFrame {
          String sysConfigFile = ((MMStudio) studio_).getSysConfigFile();  // TODO add method to API
          int nrZPanels = settings_.getInteger(NR_Z_PANELS + sysConfigFile, 0);
          if (nrZPanels > 1) {
-            settings_.putInteger(NR_Z_PANELS + sysConfigFile, nrZPanels-1);
+            settings_.putInteger(NR_Z_PANELS + sysConfigFile, nrZPanels - 1);
             initialize();
          }
       });
@@ -633,7 +660,7 @@ public final class StageControlFrame extends JFrame {
          String sysConfigFile = ((MMStudio) studio_).getSysConfigFile();  // TODO add method to API
          int nrZPanels = settings_.getInteger(NR_Z_PANELS + sysConfigFile, 0);
          if (nrZPanels < MAX_NUM_Z_PANELS) {
-            settings_.putInteger(NR_Z_PANELS + sysConfigFile, nrZPanels+1);
+            settings_.putInteger(NR_Z_PANELS + sysConfigFile, nrZPanels + 1);
             initialize();
          }
       });
@@ -663,14 +690,15 @@ public final class StageControlFrame extends JFrame {
       stopTimer();
       timer_ = new Timer(true);
       timer_.scheduleAtFixedRate(new TimerTask() {
-        @Override
-        public void run() {
-           // update positions if we aren't already doing it or paused
-           // this prevents building up task queue if something slows down
-           if (staticFrame_!=null && staticFrame_.isVisible()) {  // don't update if stage control is hidden
-              updateStagePositions();
-           }
-        }
+         @Override
+         public void run() {
+            // update positions if we aren't already doing it or paused
+            // this prevents building up task queue if something slows down
+            if (staticFrame_ != null && staticFrame_.isVisible()) {
+               // don't update if stage control is hidden
+               updateStagePositions();
+            }
+         }
       }, 0, 1000);  // 1 sec interval
    }
    
@@ -688,7 +716,7 @@ public final class StageControlFrame extends JFrame {
          if (xyPanel_.isVisible()) {
             getXYPosLabelFromCore();
          }
-         for (int idx=0; idx<MAX_NUM_Z_PANELS; idx++) {
+         for (int idx = 0; idx < MAX_NUM_Z_PANELS; idx++) {
             if (zPanel_[idx].isVisible()) {
                getZPosLabelFromCore(idx);
             }
@@ -699,7 +727,7 @@ public final class StageControlFrame extends JFrame {
    }
    
    private JPanel createSettingsPanel() {
-      JPanel result = new JPanel(new MigLayout("insets 0, gap 0"));
+      final JPanel result = new JPanel(new MigLayout("insets 0, gap 0"));
       
       // checkbox to turn updates on and off
       enableRefreshCB_ = new JCheckBox("Polling updates");
@@ -730,7 +758,7 @@ public final class StageControlFrame extends JFrame {
       // TODO: should we call moveSampleOnDisplay instead, so that sample moves as expected?
       uiMovesStageManager_.getXYNavigator().moveXYStageUm(
               core_.getXYStageDevice(), x, y);
-    }
+   }
 
    private void setRelativeStagePosition(double z, int idx) {
       String curDrive = (String) zDriveSelect_[idx].getSelectedItem();
@@ -746,7 +774,7 @@ public final class StageControlFrame extends JFrame {
       xyPositionLabel_.setText(String.format(
               "<html>X: %s \u00b5m<br>Y: %s \u00b5m</html>",
               TextUtils.removeNegativeZero(NumberUtils.doubleToDisplayString(x)),
-              TextUtils.removeNegativeZero(NumberUtils.doubleToDisplayString(y)) ));
+              TextUtils.removeNegativeZero(NumberUtils.doubleToDisplayString(y))));
    }
 
    private void getZPosLabelFromCore(int idx) throws Exception {
@@ -757,12 +785,15 @@ public final class StageControlFrame extends JFrame {
    private void setZPosLabel(double z, int idx) {
       zPositionLabel_[idx].setText(
               TextUtils.removeNegativeZero(
-                      NumberUtils.doubleToDisplayString(z)) + 
-               " \u00B5m");
+                      NumberUtils.doubleToDisplayString(z))
+                    + " \u00B5m");
    }
    
    private static JFormattedTextField createDoubleEntryFieldFromCombo(
-         final MutablePropertyMapView settings, final JComboBox<String> cb, final String prefix, final double aDefault) {
+         final MutablePropertyMapView settings,
+         final JComboBox<String> cb,
+         final String prefix,
+         final double aDefault) {
       
       class FieldListener implements PropertyChangeListener, ItemListener {
          private final JFormattedTextField tf_;
@@ -770,7 +801,10 @@ public final class StageControlFrame extends JFrame {
          private final MutablePropertyMapView settings_;
          private final String prefix_;
 
-         public FieldListener(JFormattedTextField tf, MutablePropertyMapView settings, JComboBox<String> cb, String prefix) {
+         public FieldListener(JFormattedTextField tf,
+                              MutablePropertyMapView settings,
+                              JComboBox<String> cb,
+                              String prefix) {
             tf_ = tf;
             settings_ = settings;
             cb_ = cb;
@@ -784,7 +818,7 @@ public final class StageControlFrame extends JFrame {
          
          @Override
          public void propertyChange(PropertyChangeEvent evt) {
-            settings_.putDouble(toString(), ((Number)tf_.getValue()).doubleValue());
+            settings_.putDouble(toString(), ((Number) tf_.getValue()).doubleValue());
          }
 
          @Override
@@ -805,10 +839,10 @@ public final class StageControlFrame extends JFrame {
 
    private boolean confirmLargeMovementSetting(double movementUm) {
       int response = JOptionPane.showConfirmDialog(this,
-              String.format(NumberUtils.doubleToDisplayString(movementUm, 0) +
-                      " microns could be dangerously large.  Are you sure you want to set this?",
+              String.format(NumberUtils.doubleToDisplayString(movementUm, 0)
+                       + " microns could be dangerously large.  Are you sure you want to set this?",
               "Large movement requested",
-              JOptionPane.YES_NO_OPTION) );
+              JOptionPane.YES_NO_OPTION));
 
       return response == JOptionPane.YES_OPTION;
    }
@@ -818,15 +852,25 @@ public final class StageControlFrame extends JFrame {
       initialize();
    }
 
+   /**
+    * Handles even signaling that a stage position changed.
+    *
+    * @param event Event with information about the changed stage.
+    */
    @Subscribe
    public void onStagePositionChanged(StagePositionChangedEvent event) {
-      for (int idx=0; idx<MAX_NUM_Z_PANELS; ++idx) {
+      for (int idx = 0; idx < MAX_NUM_Z_PANELS; ++idx) {
          if (event.getDeviceName().equals(zDriveSelect_[idx].getSelectedItem())) {
             setZPosLabel(event.getPos(), idx);
          }
       }
    }
 
+   /**
+    * Handles event signalling that an XY stage changes its position.
+    *
+    * @param event has information about the changed XY stage.
+    */
    @Subscribe
    public void onXYStagePositionChanged(XYStagePositionChangedEvent event) {
       if (event.getDeviceName().contentEquals(core_.getXYStageDevice())) {
@@ -834,7 +878,12 @@ public final class StageControlFrame extends JFrame {
       }
    }
 
-      
+
+   /**
+    * Handles event signalling that MM is shutting down.
+    *
+    * @param event signals that MM is shuttings down.
+    */
    @Subscribe
    public void onShutdownCommencing(InternalShutdownCommencingEvent event) {
       if (!event.isCanceled()) {

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/CenterAndDragListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/CenterAndDragListener.java
@@ -28,6 +28,8 @@ import org.micromanager.Studio;
 import org.micromanager.display.internal.event.DisplayMouseEvent;
 
 /**
+ * Implementation of the Center And DragListener that lets the user "drag" the stage.
+ *
  * @author OD, nico
  *
  */
@@ -35,7 +37,8 @@ public final class CenterAndDragListener  {
 
    private final Studio studio_;
    private final XYNavigator xyNavigator_;
-   private int lastX_, lastY_;
+   private int lastX_;
+   private int lastY_;
 
    public CenterAndDragListener(final Studio studio, final XYNavigator xyNavigator) {
       studio_ = studio;
@@ -45,11 +48,10 @@ public final class CenterAndDragListener  {
 
 
    /**
-    * Handles mouse events and does the actual stage movement
+    * Handles mouse events and does the actual stage movement.
+    * TODO: this does not take into account multiple cameras in different displays.
     *
     * @param dme DisplayMouseEvent containing information about the mouse movement
-    * TODO: this does not take into account multiple cameras in different displays
-    * 
     */
    @Subscribe
    public void onDisplayMouseEvent(DisplayMouseEvent dme) {
@@ -103,6 +105,8 @@ public final class CenterAndDragListener  {
 
             xyNavigator_.moveSampleOnDisplayPixels(tmpXUm, tmpYUm);
 
+            break;
+         default:
             break;
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/UiMovesStageManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/UiMovesStageManager.java
@@ -39,6 +39,13 @@ public final class UiMovesStageManager {
    private final XYNavigator xyNavigator_;
    private final ZNavigator zNavigator_;
 
+
+   /**
+    * This class handles setting up and disabling mouse and keyboard
+    * shortcuts for stage motion.
+    *
+    * @param studio MM API instance
+    */
    public UiMovesStageManager(Studio studio) {
       studio_ = studio;
       xyNavigator_ = new XYNavigator(studio_);
@@ -51,6 +58,7 @@ public final class UiMovesStageManager {
 
    /**
     * Keep track of enabling/disabling click-to-move for this display.
+    *
     * @param display Display to which we will listen for events
     */
    public void activate(final DisplayController display) {
@@ -76,6 +84,11 @@ public final class UiMovesStageManager {
       displayToKeyListener_.put(display, keyListener);
    }
 
+   /**
+    * Deactivates all the UI elements that move the stage for the given display.
+    *
+    * @param displayToDeActivate The Viewer that should no longer control the stage.
+    */
    public void deActivate(final DataViewer displayToDeActivate) {
       synchronized (displayToDragListener_) {
          for (DisplayController display : displayToDragListener_.keySet()) {

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
@@ -1,16 +1,7 @@
 
 package org.micromanager.internal.navigation;
 
-import javax.swing.JOptionPane;
-
 import com.google.common.util.concurrent.AtomicDouble;
-import mmcorej.MMCoreJ;
-import org.micromanager.Studio;
-import org.micromanager.events.internal.DefaultXYStagePositionChangedEvent;
-import org.micromanager.internal.utils.AffineUtils;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.ThreadFactoryFactory;
-
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.util.HashMap;
@@ -18,253 +9,263 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import javax.swing.JOptionPane;
+import mmcorej.MMCoreJ;
+import org.micromanager.Studio;
+import org.micromanager.events.internal.DefaultXYStagePositionChangedEvent;
+import org.micromanager.internal.utils.AffineUtils;
+import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.ThreadFactoryFactory;
 
 /**
- * @author Nico
+ * Class that handles transformation between what the user sees on the screen
+ * and how the stage moves.
  *
+ * @author Nico
  */
 public class XYNavigator {
-	protected Studio studio_;
-	protected boolean mirrorX_;
-	protected boolean mirrorY_;
-	protected boolean transposeXY_;
-	protected boolean correction_;
-	protected AffineTransform affineTransform_;
-	private final Map<String, XYStageTask> xyStageMoverMap_;
+   protected Studio studio_;
+   protected boolean mirrorX_;
+   protected boolean mirrorY_;
+   protected boolean transposeXY_;
+   protected boolean correction_;
+   protected AffineTransform affineTransform_;
+   private final Map<String, XYStageTask> xyStageMoverMap_;
 
-	/**
-	 * Central interface to move the default XY stage in the direction
-	 * desired by the user.  Facilities to correct movement as seen on the
-	 * screen to movement of the XY stage are included.
-	 *
-	 * The XY stage to be moved can be specified, however,
-	 * the movement corrections are likely only valid for the default XY Stage
-	 *
-	 * Each stage runs on its own executor.  These will only be created after
-	 * movement for a stage has been requested.
-	 *
-	 * @param studio Our beloved Micro-Manager Studio object
-	 */
-	public XYNavigator(Studio studio) {
-		studio_ = studio;
-		xyStageMoverMap_ = new HashMap<>();
-	}
-
-
-	/*
-	 * Ensures that the stage moves in the expected direction
-	 */
-	private void getOrientation() {
-		String camera = studio_.core().getCameraDevice();
-		if (camera == null) {
-			JOptionPane.showMessageDialog(null, "This function does not work without a camera");
-			return;
-		}
-		// If there is an affine transform, use that, otherwise fallbakc to
-		// the old mechanism
-		try {
-			double pixelSize = studio_.core().getPixelSizeUm();
-			try {
-				affineTransform_ = AffineUtils.doubleToAffine(studio_.core().getPixelSizeAffine(true));
-				if (Math.abs(pixelSize
-						- AffineUtils.deducePixelSize(affineTransform_)) > 0.1 * pixelSize) {
-					// affine transform does not correspond to pixelSize, so do not
-					// trust it and fallback to old mechanism
-					affineTransform_ = null;
-				}
-			} catch (Exception ex) {
-				ReportingUtils.logError("Failed to find affine transform");
-			}
-		} catch (Exception exc) {
-			ReportingUtils.showError(exc);
-		}
-		if (affineTransform_ == null) {
-			// we can cache the current camera and only execute the code
-			// below if the camera changed.  However, that will make it difficult
-			// to experiment with these settings, and it probably is not very expensive
-			// to check every time
-			try {
-				String tmp = studio_.core().getProperty(camera, "TransposeCorrection");
-				correction_ = !(tmp.equals("0"));
-				tmp = studio_.core().getProperty(camera, MMCoreJ.getG_Keyword_Transpose_MirrorX());
-				mirrorX_ = !(tmp.equals("0"));
-				tmp = studio_.core().getProperty(camera, MMCoreJ.getG_Keyword_Transpose_MirrorY());
-				mirrorY_ = !(tmp.equals("0"));
-				tmp = studio_.core().getProperty(camera, MMCoreJ.getG_Keyword_Transpose_SwapXY());
-				transposeXY_ = !(tmp.equals("0"));
-			} catch (Exception exc) {
-				ReportingUtils.showError(exc);
-			}
-		}
-	}
-
-	/**
-	 * Converts Camera-Pixel Space to Stage-micron space
-	 * Use the affine transform when available, otherwise uses pixelSize
-	 * and orientation booleans, determined using the getOrientation function.
-	 *
-	 * @param pixSizeUm - pixelSize in micron
-	 * @param x - Desired x movement in pixels
-	 * @param y - Desired y movement in pixels
-	 * @return - Needed stage movement as a Point2D.Double
-	 */
-	private Point2D toStageSpace(double pixSizeUm, double x, double y) {
-		getOrientation();
-		Point2D dest = new Point2D.Double();
-		if (affineTransform_ != null) {
-			Point2D source = new Point2D.Double(x, y);
-			affineTransform_.transform(source, dest);
-			// not sure why, but for the stage movement to be correct, we need
-			// to invert both axes"
-			dest.setLocation(-dest.getX(), -dest.getY());
-		} else {
-			// if camera does not toStageSpace image orientation, we'll toStageSpace for it here:
-			dest.setLocation(x * pixSizeUm, y * pixSizeUm);
-			if (!correction_) {
-				// Order: swapxy, then mirror axis
-				if (transposeXY_) {
-					dest.setLocation(y * pixSizeUm, x * pixSizeUm);
-				}
-				if (mirrorX_) {
-					dest.setLocation(-dest.getX(), dest.getY());
-				}
-				if (mirrorY_) {
-					dest.setLocation(dest.getX(), -dest.getY());
-				}
-			}
-		}
-
-		return dest;
-	}
-
-	/**
-	 * Move the XYStage in such a manner that the sample as displayed in the
-	 * viewer will move in an absolute Carthesian coordinate system.
-	 * For instance, moving 1 micron in x will move the stage so that the
-	 * image on the screen will move 1 micron to the right, which may
-	 * involve XYStage movement in both x and y.
+   /**
+    * Central interface to move the default XY stage in the direction
+    * desired by the user.  Facilities to correct movement as seen on the
+    * screen to movement of the XY stage are included.
+    * The XY stage to be moved can be specified, however,
+    * the movement corrections are likely only valid for the default XY Stage.
+    * Each stage runs on its own executor.  These will only be created after
+    * movement for a stage has been requested.
     *
-	 * @param tmpXUm amount (in microns) the sample should move in the x direction
-	 * @param tmpYUm amount (in microns) the sample should move in the y direction
-	 */
-	public void moveSampleOnDisplayUm(final double tmpXUm, final double tmpYUm) {
-		double pixSizeUm = studio_.core().getPixelSizeUm(true);
-		if (!(pixSizeUm > 0.0)) {
-			JOptionPane.showMessageDialog(null,
-					"Please provide pixel size calibration data before using this function");
-			return;
-		}
-		String xyStage = studio_.core().getXYStageDevice();
-		if (xyStage == null || xyStage.equals("")) {
-			return;
-		}
-		// It is a bit funny to calculate back to pixels and then receive
-		// a stageposition in microns, but that is likely more exact than
-		// lying about pixelSize here (by setting it to 1)
-		Point2D stagePos = toStageSpace(pixSizeUm, tmpXUm / pixSizeUm,
-				tmpYUm / pixSizeUm);
-		moveXYStageUm(studio_.core().getXYStageDevice(), stagePos.getX(),
-				stagePos.getY());
-	}
-
-	/**
-	 * Move the XYStage in such a manner that the sample as displayed in the
-	 * viewer will move in an absolute Carthesian coordinate system.
-	 * For instance, moving 1 pixel in x will move the stage so that the
-	 * image on the screen will move 1 pixels to the right, which may
-	 * involve XYStage movement in both x and y.
-	 *
-	 * @param tmpXPixels amount (in pixels) the sample should move in the x direction
-	 * @param tmpYPixels amount (in pixels) the sample should move in the y direction
-	 */
-	public void moveSampleOnDisplayPixels(final double tmpXPixels, final double tmpYPixels) {
-		double pixSizeUm = studio_.core().getPixelSizeUm(true);
-		if (!(pixSizeUm > 0.0)) {
-			JOptionPane.showMessageDialog(null,
-					"Please provide pixel size calibration data before using this function");
-			return;
-		}
-		String xyStage = studio_.core().getXYStageDevice();
-		if (xyStage == null || xyStage.equals("")) {
-			return;
-		}
-		Point2D stagePos = toStageSpace(pixSizeUm, tmpXPixels,
-				tmpYPixels);
-		moveXYStageUm(studio_.core().getXYStageDevice(), stagePos.getX(),
-				stagePos.getY());
-	}
+    * @param studio Our beloved Micro-Manager Studio object
+    */
+   public XYNavigator(Studio studio) {
+      studio_ = studio;
+      xyStageMoverMap_ = new HashMap<>();
+   }
 
 
-	/**
-	 * Moves the XYStage the desired distance in microns without corrections
-	 * Creates an XYStageTask if the stage is unknown, otherwise
-	 * adds the desired movement to the task.  If a task is still running,
-	 * it will add the movement to its future movement task.
-	 *
-	 * @param xyStage xyStage to be moved
-	 * @param xRel x distance (in microns) to move the stage
-	 * @param yRel y distance (in microns) to move the stage
-	 */
-	public void moveXYStageUm(String xyStage, double xRel, double yRel) {
-		if (!xyStageMoverMap_.containsKey(xyStage)) {
-			xyStageMoverMap_.put(xyStage, new XYStageTask(xyStage));
-		}
-		// if a
-		xyStageMoverMap_.get(xyStage).setPosition(xRel, yRel);
-	}
+   /*
+    * Ensures that the stage moves in the expected direction
+    */
+   private void getOrientation() {
+      String camera = studio_.core().getCameraDevice();
+      if (camera == null) {
+         JOptionPane.showMessageDialog(null, "This function does not work without a camera");
+         return;
+      }
+      // If there is an affine transform, use that, otherwise fallbakc to
+      // the old mechanism
+      try {
+         double pixelSize = studio_.core().getPixelSizeUm();
+         try {
+            affineTransform_ = AffineUtils.doubleToAffine(studio_.core().getPixelSizeAffine(true));
+            if (Math.abs(pixelSize
+                  - AffineUtils.deducePixelSize(affineTransform_)) > 0.1 * pixelSize) {
+               // affine transform does not correspond to pixelSize, so do not
+               // trust it and fallback to old mechanism
+               affineTransform_ = null;
+            }
+         } catch (Exception ex) {
+            ReportingUtils.logError("Failed to find affine transform");
+         }
+      } catch (Exception exc) {
+         ReportingUtils.showError(exc);
+      }
+      if (affineTransform_ == null) {
+         // we can cache the current camera and only execute the code
+         // below if the camera changed.  However, that will make it difficult
+         // to experiment with these settings, and it probably is not very expensive
+         // to check every time
+         try {
+            String tmp = studio_.core().getProperty(camera, "TransposeCorrection");
+            correction_ = !(tmp.equals("0"));
+            tmp = studio_.core().getProperty(camera, MMCoreJ.getG_Keyword_Transpose_MirrorX());
+            mirrorX_ = !(tmp.equals("0"));
+            tmp = studio_.core().getProperty(camera, MMCoreJ.getG_Keyword_Transpose_MirrorY());
+            mirrorY_ = !(tmp.equals("0"));
+            tmp = studio_.core().getProperty(camera, MMCoreJ.getG_Keyword_Transpose_SwapXY());
+            transposeXY_ = !(tmp.equals("0"));
+         } catch (Exception exc) {
+            ReportingUtils.showError(exc);
+         }
+      }
+   }
 
-	/**
-	 * Helper class that executes stage movement, and pools movement requests
-	 * if they come in while the stage is busy.
-	 *
-	 * This should reduce the number of commands send to the stage when the UI
-	 * is firing requests faster than the stage can execute them.
-	 *
-	 */
-	private class XYStageTask implements Runnable {
-		private final String xyStage_;
-		private final ExecutorService executorService_;
-		private Future<?> future_;
-		AtomicDouble moveMemoryX_ = new AtomicDouble(0.0);
-		AtomicDouble moveMemoryY_ = new AtomicDouble(0.0);
+   /**
+    * Converts Camera-Pixel Space to Stage-micron space
+    * Use the affine transform when available, otherwise uses pixelSize
+    * and orientation booleans, determined using the getOrientation function.
+    *
+    * @param pixSizeUm - pixelSize in micron
+    * @param x - Desired x movement in pixels
+    * @param y - Desired y movement in pixels
+    * @return - Needed stage movement as a Point2D.Double
+    */
+   private Point2D toStageSpace(double pixSizeUm, double x, double y) {
+      getOrientation();
+      Point2D dest = new Point2D.Double();
+      if (affineTransform_ != null) {
+         Point2D source = new Point2D.Double(x, y);
+         affineTransform_.transform(source, dest);
+         // not sure why, but for the stage movement to be correct, we need
+         // to invert both axes"
+         dest.setLocation(-dest.getX(), -dest.getY());
+      } else {
+         // if camera does not toStageSpace image orientation, we'll toStageSpace for it here:
+         dest.setLocation(x * pixSizeUm, y * pixSizeUm);
+         if (!correction_) {
+            // Order: swapxy, then mirror axis
+            if (transposeXY_) {
+               dest.setLocation(y * pixSizeUm, x * pixSizeUm);
+            }
+            if (mirrorX_) {
+               dest.setLocation(-dest.getX(), dest.getY());
+            }
+            if (mirrorY_) {
+               dest.setLocation(dest.getX(), -dest.getY());
+            }
+         }
+      }
 
-		public XYStageTask(String xyStage) {
-			xyStage_ = xyStage;
-			executorService_ = Executors.newSingleThreadExecutor(
-					ThreadFactoryFactory.createThreadFactory("XYNavigator-" + xyStage ));
-		}
+      return dest;
+   }
 
-		/**
-		 * @param xRel - relative movement in X in microns
-		 * @param yRel - relative movement in Y in microns
-		 */
-		public void setPosition(double xRel, double yRel) {
-			moveMemoryX_.addAndGet(xRel);
-			moveMemoryY_.addAndGet(yRel);
-			if (future_ == null || future_.isDone()) {
-				future_ = executorService_.submit(this);
-			}
-		}
+   /**
+    * Move the XYStage in such a manner that the sample as displayed in the
+    * viewer will move in an absolute Carthesian coordinate system.
+    * For instance, moving 1 micron in x will move the stage so that the
+    * image on the screen will move 1 micron to the right, which may
+    * involve XYStage movement in both x and y.
+    *
+    * @param tmpXUm amount (in microns) the sample should move in the x direction
+    * @param tmpYUm amount (in microns) the sample should move in the y direction
+    */
+   public void moveSampleOnDisplayUm(final double tmpXUm, final double tmpYUm) {
+      double pixSizeUm = studio_.core().getPixelSizeUm(true);
+      if (!(pixSizeUm > 0.0)) {
+         JOptionPane.showMessageDialog(null,
+               "Please provide pixel size calibration data before using this function");
+         return;
+      }
+      String xyStage = studio_.core().getXYStageDevice();
+      if (xyStage == null || xyStage.equals("")) {
+         return;
+      }
+      // It is a bit funny to calculate back to pixels and then receive
+      // a stageposition in microns, but that is likely more exact than
+      // lying about pixelSize here (by setting it to 1)
+      Point2D stagePos = toStageSpace(pixSizeUm, tmpXUm / pixSizeUm,
+            tmpYUm / pixSizeUm);
+      moveXYStageUm(studio_.core().getXYStageDevice(), stagePos.getX(),
+            stagePos.getY());
+   }
 
-		@Override
-		public void run() {
-			// Move the stage
-			try {
-				while (moveMemoryX_.get() != 0 || moveMemoryY_.get() != 0.0) {
-					double xRel = moveMemoryX_.getAndSet(0.0);
-					double yRel = moveMemoryY_.getAndSet(0.0);
-					studio_.core().setRelativeXYPosition(xyStage_, xRel, yRel);
-					studio_.core().waitForDevice(xyStage_);
-					double[] xs = new double[1];
-					double[] ys = new double[1];
-					studio_.core().getXYPosition(xyStage_, xs, ys);
-					studio_.events().post(
-							new DefaultXYStagePositionChangedEvent(xyStage_, xs[0], ys[0]));
-				}
-			} catch (Exception ex) {
-				ReportingUtils.logError(ex.getMessage());
-			}
-		}
-	}
+   /**
+    * Move the XYStage in such a manner that the sample as displayed in the
+    * viewer will move in an absolute Carthesian coordinate system.
+    * For instance, moving 1 pixel in x will move the stage so that the
+    * image on the screen will move 1 pixels to the right, which may
+    * involve XYStage movement in both x and y.
+    *
+    * @param tmpXPixels amount (in pixels) the sample should move in the x direction
+    * @param tmpYPixels amount (in pixels) the sample should move in the y direction
+    */
+   public void moveSampleOnDisplayPixels(final double tmpXPixels, final double tmpYPixels) {
+      double pixSizeUm = studio_.core().getPixelSizeUm(true);
+      if (!(pixSizeUm > 0.0)) {
+         JOptionPane.showMessageDialog(null,
+               "Please provide pixel size calibration data before using this function");
+         return;
+      }
+      String xyStage = studio_.core().getXYStageDevice();
+      if (xyStage == null || xyStage.equals("")) {
+         return;
+      }
+      Point2D stagePos = toStageSpace(pixSizeUm, tmpXPixels,
+            tmpYPixels);
+      moveXYStageUm(studio_.core().getXYStageDevice(), stagePos.getX(),
+            stagePos.getY());
+   }
+
+
+   /**
+    * Moves the XYStage the desired distance in microns without corrections
+    * Creates an XYStageTask if the stage is unknown, otherwise
+    * adds the desired movement to the task.  If a task is still running,
+    * it will add the movement to its future movement task.
+    *
+    * @param xyStage xyStage to be moved
+    * @param xRel x distance (in microns) to move the stage
+    * @param yRel y distance (in microns) to move the stage
+    */
+   public void moveXYStageUm(String xyStage, double xRel, double yRel) {
+      if (!xyStageMoverMap_.containsKey(xyStage)) {
+         xyStageMoverMap_.put(xyStage, new XYStageTask(xyStage));
+      }
+      // if a
+      xyStageMoverMap_.get(xyStage).setPosition(xRel, yRel);
+   }
+
+   /**
+    * Helper class that executes stage movement, and pools movement requests
+    * if they come in while the stage is busy.
+    *
+    * <p>This should reduce the number of commands send to the stage when the UI
+    * is firing requests faster than the stage can execute them.
+    *
+    */
+   private class XYStageTask implements Runnable {
+      private final String xyStage_;
+      private final ExecutorService executorService_;
+      private Future<?> future_;
+      AtomicDouble moveMemoryX_ = new AtomicDouble(0.0);
+      AtomicDouble moveMemoryY_ = new AtomicDouble(0.0);
+
+      public XYStageTask(String xyStage) {
+         xyStage_ = xyStage;
+         executorService_ = Executors.newSingleThreadExecutor(
+               ThreadFactoryFactory.createThreadFactory("XYNavigator-" + xyStage));
+      }
+
+      /**
+       * Sets the position of the XY stage. Uses the executorService to schedule the actual
+       * move of the hardware.
+       *
+       * @param xRel - relative movement in X in microns
+       * @param yRel - relative movement in Y in microns
+       */
+      public void setPosition(double xRel, double yRel) {
+         moveMemoryX_.addAndGet(xRel);
+         moveMemoryY_.addAndGet(yRel);
+         if (future_ == null || future_.isDone()) {
+            future_ = executorService_.submit(this);
+         }
+      }
+
+      @Override
+      public void run() {
+         // Move the stage
+         try {
+            while (moveMemoryX_.get() != 0 || moveMemoryY_.get() != 0.0) {
+               double xRel = moveMemoryX_.getAndSet(0.0);
+               double yRel = moveMemoryY_.getAndSet(0.0);
+               studio_.core().setRelativeXYPosition(xyStage_, xRel, yRel);
+               studio_.core().waitForDevice(xyStage_);
+               double[] xs = new double[1];
+               double[] ys = new double[1];
+               studio_.core().getXYPosition(xyStage_, xs, ys);
+               studio_.events().post(
+                     new DefaultXYStagePositionChangedEvent(xyStage_, xs[0], ys[0]));
+            }
+         } catch (Exception ex) {
+            ReportingUtils.logError(ex.getMessage());
+         }
+      }
+   }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
@@ -18,145 +18,166 @@
 
 package org.micromanager.internal.navigation;
 
-import com.google.common.eventbus.Subscribe;
-import mmcorej.CMMCore;
-import org.micromanager.Studio;
-import org.micromanager.display.internal.event.DisplayKeyPressEvent;
-import org.micromanager.propertymap.MutablePropertyMapView;
-
-import java.awt.event.KeyEvent;
-
 import static org.micromanager.internal.dialogs.StageControlFrame.MEDIUM_MOVEMENT_Z;
 import static org.micromanager.internal.dialogs.StageControlFrame.SELECTED_Z_DRIVE;
 import static org.micromanager.internal.dialogs.StageControlFrame.SMALL_MOVEMENT_Z;
 import static org.micromanager.internal.dialogs.StageControlFrame.X_MOVEMENTS;
 import static org.micromanager.internal.dialogs.StageControlFrame.Y_MOVEMENTS;
 
+import com.google.common.eventbus.Subscribe;
+import java.awt.event.KeyEvent;
+import mmcorej.CMMCore;
+import org.micromanager.Studio;
+import org.micromanager.display.internal.event.DisplayKeyPressEvent;
+import org.micromanager.propertymap.MutablePropertyMapView;
+
+
 /**
- * @author Nico
+ * Moves XY and X stage based on keypresses.
  *
+ * @author Nico Stuurman
  */
 public final class XYZKeyListener  {
-	private final CMMCore core_;
-	private final MutablePropertyMapView settings_;
-	private final ZNavigator zNavigator_;
-	private final XYNavigator xyNavigator_;
-	double[] xMovesMicron_;
-	double[] yMovesMicron_;
-	double[] zMovesMicron_;
+   private final CMMCore core_;
+   private final MutablePropertyMapView settings_;
+   private final ZNavigator zNavigator_;
+   private final XYNavigator xyNavigator_;
+   double[] xMovesMicron_;
+   double[] yMovesMicron_;
+   double[] zMovesMicron_;
 
-	/**
-	 * The XYZKeyListener receives settings from the StageControl plugin
-	 * by means of the user profile.
-	 *
-	 * Array sizes, etc. match those of the StageControl plugin, so changes
-	 * there may break things here.
-	 *
-	 * Movement requests funnel to the single instance of the
-	 * XYNavigator.  The XYNavigator send the actual movement comman to the
-	 * XY stage using its own executor. Movements can be send even while
-	 * the stage is moving.  Once the stage stops moving, all (added)
-	 * movement requests will be combined into a single stage movement.
-	 *
-	 * @param studio Our beloved Micro-Manager Studio object
-	 * @param xyNavigator Object that manages communication to XY Stages
-	 * @param zNavigator Object that manages communication to Z Stages.
-	 */
-	public XYZKeyListener(Studio studio, XYNavigator xyNavigator, ZNavigator zNavigator) {
-       core_ = studio.getCMMCore();
-       xyNavigator_ = xyNavigator;
-       zNavigator_ = zNavigator;
+   /**
+    * The XYZKeyListener receives settings from the StageControl plugin
+    * by means of the user profile.
+    *
+    * <p>Array sizes, etc. match those of the StageControl plugin, so changes
+    * there may break things here.
+    *
+    * <p>Movement requests funnel to the single instance of the
+    * XYNavigator.  The XYNavigator send the actual movement comman to the
+    * XY stage using its own executor. Movements can be send even while
+    * the stage is moving.  Once the stage stops moving, all (added)
+    * movement requests will be combined into a single stage movement.
+    *
+    * @param studio Our beloved Micro-Manager Studio object
+    * @param xyNavigator Object that manages communication to XY Stages
+    * @param zNavigator Object that manages communication to Z Stages.
+    */
+   public XYZKeyListener(Studio studio, XYNavigator xyNavigator, ZNavigator zNavigator) {
+      core_ = studio.getCMMCore();
+      xyNavigator_ = xyNavigator;
+      zNavigator_ = zNavigator;
 
-       xMovesMicron_ = new double[] {1.0, core_.getImageWidth() / 4, core_.getImageWidth()};
-       yMovesMicron_ = new double[] {1.0, core_.getImageHeight() / 4, core_.getImageHeight()};
-       zMovesMicron_ = new double[] {1.0, 10.0};
+      xMovesMicron_ = new double[] {1.0, core_.getImageWidth() / 4.0, core_.getImageWidth()};
+      yMovesMicron_ = new double[] {1.0, core_.getImageHeight() / 4.0, core_.getImageHeight()};
+      zMovesMicron_ = new double[] {1.0, 10.0};
 
-       settings_ = studio.profile().getSettings(
-       		org.micromanager.internal.dialogs.StageControlFrame.class);
-	}
+      settings_ = studio.profile().getSettings(
+           org.micromanager.internal.dialogs.StageControlFrame.class);
+   }
 
-	@Subscribe
-	public void keyPressed(DisplayKeyPressEvent dkpe) {
-		KeyEvent e = dkpe.getKeyEvent();
-		boolean consumed = false;
-		for (int i = 0; i < xMovesMicron_.length; ++i) {
-			xMovesMicron_[i] = settings_.getDouble(X_MOVEMENTS[i], xMovesMicron_[i]);
-		}
-		for (int i = 0; i < yMovesMicron_.length; ++i) {
-			yMovesMicron_[i] = settings_.getDouble(Y_MOVEMENTS[i], yMovesMicron_[i]);
-		}
-		zMovesMicron_[0] = settings_.getDouble(SMALL_MOVEMENT_Z, 1.1);
-		zMovesMicron_[1] = settings_.getDouble(MEDIUM_MOVEMENT_Z, 11.1);
+   /**
+    * Handles the event signalling that a key was pressed while the display had focus.
+    *
+    * @param dkpe information about the actual event.
+    */
+   @Subscribe
+   public void keyPressed(DisplayKeyPressEvent dkpe) {
+      final KeyEvent e = dkpe.getKeyEvent();
+      boolean consumed = false;
+      for (int i = 0; i < xMovesMicron_.length; ++i) {
+         xMovesMicron_[i] = settings_.getDouble(X_MOVEMENTS[i], xMovesMicron_[i]);
+      }
+      for (int i = 0; i < yMovesMicron_.length; ++i) {
+         yMovesMicron_[i] = settings_.getDouble(Y_MOVEMENTS[i], yMovesMicron_[i]);
+      }
+      zMovesMicron_[0] = settings_.getDouble(SMALL_MOVEMENT_Z, 1.1);
+      zMovesMicron_[1] = settings_.getDouble(MEDIUM_MOVEMENT_Z, 11.1);
 
-		switch (e.getKeyCode()) {
-			case KeyEvent.VK_LEFT:
-			case KeyEvent.VK_RIGHT:
-			case KeyEvent.VK_UP:
-			case KeyEvent.VK_DOWN:
-				//XY step
-				double xMicron = xMovesMicron_[1];
-				double yMicron = yMovesMicron_[1];
-				if (e.isControlDown()) {
-					xMicron = xMovesMicron_[0];
-					yMicron = yMovesMicron_[0];
-				} else if (e.isShiftDown()) {
-					xMicron = xMovesMicron_[2];
-					yMicron = yMovesMicron_[2];
-				}
-				switch (e.getKeyCode()) {
-					case KeyEvent.VK_LEFT:
-						xyNavigator_.moveSampleOnDisplayUm(-xMicron, 0);
-						consumed = true;
-						break;
-					case KeyEvent.VK_RIGHT:
-						xyNavigator_.moveSampleOnDisplayUm(xMicron, 0);
-						consumed = true;
-						break;
-					case KeyEvent.VK_UP:
-						xyNavigator_.moveSampleOnDisplayUm(0, yMicron);
-						consumed = true;
-						break;
-					case KeyEvent.VK_DOWN:
-						xyNavigator_.moveSampleOnDisplayUm(0, -yMicron);
-						consumed = true;
-				}
-				break;
-			case KeyEvent.VK_1:
-			case KeyEvent.VK_U:
-			case KeyEvent.VK_PAGE_UP:
-			case KeyEvent.VK_2:
-			case KeyEvent.VK_J:
-			case KeyEvent.VK_PAGE_DOWN:
-				double zMicron = zMovesMicron_[0];
-				if (e.isShiftDown()) {
-					zMicron = zMovesMicron_[1];
-		    }
-			switch (e.getKeyCode()) {
-			case KeyEvent.VK_1:
-			case KeyEvent.VK_U:
-			case KeyEvent.VK_PAGE_UP:
-				IncrementZ(-zMicron);
-				consumed = true;
-				break;
-			case KeyEvent.VK_2:
-			case KeyEvent.VK_J:
-			case KeyEvent.VK_PAGE_DOWN:
-				IncrementZ(zMicron);
-				consumed = true;
-			}
-		}
-		if (consumed) {
-			dkpe.consume();
-		}
-	}
+      switch (e.getKeyCode()) {
+         case KeyEvent.VK_LEFT:
+         case KeyEvent.VK_RIGHT:
+         case KeyEvent.VK_UP:
+         case KeyEvent.VK_DOWN:
+            //XY step
+            double xMicron = xMovesMicron_[1];
+            double yMicron = yMovesMicron_[1];
+            if (e.isControlDown()) {
+               xMicron = xMovesMicron_[0];
+               yMicron = yMovesMicron_[0];
+            } else if (e.isShiftDown()) {
+               xMicron = xMovesMicron_[2];
+               yMicron = yMovesMicron_[2];
+            }
+            switch (e.getKeyCode()) {
+               case KeyEvent.VK_LEFT:
+                  xyNavigator_.moveSampleOnDisplayUm(-xMicron, 0);
+                  consumed = true;
+                  break;
+               case KeyEvent.VK_RIGHT:
+                  xyNavigator_.moveSampleOnDisplayUm(xMicron, 0);
+                  consumed = true;
+                  break;
+               case KeyEvent.VK_UP:
+                  xyNavigator_.moveSampleOnDisplayUm(0, yMicron);
+                  consumed = true;
+                  break;
+               case KeyEvent.VK_DOWN:
+                  xyNavigator_.moveSampleOnDisplayUm(0, -yMicron);
+                  consumed = true;
+                  break;
+               default:
+                  break;
+            }
+            break;
+         case KeyEvent.VK_1:
+         case KeyEvent.VK_U:
+         case KeyEvent.VK_PAGE_UP:
+         case KeyEvent.VK_2:
+         case KeyEvent.VK_J:
+         case KeyEvent.VK_PAGE_DOWN:
+            double zMicron = zMovesMicron_[0];
+            if (e.isShiftDown()) {
+               zMicron = zMovesMicron_[1];
+            }
+            switch (e.getKeyCode()) {
+               case KeyEvent.VK_1:
+               case KeyEvent.VK_U:
+               case KeyEvent.VK_PAGE_UP:
+                  incrementZ(-zMicron);
+                  consumed = true;
+                  break;
+               case KeyEvent.VK_2:
+               case KeyEvent.VK_J:
+               case KeyEvent.VK_PAGE_DOWN:
+                  incrementZ(zMicron);
+                  consumed = true;
+                  break;
+               default:
+                  break;
+            }
+            break;
+         default:
+            break;
+      }
+      if (consumed) {
+         dkpe.consume();
+      }
+   }
 
-	public void IncrementZ(double micron) {
-		// Get needed info from core
-		String zStage = settings_.getString(SELECTED_Z_DRIVE, core_.getFocusDevice());
-		if (zStage == null || zStage.length() == 0)
-			return;
+   /**
+    * Relative movement of the Z stage by the given amount.
+    *
+    * @param micron How much to jove the stage in microns.
+    */
+   public void incrementZ(double micron) {
+      // Get needed info from core
+      String zStage = settings_.getString(SELECTED_Z_DRIVE, core_.getFocusDevice());
+      if (zStage == null || zStage.length() == 0) {
+         return;
+      }
 
-		zNavigator_.setPosition(zStage, micron);
-	}
+      zNavigator_.setPosition(zStage, micron);
+   }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/ZNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/ZNavigator.java
@@ -2,17 +2,19 @@ package org.micromanager.internal.navigation;
 
 
 import com.google.common.util.concurrent.AtomicDouble;
-import org.micromanager.Studio;
-import org.micromanager.events.internal.DefaultStagePositionChangedEvent;
-import org.micromanager.internal.utils.ReportingUtils;
-import org.micromanager.internal.utils.ThreadFactoryFactory;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.micromanager.Studio;
+import org.micromanager.events.internal.DefaultStagePositionChangedEvent;
+import org.micromanager.internal.utils.ReportingUtils;
+import org.micromanager.internal.utils.ThreadFactoryFactory;
 
+/**
+ * Utility class sending movement commands to the (z) stage(s).
+ */
 public class ZNavigator {
    private final Studio studio_;
    private final Map<String, ZStageTask> zStageTaskMap_;
@@ -22,6 +24,12 @@ public class ZNavigator {
       zStageTaskMap_ = new HashMap<>();
    }
 
+   /**
+    * Sets the position of the stage.
+    *
+    * @param stage name of the stage to move.
+    * @param relativeMovement Amount of the relative movement in microns.
+    */
    public void setPosition(String stage, double relativeMovement) {
       if (!zStageTaskMap_.containsKey(stage)) {
          zStageTaskMap_.put(stage, new ZStageTask(stage));
@@ -48,7 +56,7 @@ public class ZNavigator {
          stage_ = stage;
          moveMemory_ = new AtomicDouble(0.0);
          executorService_ = Executors.newSingleThreadExecutor(
-                 ThreadFactoryFactory.createThreadFactory("ZNavigator-" + stage ));
+                 ThreadFactoryFactory.createThreadFactory("ZNavigator-" + stage));
       }
 
       public void setPosition(double pos) {

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/ZWheelListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/ZWheelListener.java
@@ -25,6 +25,7 @@ import org.micromanager.Studio;
 import org.micromanager.display.internal.event.DisplayMouseWheelEvent;
 
 /**
+ * Classs that translates changes in the mouse wheel into Z stage movements.
 */
 public final class ZWheelListener  {
    private static final double MOVE_INCREMENT = 0.20;
@@ -42,7 +43,7 @@ public final class ZWheelListener  {
     * ZStageMovements are funneled through zNavigator, which runs separate
     * executors for each zStage, and combines movement requests if they come in
     * too fast.
-    * 
+    *
     * @param e DisplayMouseWheelEvent containing a MouseWheel event
     */
    @Subscribe


### PR DESCRIPTION
Closes #1278.
- Adds option to snap an image after moving.
- Now moves stage to move the sample as expected based on the image, rather than based on the stage coordinates.
- Lots of checkstyling the internal navigation code.
