### PR TITLE
macOS build: make work when version.txt has newline

### DIFF
--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -62,7 +62,7 @@ export SDKROOT=$MM_MACOSX_SDKROOT
 cd $MM_SRCDIR
 
 if [ -z "$MM_VERSION" ]; then
-   MM_VERSION="$(cat version.txt)"
+   MM_VERSION="$(cat version.txt | tr -d '[\r\n]')"
    # Include date unless release build; use US Pacific _Standard_ Time.
    # Note that POSIX TZ has the sign inverted comapred to the usual GMT-8.
    [ "$use_release_version" = yes ] || MM_VERSION="$MM_VERSION-$(TZ=Etc/GMT+8 date +%Y%m%d)"


### PR DESCRIPTION
This hasn't been a problem in the Jenkins builds because there we overwrite version.txt before running this build script.

`version.txt` used to be maintained without a trailing newline, but now contains CRLF; let's make it work either way.