### PR TITLE
Autoconf: require, and default to, C++14

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           cd micro-manager
           ./autogen.sh
-          ./configure CXXFLAGS=-std=c++03 JAVA_HOME=$JAVA_HOME_8_X64
+          ./configure JAVA_HOME=$JAVA_HOME_8_X64
           make -C mmCoreAndDevices/MMCoreJ_wrap MMCoreJ_wrap.h
 
       - name: Build Javadoc
@@ -210,7 +210,7 @@ jobs:
         run: |
           cd micro-manager
           ./autogen.sh
-          ./configure CXXFLAGS=-std=c++03 JAVA_HOME=$JAVA_HOME_8_X64
+          ./configure JAVA_HOME=$JAVA_HOME_8_X64
           make fetchdeps
           make -C buildscripts/AntExtensions
           make -C mmCoreAndDevices/MMDevice -j3

--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -20,7 +20,7 @@ MM_MACOSX_SDKROOT=$(xcode-select --print-path)/SDKs/MacOSX.sdk
 # once build supports it.
 MM_CPPFLAGS="-I$MM_DEPS_PREFIX/include -F/Library/Frameworks"
 MM_CFLAGS="-O2 -g -Wall"
-MM_CXXFLAGS="$MM_CFLAGS -std=c++03"
+MM_CXXFLAGS="$MM_CFLAGS"
 MM_LDFLAGS="-L$MM_DEPS_PREFIX/lib -F/Library/Frameworks"
 
 MM_ARCH="x86_64"

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_PROG_MKDIR_P
 
 AC_PROG_CC([cc gcc clang])
 AC_PROG_CXX([c++ g++ clang++])
+AX_CXX_COMPILE_STDCXX([14], [noext])
 
 
 # Testing (googletest, googlemock)

--- a/doc/how-to-build.md
+++ b/doc/how-to-build.md
@@ -227,19 +227,3 @@ Take a look at [issue #708](https://github.com/micro-manager/micro-manager/issue
 `iconloader` from original [svn site](https://valelab4.ucsf.edu/svn/3rdpartypublic/classext/). You should not run
 `make fetchdeps` again after you copied jar files to `dependencies/artifacts/compile`, otherwise
 `make fetchdeps` will remove copyed files. 
-
-#### C++17 refuse dynamic exception 
-
-If your gcc( such as gcc 11) compile MM by `ISO C++17` or newer than C++14 in default, 
-it will stop by dynamic exception related error:
-
-        ImageMetadata.h:334:56: error: ISO C++17 does not allow dynamic exception specifications
-        334 |    MetadataArrayTag GetArrayTag(const char* key) const throw (MetadataKeyError)
-
-Since C++17 removed dynamic exception specifications, as a result of
-[P0003](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0003r5.html), 
-which had been deprecated since C++11. Before MM codes are updated, you
-need to add CXXFLAGS `-std=c++11` or `-std=c++14`. To do so run this command
-before `./autogen.sh`:
-
-        export CXXFLAGS="-std=c++11"


### PR DESCRIPTION
Also, let automated macOS and apidoc builds use the new default.

Closes micro-manager/mmCoreAndDevices#152.