### PR TITLE
Studio-HCW: Make sure that pre-init properties can actually be editted.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/DeviceSetupDlg.java
@@ -71,6 +71,18 @@ public final class DeviceSetupDlg extends JDialog {
       portDev_ = null;
       device_ = d;
 
+      // can not change pre-initialization properties on a device that was initialized
+      if (d.isInitialized()) {
+         try {
+            core_.unloadDevice(d.getName());
+            core_.loadDevice(d.getName(), d.getLibrary(), d.getAdapterName());
+            d.setInitialized(false);
+         } catch (Exception e) {
+            studio_.logs().showError(e, "Failed to load device " + d.getName());
+            ReportingUtils.logError(e);
+         }
+      }
+
       setTitle("Device: " + device_.getAdapterName() + "; Library: "
             + device_.getLibrary());
 

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PropertyTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/PropertyTableModel.java
@@ -129,6 +129,7 @@ class PropertyTableModel extends AbstractTableModel implements MMPropertyTableMo
             dev.setPropertyValueInHardware(core_, props_[row].name, props_[row].value);
             // reload the device to update possibly changed pre-init properties
             dev.loadDataFromHardware(core_);
+            dev.updateSetupProperties();
             // the listener will rebuild the table to reflect possibly changed pre-init properties
             fireTableCellUpdated(row, col);
          } catch (Exception e) {


### PR DESCRIPTION
Previous changes had left pre-init properties uneditable.  Part of the problem is that this code is quite convoluted, and hard to grok.  This PR adresses the problem both by making sure the device is not initialized when changing the pre-init properties, and by clearing cached pre-init properties.