### PR TITLE
Studio: add way to tune extra wait for StageControl Snap after move.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -779,6 +779,9 @@ public final class StageControlFrame extends JFrame {
             core_.waitForDevice(core_.getXYStageDevice());
             // ASI stages report not busy, and then become busy again.  Add an extra wait
             // to avoid motion blur with such stages.
+            // A similar issue (movement during the Snap) is seen with the Nikon Ti2 stage.
+            // That prompted to make the extraWait_ variable settable through static functions.
+            // If all of this can be resolved in the device adapters, this wait could go.
             Thread.sleep(extraWait_);
             studio_.live().snap(true);
          } catch (Exception ex) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -93,7 +93,7 @@ public final class StageControlFrame extends JFrame {
    public static final String SMALL_MOVEMENT_Z = "SMALLMOVEMENTZ";
    public static final String MEDIUM_MOVEMENT_Z = "MEDIUMMOVEMENTZ";
 
-   private static final long EXTRA_WAIT = 100;
+   private static long extraWait_ = 100;
 
    // used to keep track of the "active" Z Drive
    public static final String SELECTED_Z_DRIVE = "SELECTED_Z_DRIVE";
@@ -764,6 +764,14 @@ public final class StageControlFrame extends JFrame {
       return panel;
    }
 
+   public static void setExtraWait(long extraWait) {
+      extraWait_ = extraWait;
+   }
+
+   public static long getExtraWait() {
+      return extraWait_;
+   }
+
    private void setRelativeXYStagePosition(double x, double y) {
       uiMovesStageManager_.getXYNavigator().moveSampleOnDisplayUm(x, y);
       if (settings_.getBoolean(SNAP, false)) {
@@ -771,7 +779,7 @@ public final class StageControlFrame extends JFrame {
             core_.waitForDevice(core_.getXYStageDevice());
             // ASI stages report not busy, and then become busy again.  Add an extra wait
             // to avoid motion blur with such stages.
-            Thread.sleep(EXTRA_WAIT);
+            Thread.sleep(extraWait_);
             studio_.live().snap(true);
          } catch (Exception ex) {
             studio_.logs().showError(ex, "Error while waiting for stage: "


### PR DESCRIPTION
The code had a 100ms wait time to accomodate ASI stages going setting BUsy to false, but then moving again.  A similar problem occurs with Nikon Stages, but they need a longer wait.  We are paving over problems in the device adapters, but at least this gives an easy way for the user to make these nice cabilities usable, wheras it may be very difficult to fix this in the device adapters.  It is interesing, however, that these types of problems do not seem to show up in MDAs, so may be something else is going on.