### PR TITLE
Add ChannelGroup setting to demo config

### DIFF
--- a/bindist/any-platform/MMConfig_demo.cfg
+++ b/bindist/any-platform/MMConfig_demo.cfg
@@ -133,6 +133,7 @@ ConfigGroup,System,Startup,Camera,BitDepth,16
 ConfigGroup,System,Startup,Camera,ScanMode,1
 ConfigGroup,System,Startup,Objective,Label,Nikon 10X S Fluor
 ConfigGroup,System,Startup,Camera,Binning,1
+ConfigGroup,System,Startup,Core,ChannelGroup,Channel
 
 
 # Group: LightPath


### PR DESCRIPTION
This adds an example to the demo config to make this more discoverable. This also helps when using the demo config to develop a GUI application. 

This is particularly important for people working with pymmcore(-plus), as when doing so you can end up working with config files not generated directly by micromanager. 

See also https://forum.image.sc/t/how-to-set-channelgroup-in-config-file/55746