### PR TITLE
Studio: Avoid bugs caused by StorageRAM keeping a reference to anyImage_.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -49,7 +49,6 @@ public final class StorageRAM implements RewritableStorage {
    private Coords maxIndex_;
    private SummaryMetadata summaryMetadata_;
    private final Set<String> axesInUse_;
-   private Image anyImage_;
 
    /**
     * Image Data Storage located in RAM.
@@ -105,14 +104,10 @@ public final class StorageRAM implements RewritableStorage {
 
    @Override
    public Image getAnyImage() {
-      if (anyImage_ != null) {
-         return anyImage_;
-      }
       synchronized (this) {
          if (coordsToImage_ != null && coordsToImage_.size() > 0) {
             Coords coords = new ArrayList<>(coordsToImage_.keySet()).get(0);
-            anyImage_ = coordsToImage_.get(coords);
-            return anyImage_;
+            return coordsToImage_.get(coords);
          }
       }
       return null;


### PR DESCRIPTION
This caused StoraRAM to hold on to images that were no longer in a (rewriteable) store.  This caused bugs (or at least, unexpected behavior) in code calling `getAnyImage()`.

Closes #1559.