### PR TITLE
ClearVolume brightness contrast

### DIFF
--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/events/CanvasDrawCompleteEvent.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/events/CanvasDrawCompleteEvent.java
@@ -3,9 +3,9 @@ package edu.ucsf.valelab.mmclearvolumeplugin.events;
 
 /**
  * Class whose sole function is to indicate that the screen update has taken place
- * 
+ *
  * @author nico
  */
 public class CanvasDrawCompleteEvent {
-    public CanvasDrawCompleteEvent() {}
+   public CanvasDrawCompleteEvent() {}
 }

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/recorder/RecorderUtils.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/recorder/RecorderUtils.java
@@ -9,62 +9,51 @@ import java.nio.ByteBuffer;
  * @author nico
  */
 public class RecorderUtils {
-    public static BufferedImage makeBufferedImage(
+   public static BufferedImage makeBufferedImage(
                                  final int pWidth,
                                  final int pHeight,
-                                 final ByteBuffer pByteBuffer)
-  {
-    try
-    {
-      int[] lPixelInts = new int[pWidth * pHeight];
-      
+                                 final ByteBuffer pByteBuffer) {
+      try {
+         int[] lPixelInts = new int[pWidth * pHeight];
 
-      // Convert RGB bytes to ARGB ints with no transparency. Flip image
-      // vertically by reading the rows of pixels in the byte buffer 
-      // in reverse - (0,0) is at bottom left in OpenGL.
+         // Convert RGB bytes to ARGB ints with no transparency. Flip image
+         // vertically by reading the rows of pixels in the byte buffer
+         // in reverse - (0,0) is at bottom left in OpenGL.
 
-      int p = pWidth * pHeight * 3; // Points to first byte (red) in each row
-      int q; // Index into ByteBuffer
-      int i = 0; // Index into target int[]
-      final int w3 = pWidth * 3; // Number of bytes in each row
+         int p = pWidth * pHeight * 3; // Points to first byte (red) in each row
+         int q; // Index into ByteBuffer
+         int i = 0; // Index into target int[]
+         final int w3 = pWidth * 3; // Number of bytes in each row
 
-      for (int row = 0; row < pHeight; row++)
-      {
-        p -= w3;
-        q = p;
-        for (int col = 0; col < pWidth; col++)
-        {
-          final int iR = pByteBuffer.get(q++);
-          final int iG = pByteBuffer.get(q++);
-          final int iB = pByteBuffer.get(q++);
+         for (int row = 0; row < pHeight; row++) {
+            p -= w3;
+            q = p;
+            for (int col = 0; col < pWidth; col++) {
+               final int iR = pByteBuffer.get(q++);
+               final int iG = pByteBuffer.get(q++);
+               final int iB = pByteBuffer.get(q++);
 
-          lPixelInts[i++] = 0xFF000000 | ((iR & 0x000000FF) << 16)
+               lPixelInts[i++] = 0xFF000000 | ((iR & 0x000000FF) << 16)
                             | ((iG & 0x000000FF) << 8)
                             | (iB & 0x000000FF);
-        }
-
-      }
-
-      BufferedImage lBufferedImage =
-                       new BufferedImage(pWidth,
-                                         pHeight,
-                                         BufferedImage.TYPE_INT_ARGB);
-    
-      lBufferedImage.setRGB(0,
-                            0,
-                            pWidth,
-                            pHeight,
-                            lPixelInts,
+            }
+         }
+         BufferedImage lBufferedImage =
+                           new BufferedImage(pWidth,
+                                             pHeight,
+                                             BufferedImage.TYPE_INT_ARGB);
+         lBufferedImage.setRGB(0,
+                                0,
+                                pWidth,
+                                pHeight,
+                                lPixelInts,
                             0,
                             pWidth);
-      
-      return lBufferedImage;
-      
-   } catch (final Throwable e)
-   {
-      e.printStackTrace();
-   }
+         return lBufferedImage;
+      } catch (final Throwable e) {
+         e.printStackTrace();
+      }
     
-   return null;
- }
+      return null;
+   }
 }

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/slider/RangeSlider.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/slider/RangeSlider.java
@@ -1,10 +1,9 @@
-/**
- * @author ernieyu
- * https://github.com/ernieyu/Swing-range-slider
- * @license MIT
- */     
-package edu.ucsf.valelab.mmclearvolumeplugin.slider;
 
+// @author ernieyu
+//https://github.com/ernieyu/Swing-range-slider
+//@license MIT
+
+package edu.ucsf.valelab.mmclearvolumeplugin.slider;
 
 
 import javax.swing.JSlider;
@@ -20,93 +19,97 @@ import javax.swing.JSlider;
  */
 public class RangeSlider extends JSlider {
 
-    /**
+   /**
      * Constructs a RangeSlider with default minimum and maximum values of 0
      * and 100.
      */
-    public RangeSlider() {
-        initSlider();
-    }
+   public RangeSlider() {
+      initSlider();
+   }
 
-    /**
-     * Constructs a RangeSlider with the specified default minimum and maximum 
-     * values.
+   /**
+    * Constructs a RangeSlider with the specified default minimum and maximum
+    * values.
+    *
     * @param min minimum value of the new RangeSlider
     * @param max maximum value of the new RangeSlider
      */
-    public RangeSlider(int min, int max) {
-        super(min, max);
-        initSlider();
-    }
+   public RangeSlider(int min, int max) {
+      super(min, max);
+      initSlider();
+   }
 
-    /**
+   /**
      * Initializes the slider by setting default properties.
      */
-    private void initSlider() {
-        setOrientation(HORIZONTAL);
-    }
+   private void initSlider() {
+      setOrientation(HORIZONTAL);
+   }
 
-    /**
+   /**
      * Overrides the superclass method to install the UI delegate to draw two
      * thumbs.
      */
-    @Override
-    public void updateUI() {
-        setUI(new RangeSliderUI(this));
-        // Update UI for slider labels.  This must be called after updating the
-        // UI of the slider.  Refer to JSlider.updateUI().
-        updateLabelUIs();
-    }
+   @Override
+   public void updateUI() {
+      setUI(new RangeSliderUI(this));
+      // Update UI for slider labels.  This must be called after updating the
+      // UI of the slider.  Refer to JSlider.updateUI().
+      updateLabelUIs();
+   }
 
-    /**
-     * Returns the lower value in the range.
+   /**
+    * Returns the lower value in the range.
+    *
     * @return lower value in the range
-     */
-    @Override
-    public int getValue() {
-        return super.getValue();
-    }
+    */
+   @Override
+   public int getValue() {
+      return super.getValue();
+   }
 
-    /**
-     * Sets the lower value in the range.
+   /**
+    * Sets the lower value in the range.
+    *
     * @param value The new lower value in the range
-     */
-    @Override
-    public void setValue(int value) {
-        int oldValue = getValue();
-        if (oldValue == value) {
-            return;
-        }
+    */
+   @Override
+   public void setValue(int value) {
+      int oldValue = getValue();
+      if (oldValue == value) {
+         return;
+      }
 
-        // Compute new value and extent to maintain upper value.
-        int oldExtent = getExtent();
-        int newValue = Math.min(Math.max(getMinimum(), value), oldValue + oldExtent);
-        int newExtent = oldExtent + oldValue - newValue;
+      // Compute new value and extent to maintain upper value.
+      int oldExtent = getExtent();
+      int newValue = Math.min(Math.max(getMinimum(), value), oldValue + oldExtent);
+      int newExtent = oldExtent + oldValue - newValue;
 
-        // Set new value and extent, and fire a single change event.
-        getModel().setRangeProperties(newValue, newExtent, getMinimum(), 
-            getMaximum(), getValueIsAdjusting());
-    }
+      // Set new value and extent, and fire a single change event.
+      getModel().setRangeProperties(newValue, newExtent, getMinimum(), getMaximum(),
+              getValueIsAdjusting());
+   }
 
-    /**
-     * Returns the upper value in the range.
+   /**
+    * Returns the upper value in the range.
+    *
     * @return Upper value in the range
-     */
-    public int getUpperValue() {
-        return getValue() + getExtent();
-    }
+    */
+   public int getUpperValue() {
+      return getValue() + getExtent();
+   }
 
-    /**
-     * Sets the upper value in the range.
+   /**
+    * Sets the upper value in the range.
+    *
     * @param value New upper value in the range
-     */
-    public void setUpperValue(int value) {
-        // Compute new extent.
-        int lowerValue = getValue();
-        int newExtent = Math.min(Math.max(0, value - lowerValue), getMaximum() - lowerValue);
-        
-        // Set extent to set upper value.
-        setExtent(newExtent);
-    }
-}
+    */
+   public void setUpperValue(int value) {
+      // Compute new extent.
+      int lowerValue = getValue();
+      int newExtent = Math.min(Math.max(0, value - lowerValue), getMaximum() - lowerValue);
 
+      // Set extent to set upper value.
+      setExtent(newExtent);
+   }
+}

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/slider/RangeSliderDemo.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/slider/RangeSliderDemo.java
@@ -7,7 +7,6 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-
 import javax.swing.BorderFactory;
 import javax.swing.JFrame;
 import javax.swing.JLabel;


### PR DESCRIPTION
Initial brightness-contrast has always been confusing with the ClearVolume viewer.  Things were worse with an image with max brightness of 4096.  Now always relates max and min to the maximum value of the pixel (i.e. 255 or 65535) rather than the max intensity delivered by the camera.  That behaves a whole lot netter.  Also linted the code.  