### PR TITLE
Emu: Prevent exception when using WindowBuilder

### DIFF
--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/ConfigurableMainFrame.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/ui/ConfigurableMainFrame.java
@@ -169,7 +169,12 @@ public abstract class ConfigurableMainFrame extends JFrame implements Configurab
       }
       this.setIconImages(lst);
 
-      WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      // allow using ConfigurableMainFrame outside Micro-Manager (e.g. Eclipse WindowBuilder)
+      try {
+         WindowPositioning.setUpBoundsMemory(this, this.getClass(), null);
+      } catch (NullPointerException e){
+         // do nothing
+      }
    }
 
    private ArrayList<ConfigurablePanel> listConfigurablePanels(Component[] c,


### PR DESCRIPTION
A recent commit (https://github.com/micro-manager/micro-manager/commit/92641596a6fb5f1022907251bdef5f23b70ef811) leads to an error when trying to use Emu outside of MM, for instance with Eclipse WindowBuilder ([example on image.sc](https://forum.image.sc/t/error-creating-configurablemainframe-emu-micromanager/72665/6)).

This fix catches the exception and solves the issue.



