### PR TITLE
Studio: can get and set ROI correctly in Composite images.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
@@ -32,6 +32,7 @@ import java.util.List;
 import javax.swing.JOptionPane;
 import org.micromanager.data.Image;
 import org.micromanager.display.DataViewer;
+import org.micromanager.display.DisplayWindow;
 import org.micromanager.internal.utils.ReportingUtils;
 
 /**
@@ -49,7 +50,15 @@ public class MMROIManager {
     * Enquires with the UI what ROI(s) are set, and send these to the camera.
     */
    public void setROI() {
-      ImagePlus curImage = WindowManager.getCurrentImage();
+      DataViewer dv = studio_.displays().getActiveDataViewer();
+      DisplayWindow dw = null;
+      if (dv instanceof DisplayWindow) {
+         dw = (DisplayWindow) studio_.displays().getActiveDataViewer();
+      }
+      ImagePlus curImage = null;
+      if (dw != null) {
+         curImage = dw.getImagePlus();
+      }
       if (curImage == null) {
          studio_.logs().showError("There is no open image window.");
          return;
@@ -145,7 +154,15 @@ public class MMROIManager {
     * Set the ROI to the center quadrant of the current ROI.
     */
    public void setCenterQuad() {
-      ImagePlus curImage = WindowManager.getCurrentImage();
+      DataViewer dv = studio_.displays().getActiveDataViewer();
+      DisplayWindow dw = null;
+      if (dv instanceof DisplayWindow) {
+         dw = (DisplayWindow) studio_.displays().getActiveDataViewer();
+      }
+      ImagePlus curImage = null;
+      if (dw != null) {
+         curImage = dw.getImagePlus();
+      }
       if (curImage == null) {
          return;
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
@@ -50,15 +50,7 @@ public class MMROIManager {
     * Enquires with the UI what ROI(s) are set, and send these to the camera.
     */
    public void setROI() {
-      DataViewer dv = studio_.displays().getActiveDataViewer();
-      DisplayWindow dw = null;
-      if (dv instanceof DisplayWindow) {
-         dw = (DisplayWindow) studio_.displays().getActiveDataViewer();
-      }
-      ImagePlus curImage = null;
-      if (dw != null) {
-         curImage = dw.getImagePlus();
-      }
+      ImagePlus curImage = getCurrentImagePlus();
       if (curImage == null) {
          studio_.logs().showError("There is no open image window.");
          return;
@@ -154,15 +146,7 @@ public class MMROIManager {
     * Set the ROI to the center quadrant of the current ROI.
     */
    public void setCenterQuad() {
-      DataViewer dv = studio_.displays().getActiveDataViewer();
-      DisplayWindow dw = null;
-      if (dv instanceof DisplayWindow) {
-         dw = (DisplayWindow) studio_.displays().getActiveDataViewer();
-      }
-      ImagePlus curImage = null;
-      if (dw != null) {
-         curImage = dw.getImagePlus();
-      }
+      ImagePlus curImage = getCurrentImagePlus();
       if (curImage == null) {
          return;
       }
@@ -210,4 +194,18 @@ public class MMROIManager {
       JOptionPane.showMessageDialog(studio_.uiManager().frame(), message);
       studio_.core().logMessage(message);
    }
+
+   private ImagePlus getCurrentImagePlus() {
+      DataViewer dv = studio_.displays().getActiveDataViewer();
+      DisplayWindow dw = null;
+      if (dv instanceof DisplayWindow) {
+         dw = (DisplayWindow) dv;
+      }
+      ImagePlus curImage = null;
+      if (dw != null) {
+         curImage = dw.getImagePlus();
+      }
+      return curImage;
+   }
+
 }


### PR DESCRIPTION
Closes issue #950. This fix pertains only to the internal MMROIManager.  Instead of relying on ImageJ to get the active ImagePlus, it uses the Studio DisplayManager and a deprecated function to get the ImagePlus.  As long as we use ImageJ behind the scenes, I do not see a way not to use this deprecated function.  