### PR TITLE
Fix live mode behavior when exception in setting camera ROI

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
@@ -206,9 +206,14 @@ public class DefaultApplication implements Application {
    @Override
    public void setROI(Rectangle r) throws Exception {
       studio_.live().setSuspended(true);
-      studio_.core().setROI(r.x, r.y, r.width, r.height);
-      ((MMStudio) studio_).cache().refreshValues();
-      studio_.live().setSuspended(false);
+      try {
+         studio_.core().setROI(r.x, r.y, r.width, r.height);
+      } catch (Exception e) {
+         studio_.logs().showError(e);
+      } finally {
+         ((MMStudio) studio_).cache().refreshValues();
+         studio_.live().setSuspended(false);
+      }
    }
 
    @Override


### PR DESCRIPTION
If a camera device adapter returns an error when setting its ROI, live mode will be cease to function, because of an incorrect value in `suspendCount_` in `SnapLiveManager`. This fix should properly handle errors, as well as show a dialog with the error to the user