### PR TITLE
Make macOS x86_64 build work on Apple arm64

### DIFF
--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -23,6 +23,7 @@ MM_CFLAGS="-O2 -g -Wall"
 MM_CXXFLAGS="$MM_CFLAGS -std=c++03"
 MM_LDFLAGS="-L$MM_DEPS_PREFIX/lib -F/Library/Frameworks"
 
+MM_ARCH="x86_64"
 MM_ARCH_FLAGS="-arch x86_64"
 MM_CC="clang $MM_ARCH_FLAGS"
 MM_CXX="clang++ $MM_ARCH_FLAGS"

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -107,6 +107,13 @@ cd "$MM_DEPS_PREFIX"/src
 tar xjf ../downloads/boost_1_77_0.tar.bz2
 pushd boost_1_77_0
 ./bootstrap.sh
+cat >project-config.jam <<EOF
+import option ;
+import feature ;
+using clang : ${MM_ARCH} : clang++ ${MM_ARCH_FLAGS} ;
+project : default-build <toolset>clang-${MM_ARCH} ;
+option.set keep-going : false ;
+EOF
 ./b2 --prefix=${MM_DEPS_PREFIX} link=static threading=multi architecture=x86 address-model=64 \
   cflags="${MM_CFLAGS}" cxxflags="${MM_CXXFLAGS}" \
   --with-atomic --with-chrono --with-date_time --with-filesystem --with-system --with-thread \


### PR DESCRIPTION
This is only useful for testing the build, for now.

The macOS nightly build script now works correctly when run on an Apple
arm64 computer, and produces x86_64 binaries.

The only change needed was figuring out how to cross-compile Boost,
which appears to be broken when using only command-line options to b2.
(I.e., the method we used to use for Intel 32/64-bit does not work.)

The method used here may become useful if we eventually decide to build
arm64 or universal2 binaries.

Actually running Micro-Manager on arm64 machines (via Rosetta 2 or
otherwise) is not addressed (the main issues are Gatekeeper path
randomization and, if running the x86_64 version, how to launch an
x86_64 JVM).