### PR TITLE
Add Java code style for IntelliJ IDEA

### DIFF
--- a/buildscripts/codestyle/idea-java-code-style.xml
+++ b/buildscripts/codestyle/idea-java-code-style.xml
@@ -1,0 +1,46 @@
+<code_scheme name="Project" version="173">
+  <JavaCodeStyleSettings>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+      <value />
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+      </value>
+    </option>
+  </JavaCodeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <option name="RIGHT_MARGIN" value="100" />
+    <option name="BLANK_LINES_BEFORE_PACKAGE" value="1" />
+    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="RESOURCE_LIST_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+    <option name="THROWS_KEYWORD_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="ASSERT_STATEMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+    <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
+    <option name="ENUM_CONSTANTS_WRAP" value="1" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="3" />
+      <option name="CONTINUATION_INDENT_SIZE" value="6" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>

--- a/doc/pre-commit.md
+++ b/doc/pre-commit.md
@@ -136,7 +136,11 @@ a lot of manual work.
     (this can be done per project). You might want to set Severity to Warning.
   - Additionally, import the Checkstyle rules into code formatting settings: go
     to `Settings > Editor > Code Style > Java`; from the Gear (⚙️) menu, choose
-    `Import Scheme > Checkstyle Configuration`.
+    `Import Scheme > Checkstyle Configuration`. Then select
+    `buildscripts/codestyle/checkstyle.xml`.
+    - If the import fails in this last step (observed on macOS), you can
+      instead use `Import Scheme > IntelliJ IDEA code style XML` and import
+      `buildscripts/codestyle/idea-java-code-style.xml`.
 
 - Eclipse has a [Checkstyle plugin](https://checkstyle.org/eclipse-cs/)
 


### PR DESCRIPTION
I think this may provide a practical short-term fix for #1509 (pending feedback), for IntelliJ IDEA only.

The file added here (`buildscripts/codestyle/idea-java-code-style.xml`) is exported from IDEA's `Settings > Editor > Code Style > Java`, after having imported code style settings from `checkstyle.xml`. Adding this because import of `checkstyle.xml` into IDEA seems to fail on macOS (#1501) (this export was created on Windows).

It can be imported by going to `Settings > Editor > Code Style > Java`, clicking the Gear next to the Scheme, and selecting `Import Scheme > IntelliJ IDEA code style XML`. (`Settings` is `Preferences` on macOS.)

You probably want to set the Scheme to "Project" (as opposed to "Default") before importing and choose to import into the current scheme when asked. That way the settings will only apply to the current project.

If this works, we can update `doc/pre-commit.md` to refer to this.

The only catch is that it may need regenerating if we change the Checkstyle settings, but I suspect it will be rare that we change the types of settings contained in this file. (And in any case it's not hard to regenerate.)

Cc: @henrypinkard @nicost.