### PR TITLE
Studio: Snap/Live now ask GetTaggedImage not to include the System State Cache in the metadata.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -256,6 +256,8 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
          throw new RuntimeException("No camera configured.");
       }
       core.snapImage();
+      boolean includeSystemStateCache = core.getIncludeSystemStateCache();
+      core.setIncludeSystemStateCache(false);
       ArrayList<Image> result = new ArrayList<>();
       for (int c = 0; c < core.getNumberOfCameraChannels(); ++c) {
          TaggedImage tagged = core.getTaggedImage(c);
@@ -265,6 +267,7 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
          temp = temp.copyWith(newCoords, newMetadata);
          result.add(temp);
       }
+      core.setIncludeSystemStateCache(includeSystemStateCache);
       return result;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -259,15 +259,20 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
       boolean includeSystemStateCache = core.getIncludeSystemStateCache();
       core.setIncludeSystemStateCache(false);
       ArrayList<Image> result = new ArrayList<>();
-      for (int c = 0; c < core.getNumberOfCameraChannels(); ++c) {
-         TaggedImage tagged = core.getTaggedImage(c);
-         Image temp = new DefaultImage(tagged);
-         Coords newCoords = temp.getCoords().copyBuilder().channel(c).build();
-         Metadata newMetadata = temp.getMetadata().copyBuilderWithNewUUID().build();
-         temp = temp.copyWith(newCoords, newMetadata);
-         result.add(temp);
+      try {
+         for (int c = 0; c < core.getNumberOfCameraChannels(); ++c) {
+            TaggedImage tagged = core.getTaggedImage(c);
+            Image temp = new DefaultImage(tagged);
+            Coords newCoords = temp.getCoords().copyBuilder().channel(c).build();
+            Metadata newMetadata = temp.getMetadata().copyBuilderWithNewUUID().build();
+            temp = temp.copyWith(newCoords, newMetadata);
+            result.add(temp);
+         }
+      } catch (Exception ex) {
+         studio_.logs().logError(ex);
+      } finally {
+         core.setIncludeSystemStateCache(includeSystemStateCache);
       }
-      core.setIncludeSystemStateCache(includeSystemStateCache);
       return result;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -268,8 +268,6 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
             temp = temp.copyWith(newCoords, newMetadata);
             result.add(temp);
          }
-      } catch (Exception ex) {
-         studio_.logs().logError(ex);
       } finally {
          core.setIncludeSystemStateCache(includeSystemStateCache);
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -384,6 +384,7 @@ public final class SnapLiveManager extends DataViewerListener
       try {
          if (core_.isSequenceRunning()) {
             core_.stopSequenceAcquisition();
+            core_.setIncludeSystemStateCache(includeSystemStateCache_);
          }
          while (core_.isSequenceRunning()) {
             core_.sleep(2);
@@ -392,7 +393,6 @@ public final class SnapLiveManager extends DataViewerListener
          ReportingUtils.showError(e,
                "Failed to stop sequence acquisition. Double-check shutter status.");
       }
-      core_.setIncludeSystemStateCache(includeSystemStateCache_);
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -125,6 +125,8 @@ public final class SnapLiveManager extends DataViewerListener
    // suspended. This gets unexpectedly complicated See setSuspended().
    private int suspendCount_ = 0;
 
+   private boolean includeSystemStateCache_;
+
    private final PerformanceMonitor perfMon_ =
          PerformanceMonitor.createWithTimeConstantMs(1000.0);
    private final PerformanceMonitorUI pmUI_ =
@@ -181,6 +183,7 @@ public final class SnapLiveManager extends DataViewerListener
    public SnapLiveManager(MMStudio mmStudio, CMMCore core) {
       mmStudio_ = mmStudio;
       core_ = core;
+      includeSystemStateCache_ = core_.getIncludeSystemStateCache();
       uiMovesStageManager_ = mmStudio_.getUiMovesStageManager();
       displayInfoLock_ = new Object();
    }
@@ -291,6 +294,8 @@ public final class SnapLiveManager extends DataViewerListener
       }
 
       synchronized (this) {
+         includeSystemStateCache_ = core_.getIncludeSystemStateCache();
+         core_.setIncludeSystemStateCache(false);
          final long liveModeCount = ++liveModeStartCount_;
          final Runnable grab;
          grab = new Runnable() {
@@ -387,6 +392,7 @@ public final class SnapLiveManager extends DataViewerListener
          ReportingUtils.showError(e,
                "Failed to stop sequence acquisition. Double-check shutter status.");
       }
+      core_.setIncludeSystemStateCache(includeSystemStateCache_);
    }
 
    /**


### PR DESCRIPTION
This avoids the superfluous "user" metadata replicating the device state already available under the "device" metadata.