### PR TITLE
Hardware Configuration Wizard: Only show State devices thave have a Label property on the label page.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/LabelsPage.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/LabelsPage.java
@@ -176,7 +176,7 @@ public final class LabelsPage extends PagePanel {
          Device[] devs = model.getDevices();
          devices_.clear();
          for (Device dev : devs) {
-            if (dev.isStateDevice()) {
+            if (dev.isStateDevice() && (dev.findProperty("Label") != null)) {
                devices_.add(dev);
             }
          }

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/MicroscopeModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/MicroscopeModel.java
@@ -351,7 +351,9 @@ public final class MicroscopeModel {
       for (Device dev : devices_) {
          Label[] setupLabels = dev.getAllSetupLabels();
          for (int j = 0; j < setupLabels.length; j++) {
-            core.defineStateLabel(dev.getName(), setupLabels[j].state_, setupLabels[j].label_);
+            String defaultName =  "State-" + setupLabels[j].state_;
+            if (!setupLabels[j].label_.equals(defaultName))
+               core.defineStateLabel(dev.getName(), setupLabels[j].state_, setupLabels[j].label_);
          }
       }
    }


### PR DESCRIPTION
State devices with more than 10 or states become very unwieldy on the Label page of the HCW.  Moreover, many of these (often digital Output) devices really do not need labels.  I run in an issue with a 32 pin output port that needed 2^32 labels, and run out of JVM memroy.  This PR only shows state devices that have the "Label" property defined.  Therefore, not defining it ensures that the user does not need to define labels.  Also, only labels that differ from the default "State-#" will now be written to file (but note that existing "State-#" labels will not be removed from a config file).