### PR TITLE
Remove unused cl-kernel-bindings dependency

### DIFF
--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -92,10 +92,6 @@
 
       <!-- Patched version of clearvolume from Nico -->
       <dependency org="net.clearvolume" name="clearvolume" rev="1.4.1"/>
-      <!-- cl-kernel-binding from nico brings in clij-kernels, and clij version of the cleacl libraries.  Ugly, but the harsh truth if we want to use this code -->
-      <dependency org="org.micromanager" name="cl-kernel-bindings" rev="0.1.1-SNAPSHOT"/>
-
-
 
       <dependency org="org.boofcv" name="boofcv-ip" rev="0.36"/>
       <dependency org="org.boofcv" name="boofcv-geo" rev="0.36"/>


### PR DESCRIPTION
Closes #1394.
With this change, all dependencies are resolved.