### PR TITLE
Remove Boost from toplevel configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,15 +20,6 @@ MM_GMOCK([$srcdir/testing/googletest], [\$(top_srcdir)/testing/googletest])
 AM_CONDITIONAL([BUILD_CPP_TESTS], [test "x$have_gmock" = xyes])
 
 
-# Boost
-# TODO Reflect results in configuration
-AX_BOOST_BASE([1.48.0])
-AX_BOOST_DATE_TIME
-AX_BOOST_FILESYSTEM
-AX_BOOST_SYSTEM
-AX_BOOST_THREAD
-
-
 # AppleHost dependencies
 case $host in
    *apple-darwin*) MMCORE_APPLEHOST_LDFLAGS="-framework CoreFoundation -framework IOKit" ;;


### PR DESCRIPTION
We don't need it any more, because MMCore no longer depends on Boost. The DeviceAdapters configure.ac still configures Boost for the device adapters that require it.