### PR TITLE
CRISP: fixed plot button and timer skip counter

### DIFF
--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
@@ -22,7 +22,7 @@ public class CRISPPlugin implements MenuPlugin, SciJavaPlugin {
     public static final String copyright = "Applied Scientific Instrumentation (ASI), 2014-2021";
     public static final String description = "Interface to control ASIs CRISP Autofocus system.";
     public static final String menuName = "ASI CRISP Control";
-    public static final String version = "2.2.0";
+    public static final String version = "2.2.1";
 
     private Studio studio;
     private CRISPFrame frame;

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISPTimer.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISPTimer.java
@@ -102,7 +102,6 @@ public class CRISPTimer {
      * Called in the CRISP setStateLogCal method to skip timer updates.
      */
     public void onLogCal() {
-        skipCounter = skipRefresh;
         // controller becomes unresponsive during loG_cal => skip polling a few times
         if (timer.isRunning()) {
             skipCounter = skipRefresh;

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/PlotPanel.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/PlotPanel.java
@@ -173,7 +173,7 @@ public class PlotPanel extends Panel {
                 if (isPollingEnabled) {
                     frame.getSpinnerPanel().setPollingCheckBox(true);
                 }
-                btnPlot.setEnabled(isPollingEnabled);
+                btnPlot.setEnabled(true);
                 showPlotWindow();
             }
             


### PR DESCRIPTION
Fixed a bug with the focus curve plot button not being re-enabled after plotting. Fixed the CRISP timer during logCal, if you clicked on log cal when polling was off it would set the skip counter and count down as soon as you enabled polling again in any state.