### PR TITLE
CRISP: increase GainMultiplier spinner max value

### DIFF
--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Ranges.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Ranges.java
@@ -20,7 +20,7 @@ public class Ranges {
     
     // integer sliders
     public static final int MIN_GAIN = 1;
-    public static final int MAX_GAIN = 10;
+    public static final int MAX_GAIN = 100;
     public static final int MIN_NUM_AVERAGES = 0;
     public static final int MAX_NUM_AVERAGES = 8;
     public static final int MIN_POLL_RATE_MS = 50;


### PR DESCRIPTION
When fixing the device adapters I realized this value needs to be higher.