### PR TITLE
HCS: ZStage now is the stage used in 3 point calibration, rather than always the core focus device.

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/ParentPlateGUI.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/ParentPlateGUI.java
@@ -14,6 +14,8 @@ public interface ParentPlateGUI {
 
    String getXYStageName();
 
+   String getZStageName();
+
    boolean useThreePtAF();
 
    PositionList getThreePointList();

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
@@ -272,7 +272,7 @@ public class PlatePanel extends JPanel {
             //wait for the stage to stop moving before updating the gui.
             app_.getCMMCore().waitForDeviceType(DeviceType.XYStageDevice);
             xyStagePos_ = app_.getCMMCore().getXYStagePosition();
-            zStagePos_ = app_.getCMMCore().getPosition(app_.getCMMCore().getFocusDevice());
+            zStagePos_ = app_.getCMMCore().getPosition(gui_.getZStageName());
             gui_.updateStagePositions(xyStagePos_.x, xyStagePos_.y, zStagePos_, well, "undefined");
             refreshStagePosition();
             repaint();
@@ -769,7 +769,7 @@ public class PlatePanel extends JPanel {
       if (app_ != null) {
          try {
             xyStagePos_ = app_.getCMMCore().getXYStagePosition();
-            zStagePos_ = app_.getCMMCore().getPosition(app_.getCMMCore().getFocusDevice());
+            zStagePos_ = app_.getCMMCore().getPosition(gui_.getZStageName());
          } catch (Exception e) {
             throw new HCSException(e);
          }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -777,6 +777,21 @@ public class SiteGenerator extends JFrame implements ParentPlateGUI {
       }
    }
 
+   /**
+    * Returns the Z stage in use by the HCS plugin.
+    * If a 3 point calibration has been carried out, it will return the
+    * Z Stage of the 3 point calibration.  Otherwise, the default Core focusdevice.
+    *
+    * @return Name of the Z stage in use by the HCS plugin.
+    */
+   @Override
+   public String getZStageName() {
+      if (useThreePtAF() && focusPlane_ != null) {
+         return focusPlane_.getZStage();
+      }
+      return studio_.core().getFocusDevice();
+   }
+
    @Override
    public void displayError(String txt) {
       if (studio_ != null) {


### PR DESCRIPTION
Previously, the plugin would sometimes use the ZStage identified in the 3 point calibration, other times the Core Focus device.  This PR ensures that the Z Stage identified in the 3 point calibration will always be used.