### PR TITLE
HCW now updates device pre-init properties after each change

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/Device.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/Device.java
@@ -300,6 +300,14 @@ public final class Device {
       }
       p.value = value;
    }
+
+   public void setPropertyValueInHardware(CMMCore core, String propName, String value) throws MMConfigFileException {
+      try {
+         core.setProperty(name_, propName, value);
+      } catch (Exception ex) {
+         core.logMessage("HCW Device " + name_ + " failed to set property " + propName + " to value " + value);
+      }
+   }
    
    public int getNumberOfSetupProperties() {
       return setupProperties_.size();

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/Device.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/Device.java
@@ -301,7 +301,7 @@ public final class Device {
       p.value = value;
    }
 
-   public void setPropertyValueInHardware(CMMCore core, String propName, String value) throws MMConfigFileException {
+   public void setPropertyValueInHardware(CMMCore core, String propName, String value)  {
       try {
          core.setProperty(name_, propName, value);
       } catch (Exception ex) {
@@ -413,7 +413,7 @@ public final class Device {
 
    public void setFocusDirection(int direction) {
       if (direction > 0) {
-         focusDirection_ = +1;
+         focusDirection_ = 1;
       } else if (direction < 0) {
          focusDirection_ = -1;
       } else {

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
@@ -1,8 +1,6 @@
 package org.micromanager.internal.hcwizard;
 
 import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -17,6 +15,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
 import javax.swing.table.TableColumn;
 import mmcorej.CMMCore;
 import mmcorej.DeviceDetectionStatus;
@@ -294,8 +294,7 @@ public final class DeviceSetupDlg extends JDialog {
    }
 
    private void rebuildPropTable() {
-
-      PropertyTableModel tm = new PropertyTableModel(model_, device_, this);
+      PropertyTableModel tm = new PropertyTableModel(model_, core_, device_, this);
       propTable_.setModel(tm);
       PropertyValueCellEditor propValueEditor = new PropertyValueCellEditor();
       PropertyValueCellRenderer propValueRenderer = new PropertyValueCellRenderer(studio_);
@@ -329,6 +328,13 @@ public final class DeviceSetupDlg extends JDialog {
       }
       detectButton_.setEnabled(any);
       propTable_.repaint();
+      propTable_.putClientProperty("terminateEditOnFocusLost", true);
+      tm.addTableModelListener(new TableModelListener() {
+         @Override
+         public void tableChanged(TableModelEvent e) {
+            rebuildPropTable();
+         }
+      });
    }
 
    public void rebuildComTable(String portName) {

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PropertyTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PropertyTableModel.java
@@ -81,15 +81,15 @@ class PropertyTableModel extends AbstractTableModel implements MMPropertyTableMo
          devices_[0] = dev;
       }
       
-      model_.dumpComPortsSetupProps(); // >>>>>>>
-      
+      model_.dumpComPortsSetupProps();
+
       ArrayList<PropertyItem> props = new ArrayList<>();
       ArrayList<String> dn = new ArrayList<>();
       for (Device device : devices_) {
          for (int j = 0; j < device.getNumberOfProperties(); j++) {
             PropertyItem p = device.getProperty(j);
             if (mode == PREINIT) {
-               if (!p.readOnly && p.preInit && !device.isSerialPort() && !p.readOnly) {
+               if (!p.readOnly && p.preInit && !device.isSerialPort()) {
                   props.add(p);
                   dn.add(device.getName());
                   PropertyItem setupProp = device.findSetupProperty(p.name);

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PropertyTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PropertyTableModel.java
@@ -41,11 +41,7 @@ class PropertyTableModel extends AbstractTableModel implements MMPropertyTableMo
          "Property",
          "Value"
    };
-   
-   // TODO: should be enum in Java 5.0
-   public static final int PREINIT = 1;
-   public static final int COMPORT = 2;
-   
+
    MicroscopeModel model_;
    Device[] devices_;
    PropertyItem[] props_;
@@ -53,11 +49,6 @@ class PropertyTableModel extends AbstractTableModel implements MMPropertyTableMo
    DeviceSetupDlg setupDlg_;
    CMMCore core_;
 
-   // OK to delete?
-   public PropertyTableModel(MicroscopeModel model, int mode) {
-      setupDlg_ = null;
-      updateValues(model, mode, null);
-   }
 
    /**
     * Handles single device case.
@@ -65,17 +56,13 @@ class PropertyTableModel extends AbstractTableModel implements MMPropertyTableMo
    public PropertyTableModel(MicroscopeModel model, CMMCore core, Device dev, DeviceSetupDlg dlg) {
       core_ = core;
       setupDlg_ = dlg;
-      updateValues(model, PREINIT, dev);
+      updateValues(model, dev);
    }
 
-   public void updateValues(MicroscopeModel model, int mode, Device dev) {
+   public void updateValues(MicroscopeModel model, Device dev) {
       model_ = model;
       if (dev == null) {
-         if (mode == COMPORT) {
-            devices_ = model.getAvailableSerialPorts();
-         } else {
             devices_ = model.getDevices();
-         }
       } else {
          devices_ = new Device[1];
          devices_[0] = dev;
@@ -88,32 +75,12 @@ class PropertyTableModel extends AbstractTableModel implements MMPropertyTableMo
       for (Device device : devices_) {
          for (int j = 0; j < device.getNumberOfProperties(); j++) {
             PropertyItem p = device.getProperty(j);
-            if (mode == PREINIT) {
-               if (!p.readOnly && p.preInit && !device.isSerialPort()) {
-                  props.add(p);
-                  dn.add(device.getName());
-                  PropertyItem setupProp = device.findSetupProperty(p.name);
-                  if (setupProp != null) {
-                     p.value = setupProp.value;
-                  }
-               }
-            } else if (mode == COMPORT) {
-               if (device.isSerialPort() && model_.isPortInUse(device) && !p.readOnly) {
-                  props.add(p);
-                  dn.add(device.getName());
-                  PropertyItem setupProp = device.findSetupProperty(p.name);
-                  if (setupProp != null) {
-                     p.value = setupProp.value;
-                  }
-               }
-            } else {
-               if (!p.readOnly && !device.isSerialPort()) {
-                  props.add(p);
-                  dn.add(device.getName());
-                  PropertyItem setupProp = device.findSetupProperty(p.name);
-                  if (setupProp != null) {
-                     p.value = setupProp.value;
-                  }
+            if (!p.readOnly && p.preInit && !device.isSerialPort()) {
+               props.add(p);
+               dn.add(device.getName());
+               PropertyItem setupProp = device.findSetupProperty(p.name);
+               if (setupProp != null) {
+                  p.value = setupProp.value;
                }
             }
          }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyItem.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyItem.java
@@ -14,7 +14,7 @@ public class PropertyItem {
    public String value;   // property value
    public boolean readOnly = false;    // is it read-only ?
    public boolean preInit = false; // is it a pre-initialization property ?
-   public String allowed[];            // the list of allowed values
+   public String[] allowed;            // the list of allowed values
    public boolean confInclude = false; // is it included in the current configuration ?
    public boolean hasRange = false; // is there a range for values
    public double lowerLimit = 0.0;
@@ -22,9 +22,7 @@ public class PropertyItem {
    public PropertyType type;
    
    public PropertyItem() {
-      device = new String();
       name = "Undefined";
-      value = new String();
       allowed = new String[0];
    }
 
@@ -46,8 +44,7 @@ public class PropertyItem {
       ReportingUtils.logMessage("Property : " + name);
       ReportingUtils.logMessage("Property : " + value);
       ReportingUtils.logMessage("   allowed :");
-      for (int i=0; i<allowed.length; i++)
-         ReportingUtils.logMessage("   " + allowed[i]);
+      for (String s : allowed) ReportingUtils.logMessage("   " + s);
       
    }
    
@@ -122,22 +119,22 @@ public class PropertyItem {
                boolean allNumeric = true;
                // test that first character of every possible value is a numeral
                // if so, show user the list sorted by the numeric prefix
-               for (int k = 0; k < allowed.length; k++) {
-                  if ( null != allowed[k]){
-                     if( 0 < allowed[k].length()){
-                        if (!Character.isDigit(allowed[k].charAt(0))) {
-                           allNumeric = false;
-                           break;
+                for (String s : allowed) {
+                    if (null != s) {
+                        if (0 < s.length()) {
+                            if (!Character.isDigit(s.charAt(0))) {
+                                allNumeric = false;
+                                break;
+                            }
+                        } else {
+                            allNumeric = false;
+                            break;
                         }
-                     }else {
+                    } else {
                         allNumeric = false;
                         break;
-                     }
-                  }else {
-                     allNumeric = false;
-                     break;
-                  }
-               }
+                    }
+                }
 
                if (allNumeric) {
                   Arrays.sort(allowed, new SortFunctionObjects.NumericPrefixStringComp());

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
@@ -1,7 +1,6 @@
 package org.micromanager.internal.utils;
 
 import java.awt.Component;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
@@ -25,7 +24,7 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
     private static final long serialVersionUID = 1L;
     // This is the component that will handle the editing of the cell value
     JTextField text_ = new JTextField();
-    JComboBox combo_ = new JComboBox();
+    JComboBox<String> combo_ = new JComboBox<>();
     SliderPanel slider_ = new SliderPanel();
 
     PropertyItem item_;
@@ -43,19 +42,8 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
         disableExcluded_ = disableExcluded;
 
         // end editing on selection change
-        combo_.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                fireEditingStopped();
-            }
-        });
-
-        slider_.addEditActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                fireEditingStopped();
-            }
-        });
+        combo_.addActionListener(e -> fireEditingStopped());
+        slider_.addEditActionListener(e -> fireEditingStopped());
 
         slider_.addSliderMouseListener(new MouseAdapter() {
             @Override
@@ -111,8 +99,8 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
                 }
             } else {
                 ActionListener[] l = combo_.getActionListeners();
-                for (int i = 0; i < l.length; i++) {
-                    combo_.removeActionListener(l[i]);
+                for (ActionListener actionListener : l) {
+                    combo_.removeActionListener(actionListener);
                 }
                 combo_.removeAllItems();
                 for (int i = 0; i < item_.allowed.length; i++) {
@@ -121,13 +109,7 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
                 combo_.setSelectedItem(item_.value);
 
                 // end editing on selection change
-                combo_.addActionListener(new ActionListener() {
-
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        fireEditingStopped();
-                    }
-                });
+                combo_.addActionListener(e -> fireEditingStopped());
 
                 return combo_;
             }


### PR DESCRIPTION
It is sometimes desirable for a device to change its pre-initialization properties based on the setting of one or more pre-initialization properties.  This PR modifies the HCW so that it writes each pre-init property to the device after each change, and then reads back in all now available pre-init properties.  This may be a problem with devices that take a long time to read in such properties (I am not sure if this a problem in reality or not).  Since this code is needed by anyone configuring Micro-Manager it may need some scrutiny.  I used the demo state device in the branch HCWPropChangeDemoTest of mmCoreAndDevices to test this code.  That branch can be deleted after testing.

Closes #1442.