### PR TITLE
HCS: change calibration method default to recommended.

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -168,7 +168,7 @@ public class CalibrationFrame extends JFrame {
                       + "is consistent between sessions."
                       + "</html>");
       contents.add(methodPanel, "span 2");
-      methodCombo.setSelectedItem(settings.getString(CALIBRATIONMETHOD, CALIBRATIONLEGACY));
+      methodCombo.setSelectedItem(settings.getString(CALIBRATIONMETHOD, CALIBRATIONRECOMMENDED));
       
       JButton cancelButton = new JButton ("Cancel");
       cancelButton.addActionListener(new ActionListener() {


### PR DESCRIPTION
If it is really recommended, then why is it not the default?   We have now
tested this for many years and have not found porblems, whereas it makes
things much easier, so lets switch now.