### PR TITLE
Remove timestamp from mmcorej Javadoc

### DIFF
--- a/swig-doc-converter/convert
+++ b/swig-doc-converter/convert
@@ -2,4 +2,4 @@ rm -rf mmcorej javadoc
 cp -R ../mmCoreAndDevices/MMCoreJ_wrap/gensrc/mmcorej .
 cp -R ../mmCoreAndDevices/MMCoreJ_wrap/src/main/java/mmcorej/org mmcorej/
 java -jar swig-doc-converter-0.0.1-standalone.jar ../doxygen/out/MMCore/html/class_c_m_m_core.html
-javadoc mmcorej/org/json/*.java mmcorej/*.java -d javadoc
+javadoc mmcorej/org/json/*.java mmcorej/*.java -d javadoc -use -notimestamp


### PR DESCRIPTION
This should reduce commit noise in the apidoc repo.

Also enable "Use" pages.