### PR TITLE
Update how-to-build.md

### DIFF
--- a/doc/how-to-build.md
+++ b/doc/how-to-build.md
@@ -53,7 +53,7 @@ cd micro-manager
 git submodule update --init --recursive
 
 mamba create -n micro-manager -c conda-forge swig=3 openjdk=8
-mamba activate micro-manager
+conda activate micro-manager
 
 ./autogen.sh
 ./configure


### PR DESCRIPTION
fixed typo in Ubuntu quickstart.  conda env's have to be activated with `conda`, can't activate with `mamba`.