### PR TITLE
HCS: revert position generation to use their corresponding spacing  

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -697,13 +697,13 @@ public class SiteGenerator extends JFrame implements ParentPlateGUI {
       double x;
       double y;
       if (cols > 1) {
-         x = -cols * ySpacing_ / 2.0 + ySpacing_ * col + ySpacing_ / 2.0;
+         x = -cols * xSpacing_ / 2.0 + xSpacing_ * col + xSpacing_ / 2.0;
       } else {
          x = 0.0;
       }
 
       if (rows > 1) {
-         y = -rows * xSpacing_ / 2.0 + xSpacing_ * row + xSpacing_ / 2.0;
+         y = -rows * ySpacing_ / 2.0 + ySpacing_ * row + ySpacing_ / 2.0;
       } else {
          y = 0.0;
       }


### PR DESCRIPTION
I noticed with my (non square sensor) camera that the intra-well positions in hcs where spaced wrong. In a recent commit we saw that the x position was generated using the ySpacing_ and vice versa for y position. This PR just changes that behaviour to what it was before - x position generated using the x spacing and y position generated using the y spacing - which fixed the bug for us.