### PR TITLE
Fix error in the signature call to DoubleVector constructor that arises when compiling with Swig 4.0.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AffineEditorPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AffineEditorPanel.java
@@ -122,7 +122,7 @@ public class AffineEditorPanel extends JPanel {
     * @return Copy of the input
     */
    public static DoubleVector copyDoubleVector(DoubleVector in) {
-      DoubleVector out = new DoubleVector(in.size());
+      DoubleVector out = new DoubleVector(in.size(), 0);
       for (int i = 0; i < in.size(); i++) {
          out.set(i, in.get(i));
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/MicroscopeModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/MicroscopeModel.java
@@ -670,7 +670,7 @@ public final class MicroscopeModel {
                if (tokens.length == 8) {
                   ConfigPreset cp = pixelSizeGroup_.findConfigPreset(tokens[1]);
                   if (cp != null) {
-                     DoubleVector aft = new DoubleVector(6);
+                     DoubleVector aft = new DoubleVector(6, 0);
                      for (int i = 0; i < 6; i++) {
                         aft.set(i, Double.parseDouble(tokens[i + 2]));
                      }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AffineUtils.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AffineUtils.java
@@ -35,7 +35,7 @@ import org.apache.commons.math.util.MathUtils;
 public class AffineUtils {
 
    public static DoubleVector noTransform() {
-      DoubleVector affineTransform = new DoubleVector(6);
+      DoubleVector affineTransform = new DoubleVector(6, 0);
       for (int i = 1; i < 6; i++) {
          affineTransform.set(i, 0.0);
       }
@@ -55,7 +55,7 @@ public class AffineUtils {
    }
    
    public static DoubleVector affineToDouble(AffineTransform atf) {
-      DoubleVector out = new DoubleVector(6);
+      DoubleVector out = new DoubleVector(6, 0);
       out.set(0, atf.getScaleX());
       out.set(1, atf.getShearX());
       out.set(2, atf.getTranslateX());


### PR DESCRIPTION
This is a workaround related to issue #838 (and also issue 37 of mmCoreAndDevices). In essence, this PR addresses the java compilation errors thrown when creating DoubleVector objects in MMCoreJ; it does it by changing the call signature from "new DoubleVector(count)" to "new DoubleVector(count, value)", with value=0 (proposed as a workaround in the Swig Changelog of version 4.0.0).

Compilation goes well under Linux; haven't tested it under Windows or MacOS. This change might potentially need some further testing. I am happy to keep updating the PR if required.

Related issue in mmCoreAndDevices https://github.com/micro-manager/mmCoreAndDevices/issues/37