### PR TITLE
CRISP: make sure to set firmware version and letter

### DIFF
--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
@@ -20,7 +20,7 @@ public class CRISPPlugin implements MenuPlugin, SciJavaPlugin {
     public static final String copyright = "Applied Scientific Instrumentation (ASI), 2014-2021";
     public static final String description = "Interface to control ASIs CRISP Autofocus system.";
     public static final String menuName = "ASI CRISP Control";
-    public static final String version = "2.4.2";
+    public static final String version = "2.4.3";
 
     private Studio studio;
     private CRISPFrame frame;

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISP.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/device/CRISP.java
@@ -192,6 +192,9 @@ public class CRISP {
                 }
             }
         }
+        if (found) {
+            setFirmwareVersion(); // sets firmwareVersion and firmwareVersionLetter
+        }
         return found;
     }
     


### PR DESCRIPTION
This will make sure that the "update rate ms" spinner is usable on CRISP firmware version 3.38.