### PR TITLE
CRISP: removed log cal timer skips for Tiger firmware >= 3.38

### DIFF
--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPFrame.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPFrame.java
@@ -131,15 +131,14 @@ public class CRISPFrame extends JFrame {
             buttonPanel.setCalibrationButtonStates(false);
         }
         
-        // TODO: better method for parsing version strings
         // disable update rate spinner if using old firmware
-        final String version = crisp.getFirmwareVersion();
         if (crisp.getDeviceType() == ControllerType.TIGER) {
-            if (!version.startsWith("3.38")) {
+            if (crisp.getFirmwareVersion() < 3.38) {
                 spinnerPanel.setEnabledUpdateRateSpinner(false);
             }
         } else {
-            if (!version.startsWith("USB-9.2n")) {
+            if (crisp.getFirmwareVersion() < 9.2
+                    || crisp.getFirmwareVersionLetter() < 'n') {
                 spinnerPanel.setEnabledUpdateRateSpinner(false);
             }
         }
@@ -250,11 +249,8 @@ public class CRISPFrame extends JFrame {
         return spinnerPanel;
     }
 
-    public CRISPTimer getTimer() {
-        return timer;
-    }
-
     public CRISP getCRISP() {
         return crisp;
     }
+    
 }

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
@@ -20,7 +20,7 @@ public class CRISPPlugin implements MenuPlugin, SciJavaPlugin {
     public static final String copyright = "Applied Scientific Instrumentation (ASI), 2014-2021";
     public static final String description = "Interface to control ASIs CRISP Autofocus system.";
     public static final String menuName = "ASI CRISP Control";
-    public static final String version = "2.4.0";
+    public static final String version = "2.4.1";
 
     private Studio studio;
     private CRISPFrame frame;

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Defaults.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/data/Defaults.java
@@ -13,8 +13,8 @@ package com.asiimaging.crisp.data;
 public final class Defaults {
     
     // CRISPSettings
-    public static final int LOOP_GAIN = 1;
-    public static final int NUM_AVERAGES = 1;
+    public static final int LOOP_GAIN = 10;
+    public static final int NUM_AVERAGES = 0;
     public static final int LED_INTENSITY = 50;
     public static final int UPDATE_RATE_MS = 10;
     public static final float LOCK_RANGE = 1.0f;

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISPTimer.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISPTimer.java
@@ -29,7 +29,7 @@ public class CRISPTimer {
     public CRISPTimer(final CRISP crisp) {
         this.crisp = crisp;
         skipCounter = 0;
-        skipRefresh = 20;
+        skipRefresh = 10; // this value changes based on pollRateMs
         pollRateMs = 250;
     }
     
@@ -125,13 +125,10 @@ public class CRISPTimer {
      * @param rate the polling rate in milliseconds
      */
     public void setPollRateMs(final int rate) {
-        timer.setDelay(rate);
-        skipRefresh = Math.round(5000.0f/rate);
+        skipRefresh = Math.round(2500.0f/rate);
         pollRateMs = rate;
+        timer.setDelay(rate);
     }
 
-    public void setSkipCounter(final int n) {
-        skipCounter = n;
-    }
 }
 


### PR DESCRIPTION
Also removed the log cal timer skips for MS2000 firmware going back to ~2016 as this issue had already been fixed.