### PR TITLE
Remove mu/micro symbol from Java source

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/IntroPlugin.java
+++ b/mmstudio/src/main/java/org/micromanager/IntroPlugin.java
@@ -31,7 +31,8 @@ import javax.swing.Icon;
 public interface IntroPlugin extends MMPlugin {
    /**
     * Provide a "splash" image to display at the top of the intro dialog. If
-    * this method returns null, then the default µManager logo will be used.
+    * this method returns null, then the default Micro-Manager logo will be
+    * used.
     *
     * @return The image to use at the top of the intro dialog, or null.
     */

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
@@ -187,7 +187,7 @@ public final class ImageJBridge {
 
       imagePlus_ = MMImagePlus.create(this);
 
-      imagePlus_.setStack("New µManager-ImageJ Bridge", proxyStack_);
+      imagePlus_.setStack("New Micro-Manager-to-ImageJ Bridge", proxyStack_);
       imagePlus_.setOpenAsHyperStack(true);
       applyColorMode(colorModeStrategy_);
 


### PR DESCRIPTION
Best to escape non-ascii characters, even though our source is
understood to be UTF8. See #945.