### PR TITLE
Studio: fix inability to set exposure time in certain conditions.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultChannelExposureEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultChannelExposureEvent.java
@@ -1,6 +1,8 @@
 package org.micromanager.events.internal;
 
-public class DefaultChannelExposureEvent {
+import org.micromanager.events.ChannelExposureEvent;
+
+public class DefaultChannelExposureEvent implements ChannelExposureEvent {
    private final double newExposureTime_;
    private final String channelGroup_;
    private final String channel_;

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
@@ -97,7 +97,8 @@ public class DefaultApplication implements Application {
       try {
          channelGroup = studio_.core().getChannelGroup();
          channel = studio_.core().getCurrentConfigFromCache(channelGroup);
-         storeChannelExposureTime(channelGroup, channel, exposureTime);
+         studio_.events().post(new DefaultChannelExposureEvent(exposureTime,
+               channelGroup, channel, true));
       } catch (Exception e) {
          studio_.logs().logError("Unable to determine channel group");
       }
@@ -109,18 +110,15 @@ public class DefaultApplication implements Application {
             studio_.core().waitForDevice(studio_.core().getCameraDevice());
          } catch (Exception e) {
             ReportingUtils.logError(e, "Failed to set core exposure time.");
+            try {
+               double exposure = studio_.core().getExposure();
+               studio_.events().post(new DefaultChannelExposureEvent(exposure,
+                     channelGroup, channel, true));
+            } catch (Exception ex) {
+               ReportingUtils.logError(ex, "Failed to read exposure time.");
+            }
          }
          studio_.live().setSuspended(false);
-      }
-
-      // Display the new exposure time
-      double exposure;
-      try {
-         exposure = studio_.core().getExposure();
-         studio_.events().post(new DefaultChannelExposureEvent(exposure,
-                  channelGroup, channel, true));
-      } catch (Exception e) {
-         ReportingUtils.logError(e, "Couldn't set exposure time.");
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -376,6 +376,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
             }
          }
       };
+      mmStudio_.events().registerForEvents(this);
       super.addWindowFocusListener(windowFocusListener);
    }
 
@@ -1014,7 +1015,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    /**
     * Called when the GUI needs updating.
     *
-    * @param event Event signaling GUI Refresh reuest.
+    * @param event Event signaling GUI Refresh request.
     */
    @Subscribe
    public void onGUIRefresh(GUIRefreshEvent event) {


### PR DESCRIPTION
When the device adapter calls OnPropertiesChanged in the setExposure method
(such as done by the PVCAM adapter), the exposure time would reset to the
previously known exposure time for the channel and group (when synchronization
with the MDA was requested).  This was caused by the setExposure function not
updating the value stored by AcqDialog.  It so turns out that the DefaultChannelExposureEvent
was not inheriting from ChannelExposureEvent, hence the event was never processed
(this is one of those instances where I do not like the opaque structure of
the agave-google bus).  Fixing this, and making sure the event is posted
before actually setting the exposure time in the core (which can result in
the OnPropertiesChanged callback) solves the issue hopefully for good.
Closes #1319 
