### PR TITLE
New mac build scripts for recent macOS and Xcode tools

### DIFF
--- a/buildscripts/nightly/mkportableapp_OSX/mkportableapp.py
+++ b/buildscripts/nightly/mkportableapp_OSX/mkportableapp.py
@@ -87,7 +87,7 @@ def get_all_macho(dir):
          if is_macho_file(file):
             macho_files.append(os.path.relpath(file, dir))
    return macho_files
-   
+
 
 def process_libs(destdir, staged_seeds, srcdir,
                  path_map, forbidden_dirs):
@@ -127,6 +127,11 @@ def process_libs(destdir, staged_seeds, srcdir,
             update_dep(os.path.join(destdir, staged_lib), dep,
                        loader_relpath(staged_lib, staged_lib))
 
+         elif dep == os.path.basename(staged_lib).replace('.jnilib', '.dylib'):
+            # Special case for JOGL jnilibs, which have incorrect suffixes
+            # recorded in the load commands. Don't bother to fix.
+            continue
+
          elif dep in staged_path_map: # dep is already staged
             if arch_status != "all":
                raise RuntimeError("{} has dependency {} " +
@@ -159,7 +164,7 @@ def process_libs(destdir, staged_seeds, srcdir,
    for ignored in sorted(ignored_deps):
       print("external dependency: {}".format(ignored))
 
-            
+
 def map_path(file, path_map):
    # path_map is a sequence of pairs (pattern, dest), where pattern is either a
    # shell glob pattern matching files or a non-glob directory path ending in

--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -23,7 +23,7 @@ MM_CFLAGS="-O2 -g -Wall"
 MM_CXXFLAGS="$MM_CFLAGS"
 MM_LDFLAGS="-L$MM_DEPS_PREFIX/lib -F/Library/Frameworks"
 
-MM_ARCH_FLAGS="-arch i386 -arch x86_64"
+MM_ARCH_FLAGS="-arch x86_64"
 MM_CC="clang $MM_ARCH_FLAGS"
 MM_CXX="clang++ $MM_ARCH_FLAGS"
 MM_CPP="clang -E"

--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -20,7 +20,7 @@ MM_MACOSX_SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.p
 # once build supports it.
 MM_CPPFLAGS="-I$MM_DEPS_PREFIX/include -F/Library/Frameworks"
 MM_CFLAGS="-O2 -g -Wall"
-MM_CXXFLAGS="$MM_CFLAGS"
+MM_CXXFLAGS="$MM_CFLAGS -std=c++03"
 MM_LDFLAGS="-L$MM_DEPS_PREFIX/lib -F/Library/Frameworks"
 
 MM_ARCH_FLAGS="-arch x86_64"

--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -37,3 +37,5 @@ MM_DEPS_CONFIGUREFLAGS_NOCPPLD="--prefix=\"\$MM_DEPS_PREFIX\" $MM_CONFIGUREFLAGS
 MM_DEPS_CONFIGUREFLAGS="--prefix=\"\$MM_DEPS_PREFIX\" $MM_CONFIGUREFLAGS"
 
 MM_PARALLELMAKEFLAG=-j$(sysctl -n hw.ncpu)
+
+MM_JDK_HOME=/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home

--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Common definitions for Micro-Manager macOS binary distribution build
+
+MM_BUILDDIR=`pwd`
+[ -z "$MM_DEPS_PREFIX" ] && MM_DEPS_PREFIX="$MM_BUILDDIR/dependencies"
+MM_STAGEDIR="$MM_BUILDDIR/stage"
+MM_CPP_DIR=$MM_BUILDDIR/mmCoreAndDevices
+
+# The correct minimum macOS version is critical when building
+# backward-compatible binaries. Omitting this will produce binaries that will
+# only run on the macOS version of the build host or newer. Also, mixing
+# different minimum versions may cause C++ linking issues.
+MM_MACOSX_VERSION_SDK=10.9
+MM_MACOSX_VERSION_MIN=10.5
+MM_MACOSX_SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MM_MACOSX_VERSION_SDK}.sdk"
+
+# TODO Third-party frameworks should be in $MM_DEPS_PREFIX/Library/Frameworks,
+# once build supports it.
+MM_CPPFLAGS="-I$MM_DEPS_PREFIX/include -F/Library/Frameworks"
+MM_CFLAGS="-O2 -g -Wall"
+MM_CXXFLAGS="$MM_CFLAGS"
+MM_LDFLAGS="-L$MM_DEPS_PREFIX/lib -F/Library/Frameworks"
+
+MM_ARCH_FLAGS="-arch i386 -arch x86_64"
+MM_CC="clang $MM_ARCH_FLAGS"
+MM_CXX="clang++ $MM_ARCH_FLAGS"
+MM_CPP="clang -E"
+MM_CXXCPP="clang++ -E"
+
+# These are set to strings containing shell syntax that should be expanded
+# before use.
+MM_CONFIGUREFLAGS_NOCPPLD="CC=\"\$MM_CC\" CXX=\"\$MM_CXX\" CPP=\"\$MM_CPP\" CXXCPP=\"\$MM_CXXCPP\" CFLAGS=\"\$MM_CFLAGS\" CXXFLAGS=\"\$MM_CXXFLAGS\""
+MM_CONFIGUREFLAGS="$MM_CONFIGUREFLAGS_NOCPPLD CPPFLAGS=\"\$MM_CPPFLAGS\" LDFLAGS=\"\$MM_LDFLAGS\""
+MM_DEPS_CONFIGUREFLAGS_NOCPPLD="--prefix=\"\$MM_DEPS_PREFIX\" $MM_CONFIGUREFLAGS_NOCPPLD"
+MM_DEPS_CONFIGUREFLAGS="--prefix=\"\$MM_DEPS_PREFIX\" $MM_CONFIGUREFLAGS"
+
+MM_PARALLELMAKEFLAG=-j$(sysctl -n hw.ncpu)

--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -11,8 +11,9 @@ MM_CPP_DIR=$MM_BUILDDIR/mmCoreAndDevices
 # backward-compatible binaries. Omitting this will produce binaries that will
 # only run on the macOS version of the build host or newer. Also, mixing
 # different minimum versions may cause C++ linking issues.
-MM_MACOSX_VERSION_SDK=10.9
-MM_MACOSX_VERSION_MIN=10.5
+# 10.9 is the oldest deployment target that uses libc++ (vs libstdc++).
+MM_MACOSX_VERSION_SDK=12.0
+MM_MACOSX_VERSION_MIN=10.9
 MM_MACOSX_SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MM_MACOSX_VERSION_SDK}.sdk"
 
 # TODO Third-party frameworks should be in $MM_DEPS_PREFIX/Library/Frameworks,

--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -5,7 +5,6 @@
 MM_BUILDDIR=`pwd`
 [ -z "$MM_DEPS_PREFIX" ] && MM_DEPS_PREFIX="$MM_BUILDDIR/dependencies"
 MM_STAGEDIR="$MM_BUILDDIR/stage"
-MM_CPP_DIR=$MM_BUILDDIR/mmCoreAndDevices
 
 # The correct minimum macOS version is critical when building
 # backward-compatible binaries. Omitting this will produce binaries that will

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -74,7 +74,7 @@ if [ "$do_download" = yes ]; then
    [ -f libgphoto2-2.5.2.tar.bz2 ] || curl -L -o libgphoto2-2.5.2.tar.bz2 http://sourceforge.net/projects/gphoto/files/libgphoto/2.5.2/libgphoto2-2.5.2.tar.bz2/download
    [ -f FreeImage3154.zip ] || curl -LO http://downloads.sourceforge.net/freeimage/FreeImage3154.zip
    [ -f libdc1394-2.2.1.tar.gz ] || curl -L -o libdc1394-2.2.1.tar.gz http://sourceforge.net/projects/libdc1394/files/libdc1394-2/2.2.1/libdc1394-2.2.1.tar.gz/download
-   [ -f opencv-2.4.9.zip ] || curl -L -o opencv-2.4.9.zip http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/2.4.9/opencv-2.4.9.zip/download
+   [ -f opencv-2.4.13.6.zip ] || curl -L -o opencv-2.4.13.6.zip https://github.com/opencv/opencv/archive/refs/tags/2.4.13.6.zip
 fi
 
 cat >sha1sums <<EOF
@@ -87,7 +87,7 @@ a52219b12dbc8d33fc096468591170fda71316c0  libexif-0.6.21.tar.bz2
 6b70ff6feec62a955bef1fc9a2b16dd07f0e277a  libgphoto2-2.5.2.tar.bz2
 1d30057a127b2016cf9b4f0f8f2ba92547670f96  FreeImage3154.zip
 b92c9670b68c4e5011148f16c87532bef2e5b808  libdc1394-2.2.1.tar.gz
-4f5166e2bd22bd6167cb56dd04f2c6ed68148b2c  opencv-2.4.9.zip
+a6c3d6ac8091e3311fc44125e017dd1e88e74825  opencv-2.4.13.6.zip
 EOF
 shasum -c sha1sums || { echo "SHA1 checksum mismatch or missing file; remove file and rerun with -d flag"; exit 1; }
 
@@ -404,8 +404,8 @@ popd
 
 ############### TODO check deployment target and sdkroot; set cflags and cxxflags (esp. -v)
 
-unzip -oq ../downloads/opencv-2.4.9.zip
-pushd opencv-2.4.9
+unzip -oq ../downloads/opencv-2.4.13.6.zip
+pushd opencv-2.4.13.6
 # OpenCV modules: highgui depends on imgproc; imgproc depends on core; OpenCVgrabber requires highgui and core
 mkdir -p build-for-mm && cd build-for-mm
 PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig cmake \

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -236,7 +236,7 @@ END_OF_PATCH
 # Now build the patched source.
 
 ./bootstrap.sh
-./b2 --prefix=${MM_DEPS_PREFIX} link=static threading=multi architecture=x86 address-model=32_64 \
+./b2 --prefix=${MM_DEPS_PREFIX} link=static threading=multi architecture=x86 address-model=64 \
   cflags="${MM_CFLAGS}" cxxflags="${MM_CXXFLAGS}" \
   --with-atomic --with-chrono --with-date_time --with-filesystem --with-log --with-system --with-thread --with-timer \
   $MM_PARALLELMAKEFLAG install
@@ -546,7 +546,7 @@ PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig cmake \
 -DCMAKE_CXX_COMPILER:STRING=/usr/bin/clang++ \
 -DCMAKE_CXX_FLAGS:STRING="-v" \
 -DCMAKE_INSTALL_PREFIX="$MM_DEPS_PREFIX" \
--DCMAKE_OSX_ARCHITECTURES:STRING="i386;x86_64" \
+-DCMAKE_OSX_ARCHITECTURES:STRING="x86_64" \
 -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9 \
 -DCMAKE_OSX_SYSROOT:STRING=$SDKROOT \
 -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -145,6 +145,18 @@ popd
 
 tar xzf ../downloads/hidapi-0.8.0-rc1.tar.gz
 pushd hidapi-hidapi-0.8.0-rc1
+patch -p2 <<'END_OF_PATCH'
+--- a/hidapi-hidapi-0.8.0-rc1/configure.ac	2021-12-10 12:07:50.000000000 -0600
++++ b/hidapi-hidapi-0.8.0-rc1/configure.ac	2021-12-10 12:08:29.000000000 -0600
+@@ -20,7 +20,6 @@
+ 
+ AC_CONFIG_MACRO_DIR([m4])
+ AM_INIT_AUTOMAKE([foreign -Wall -Werror])
+-AC_CONFIG_MACRO_DIR([m4])
+ 
+ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+ LT_INIT
+END_OF_PATCH
 ./bootstrap
 eval ./configure $MM_DEPS_CONFIGUREFLAGS --enable-static --disable-shared --with-pic
 make

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -47,7 +47,7 @@ source "`dirname $0`/nightlybuild_macOS_defs.sh"
 
 # GNU libtool (i.e. any libtoolized project) can mess around with the value of
 # MACOSX_DEPLOYMENT_TARGET, so passing the correct compiler and linker flags
-# (clang -mmacosx-version-min=10.5; ld -macosx_version_min 10.5) is not enough;
+# (clang -mmacosx-version-min=10.9; ld -macosx_version_min 10.9) is not enough;
 # we need to set this environment variable. It is also simpler than using
 # command line flags.  Do the same for SDKROOT (instead of clang -isysroot; ld
 # -syslibroot).
@@ -547,7 +547,7 @@ PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig cmake \
 -DCMAKE_CXX_FLAGS:STRING="-v" \
 -DCMAKE_INSTALL_PREFIX="$MM_DEPS_PREFIX" \
 -DCMAKE_OSX_ARCHITECTURES:STRING="i386;x86_64" \
--DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.5 \
+-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9 \
 -DCMAKE_OSX_SYSROOT:STRING=$SDKROOT \
 -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
 -DENABLE_PRECOMPILED_HEADERS:BOOL=ON \

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -1,0 +1,573 @@
+#!/bin/bash
+
+# Build external open-source library dependencies for Micro-Manager macOS build.
+#
+# All libraries are currently built as static-only libraries, except for
+# libgphoto2 and its dependency libltdl, which need to be shared to work
+# (because libgphoto2 uses libltdl for dynamic loading, and building a static
+# version would not allow that due to libtool and libltdl's design).
+#
+# However, using dynamic libraries for dependencies could potentially simplify
+# the build by eliminating the need to explicitly specify transitive
+# dependencies in many cases. This would require that we write an install
+# script that rewrites the library paths using @rpath or (better yet)
+# @loader_path; see dyld(1).
+#
+# Third-party packages not represented here:
+# - Build tools: should be installed using Homebrew (swig, cmake, autoconf,
+#   automake, libtool, pkg-config, python3)
+# - JDK: Apple JDK 6 from http://support.apple.com/kb/DL1572
+#        Apple Java for OS X 2013-005 Developer Package (download requires
+#        Apple Developer account)
+# - Device-specific proprietary frameworks (currently in /Library/Frameworks)
+
+# This script places and builds everything under $MM_DEPS_PREFIX.
+# $MM_DEPS_PREFIX/downloads - tarballs
+# $MM_DEPS_PREFIX/src - source and build (VPATH is not used)
+# $MM_DEPS_PREFIX/include, $MM_DEPS_PREFIX/lib, etc. - staged libraries
+
+set -e
+
+usage() { echo "Usage: $0 [-d]" 1>&2; exit 1; }
+
+do_download=no
+while getopts ":d" o; do
+   case "$o" in
+      d) do_download=yes ;;
+      *) usage ;;
+   esac
+done
+
+
+##
+## Setup
+##
+
+source "`dirname $0`/nightlybuild_macOS_defs.sh"
+
+# GNU libtool (i.e. any libtoolized project) can mess around with the value of
+# MACOSX_DEPLOYMENT_TARGET, so passing the correct compiler and linker flags
+# (clang -mmacosx-version-min=10.5; ld -macosx_version_min 10.5) is not enough;
+# we need to set this environment variable. It is also simpler than using
+# command line flags.  Do the same for SDKROOT (instead of clang -isysroot; ld
+# -syslibroot).
+# Note that manually running e.g. `make' on directories configured with this
+# script requires manually setting these environment variables. Failure to do
+# so will result in broken binaries.
+export MACOSX_DEPLOYMENT_TARGET=$MM_MACOSX_VERSION_MIN
+export SDKROOT=$MM_MACOSX_SDKROOT
+
+
+##
+## Download
+##
+
+mkdir -p "$MM_DEPS_PREFIX"/downloads
+cd "$MM_DEPS_PREFIX"/downloads
+if [ "$do_download" = yes ]; then
+   [ -f boost_1_55_0.tar.bz2 ] || curl -L -o boost_1_55_0.tar.bz2 http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2/download
+   [ -f libusb-1.0.18.tar.bz2 ] || curl -LO http://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-1.0.18/libusb-1.0.18.tar.bz2
+   [ -f libusb-compat-0.1.5.tar.bz2 ] || curl -LO http://sourceforge.net/projects/libusb/files/libusb-compat-0.1/libusb-compat-0.1.5/libusb-compat-0.1.5.tar.bz2
+   [ -f hidapi-0.8.0-rc1.tar.gz ] || curl -LO https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz
+   [ -f libexif-0.6.21.tar.bz2 ] || curl -L -o libexif-0.6.21.tar.bz2 http://sourceforge.net/projects/libexif/files/libexif/0.6.21/libexif-0.6.21.tar.bz2/download
+   [ -f libtool-2.4.2.tar.gz ] || curl -LO https://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz
+   [ -f libgphoto2-2.5.2.tar.bz2 ] || curl -L -o libgphoto2-2.5.2.tar.bz2 http://sourceforge.net/projects/gphoto/files/libgphoto/2.5.2/libgphoto2-2.5.2.tar.bz2/download
+   [ -f FreeImage3154.zip ] || curl -LO http://downloads.sourceforge.net/freeimage/FreeImage3154.zip
+   [ -f libdc1394-2.2.1.tar.gz ] || curl -L -o libdc1394-2.2.1.tar.gz http://sourceforge.net/projects/libdc1394/files/libdc1394-2/2.2.1/libdc1394-2.2.1.tar.gz/download
+   [ -f opencv-2.4.9.zip ] || curl -L -o opencv-2.4.9.zip http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/2.4.9/opencv-2.4.9.zip/download
+fi
+
+cat >sha1sums <<EOF
+cef9a0cc7084b1d639e06cd3bc34e4251524c840  boost_1_55_0.tar.bz2
+5f7bbf42a4d6e6b88d5e7666958c80f8455ee915  libusb-1.0.18.tar.bz2
+062319276d913c753a4b1341036e6a2e42abccc9  libusb-compat-0.1.5.tar.bz2
+5e72a4c7add8b85c8abcdd360ab8b1e1421da468  hidapi-0.8.0-rc1.tar.gz
+a52219b12dbc8d33fc096468591170fda71316c0  libexif-0.6.21.tar.bz2
+22b71a8b5ce3ad86e1094e7285981cae10e6ff88  libtool-2.4.2.tar.gz
+6b70ff6feec62a955bef1fc9a2b16dd07f0e277a  libgphoto2-2.5.2.tar.bz2
+1d30057a127b2016cf9b4f0f8f2ba92547670f96  FreeImage3154.zip
+b92c9670b68c4e5011148f16c87532bef2e5b808  libdc1394-2.2.1.tar.gz
+4f5166e2bd22bd6167cb56dd04f2c6ed68148b2c  opencv-2.4.9.zip
+EOF
+shasum -c sha1sums || { echo "SHA1 checksum mismatch or missing file; remove file and rerun with -d flag"; exit 1; }
+
+
+##
+## Build
+##
+
+mkdir -p "$MM_DEPS_PREFIX"/src
+cd "$MM_DEPS_PREFIX"/src
+
+
+#
+# Boost
+#
+
+tar xjf ../downloads/boost_1_55_0.tar.bz2
+pushd boost_1_55_0
+
+# Boost 1.55.0 + Xcode 5.1 (Clang 3.4) requires patches to Boost.Atomic (1.56
+# is expected to be fixed).
+
+# The following two patches for Boost 1.55.0 are from GitHub, but we avoid
+# downloding from this script because their checksums keep changing (due to
+# subtle changes in the diff output, presumably corresponding to Git version
+# differences).
+
+# https://github.com/boostorg/atomic/commit/6bb71fdd.patch
+patch -p2 <<'END_OF_PATCH'
+From 6bb71fdd8f7cc346d90fb14beb38b7297fc1ffd9 Mon Sep 17 00:00:00 2001
+From: Andrey Semashev <andrey.semashev@gmail.com>
+Date: Sun, 26 Jan 2014 13:58:48 +0400
+Subject: [PATCH] Fixed incorrect initialization of 128-bit values, when no
+ native support for 128-bit integers is available.
+
+---
+ include/boost/atomic/detail/cas128strong.hpp | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/include/boost/atomic/detail/cas128strong.hpp b/include/boost/atomic/detail/cas128strong.hpp
+index 906c13e..dcb4d7d 100644
+--- a/include/boost/atomic/detail/cas128strong.hpp
++++ b/include/boost/atomic/detail/cas128strong.hpp
+@@ -196,15 +196,17 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void
+     store(value_type const& value, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type value_s = 0;
++        storage_type value_s;
++        memset(&value_s, 0, sizeof(value_s));
+         memcpy(&value_s, &value, sizeof(value_type));
+         platform_fence_before_store(order);
+         platform_store128(value_s, &v_);
+@@ -247,7 +249,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+ 
+END_OF_PATCH
+
+# https://github.com/boostorg/atomic/commit/e4bde20f.patch
+patch -p2 <<'END_OF_PATCH'
+From e4bde20f2eec0a51be14533871d2123bd2ab9cf3 Mon Sep 17 00:00:00 2001
+From: Andrey Semashev <andrey.semashev@gmail.com>
+Date: Fri, 28 Feb 2014 12:43:11 +0400
+Subject: [PATCH] More compilation fixes for the case when 128-bit integers are
+ not supported.
+
+---
+ include/boost/atomic/detail/gcc-atomic.hpp | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/include/boost/atomic/detail/gcc-atomic.hpp b/include/boost/atomic/detail/gcc-atomic.hpp
+index a130590..4af99a1 100644
+--- a/include/boost/atomic/detail/gcc-atomic.hpp
++++ b/include/boost/atomic/detail/gcc-atomic.hpp
+@@ -958,14 +958,16 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void store(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         __atomic_store_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+     }
+@@ -980,7 +982,8 @@ class base_atomic<T, void, 16, Sign>
+ 
+     value_type exchange(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         tmp = __atomic_exchange_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+         value_type res;
+@@ -994,7 +997,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, false,
+@@ -1010,7 +1015,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, true,
+END_OF_PATCH
+
+# Now build the patched source.
+
+./bootstrap.sh
+./b2 --prefix=${MM_DEPS_PREFIX} link=static threading=multi architecture=x86 address-model=32_64 \
+  cflags="${MM_CFLAGS}" cxxflags="${MM_CXXFLAGS}" \
+  --with-atomic --with-chrono --with-date_time --with-filesystem --with-log --with-system --with-thread --with-timer \
+  $MM_PARALLELMAKEFLAG install
+popd
+
+
+#
+# libusb-1.0
+#
+
+tar xjf ../downloads/libusb-1.0.18.tar.bz2
+pushd libusb-1.0.18
+eval ./configure $MM_DEPS_CONFIGUREFLAGS --enable-static --disable-shared --with-pic
+make $MM_PARALLELMAKEFLAG
+make install
+popd
+
+
+#
+# libusb-compat
+# (depends on libusb-1.0)
+#
+
+tar xjf ../downloads/libusb-compat-0.1.5.tar.bz2
+pushd libusb-compat-0.1.5
+eval ./configure $MM_DEPS_CONFIGUREFLAGS --enable-static --disable-shared --with-pic PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig
+make $MM_PARALLELMAKEFLAG
+make install
+popd
+ 
+
+#
+# HIDAPI
+#
+
+tar xzf ../downloads/hidapi-0.8.0-rc1.tar.gz
+pushd hidapi-hidapi-0.8.0-rc1
+./bootstrap
+eval ./configure $MM_DEPS_CONFIGUREFLAGS --enable-static --disable-shared --with-pic
+make
+make install
+popd
+
+
+#
+# libexif
+# (dependency of libgphoto2)
+#
+
+tar xjf ../downloads/libexif-0.6.21.tar.bz2
+pushd libexif-0.6.21
+eval ./configure $MM_DEPS_CONFIGUREFLAGS --enable-static --disable-shared --with-pic PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig
+make $MM_PARALLELMAKEFLAG
+make install
+popd
+
+
+#
+# libtool
+#
+
+tar xzf ../downloads/libtool-2.4.2.tar.gz
+pushd libtool-2.4.2
+eval ./configure $MM_DEPS_CONFIGUREFLAGS --enable-shared --disable-static --enable-ltdl-install
+make $MM_PARALLELMAKEFLAG
+make install
+popd
+
+
+#
+# libgphoto2
+# Currently, we use a shared library and rewrite the paths in the Makefile.am
+# install target for libmmgr_dal_GPhoto.
+#
+
+tar xjf ../downloads/libgphoto2-2.5.2.tar.bz2
+pushd libgphoto2-2.5.2
+
+# The configure script requires explicit LTDLINCL, LIBLTDL, and LDFLAGS to find
+# libltdl (which must of course be dual-arch).
+
+# libxml2 from the Mac OS X SDK (i.e. the dylib bundled with Mac OS X) is used.
+
+# _DARWIN_C_SOURCE needs to be defined for flock() calls to compile (see
+# sys/fcntl.h).
+
+# --without-libusb is key to prevent errors when both libusb-1.0 and libusb (0.1 or compat) are installed.
+
+
+eval ./configure $MM_DEPS_CONFIGUREFLAGS_NOCPPLD "CPPFLAGS=\"\$MM_CPPFLAGS -isystem \$SDKROOT/usr/include/libxml2 -D_DARWIN_C_SOURCE\" LDFLAGS=\"\$MM_LDFLAGS\"" LTDLINCL=-I$MM_DEPS_PREFIX LIBLTDL=-lltdl PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig --without-libusb "LIBUSB1_LIBS=\"-lusb-1.0 -framework IOKit -framework CoreFoundation\" LIBUSB1_CFLAGS=\"-I\$MM_DEPS_PREFIX/include/libusb-1.0\"" --enable-shared --disable-static
+make $MM_PARALLELMAKEFLAG
+make install
+popd
+
+
+#
+# FreeImage
+#
+
+unzip -oq ../downloads/FreeImage3154.zip
+pushd FreeImage
+
+# FreeImage 3.15.4 comes with a Makefile.osx, but it is hardcoded to use
+# outdated tools and is therefore useless. Replace the makefile with a minimal
+# version for building a fat static library.
+cat > Makefile.clang <<'END_OF_MAKEFILE'
+include Makefile.srcs
+
+CC = cc-from-cmdline
+CXX = cxx-from-cmdline
+CFLAGS = -Os -fexceptions -fvisibility=hidden -DPIC -fno-common
+CXXFLAGS = $(CFLAGS) -Wno-ctor-dtor-privacy
+CPPFLAGS = -DNO_LCMS $(MM_CPPFLAGS) $(INCLUDE)
+LIBTOOL = /usr/bin/libtool
+
+TARGET = freeimage
+STATICLIB = lib$(TARGET).a
+HEADER = Source/FreeImage.h
+
+MODULES = $(SRCS:.c=.o)
+MODULES := $(MODULES:.cpp=.o)
+
+all: dist
+
+dist: FreeImage
+	cp $(STATICLIB) Dist
+	cp $(HEADER) Dist
+
+FreeImage: $(STATICLIB)
+
+$(STATICLIB): $(MODULES)
+	$(LIBTOOL) -static -o $@ $(MODULES)
+
+clean:
+	rm -f Dist/$(STATICLIB) Dist/$(HEADER) $(MODULES) $(STATICLIB)
+END_OF_MAKEFILE
+
+# Patch to add a missing #include
+patch -p1 <<'END_OF_PATCH'
+--- FreeImage3154/Source/OpenEXR/IlmImf/ImfAutoArray.h  2014-01-16 12:44:00.000000000 -0800
++++ FreeImage-patched/Source/OpenEXR/IlmImf/ImfAutoArray.h      2014-01-16 13:29:32.000000000 -0800
+@@ -37,6 +37,8 @@
+ #ifndef INCLUDED_IMF_AUTO_ARRAY_H
+ #define INCLUDED_IMF_AUTO_ARRAY_H
+
++#include <string.h>
++
+ //-----------------------------------------------------------------------------
+ //
+ //     class AutoArray -- a workaround for systems with
+END_OF_PATCH
+
+make -f Makefile.clang $MM_PARALLELMAKEFLAG CC="$MM_CC" CXX="$MM_CXX" MM_CPPFLAGS="$MM_CPPFLAGS"
+cp Dist/FreeImage.h $MM_DEPS_PREFIX/include
+cp Dist/libfreeimage.a $MM_DEPS_PREFIX/lib
+
+pushd Wrapper/FreeImagePlus
+# This one doesn't even come with a makefile(!)
+cat > Makefile.clang <<'END_OF_MAKEFILE'
+CC = cc-from-cmdline
+CXX = cxx-from-cmdline
+CFLAGS = -Os -fexceptions -fvisibility=hidden -DPIC -fno-common
+CXXFLAGS = $(CFLAGS) -Wno-ctor-dtor-privacy
+CPPFLAGS = -DNO_LCMS $(MM_CPPFLAGS) -I. -I../../Source
+LIBTOOL = /usr/bin/libtool
+
+TARGET = freeimageplus
+STATICLIB = lib$(TARGET).a
+HEADER = FreeImagePlus.h
+
+SRCS = $(wildcard src/*.cpp)
+MODULES = $(SRCS:.c=.o)
+MODULES := $(MODULES:.cpp=.o)
+
+all: dist
+
+dist: FreeImagePlus
+	cp *.a Dist
+	cp $(HEADER) Dist
+
+FreeImagePlus: $(STATICLIB)
+
+$(STATICLIB): $(MODULES)
+	$(LIBTOOL) -static -o $@ $(MODULES)
+
+clean:
+	rm -f Dist/$(STATICLIB) Dist/$(HEADER) $(MODULES) $(STATICLIB)
+END_OF_MAKEFILE
+
+make -f Makefile.clang $MM_PARALLELMAKEFLAG CC="$MM_CC" CXX="$MM_CXX" MM_CPPFLAGS="$MM_CPPFLAGS"
+cp Dist/FreeImagePlus.h $MM_DEPS_PREFIX/include
+cp Dist/libfreeimageplus.a $MM_DEPS_PREFIX/lib
+popd # Wrapper
+
+popd # FreeImage
+
+
+#
+# libdc1394-2
+#
+
+tar xzf ../downloads/libdc1394-2.2.1.tar.gz
+pushd libdc1394-2.2.1
+
+# Skip broken check for IOKit (patch configure, not configure.in, because
+# autoreconf does not run -- looks like some m4 files are missing from the
+# tarball)
+patch -p2 <<'END_OF_PATCH'
+--- a/libdc1394-2.2.1/configure 2013-01-28 02:47:43.000000000 +0000
++++ b/libdc1394-2.2.1/configure   2014-01-16 23:28:55.000000000 +0000
+@@ -13609,13 +13609,13 @@
+
+     ;;
+ *-*-darwin*)
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for IOMasterPort in -lIOKit" >&5
+-$as_echo_n "checking for IOMasterPort in -lIOKit... " >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for IOMasterPort in -framework IOKit" >&5
++$as_echo_n "checking for IOMasterPort in -framework IOKit... " >&6; }
+ if test "${ac_cv_lib_IOKit_IOMasterPort+set}" = set; then :
+   $as_echo_n "(cached) " >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lIOKit  $LIBS"
++LIBS="-framework IOKit  $LIBS"
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+
+END_OF_PATCH
+
+# Patch makefiles to fix library flag
+patch -p2 <<'END_OF_PATCH'
+--- a/libdc1394-2.2.1/dc1394/macosx/Makefile.am 2013-01-27 18:43:18.000000000 -0800
++++ b/libdc1394-2.2.1/dc1394/macosx/Makefile.am   2014-01-16 15:29:43.000000000 -0800
+@@ -10,7 +10,7 @@
+
+ AM_CFLAGS = -I..
+ libdc1394_macosx_la_LDFLAGS = -framework CoreFoundation -framework Carbon
+-libdc1394_macosx_la_LIBADD = -lIOKit
++libdc1394_macosx_la_LIBADD = -framework IOKit
+ libdc1394_macosx_la_SOURCES =  \
+        control.c \
+        capture.c \
+END_OF_PATCH
+patch -p2 <<'END_OF_PATCH'
+--- a/libdc1394-2.2.1/dc1394/macosx/Makefile.in 2013-01-27 18:47:45.000000000 -0800
++++ b/libdc1394-2.2.1/dc1394/macosx/Makefile.in   2014-01-16 15:31:28.000000000 -0800
+@@ -265,7 +265,7 @@
+
+ AM_CFLAGS = -I..
+ libdc1394_macosx_la_LDFLAGS = -framework CoreFoundation -framework Carbon
+-libdc1394_macosx_la_LIBADD = -lIOKit
++libdc1394_macosx_la_LIBADD = -framework IOKit
+ libdc1394_macosx_la_SOURCES = \
+        control.c \
+        capture.c \
+END_OF_PATCH
+
+eval ./configure $MM_DEPS_CONFIGUREFLAGS --disable-shared --enable-static --with-pic --disable-sdltest --disable-examples "LIBS=\"-framework IOKit\""
+make $MM_PARALLELMAKEFLAG
+make install
+popd
+
+
+#
+# OpenCV
+#
+
+############### TODO check deployment target and sdkroot; set cflags and cxxflags (esp. -v)
+
+unzip -oq ../downloads/opencv-2.4.9.zip
+pushd opencv-2.4.9
+# OpenCV modules: highgui depends on imgproc; imgproc depends on core; OpenCVgrabber requires highgui and core
+mkdir -p build-for-mm && cd build-for-mm
+PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig cmake \
+-DBUILD_DOCS:BOOL=OFF \
+-DBUILD_EXAMPLES:BOOL=OFF \
+-DBUILD_PERF_TESTS:BOOL=OFF \
+-DBUILD_SHARED_LIBS:BOOL=OFF \
+-DBUILD_TESTS:BOOL=OFF \
+-DBUILD_ZLIB:BOOL=OFF \
+-DBUILD_opencv_core:BOOL=ON \
+-DBUILD_opencv_imgproc:BOOL=ON \
+-DBUILD_opencv_highgui:BOOL=ON \
+-DBUILD_opencv_apps:BOOL=OFF \
+-DBUILD_opencv_calib3d:BOOL=OFF \
+-DBUILD_opencv_contrib:BOOL=OFF \
+-DBUILD_opencv_features2d:BOOL=OFF \
+-DBUILD_opencv_flann:BOOL=OFF \
+-DBUILD_opencv_gpu:BOOL=OFF \
+-DBUILD_opencv_java:BOOL=OFF \
+-DBUILD_opencv_legacy:BOOL=OFF \
+-DBUILD_opencv_ml:BOOL=OFF \
+-DBUILD_opencv_nonfree:BOOL=OFF \
+-DBUILD_opencv_objdetect:BOOL=OFF \
+-DBUILD_opencv_ocl:BOOL=OFF \
+-DBUILD_opencv_photo:BOOL=OFF \
+-DBUILD_opencv_python:BOOL=OFF \
+-DBUILD_opencv_stitching:BOOL=OFF \
+-DBUILD_opencv_superres:BOOL=OFF \
+-DBUILD_opencv_ts:BOOL=OFF \
+-DBUILD_opencv_video:BOOL=OFF \
+-DBUILD_opencv_videostab:BOOL=OFF \
+-DBUILD_opencv_world:BOOL=OFF \
+-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+-DCMAKE_C_COMPILER:STRING=/usr/bin/clang \
+-DCMAKE_C_FLAGS:STRING="-v" \
+-DCMAKE_CXX_COMPILER:STRING=/usr/bin/clang++ \
+-DCMAKE_CXX_FLAGS:STRING="-v" \
+-DCMAKE_INSTALL_PREFIX="$MM_DEPS_PREFIX" \
+-DCMAKE_OSX_ARCHITECTURES:STRING="i386;x86_64" \
+-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.5 \
+-DCMAKE_OSX_SYSROOT:STRING=$SDKROOT \
+-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+-DENABLE_PRECOMPILED_HEADERS:BOOL=ON \
+-DWITH_1394:BOOL=ON \
+-DWITH_CUDA:BOOL=OFF \
+-DWITH_EIGEN:BOOL=OFF \
+-DWITH_FFMPEG:BOOL=ON \
+-DWITH_JASPER:BOOL=OFF \
+-DWITH_JPEG:BOOL=OFF \
+-DWITH_OPENCL:BOOL=OFF \
+-DWITH_OPENEXR:BOOL=OFF \
+-DWITH_OPENMP:BOOL=OFF \
+-DWITH_OPENNI:BOOL=OFF \
+-DWITH_PNG:BOOL=OFF \
+-DWITH_TIFF:BOOL=OFF \
+-DZLIB_INCLUDE_DIR:STRING=$SDKROOT/usr/include \
+-DZLIB_LIBRARY:STRING=$SDKROOT/usr/lib/libz.dylib \
+..
+make $MM_PARALLELMAKEFLAG
+make install
+popd
+
+echo "Finished building dependencies"

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -65,7 +65,7 @@ export SDKROOT=$MM_MACOSX_SDKROOT
 mkdir -p "$MM_DEPS_PREFIX"/downloads
 cd "$MM_DEPS_PREFIX"/downloads
 if [ "$do_download" = yes ]; then
-   [ -f boost_1_55_0.tar.bz2 ] || curl -L -o boost_1_55_0.tar.bz2 http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2/download
+   [ -f boost_1_77_0.tar.bz2 ] || curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.bz2
    [ -f libusb-1.0.18.tar.bz2 ] || curl -LO http://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-1.0.18/libusb-1.0.18.tar.bz2
    [ -f libusb-compat-0.1.5.tar.bz2 ] || curl -LO http://sourceforge.net/projects/libusb/files/libusb-compat-0.1/libusb-compat-0.1.5/libusb-compat-0.1.5.tar.bz2
    [ -f hidapi-0.8.0-rc1.tar.gz ] || curl -LO https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz
@@ -78,7 +78,7 @@ if [ "$do_download" = yes ]; then
 fi
 
 cat >sha1sums <<EOF
-cef9a0cc7084b1d639e06cd3bc34e4251524c840  boost_1_55_0.tar.bz2
+0cb4f947d094fc311e13ffacaff00418130ef5ef  boost_1_77_0.tar.bz2
 5f7bbf42a4d6e6b88d5e7666958c80f8455ee915  libusb-1.0.18.tar.bz2
 062319276d913c753a4b1341036e6a2e42abccc9  libusb-compat-0.1.5.tar.bz2
 5e72a4c7add8b85c8abcdd360ab8b1e1421da468  hidapi-0.8.0-rc1.tar.gz
@@ -104,141 +104,12 @@ cd "$MM_DEPS_PREFIX"/src
 # Boost
 #
 
-tar xjf ../downloads/boost_1_55_0.tar.bz2
-pushd boost_1_55_0
-
-# Boost 1.55.0 + Xcode 5.1 (Clang 3.4) requires patches to Boost.Atomic (1.56
-# is expected to be fixed).
-
-# The following two patches for Boost 1.55.0 are from GitHub, but we avoid
-# downloding from this script because their checksums keep changing (due to
-# subtle changes in the diff output, presumably corresponding to Git version
-# differences).
-
-# https://github.com/boostorg/atomic/commit/6bb71fdd.patch
-patch -p2 <<'END_OF_PATCH'
-From 6bb71fdd8f7cc346d90fb14beb38b7297fc1ffd9 Mon Sep 17 00:00:00 2001
-From: Andrey Semashev <andrey.semashev@gmail.com>
-Date: Sun, 26 Jan 2014 13:58:48 +0400
-Subject: [PATCH] Fixed incorrect initialization of 128-bit values, when no
- native support for 128-bit integers is available.
-
----
- include/boost/atomic/detail/cas128strong.hpp | 10 +++++++---
- 1 file changed, 7 insertions(+), 3 deletions(-)
-
-diff --git a/include/boost/atomic/detail/cas128strong.hpp b/include/boost/atomic/detail/cas128strong.hpp
-index 906c13e..dcb4d7d 100644
---- a/include/boost/atomic/detail/cas128strong.hpp
-+++ b/include/boost/atomic/detail/cas128strong.hpp
-@@ -196,15 +196,17 @@ class base_atomic<T, void, 16, Sign>
- 
- public:
-     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
--    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
-+    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
-     {
-+        memset(&v_, 0, sizeof(v_));
-         memcpy(&v_, &v, sizeof(value_type));
-     }
- 
-     void
-     store(value_type const& value, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
-     {
--        storage_type value_s = 0;
-+        storage_type value_s;
-+        memset(&value_s, 0, sizeof(value_s));
-         memcpy(&value_s, &value, sizeof(value_type));
-         platform_fence_before_store(order);
-         platform_store128(value_s, &v_);
-@@ -247,7 +249,9 @@ class base_atomic<T, void, 16, Sign>
-         memory_order success_order,
-         memory_order failure_order) volatile BOOST_NOEXCEPT
-     {
--        storage_type expected_s = 0, desired_s = 0;
-+        storage_type expected_s, desired_s;
-+        memset(&expected_s, 0, sizeof(expected_s));
-+        memset(&desired_s, 0, sizeof(desired_s));
-         memcpy(&expected_s, &expected, sizeof(value_type));
-         memcpy(&desired_s, &desired, sizeof(value_type));
- 
-END_OF_PATCH
-
-# https://github.com/boostorg/atomic/commit/e4bde20f.patch
-patch -p2 <<'END_OF_PATCH'
-From e4bde20f2eec0a51be14533871d2123bd2ab9cf3 Mon Sep 17 00:00:00 2001
-From: Andrey Semashev <andrey.semashev@gmail.com>
-Date: Fri, 28 Feb 2014 12:43:11 +0400
-Subject: [PATCH] More compilation fixes for the case when 128-bit integers are
- not supported.
-
----
- include/boost/atomic/detail/gcc-atomic.hpp | 17 ++++++++++++-----
- 1 file changed, 12 insertions(+), 5 deletions(-)
-
-diff --git a/include/boost/atomic/detail/gcc-atomic.hpp b/include/boost/atomic/detail/gcc-atomic.hpp
-index a130590..4af99a1 100644
---- a/include/boost/atomic/detail/gcc-atomic.hpp
-+++ b/include/boost/atomic/detail/gcc-atomic.hpp
-@@ -958,14 +958,16 @@ class base_atomic<T, void, 16, Sign>
- 
- public:
-     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
--    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
-+    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
-     {
-+        memset(&v_, 0, sizeof(v_));
-         memcpy(&v_, &v, sizeof(value_type));
-     }
- 
-     void store(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
-     {
--        storage_type tmp = 0;
-+        storage_type tmp;
-+        memset(&tmp, 0, sizeof(tmp));
-         memcpy(&tmp, &v, sizeof(value_type));
-         __atomic_store_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
-     }
-@@ -980,7 +982,8 @@ class base_atomic<T, void, 16, Sign>
- 
-     value_type exchange(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
-     {
--        storage_type tmp = 0;
-+        storage_type tmp;
-+        memset(&tmp, 0, sizeof(tmp));
-         memcpy(&tmp, &v, sizeof(value_type));
-         tmp = __atomic_exchange_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
-         value_type res;
-@@ -994,7 +997,9 @@ class base_atomic<T, void, 16, Sign>
-         memory_order success_order,
-         memory_order failure_order) volatile BOOST_NOEXCEPT
-     {
--        storage_type expected_s = 0, desired_s = 0;
-+        storage_type expected_s, desired_s;
-+        memset(&expected_s, 0, sizeof(expected_s));
-+        memset(&desired_s, 0, sizeof(desired_s));
-         memcpy(&expected_s, &expected, sizeof(value_type));
-         memcpy(&desired_s, &desired, sizeof(value_type));
-         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, false,
-@@ -1010,7 +1015,9 @@ class base_atomic<T, void, 16, Sign>
-         memory_order success_order,
-         memory_order failure_order) volatile BOOST_NOEXCEPT
-     {
--        storage_type expected_s = 0, desired_s = 0;
-+        storage_type expected_s, desired_s;
-+        memset(&expected_s, 0, sizeof(expected_s));
-+        memset(&desired_s, 0, sizeof(desired_s));
-         memcpy(&expected_s, &expected, sizeof(value_type));
-         memcpy(&desired_s, &desired, sizeof(value_type));
-         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, true,
-END_OF_PATCH
-
-# Now build the patched source.
-
+tar xjf ../downloads/boost_1_77_0.tar.bz2
+pushd boost_1_77_0
 ./bootstrap.sh
 ./b2 --prefix=${MM_DEPS_PREFIX} link=static threading=multi architecture=x86 address-model=64 \
   cflags="${MM_CFLAGS}" cxxflags="${MM_CXXFLAGS}" \
-  --with-atomic --with-chrono --with-date_time --with-filesystem --with-log --with-system --with-thread --with-timer \
+  --with-atomic --with-chrono --with-date_time --with-filesystem --with-system --with-thread \
   $MM_PARALLELMAKEFLAG install
 popd
 

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -272,6 +272,21 @@ patch -p1 <<'END_OF_PATCH'
  //     class AutoArray -- a workaround for systems with
 END_OF_PATCH
 
+# Patch to add another missing #include
+patch -p2 <<'END_OF_PATCH'
+--- a/FreeImage3154/Source/ZLib/gzguts.h	2021-12-10 13:02:41.000000000 -0600
++++ b/FreeImage3154/Source/ZLib/gzguts.h	2021-12-10 13:03:06.000000000 -0600
+@@ -29,6 +29,8 @@
+ 
+ #ifdef _WIN32
+ #  include <stddef.h>
++#else
++#  include <unistd.h>
+ #endif
+ 
+ #if defined(__TURBOC__) || defined(_MSC_VER) || defined(_WIN32)
+END_OF_PATCH
+
 make -f Makefile.clang $MM_PARALLELMAKEFLAG CC="$MM_CC" CXX="$MM_CXX" MM_CPPFLAGS="$MM_CPPFLAGS"
 cp Dist/FreeImage.h $MM_DEPS_PREFIX/include
 cp Dist/libfreeimage.a $MM_DEPS_PREFIX/lib

--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -166,7 +166,9 @@ mkdir -p $MM_STAGEDIR/libgphoto2/libgphoto2
 mkdir -p $MM_STAGEDIR/libgphoto2/libgphoto2_port
 cp $MM_DEPS_PREFIX/lib/libgphoto2/2.5.2/*.so $MM_STAGEDIR/libgphoto2/libgphoto2
 cp $MM_DEPS_PREFIX/lib/libgphoto2_port/0.10.0/*.so $MM_STAGEDIR/libgphoto2/libgphoto2_port
+echo 'Staging portable app with mkportableapp.py...'
 buildscripts/nightly/mkportableapp_OSX/mkportableapp.py \
+   --verbose \
    --srcdir $MM_DEPS_PREFIX/lib \
    --destdir $MM_STAGEDIR \
    --forbid-from $MM_BUILDDIR/share \
@@ -175,6 +177,7 @@ buildscripts/nightly/mkportableapp_OSX/mkportableapp.py \
    --forbid-from /usr/local \
    --map-path 'libltdl*.dylib:libgphoto2' \
    --map-path 'libgphoto2*.dylib:libgphoto2'
+echo 'Finished staging portable app'
 
 
 # Stage third-party JARs.

--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -136,12 +136,12 @@ make $MAKEFLAGS
 # Remove device adapters that build for x86_64 but depend on 32-bit-only
 # frameworks. This is only for safety; these adapters should not build if their
 # dependencies are not installed in /Library/Frameworks.
-for file in $MM_CPP_DIR/DeviceAdapters/PVCAM/.libs/libmmgr_dal_PVCAM \
-            $MM_CPP_DIR/DeviceAdapters/PrincetonInstruments/.libs/libmmgr_dal_PrincetonInstruments \
-            $MM_CPP_DIR/DeviceAdapters/QCam/.libs/libmmgr_dal_QCam \
-            $MM_CPP_DIR/DeviceAdapters/ScionCam/.libs/libmmgr_dal_ScionCam \
-            $MM_CPP_DIR/DeviceAdapters/Spot/.libs/libmmgr_dal_Spot \
-            $MM_CPP_DIR/SecretDeviceAdapters/HamamatsuMac/.libs/libmmgr_dal_Hamamatsu
+for file in mmCoreAndDevices/DeviceAdapters/PVCAM/.libs/libmmgr_dal_PVCAM \
+            mmCoreAndDevices/DeviceAdapters/PrincetonInstruments/.libs/libmmgr_dal_PrincetonInstruments \
+            mmCoreAndDevices/DeviceAdapters/QCam/.libs/libmmgr_dal_QCam \
+            mmCoreAndDevices/DeviceAdapters/ScionCam/.libs/libmmgr_dal_ScionCam \
+            mmCoreAndDevices/DeviceAdapters/Spot/.libs/libmmgr_dal_Spot \
+            mmCoreAndDevices/SecretDeviceAdapters/HamamatsuMac/.libs/libmmgr_dal_Hamamatsu
 do
    rm -f $file
 done

--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -44,7 +44,7 @@ pushd "`dirname $0`/../.." >/dev/null; MM_SRCDIR=`pwd`; popd >/dev/null
 
 # GNU libtool (i.e. any libtoolized project) can mess around with the value of
 # MACOSX_DEPLOYMENT_TARGET, so passing the correct compiler and linker flags
-# (clang -mmacosx-version-min=10.5; ld -macosx_version_min 10.5) is not enough;
+# (clang -mmacosx-version-min=10.9; ld -macosx_version_min 10.9) is not enough;
 # we need to set this environment variable. It is also simpler than using
 # command line flags.  Do the same for SDKROOT (instead of clang -isysroot; ld
 # -syslibroot).

--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+   echo "Usage: $0 [-cCIr] [-D PATH] [-R | -v VERSION]" 1>&2
+   echo "   -r         -- skip autogen.sh" 1>&2
+   echo "   -C         -- skip ./configure" 1>&2
+   echo "   -I         -- do not create disk image" 1>&2
+   echo "   -c         -- print the ./configure command line and exit" 1>&2
+   echo "   -D PATH    -- use dependencies at prefix PATH" 1>&2
+   echo "   -R         -- use release version string (no date)" 1>&2
+   echo "   -v VERSION -- set version string" 1>&2
+   echo "Environment:" 1>&2
+   echo "   MAKEFLAGS  -- flags to pass to make(1) for building" 1>&2
+   exit 1
+}
+
+skip_autogen=no
+skip_config=no
+make_disk_image=yes
+print_config_only=no
+use_release_version=no
+while getopts ":rIcCD:Rv:" o; do
+   case $o in
+      r) skip_autogen=yes ;;
+      C) skip_config=yes ;;
+      I) make_disk_image=no ;;
+      c) print_config_only=yes ;;
+      D) MM_DEPS_PREFIX="$OPTARG" ;;
+      R) use_release_version=yes ;;
+      v) MM_VERSION="$OPTARG" ;;
+      *) usage ;;
+   esac
+done
+
+
+##
+## Setup
+##
+
+source "`dirname $0`/nightlybuild_macOS_defs.sh"
+pushd "`dirname $0`/../.." >/dev/null; MM_SRCDIR=`pwd`; popd >/dev/null
+
+# GNU libtool (i.e. any libtoolized project) can mess around with the value of
+# MACOSX_DEPLOYMENT_TARGET, so passing the correct compiler and linker flags
+# (clang -mmacosx-version-min=10.5; ld -macosx_version_min 10.5) is not enough;
+# we need to set this environment variable. It is also simpler than using
+# command line flags.  Do the same for SDKROOT (instead of clang -isysroot; ld
+# -syslibroot).
+# Note that manually running e.g. `make' on directories configured with this
+# script requires manually setting these environment variables. Failure to do
+# so will result in broken binaries.
+export MACOSX_DEPLOYMENT_TARGET=$MM_MACOSX_VERSION_MIN
+export SDKROOT=$MM_MACOSX_SDKROOT
+
+
+##
+## Build
+##
+
+cd $MM_SRCDIR
+
+if [ -z "$MM_VERSION" ]; then
+   MM_VERSION="$(cat version.txt)"
+   [ "$use_release_version" = yes ] || MM_VERSION="$MM_VERSION-$(date +%Y%m%d)"
+fi
+sed -e "s/@VERSION_STRING@/$MM_VERSION/" buildscripts/MMVersion.java.in > mmstudio/src/main/java/org/micromanager/internal/MMVersion.java || exit
+
+if [ "$skip_autogen" != yes ]; then
+   sh autogen.sh
+fi
+
+# Note on Java variables.
+# JDK 1.6 from Apple and its development kit need to be installed. We could
+# conceivably use JDK 1.7 to cross-compile to 1.6, but that would still need
+# the 1.6 classpath and a -bootclasspath flag to javac.
+# To build with JDK 1.6 when /usr/bin/javac points to JDK 1.7, we need to set
+# JAVA_HOME. But this breaks the build because 1.6.0.jdk does not contain
+# (symlinks to) the JNI headers as whould be expected for a Java home. So we
+# explicitly set JNI_CPPFLAGS.
+
+# Note on OpenCV library flags.
+# Since OpenCV is a CMake project, it does not produce the convenient libtool
+# .la files that specify the link dependencies for its static libraries. It
+# also produces broken pkg-config metadata (on OS X, at least), so the LIBS
+# need to be given manually. The list of dependencies can be obtained from
+# either the pkg-config .pc file (after appropriate corrections) or from the
+# opencv_*_LIB_DEPENS:STATIC entries in CMakeCache.txt. The built
+# libmmgr_dal_OpenCVgrabber should be checked for undefined symbols in the flat
+# namespace using nm -m ... | grep 'dynamically looked up'
+# The C++ standard library (libstdc++ if deployment target <= 10.8) need not be
+# specified as we are using the C++ linker driver.
+
+# Note on libusb library flags.
+# It looks like both libusb-1.0 and libusb-compat fail to include IOKit and
+# CoreFoundation in their respective .la files.
+
+if [ "$print_config_only" = yes ]; then
+   EVAL="eval printf '\"%s\" '"
+else
+   EVAL=eval
+fi
+
+if [ "$skip_config" != yes ]; then
+
+if [ "$print_config_only" = yes ]; then
+   printf "MACOSX_DEPLOYMENT_TARGET=\"$MM_MACOSX_VERSION_MIN\" SDKROOT=\"$MM_MACOSX_SDKROOT\" "
+fi
+$EVAL ./configure \
+   --prefix=$MM_BUILDDIR/it-is-a-bug-if-files-go-in-here \
+   --disable-hardcoded-mmcorej-library-path \
+   --with-boost=$MM_DEPS_PREFIX \
+   --with-libdc1394 \
+   --with-libusb-0-1 \
+   --with-hidapi \
+   --with-opencv \
+   --with-gphoto2 \
+   --with-freeimageplus \
+   $MM_CONFIGUREFLAGS \
+   "JAVA_HOME=\"/Library/Java/JavaVirtualMachines/jdk1.8.0/Contents/Home\"" \
+   "JNI_CPPFLAGS=\"-I/Library/Java/JavaVirtualMachines/jdk1.8.0/Contents/Home/include -I/Library/Java/JavaVirtualMachines/jdk1.8.0/Contents/Home/include/darwin\"" \
+   "JAVACFLAGS=\"-Xlint:all,-path,-serial -source 1.8 -target 1.8\"" \
+   "OPENCV_LDFLAGS=\"-framework Cocoa -framework QTKit -framework QuartzCore -framework AppKit\"" \
+   "OPENCV_LIBS=\"$MM_DEPS_PREFIX/lib/libopencv_highgui.a $MM_DEPS_PREFIX/lib/libopencv_imgproc.a $MM_DEPS_PREFIX/lib/libopencv_core.a -lz $MM_DEPS_PREFIX/lib/libdc1394.la\"" \
+   PKG_CONFIG=$MM_DEPS_PREFIX/bin/pkg-config \
+   "LIBUSB_0_1_LDFLAGS=\"-framework IOKit -framework CoreFoundation\"" \
+   LIBUSB_0_1_LIBS=$MM_DEPS_PREFIX/lib/libusb.la \
+   HIDAPI_LIBS=$MM_DEPS_PREFIX/lib/libhidapi.la
+if [ "$print_config_only" = yes ]; then
+   printf \\n
+fi
+
+fi # skip_config
+
+if [ "$print_config_only" = yes ]; then
+   exit 0
+fi
+
+
+make fetchdeps # Safe, since everything is checksummed
+
+make $MAKEFLAGS
+
+# Remove x86_64 from device adapters that depend on 32-bit only frameworks.
+# Hamamatsu is 32-bit only even though dcamapi.framework contains an
+# unsupported 64-bit binary.
+for file in $MM_CPP_DIR/DeviceAdapters/PVCAM/.libs/libmmgr_dal_PVCAM \
+            $MM_CPP_DIR/DeviceAdapters/PrincetonInstruments/.libs/libmmgr_dal_PrincetonInstruments \
+            $MM_CPP_DIR/DeviceAdapters/QCam/.libs/libmmgr_dal_QCam \
+            $MM_CPP_DIR/DeviceAdapters/ScionCam/.libs/libmmgr_dal_ScionCam \
+            $MM_CPP_DIR/DeviceAdapters/Spot/.libs/libmmgr_dal_Spot \
+            $MM_CPP_DIR/SecretDeviceAdapters/HamamatsuMac/.libs/libmmgr_dal_Hamamatsu
+do
+   if [ -f $file ]; then
+      lipo -extract i386 -output $file.i386 $file
+      mv $file.i386 $file
+   fi
+done
+
+
+##
+## Stage application
+##
+
+MM_JARDIR=$MM_STAGEDIR/plugins/Micro-Manager
+make install pkglibdir=$MM_STAGEDIR pkgdatadir=$MM_STAGEDIR jardir=$MM_JARDIR
+rm -f $MM_STAGEDIR/*.la
+
+
+# Stage other files
+cp -R $MM_SRCDIR/bindist/any-platform/* $MM_STAGEDIR/
+cp -R $MM_SRCDIR/bindist/MacOSX/* $MM_STAGEDIR/
+
+
+# Stage the libgphoto2 dylibs.
+mkdir -p $MM_STAGEDIR/libgphoto2/libgphoto2
+mkdir -p $MM_STAGEDIR/libgphoto2/libgphoto2_port
+cp $MM_DEPS_PREFIX/lib/libgphoto2/2.5.2/*.so $MM_STAGEDIR/libgphoto2/libgphoto2
+cp $MM_DEPS_PREFIX/lib/libgphoto2_port/0.10.0/*.so $MM_STAGEDIR/libgphoto2/libgphoto2_port
+buildscripts/nightly/mkportableapp_OSX/mkportableapp.py \
+   --srcdir $MM_DEPS_PREFIX/lib \
+   --destdir $MM_STAGEDIR \
+   --forbid-from $MM_BUILDDIR/share \
+   --forbid-from $MM_DEPS_PREFIX/src \
+   --forbid-from $MM_DEPS_PREFIX/share \
+   --forbid-from /usr/local \
+   --map-path 'libltdl*.dylib:libgphoto2' \
+   --map-path 'libgphoto2*.dylib:libgphoto2'
+
+
+# Stage third-party JARs.
+for artifact_dir in compile optional runtime; do
+   if ls $MM_SRCDIR/dependencies/artifacts/$artifact_dir/*.jar 1>/dev/null; then
+      cp $MM_SRCDIR/dependencies/artifacts/$artifact_dir/*.jar $MM_JARDIR
+   fi
+done
+# Include jogl/gluegen native libraries.  
+mkdir -p $MM_STAGEDIR/natives/macosx-universal
+cp ../3rdpartypublic/javalib3d/lib/natives/macosx-universal/* $MM_STAGEDIR/natives/macosx-universal/
+
+# ij.jar goes into the ImageJ.app directory
+# Note: this copying step messes up the code signing that previously happened
+# So, for now, rely on the copy of ij.jar in the repository.  
+# Revisit this once we are signing the app ourselves.
+#mkdir -p $MM_STAGEDIR/ImageJ.app/Contents/Java
+#cp $MM_SRCDIR/dependencies/artifacts/imagej/ij-*.jar $MM_STAGEDIR/ImageJ.app/Contents/Java/ij.jar
+
+# Ensure no SVN data gets into the installer (e.g. when copying from bindist/)
+find $MM_STAGEDIR -name .svn -prune -exec rm -rf {} +
+
+if [ -n "$MM_PREPACKAGE_HOOK" ]; then
+   pushd $MM_STAGEDIR
+   $MM_PREPACKAGE_HOOK
+   popd
+fi
+
+# Apply ad-hoc signature to the launchers, to prevent "damaged" messages on
+# Mountain Lion and later.
+# This now creates problems.  Try to verbatim copy the ImageJ.app
+# Revisit once we have our own developer keys
+# codesign -s - -f $MM_STAGEDIR/ImageJ.app
+
+if [ "$make_disk_image" != yes ]; then
+   exit 0
+fi
+
+
+##
+## Create disk image
+##
+
+cd $MM_BUILDDIR
+rm -f Micro-Manager.dmg Micro-Manager.sparseimage
+
+hdiutil convert $MM_SRCDIR/buildscripts/MacInstaller/Micro-Manager.dmg -format UDSP -o Micro-Manager.sparseimage
+mkdir -p mm-mnt
+hdiutil attach Micro-Manager.sparseimage -mountpoint mm-mnt
+cp -R $MM_STAGEDIR/* mm-mnt/Micro-Manager
+mv mm-mnt/Micro-Manager mm-mnt/Micro-Manager-$MM_VERSION
+hdiutil detach mm-mnt
+rmdir mm-mnt
+hdiutil convert Micro-Manager.sparseimage -format UDBZ -o Micro-Manager-$MM_VERSION.dmg

--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -133,9 +133,9 @@ make fetchdeps # Safe, since everything is checksummed
 
 make $MAKEFLAGS
 
-# Remove x86_64 from device adapters that depend on 32-bit only frameworks.
-# Hamamatsu is 32-bit only even though dcamapi.framework contains an
-# unsupported 64-bit binary.
+# Remove device adapters that build for x86_64 but depend on 32-bit-only
+# frameworks. This is only for safety; these adapters should not build if their
+# dependencies are not installed in /Library/Frameworks.
 for file in $MM_CPP_DIR/DeviceAdapters/PVCAM/.libs/libmmgr_dal_PVCAM \
             $MM_CPP_DIR/DeviceAdapters/PrincetonInstruments/.libs/libmmgr_dal_PrincetonInstruments \
             $MM_CPP_DIR/DeviceAdapters/QCam/.libs/libmmgr_dal_QCam \
@@ -143,10 +143,7 @@ for file in $MM_CPP_DIR/DeviceAdapters/PVCAM/.libs/libmmgr_dal_PVCAM \
             $MM_CPP_DIR/DeviceAdapters/Spot/.libs/libmmgr_dal_Spot \
             $MM_CPP_DIR/SecretDeviceAdapters/HamamatsuMac/.libs/libmmgr_dal_Hamamatsu
 do
-   if [ -f $file ]; then
-      lipo -extract i386 -output $file.i386 $file
-      mv $file.i386 $file
-   fi
+   rm -f $file
 done
 
 

--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -71,15 +71,6 @@ if [ "$skip_autogen" != yes ]; then
    sh autogen.sh
 fi
 
-# Note on Java variables.
-# JDK 1.6 from Apple and its development kit need to be installed. We could
-# conceivably use JDK 1.7 to cross-compile to 1.6, but that would still need
-# the 1.6 classpath and a -bootclasspath flag to javac.
-# To build with JDK 1.6 when /usr/bin/javac points to JDK 1.7, we need to set
-# JAVA_HOME. But this breaks the build because 1.6.0.jdk does not contain
-# (symlinks to) the JNI headers as whould be expected for a Java home. So we
-# explicitly set JNI_CPPFLAGS.
-
 # Note on OpenCV library flags.
 # Since OpenCV is a CMake project, it does not produce the convenient libtool
 # .la files that specify the link dependencies for its static libraries. It
@@ -118,8 +109,8 @@ $EVAL ./configure \
    --with-gphoto2 \
    --with-freeimageplus \
    $MM_CONFIGUREFLAGS \
-   "JAVA_HOME=\"/Library/Java/JavaVirtualMachines/jdk1.8.0/Contents/Home\"" \
-   "JNI_CPPFLAGS=\"-I/Library/Java/JavaVirtualMachines/jdk1.8.0/Contents/Home/include -I/Library/Java/JavaVirtualMachines/jdk1.8.0/Contents/Home/include/darwin\"" \
+   "JAVA_HOME=\"$MM_JDK_HOME\"" \
+   "JNI_CPPFLAGS=\"-I$MM_JDK_HOME/include -I$MM_JDK_HOME/include/darwin\"" \
    "JAVACFLAGS=\"-Xlint:all,-path,-serial -source 1.8 -target 1.8\"" \
    "OPENCV_LDFLAGS=\"-framework Cocoa -framework QTKit -framework QuartzCore -framework AppKit\"" \
    "OPENCV_LIBS=\"$MM_DEPS_PREFIX/lib/libopencv_highgui.a $MM_DEPS_PREFIX/lib/libopencv_imgproc.a $MM_DEPS_PREFIX/lib/libopencv_core.a -lz $MM_DEPS_PREFIX/lib/libdc1394.la\"" \

--- a/configure.ac
+++ b/configure.ac
@@ -311,7 +311,7 @@ AM_CONDITIONAL([INSTALL_MMDEVAPI], [test x$install_mmdevapi = xtrue])
 ##
 
 AC_MSG_CHECKING([for proprietary device adapter source])
-AS_IF([test -f "$srcdir/$MM_CPP_DIR/SecretDeviceAdapters/configure"],
+AS_IF([test -f "$srcdir/mmCoreAndDevices/SecretDeviceAdapters/configure"],
    [build_secretdeviceadapters=yes], [build_secretdeviceadapters=no])
 AM_CONDITIONAL([BUILD_SECRETDEVICEADAPTERS],
    [test "x$build_secretdeviceadapters" = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,7 @@
-
-m4_define([MM_CPP_DIR], [mmCoreAndDevices])  # Define a macro substitution to be used in this file.
 AC_PREREQ([2.64])
 AC_INIT([Micro-Manager], [1.4], [info@micro-manager.org])
 AC_CONFIG_MACRO_DIR([m4])
-AC_CONFIG_SRCDIR(MM_CPP_DIR[/MMCore/MMCore.cpp])
+AC_CONFIG_SRCDIR([mmCoreAndDevices/MMCore/MMCore.cpp])
 AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([foreign 1.11])
@@ -45,10 +43,6 @@ can_build_mmcore=yes
 ##
 ## MMCoreJ
 ##
-
-# Define a shell variable based on the earlier m4_define
-[MM_CPP_DIR]=MM_CPP_DIR
-AC_ARG_VAR([MM_CPP_DIR], [The directory containing the c++ code])
 
 # SWIG
 AC_ARG_VAR([SWIG], [Simple Wrapper and Interface Generator])
@@ -316,9 +310,9 @@ AS_IF([test -f "$srcdir/mmCoreAndDevices/SecretDeviceAdapters/configure"],
 AM_CONDITIONAL([BUILD_SECRETDEVICEADAPTERS],
    [test "x$build_secretdeviceadapters" = xyes])
 
-AC_CONFIG_SUBDIRS(MM_CPP_DIR[/DeviceAdapters])
+AC_CONFIG_SUBDIRS([mmCoreAndDevices/DeviceAdapters])
 AS_IF([test "x$build_secretdeviceadapters" = xyes], [
-   AC_CONFIG_SUBDIRS(MM_CPP_DIR[/SecretDeviceAdapters])
+   AC_CONFIG_SUBDIRS([mmCoreAndDevices/SecretDeviceAdapters])
 ])
 
 
@@ -330,11 +324,11 @@ AC_CONFIG_FILES(m4_strip([
    Makefile
    buildscripts/AntExtensions/Makefile
    testing/Makefile
-   ]MM_CPP_DIR[/MMDevice/Makefile
-   ]MM_CPP_DIR[/MMDevice/unittest/Makefile
-   ]MM_CPP_DIR[/MMCore/Makefile
-   ]MM_CPP_DIR[/MMCore/unittest/Makefile
-   ]MM_CPP_DIR[/MMCoreJ_wrap/Makefile
+   mmCoreAndDevices/MMDevice/Makefile
+   mmCoreAndDevices/MMDevice/unittest/Makefile
+   mmCoreAndDevices/MMCore/Makefile
+   mmCoreAndDevices/MMCore/unittest/Makefile
+   mmCoreAndDevices/MMCoreJ_wrap/Makefile
    mmstudio/Makefile
    acqEngine/Makefile
    libraries/Makefile

--- a/mmstudio/Makefile.am
+++ b/mmstudio/Makefile.am
@@ -22,7 +22,7 @@ javadoc:
 	-rm -rf doc
 	$(MKDIR_P) doc
 	javadoc \
-		-classpath ../$(MM_CPP_DIR)/MMCoreJ_wrap/MMCoreJ.jar:../dependencies/artifacts/compile/"*":../dependencies/artifacts/imagej/"*" \
+		-classpath ../mmCoreAndDevices/MMCoreJ_wrap/MMCoreJ.jar:../dependencies/artifacts/compile/"*":../dependencies/artifacts/imagej/"*" \
 		-d doc \
 		-sourcepath $(srcdir)/src/main/java \
 		-subpackages org.micromanager \


### PR DESCRIPTION
This adds `buildscripts/nightly/nightlybuild_macOS_*.sh`, which work with macOS 12.0 SDK.
The existing scripts (`buildscripts/nightly/nightlybuild_OSX_*.sh`) are kept unmodified (they should be removed once our CI no longer needs them).

The new scripts build only 64-bit.