### PR TITLE
Studio: When XY stage movement fails, show an error rather than only log.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
@@ -263,7 +263,7 @@ public class XYNavigator {
                      new DefaultXYStagePositionChangedEvent(xyStage_, xs[0], ys[0]));
             }
          } catch (Exception ex) {
-            ReportingUtils.logError(ex.getMessage());
+            ReportingUtils.showError(ex.getMessage());
          }
       }
    }


### PR DESCRIPTION
Closes #1327 