### PR TITLE
Studio: loading a new config file now populates the shutter dropdown correctly

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -858,7 +858,7 @@ public final class MMStudio implements Studio {
             GUIUtils.preventDisplayAdapterChangeExceptions();
             core_.waitForSystem();
             coreCallback_.setIgnoring(true);
-            HardwareConfigurationManager.create(profile(), core_)
+            HardwareConfigurationManager.create(profile(), this)
                   .loadHardwareConfiguration(sysConfigFile_);
             coreCallback_.setIgnoring(false);
             GUIUtils.preventDisplayAdapterChangeExceptions();

--- a/mmstudio/src/main/java/org/micromanager/profile/internal/gui/HardwareConfigurationManager.java
+++ b/mmstudio/src/main/java/org/micromanager/profile/internal/gui/HardwareConfigurationManager.java
@@ -17,7 +17,9 @@ import java.util.prefs.Preferences;
 import mmcorej.CMMCore;
 import org.micromanager.PropertyMap;
 import org.micromanager.PropertyMaps;
+import org.micromanager.Studio;
 import org.micromanager.UserProfile;
+import org.micromanager.events.internal.DefaultSystemConfigurationLoadedEvent;
 import org.micromanager.profile.internal.LegacyMM1Preferences;
 import org.micromanager.propertymap.MutablePropertyMapView;
 import org.micromanager.profile.UserProfileMigration;
@@ -72,17 +74,18 @@ public class HardwareConfigurationManager {
    }
 
    private final UserProfile profile_;
+   private final Studio studio_;
    private final CMMCore core_;
    private File currentConfiguration_;
 
-   public static HardwareConfigurationManager create(UserProfile profile,
-         CMMCore core) {
-      return new HardwareConfigurationManager(profile, core);
+   public static HardwareConfigurationManager create(UserProfile profile, Studio studio) {
+      return new HardwareConfigurationManager(profile, studio);
    }
 
-   private HardwareConfigurationManager(UserProfile profile, CMMCore core) {
+   private HardwareConfigurationManager(UserProfile profile, Studio studio) {
       profile_ = profile;
-      core_ = core;
+      studio_ = studio;
+      core_ = studio.getCMMCore();
    }
 
    /**
@@ -146,6 +149,7 @@ public class HardwareConfigurationManager {
       currentConfiguration_ = file;
       // TODO Modal dialog
       core_.loadSystemConfiguration(file.getAbsolutePath());
+      studio_.events().post(new DefaultSystemConfigurationLoadedEvent());
    }
 
    private void rememberLoadedConfig(File newFile) {


### PR DESCRIPTION
Closes issue #1437.

Not sure why the HardwareConfigurationManager lives in profile-internal.