### PR TITLE
Avoid moving C++ build dir in Windows Ant build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,7 +18,7 @@
 				<property name="mm.java.autofocus.installdir" value="${mm.java.autofocus.installdir}"/>
 				<filelist dir="${mm.basedir}">
 					<!-- Note: Order matters -->
-					<file name="${mm.cpp.srcdir}/MMCoreJ_wrap/build.xml"/>
+					<file name="${mm.cpp.basedir}/MMCoreJ_wrap/build.xml"/>
 					<file name="mmstudio/build.xml"/>
 					<file name="acqEngine/build.xml"/>
 					<file name="libraries/build.xml"/>
@@ -35,7 +35,7 @@
 	</target>
 
 	<target name="build-cpp" description="Build all C++ components">
-		<mm-msbuild project="${mm.cpp.srcdir}/micromanager.sln" target="Build" failonerror="${mm.build.failonerror}"
+		<mm-msbuild project="${mm.cpp.basedir}/micromanager.sln" target="Build" failonerror="${mm.build.failonerror}"
 			logbasename="msbuild-micromanager${mm.build.logsuffix}"/>
 	</target>
 
@@ -58,7 +58,7 @@
 				<copy todir="${mm.dll.installdir}">
 					<fileset dir="${mm.cpp.outdir}" includes="mmgr_dal_*.dll"/>
 				</copy>
-				<ant antfile="${mm.cpp.srcdir}/DeviceAdapters/build.xml" useNativeBasedir="true" target="install">
+				<ant antfile="${mm.cpp.basedir}/DeviceAdapters/build.xml" useNativeBasedir="true" target="install">
 					<property name="mm.dll.installdir" value="${mm.dll.installdir}"/>
 					<property name="mm.dll.helper.installdir" value="${mm.dll.helper.installdir}"/>
 				</ant>
@@ -190,26 +190,31 @@
 	</target>
 
 	<target name="clean-swig">
-		<!-- Delete SWIG-generated source
+		<!-- Delete SWIG-generated files not covered by clean-cpp
 		     Sorry for the hard-coding, but even running the Clean
 		     target using MSBuild doesn't seem to delete these. -->
-		<delete file="${mm.cpp.srcdir}/MMCoreJ_wrap/MMCoreJ_wrap.cpp"/>
-		<delete file="${mm.cpp.srcdir}/MMCoreJ_wrap/MMCoreJ_wrap.h"/>
-		<delete dir="${mm.basedir}/build/intermediates/Swig"/>
+		<delete file="${mm.cpp.basedir}/MMCoreJ_wrap/MMCoreJ_wrap.cxx"/>
+		<delete file="${mm.cpp.basedir}/MMCoreJ_wrap/MMCoreJ_wrap.h"/>
+		<delete dir="${mm.swig.javasrcdir}"/>
+	</target>
+
+	<target name="clean-cpp" depends="clean-swig" description="Clean only the C++ components">
+		<delete dir="${mm.cpp.outdir}"/>
+		<delete dir="${mm.cpp.intdir}"/>
 	</target>
 
 	<target name="clean-java" description="Clean only the Java components">
 		<run-all-java-projects target="clean"/>
 	</target>
 
-	<target name="clean" depends="clean-swig,clean-java" description="Delete build intermediate and output files">
-		<delete dir="${mm.cpp.outdir}"/>
-		<delete dir="${mm.cpp.intdir}"/>
+	<target name="clean" depends="clean-cpp,clean-java" description="Delete build intermediate and output files">
 	</target>
 
-	<target name="clean-all" depends="clean-swig" description="Delete build files for all configurations and architectures">
+	<target name="clean-all" depends="clean-cpp" description="Delete build files for all configurations and architectures">
+		<!-- Skip clean-java (which is slow and redundant here) -->
 		<delete dir="${mm.outdir}"/>
 		<delete dir="${mm.intdir}"/>
+		<delete dir="${mm.cpp.basedir}/build"/>
 	</target>
 
 	<target name="unstage" description="Delete staged files">

--- a/buildscripts/Ant/unixprops.xml
+++ b/buildscripts/Ant/unixprops.xml
@@ -12,12 +12,12 @@
 	<property name="mm.tmpdir" location="${mm.basedir}"/>
 
 	<!-- C++ artifacts used during build -->
-	<property name="mm.build.java.library.path" location="${mm.basedir}/MMCoreJ_wrap/.libs"/>
+	<property name="mm.build.java.library.path" location="${mm.cpp.basedir}/MMCoreJ_wrap/.libs"/>
 
 	<!-- Java artifacts -->
 	<property name="mm.java.lib.AntExtensions"
 		location="${mm.basedir}/buildscripts/AntExtensions/AntExtensions.jar"/>
-	<property name="mm.java.lib.mmcorej" location="${mm.cpp.srcdir}/MMCoreJ_wrap/MMCoreJ.jar"/>
+	<property name="mm.java.lib.mmcorej" location="${mm.cpp.basedir}/MMCoreJ_wrap/MMCoreJ.jar"/>
 	<property name="mm.java.lib.mmstudio" location="${mm.basedir}/mmstudio/MMJ_.jar"/>
 	<property name="mm.java.lib.acq-engine" location="${mm.basedir}/acqEngine/MMAcqEngine.jar"/>
 

--- a/buildscripts/Ant/windowsprops.xml
+++ b/buildscripts/Ant/windowsprops.xml
@@ -41,8 +41,8 @@
 	<property name="mm.tmpdir" location="${mm.intdir}"/>
 
 	<!-- C++ components -->
-	<property name="mm.cpp.intdir" location="${mm.intdir}/${mm.configuration}/${mm.architecture}"/>
-	<property name="mm.cpp.outdir" location="${mm.outdir}/${mm.configuration}/${mm.architecture}"/>
+	<property name="mm.cpp.intdir" location="${mm.cpp.basedir}/build/intermediates/${mm.configuration}/${mm.architecture}"/>
+	<property name="mm.cpp.outdir" location="${mm.cpp.basedir}/build/${mm.configuration}/${mm.architecture}"/>
 	<if>
 		<istrue value="${mm.build.for.imagej2updater}"/>
 		<then>
@@ -55,14 +55,13 @@
 	<property name="mm.dll.helper.installdir" location="${mm.dll.installdir}"/>
 
 	<!-- C++ DLLs matching the build system architecture -->
-	<property name="mm.build.cpp.outdir" location="${mm.outdir}/${mm.configuration}/${mm.build.architecture}"/>
+	<property name="mm.build.cpp.outdir" location="${mm.cpp.basedir}/build/${mm.configuration}/${mm.build.architecture}"/>
 
 	<!-- Only include demo device adapter -->
 	<property name="mm.build.stage.demo.only" value="false"/>
 
 	<!-- Swig output -->
-	<property name="mm.swig.javasrcdir" location="${mm.intdir}/Swig"/>
-	<property name="mm.swig.pysrcdir" location="${mm.outdir}/Swig"/>
+	<property name="mm.swig.javasrcdir" location="${mm.cpp.basedir}/build/intermediates/Swig"/>
 
 	<!-- C++ artifacts used during build (architecture matches build system) -->
 	<property name="mm.build.java.library.path" location="${mm.build.cpp.outdir}"/>
@@ -134,7 +133,7 @@
 
 			<local name="msbuild.params"/>
 			<property name="msbuild.params"
-				value="@{project} /t:@{target} /p:Configuration=${mm.configuration} /p:Platform=${mm.architecture} /p:MM_BUILDDIR=${mm.outdir} /v:@{verbosity} /flp:LogFile=${msbuild.log} ${msbuild.flag.parallel}"/>
+				value="@{project} /t:@{target} /p:Configuration=${mm.configuration} /p:Platform=${mm.architecture} /v:@{verbosity} /flp:LogFile=${msbuild.log} ${msbuild.flag.parallel}"/>
 
 			<!-- Find the bat file that activates the Visual Studio environment -->
 			<local name="vsDevCmdBat"/>

--- a/buildscripts/buildprops.xml
+++ b/buildscripts/buildprops.xml
@@ -1,7 +1,7 @@
 <project name="mm.props">
 	<!-- Path of repository root, from the project basedir -->
 	<dirname property="mm.basedir" file="${ant.file.mm.props}/.."/>
-	<property name="mm.cpp.srcdir" value="${mm.basedir}/mmCoreAndDevices"/>
+	<property name="mm.cpp.basedir" value="${mm.basedir}/mmCoreAndDevices"/>
 
 	<!-- Get classpaths of retrieved JARs -->
 	<include file="fetchdeps.xml"/>


### PR DESCRIPTION
Let C++ components, including SWIG-generated sources, build where they normally do when built from Visual Studio, instead of forcing to `build/` outside of `mmCoreAndDevices/`.

This means that `ant jar` in `mmCoreAndDevices/MMCoreJ_wrap` should work after building `MMCoreJ_wrap` in Visual Studio.

Added Ant target `clean-cpp`. Fixed all clean targets.

Closes micro-manager/mmCoreAndDevices#255.