### PR TITLE
Crisp plugin: fixed license comment type

### DIFF
--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPFrame.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/UserSettings.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/UserSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Defaults.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Defaults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Icons.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Icons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Ranges.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Ranges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISP.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISPSettings.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISPSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISPTimer.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISPTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/ControllerType.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/ControllerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/PropName.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/PropName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/PropValue.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/PropValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/ButtonPanel.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/ButtonPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/PlotPanel.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/PlotPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/SpinnerPanel.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/SpinnerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/StatusPanel.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/StatusPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/plot/FocusData.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/plot/FocusData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/plot/FocusDataSet.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/plot/FocusDataSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/plot/PlotFrame.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/plot/PlotFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/utils/DialogUtils.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/utils/DialogUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/utils/FileUtils.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/utils/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/utils/WindowUtils.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/utils/WindowUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/ui/Button.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/ui/Button.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/ui/CheckBox.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/ui/CheckBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/ui/ComboBox.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/ui/ComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/ui/Method.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/ui/Method.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/ui/Panel.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/ui/Panel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)

--- a/plugins/CRISP/src/main/java/com/asiimaging/ui/Spinner.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/ui/Spinner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Project: ASI CRISP Control
  * License: BSD 3-clause, see LICENSE.md
  * Author: Brandon Simpson (brandon@asiimaging.com)


### PR DESCRIPTION
Nothing major, just changing license comment type from javadoc to block comment.