### PR TITLE
Adds a flag to temporarily disable processing of core events

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/events/internal/ChannelColorEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/ChannelColorEvent.java
@@ -3,14 +3,21 @@ package org.micromanager.events.internal;
 import java.awt.Color;
 
 /**
- * Signals that the user assigned a new color to a channel
- * Used to synchronize the color used to display a channel in the UI
+ * Signals that the user assigned a new color to a channel.
+ * Used to synchronize the color for a channel in the UI.
  */
 public class ChannelColorEvent {
    private final String channelGroup_;
    private final String channel_;
    private final Color color_;
 
+   /**
+    * Creates an event signalling that the color of a channel has changed.
+    *
+    * @param channelGroup Channel group to which this channel (Preset) belongs.
+    * @param channel Preset
+    * @param color New color for this channel (Preset)
+    */
    public ChannelColorEvent(String channelGroup, String channel, Color color) {
       channelGroup_ = channelGroup;
       channel_ = channel;

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultApplicationSkinEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultApplicationSkinEvent.java
@@ -11,18 +11,19 @@ import org.micromanager.ApplicationSkin;
 import org.micromanager.events.ApplicationSkinEvent;
 
 /**
+ * Event signalling that the Application Skin was changed.
  *
  * @author marc
  */
 public final class DefaultApplicationSkinEvent implements ApplicationSkinEvent {
-    private final ApplicationSkin.SkinMode mode_;
+   private final ApplicationSkin.SkinMode mode_;
 
-    public DefaultApplicationSkinEvent(ApplicationSkin.SkinMode mode) {
-        mode_ = mode;
-    }
+   public DefaultApplicationSkinEvent(ApplicationSkin.SkinMode mode) {
+      mode_ = mode;
+   }
     
-    @Override
-    public ApplicationSkin.SkinMode getSkinMode() {
-        return mode_;
-    }
+   @Override
+   public ApplicationSkin.SkinMode getSkinMode() {
+      return mode_;
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultAutoShutterEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultAutoShutterEvent.java
@@ -28,7 +28,8 @@ import org.micromanager.events.AutoShutterEvent;
  *  {@link org.micromanager.events.EventManager}.
  */
 public final class DefaultAutoShutterEvent implements AutoShutterEvent {
-   private boolean isAutoOn_;
+   private final boolean isAutoOn_;
+
    public DefaultAutoShutterEvent(boolean isOn) {
       isAutoOn_ = isOn;
    }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultChannelExposureEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultChannelExposureEvent.java
@@ -2,12 +2,23 @@ package org.micromanager.events.internal;
 
 import org.micromanager.events.ChannelExposureEvent;
 
+/**
+ * Event signalling that the channel's default exposure time changed.
+ */
 public class DefaultChannelExposureEvent implements ChannelExposureEvent {
    private final double newExposureTime_;
    private final String channelGroup_;
    private final String channel_;
    private final boolean isMainExposureTime_;
 
+   /**
+    * Constructs the event signalling that a channel's default exposure time changed.
+    *
+    * @param newExposureTime New Exposure Time (ms)
+    * @param channelGroup Group to which this channel belongs
+    * @param channel Channel (Preset)
+    * @param isMainExposureTime True if this channel is currently the "active" channel
+    */
    public DefaultChannelExposureEvent(double newExposureTime, String channelGroup,
                                String channel, boolean isMainExposureTime) {
       newExposureTime_ = newExposureTime;
@@ -50,6 +61,7 @@ public class DefaultChannelExposureEvent implements ChannelExposureEvent {
    }
 
    /**
+    * Indicates if this channel is the currently active channel.
     *
     * @return true if this channel is the currently-active channel.
     * @deprecated use {@link #isMainExposureTime()} instead

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultChannelGroupChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultChannelGroupChangedEvent.java
@@ -4,10 +4,10 @@ import org.micromanager.events.ChannelGroupChangedEvent;
 
 
 /**
- * Event signaling that the "Channel Group" changed
+ * Event signaling that the "Channel Group" changed.
  *
- * This event is posted on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event is posted on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultChannelGroupChangedEvent implements ChannelGroupChangedEvent {
    private final String channelGroup_;
@@ -17,7 +17,8 @@ public class DefaultChannelGroupChangedEvent implements ChannelGroupChangedEvent
    }
 
    /**
-    * Provides the name of the newly selected channel group
+    * Provides the name of the newly selected channel group.
+    *
     * @return name of the newly selected ChannelGroup
     */
    @Override

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultConfigGroupChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultConfigGroupChangedEvent.java
@@ -17,17 +17,21 @@ public class DefaultConfigGroupChangedEvent implements ConfigGroupChangedEvent {
    }
 
    /**
+    * Name of the newly selected configuration (preset).
+    *
     * @return The name of the newly selected configuration
     */
    public String getNewConfig() {
-         return newConfig_;
-      }
+      return newConfig_;
+   }
 
    /**
+    * Name of the Group to which this configuration (Preset) belongs.
+    *
     * @return Name of the group to which this newly selected configuration belongs.
-   */
+    */
    public String getGroupName() {
-         return groupName_;
-      }
+      return groupName_;
+   }
 }
 

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultEventManager.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultEventManager.java
@@ -6,16 +6,17 @@ import org.micromanager.events.EventManager;
 import org.micromanager.internal.utils.EventBusExceptionLogger;
 import org.micromanager.internal.utils.ReportingUtils;
 
-// This is a singleton wrapper around the Guava library's EventBus. It exposes
-// a system-wide EventBus for certain general-purpose events.
+/**
+ * This is a singleton wrapper around the Guava library's EventBus. It exposes
+ * a system-wide EventBus for certain general-purpose events.
+ */
 public final class DefaultEventManager implements EventManager {
 
    private final EventBus bus_;
    private final LogManager logger_;
    
    /**
-    * DefaultEventManager is basically a pass-through to the Google Eventbus
-    * 
+    * This DefaultEventManager is basically a pass-through to the Google (formerly Guava) Eventbus.
     */
    public DefaultEventManager() {
       bus_ = new EventBus(EventBusExceptionLogger.getInstance());

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultExposureChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultExposureChangedEvent.java
@@ -5,8 +5,8 @@ import org.micromanager.events.ExposureChangedEvent;
 /**
  * This class signals when the exposure time for a given camera has changed.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultExposureChangedEvent implements ExposureChangedEvent {
    private final String cameraName_;
@@ -19,17 +19,19 @@ public class DefaultExposureChangedEvent implements ExposureChangedEvent {
 
    /**
     * Camera whose exposure time changed.
+    *
     * @return Camera whose exposure time changed.
     */
    public String getCameraName() {
-         return cameraName_;
-      }
+      return cameraName_;
+   }
 
    /**
-    * New exposure time
+    * New exposure time.
+    *
     * @return New exposure time.
     */
    public double getNewExposureTime() {
-         return newExposureTime_;
-      }
+      return newExposureTime_;
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultGUIRefreshEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultGUIRefreshEvent.java
@@ -7,8 +7,8 @@ import org.micromanager.events.GUIRefreshEvent;
  * (e.g. when the user clicks the "Refresh" button or when code calls the
  * refreshGUI() method in CompatibilityInterface).
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultGUIRefreshEvent implements GUIRefreshEvent {
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultLiveModeEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultLiveModeEvent.java
@@ -25,11 +25,11 @@ import org.micromanager.events.LiveModeEvent;
 /**
  * This class signals that live mode has been turned on or off.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public final class DefaultLiveModeEvent implements LiveModeEvent {
-   private boolean isOn_;
+   private final boolean isOn_;
 
 
    public DefaultLiveModeEvent(boolean isOn) {
@@ -38,8 +38,8 @@ public final class DefaultLiveModeEvent implements LiveModeEvent {
 
    /**
     * Informs the caller if live mode is on or off.
-    * @return True if live mode has been turned on, false if it has been turned
-    *         off.
+    *
+    * @return True if live mode has been turned on, false if it has been turned off.
     */
    @Override
    public boolean isOn() {

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultNewPositionListEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultNewPositionListEvent.java
@@ -27,11 +27,11 @@ import org.micromanager.events.NewPositionListEvent;
  * This event posts when the application's Stage Position List changes
  * (positions added, removed, or moved).
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public final class DefaultNewPositionListEvent implements NewPositionListEvent {
-   private PositionList newList_;
+   private final PositionList newList_;
 
    public DefaultNewPositionListEvent(PositionList newList) {
       newList_ = newList;
@@ -39,8 +39,9 @@ public final class DefaultNewPositionListEvent implements NewPositionListEvent {
 
    /**
     * Returns the new stage position list.
+    *
     * @return PositionList that is modified, usually the application's Stage
-    * Position List.
+    *         Position List.
     */
    @Override
    public PositionList getPositionList() {

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPixelSizeAffineChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPixelSizeAffineChangedEvent.java
@@ -1,14 +1,14 @@
 package org.micromanager.events.internal;
 
-import org.micromanager.events.PixelSizeAffineChangedEvent;
 import java.awt.geom.AffineTransform;
+import org.micromanager.events.PixelSizeAffineChangedEvent;
 
 /**
  * This event posts when the affine transform, describing the relation between
  * stage movement and camera coordinates, changes.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultPixelSizeAffineChangedEvent implements PixelSizeAffineChangedEvent {
    private final AffineTransform affine_;
@@ -19,8 +19,9 @@ public class DefaultPixelSizeAffineChangedEvent implements PixelSizeAffineChange
 
    /**
     * New affine transform.
+    *
     * @return New affine transform describing relation between stage movement and
-    * camera coordinates.
+    *         camera coordinates.
     */
    public AffineTransform getNewPixelSizeAffine() {
       return affine_;

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPixelSizeChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPixelSizeChangedEvent.java
@@ -6,16 +6,19 @@ import org.micromanager.events.PixelSizeChangedEvent;
  * This event posts when the pixel size, the size of a camera pixel in the object
  * plane, changes.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultPixelSizeChangedEvent implements PixelSizeChangedEvent {
    private final double newPixelSizeUm_;
-   public DefaultPixelSizeChangedEvent (double newPixelSizeUm) {
+
+   public DefaultPixelSizeChangedEvent(double newPixelSizeUm) {
       newPixelSizeUm_ = newPixelSizeUm;
    }
 
    /**
+    * The new pixel size in microns.
+    *
     * @return new pixel size in microns.
     */
    public double getNewPixelSizeUm() {

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPropertiesChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPropertiesChangedEvent.java
@@ -9,8 +9,8 @@ import org.micromanager.events.PropertiesChangedEvent;
  * Since the Core callbacks into this event, there is a mismatch here that needs
  * to be resolved.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultPropertiesChangedEvent implements PropertiesChangedEvent {
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPropertyChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultPropertyChangedEvent.java
@@ -5,8 +5,8 @@ import org.micromanager.events.PropertyChangedEvent;
 /**
  * This class provides information when a specific property changes.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultPropertyChangedEvent implements PropertyChangedEvent {
 
@@ -14,13 +14,22 @@ public class DefaultPropertyChangedEvent implements PropertyChangedEvent {
    private final String property_;
    private final String value_;
 
+   /**
+    * Event signalling that a Property changed its value.
+    *
+    * @param device Device to which this property belongs.
+    * @param property Name of the Property that changed.
+    * @param value New value of the Property.
+    */
    public DefaultPropertyChangedEvent(String device, String property, String value) {
       device_ = device;
       property_ = property;
       value_ = value;
    }
+
    /**
-    * Device to which the changed property belongs
+    * Device to which the changed property belongs.
+    *
     * @return Device to which the changed property belongs
     */
    public String getValue() {
@@ -28,6 +37,8 @@ public class DefaultPropertyChangedEvent implements PropertyChangedEvent {
    }
 
    /**
+    * New value of the Property that changed.
+    *
     * @return new value of the property
     */
    public String getProperty() {
@@ -35,6 +46,8 @@ public class DefaultPropertyChangedEvent implements PropertyChangedEvent {
    }
 
    /**
+    * Name of the Property that changed.
+    *
     * @return Property name (key)
     */
    public String getDevice() {

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultSLMExposureChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultSLMExposureChangedEvent.java
@@ -6,19 +6,21 @@ import org.micromanager.events.SLMExposureChangedEvent;
  * This interface posts when the exposure time for a given Spatial Light Modulator
  * (such as a Digital Mirror Device) changes.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultSLMExposureChangedEvent implements SLMExposureChangedEvent {
    private final String deviceName_;
    private final double newExposureTime_;
 
-   public DefaultSLMExposureChangedEvent (String deviceName, double newExposureTime) {
+   public DefaultSLMExposureChangedEvent(String deviceName, double newExposureTime) {
       deviceName_ = deviceName;
       newExposureTime_ = newExposureTime;
    }
 
    /**
+    * Name of the SLM device.
+    *
     * @return Name of the (SLM) device that changes exposure.
     */
    public String getDeviceName() {
@@ -26,7 +28,9 @@ public class DefaultSLMExposureChangedEvent implements SLMExposureChangedEvent {
    }
 
    /**
-    * @return new exposure time of thr (SLM) device.
+    * New exposure time of the SLM device (in ms).
+    *
+    * @return new exposure time of the (SLM) device.
     */
    public double getNewExposureTime() {
       return newExposureTime_;

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultShutdownCommencingEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultShutdownCommencingEvent.java
@@ -5,15 +5,15 @@ import org.micromanager.events.ShutdownCommencingEvent;
 /**
  * This event posts when the user requests the program to shut down.
  *
- * It gives subscribers the opportunity to cancel shutdown (ideally only to
- * ensure that data can be saved or other similarly-critical decisions).
+ * <p>It gives subscribers the opportunity to cancel shutdown (ideally only to
+ * ensure that data can be saved or other similarly-critical decisions).</p>
  *
- * All subscribers must first check if the shutdown has been canceled by
+ * <p>All subscribers must first check if the shutdown has been canceled by
  * calling {@link #isCanceled()}. If the shutdown has been canceled, the
- * event must be ignored.
+ * event must be ignored.</p>
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultShutdownCommencingEvent implements ShutdownCommencingEvent {
    private boolean isCanceled_ = false;
@@ -27,6 +27,7 @@ public class DefaultShutdownCommencingEvent implements ShutdownCommencingEvent {
 
    /**
     * Return whether or not shutdown has been canceled.
+    *
     * @return true when shutdown was canceled
     */
    public boolean isCanceled() {
@@ -34,6 +35,8 @@ public class DefaultShutdownCommencingEvent implements ShutdownCommencingEvent {
    }
 
    /**
+    * Deprecated version of isCanceled().
+    *
     * @return true when shutdown was canceled
     * @deprecated use {@link #isCanceled()} instead
     */

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultShutterEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultShutterEvent.java
@@ -25,16 +25,24 @@ import org.micromanager.events.ShutterEvent;
 /**
  * This event posts when the shutter opens or closes.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public final class DefaultShutterEvent implements ShutterEvent {
-   private boolean isOn_;
+   private final boolean isOn_;
+
+   /**
+    * Event signalling that the shutter changed its state.
+    *
+    * @param isOn true if the shutter is now open, false otherwise.
+    */
    public DefaultShutterEvent(boolean isOn) {
       isOn_ = isOn;
    }
 
    /**
+    * Returns the new state of the shutter.
+    *
     * @return true if the shutter is open, false if it is closed.
     */
    @Override

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultStagePositionChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultStagePositionChangedEvent.java
@@ -5,8 +5,8 @@ import org.micromanager.events.StagePositionChangedEvent;
 /**
  * This class signals when a single-axis drive has moved.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultStagePositionChangedEvent implements StagePositionChangedEvent {
    private final String deviceName_;
@@ -18,21 +18,20 @@ public class DefaultStagePositionChangedEvent implements StagePositionChangedEve
    }
 
    /**
-    * The new (current) position of the stage
+    * The new (current) position of the stage.
+    *
     * @return The new (current) position of the stage
     */
-
    public double getPos() {
-         return pos_;
-      }
-
+      return pos_;
+   }
 
    /**
-    * Name of the stage that moved
+    * Name of the stage that moved.
+    *
     * @return Name of the stage that moved
     */
    public String getDeviceName() {
-         return deviceName_;
-      }
-
+      return deviceName_;
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultStartupCompleteEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultStartupCompleteEvent.java
@@ -5,8 +5,8 @@ import org.micromanager.events.StartupCompleteEvent;
 /**
  * This event signifies that the system finished starting up.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultStartupCompleteEvent implements StartupCompleteEvent {
 }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultSystemConfigurationLoadedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultSystemConfigurationLoadedEvent.java
@@ -5,8 +5,8 @@ import org.micromanager.events.SystemConfigurationLoadedEvent;
 /**
  * This interface signals when a configuration file is loaded.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultSystemConfigurationLoadedEvent  implements
         SystemConfigurationLoadedEvent {

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultXYStagePositionChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultXYStagePositionChangedEvent.java
@@ -5,14 +5,21 @@ import org.micromanager.events.XYStagePositionChangedEvent;
 /**
  * This class signals when any XY stage changes position.
  *
- * This event posts on the Studio event bus,
- * so subscribe using {@link org.micromanager.events.EventManager}.
+ * <p>This event posts on the Studio event bus,
+ * so subscribe using {@link org.micromanager.events.EventManager}.</p>
  */
 public class DefaultXYStagePositionChangedEvent implements XYStagePositionChangedEvent {
    private final String deviceName_;
    private final double xPos_;
    private final double yPos_;
 
+   /**
+    * Event signalling that the position of 2D stage has changed.
+    *
+    * @param deviceName Name of the 2D stage device
+    * @param xPos New X position (in microns)
+    * @param yPos New Y position (in microns)
+    */
    public DefaultXYStagePositionChangedEvent(String deviceName,
                                       double xPos, double yPos) {
       deviceName_ = deviceName;
@@ -21,6 +28,8 @@ public class DefaultXYStagePositionChangedEvent implements XYStagePositionChange
    }
 
    /**
+    * Returns the new X position of this 2D stage.
+    *
     * @return New X position of the stage in microns
     */
    public double getXPos() {
@@ -28,6 +37,8 @@ public class DefaultXYStagePositionChangedEvent implements XYStagePositionChange
    }
 
    /**
+    * Returns the new Y position of this 2D stage.
+    *
     * @return New Y position of the stage in microns
     */
    public double getYPos() {
@@ -35,7 +46,8 @@ public class DefaultXYStagePositionChangedEvent implements XYStagePositionChange
    }
 
    /**
-    * Name of the (XYStage) device that change position
+    * Name of the (XYStage) device that change position.
+    *
     * @return Name of the (XYStage) device that changed position
     */
    public String getDeviceName() {

--- a/mmstudio/src/main/java/org/micromanager/events/internal/NewPluginEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/NewPluginEvent.java
@@ -6,7 +6,8 @@ import org.micromanager.MMGenericPlugin;
  * This class represents the discovery of a new MMPlugin.
  */
 public final class NewPluginEvent {
-   private MMGenericPlugin plugin_;
+   private final MMGenericPlugin plugin_;
+
    public NewPluginEvent(MMGenericPlugin plugin) {
       plugin_ = plugin;
    }

--- a/mmstudio/src/main/java/org/micromanager/events/internal/ShutterDevicesEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/ShutterDevicesEvent.java
@@ -27,7 +27,7 @@ import java.util.List;
  * shutter devices to other entities.
  */
 public final class ShutterDevicesEvent {
-   private List<String> devices_;
+   private final List<String> devices_;
 
    public ShutterDevicesEvent(List<String> devices) {
       devices_ = devices;


### PR DESCRIPTION
It is difficult to completely avoid loops cause by event callbacks from the core.  The Java class "CoreEventCallback" has a function "setIgnoring" that so far was only used for "OnPropertiesChanged" callbacks.  This PR uses the flag for all Core Callbacks, so when the flag is set to true, no events will be passed through to the Java layer.  This is useful, for instance when loading a configuration file.  

I expect that this will avoid the situation where MM on startup does not respond because it continues in a loop setting and unsetting the channel group.  This bug is difficult to reproduce on my system, but others seem to run into it a lot.