### PR TITLE
Studio: Fix bug in MpTiffWRiter resulting in many large files.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
@@ -529,7 +529,7 @@ public final class MultipageTiffWriter {
       // If everything went ok, try to split "intelligently", keeping frames together
       if (splitByFrame) {
          size = singleImageBytes * axis1ImagesLeft
-               + singleImageBytes * axis1Size * axis2ImagesLeft
+               + singleImageBytes * axis1Size * (axis2ImagesLeft - 1)
                + SPACE_FOR_COMMENTS + numChannels_ * DISPLAY_SETTINGS_BYTES_PER_CHANNEL
                + extraPadding + filePosition_;
          size += omeMDLength;


### PR DESCRIPTION
Calculation of the expected file size was wrong.  Classis 0 or 1 issue. Closes #1579.