### PR TITLE
Studio: Prevent null pointer exception in SCOPE_DATA_KEYS metadata handling. 

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -1252,13 +1252,15 @@ public enum PropertyKey {
          if (SCOPE_DATA_KEYS.extractFromGsonObject(jo, tmp)) {
             PropertyMap.Builder builder = PropertyMaps.builder();
             for (String key : tmp.build().getStringList(SCOPE_DATA_KEYS.key())) {
-               String val = "";
-               if (jo.get(key).isJsonObject()) {
-                  val = jo.get(key).getAsJsonObject().get("PropVal").getAsString();
-               } else if (jo.get(key).isJsonPrimitive()) {
-                  val = jo.get(key).getAsString();
+               if (jo.get(key) != null) {
+                  String val = "";
+                  if (jo.get(key).isJsonObject()) {
+                     val = jo.get(key).getAsJsonObject().get("PropVal").getAsString();
+                  } else if (jo.get(key).isJsonPrimitive()) {
+                     val = jo.get(key).getAsString();
+                  }
+                  builder.putString(key, val);
                }
-               builder.putString(key, val);
             }
             dest.putPropertyMap(key(), builder.build());
             return true;


### PR DESCRIPTION
 This code is very difficult to understand (still, after all these years), but I do believe it relied on a side effect.  When the Core no longer inserts the system state cache in tagged image metadata, this code throws a null pointer exception. Keep it in place just in case, but prevent null pointer exceptions.  