### PR TITLE
Better error reporting in ReportingUtils and ProfileAdmin

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ReportingUtils.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ReportingUtils.java
@@ -260,15 +260,31 @@ public final class ReportingUtils {
    }
 
    public static void showError(Throwable e) {
-      showError(e, "", MMStudio.getInstance().app().getMainWindow());
+      showError(e, "", getMainWindow());
    }
 
    public static void showError(String msg) {
-      showError(null, msg, MMStudio.getInstance().app().getMainWindow());
+      showError(null, msg, getMainWindow());
    }
 
    public static void showError(Throwable e, String msg) {
-      showError(e, msg, MMStudio.getInstance().app().getMainWindow());
+      showError(e, msg, getMainWindow());
+   }
+
+   /**
+    * Introduced to catch null pointer exception when mmstudio.app does not exit yet
+    * Will return null if null pointer exception is thrown.
+    * @return MainWindow or null
+    */
+   public static JFrame getMainWindow() {
+      JFrame mainWindow = null;
+      try {
+         mainWindow = MMStudio.getInstance().app().getMainWindow();
+      } catch (NullPointerException npe) {
+         // this will happen when MM has not fully initialized yet.
+         logError(npe);
+      }
+      return mainWindow;
    }
 
    public static void showError(Throwable e, Component parent) {

--- a/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
+++ b/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
@@ -79,6 +79,7 @@ public final class UserProfileAdmin {
 
    private UUID currentProfileUUID_ = null;
    private DefaultUserProfile currentProfile_ = null;
+   private boolean userProfileErrorShown_ = false;
 
    private final EventListenerSupport<ChangeListener> currentProfileListeners_ =
          EventListenerSupport.create(ChangeListener.class);
@@ -259,13 +260,18 @@ public final class UserProfileAdmin {
                   uuid, new ExceptionListener() {
                      @Override
                      public void exceptionThrown(Exception e) {
-                        // TODO User should probably receive warning for the first error.
-                        ReportingUtils.logError(e, "Error saving user profile");
+                        if (userProfileErrorShown_) {
+                           ReportingUtils.logError(e, "Error saving user profile");
+                        } else {
+                           ReportingUtils.showError(e, "Error saving user profile");
+                           userProfileErrorShown_ = true;
+                        }
                      }
                   });
          } catch (IOException ex) {
-            ex.printStackTrace();
-            // TODO Notify user of error
+            String profileDir = getProfilesDirectory().getAbsolutePath();
+            ReportingUtils.showError(ex, "Error reading Micro-Manager profile.  Delete or move "
+                        + profileDir + ".");
             // TODO Virtual profile?
          }
       }


### PR DESCRIPTION
Previously, certain calls to ReportingUtil.showError would lead to null pointer exceptions and no display of the error to the user.  In addition, errors in ProfileAdmin were not shown to the user.  This PR should somewhat improve that situation.  I believe there was an issue related to this, but I can not locate it.