### PR TITLE
Remove JOGL DLLs upon installation

### DIFF
--- a/buildscripts/installer_Windows.iss
+++ b/buildscripts/installer_Windows.iss
@@ -129,6 +129,14 @@ Type: files; Name: "{app}\mmgr_dal_CONEX.dll"
 ; Retired
 Type: files; Name: "{app}\mmgr_dal_Hamamatsu.dll"
 
+; JOGL DLLs, now auto-extracted from Jars
+Type: files; Name: "{app}\gluegen-rt.dll"
+Type: files; Name: "{app}\jogl_desktop.dll"
+Type: files; Name: "{app}\jogl_mobile.dll"
+Type: files; Name: "{app}\nativewindow_awt.dll"
+Type: files; Name: "{app}\nativewindow_win32.dll"
+Type: files; Name: "{app}\newt.dll"
+
 [Files]
 
 ; ImageJ files


### PR DESCRIPTION
This follows #1387. We don't want the DLLs installed by previous
versions hanging around, in case (in the future) JOGL is updated and a
conflict arises.