### PR TITLE
Duplicator plugin: select any channel, and saves output

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/metadata/PlaneMetadataInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/metadata/PlaneMetadataInspectorPanelController.java
@@ -181,7 +181,7 @@ public final class PlaneMetadataInspectorPanelController extends AbstractInspect
          ReportingUtils.logError(e, "Exception in PlaneMetadataInspectorPanelController");
          return;
       } catch (NullPointerException e) {
-         ReportingUtils.logError("attachDataViewer called on DataViewer without images");
+         ReportingUtils.logDebugMessage("attachDataViewer called on DataViewer without images");
       }
 
       final List<Image> finalImages = images;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/animate/AnimationController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/animate/AnimationController.java
@@ -442,9 +442,13 @@ public final class AnimationController<P> {
       // Wait for cancellation
       try {
          scheduledTickFuture_.get();
-      } catch (ExecutionException | CancellationException e) {
+      } catch (ExecutionException e) {
          ReportingUtils.logError(e);
-      } catch (InterruptedException notUsedByUs) {
+      } catch (CancellationException e) {
+         // nothing to do, we were waiting for this cancellation;
+         ReportingUtils.logDebugMessage(
+               "scheduledTickFuture task cancelled in animationController");
+      } catch (InterruptedException e) {
          Thread.currentThread().interrupt();
       }
       scheduledTickFuture_ = null;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
@@ -37,6 +37,7 @@ import java.awt.geom.Rectangle2D;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.SwingUtilities;
 import net.imglib2.display.ColorTable8;
 import org.micromanager.data.Coords;
 import org.micromanager.data.DataProvider;
@@ -305,6 +306,14 @@ public final class ImageJBridge {
 
    @MustCallOnEDT
    public void mm2ijEnsureDisplayAxisExtents() {
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+               mm2ijEnsureDisplayAxisExtents();
+            }
+         });
+      }
       int newNChannels = getMMNumberOfChannels();
       int newNSlices = getMMNumberOfZSlices();
       int newNFrames = getMMNumberOfTimePoints();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
@@ -306,14 +306,6 @@ public final class ImageJBridge {
 
    @MustCallOnEDT
    public void mm2ijEnsureDisplayAxisExtents() {
-      if (!SwingUtilities.isEventDispatchThread()) {
-         SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-               mm2ijEnsureDisplayAxisExtents();
-            }
-         });
-      }
       int newNChannels = getMMNumberOfChannels();
       int newNSlices = getMMNumberOfZSlices();
       int newNFrames = getMMNumberOfTimePoints();

--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorExecutor.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorExecutor.java
@@ -25,6 +25,7 @@ import ij.gui.Roi;
 import ij.process.ImageProcessor;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.swing.SwingWorker;
@@ -51,6 +52,7 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
    private final String newName_;
    private final Map<String, Integer> mins_;
    private final Map<String, Integer> maxes_;
+   private final LinkedHashMap<String, Boolean> channels_;
    
    /**
     * Performs the actual creation of a new image with reduced content.
@@ -60,17 +62,21 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
     * @param newName - name for the copy
     * @param mins - Map with new (or unchanged) minima for the given axis
     * @param maxes - Map with new (or unchanged) maxima for the given axis
+    * @param channels - Map with names of channels and flag whether or not they should be duplicated
     */
    public DuplicatorExecutor(final Studio studio, 
            final DisplayWindow theWindow, 
            final String newName, 
            final Map<String, Integer> mins,
-           final Map<String, Integer> maxes) {
+           final Map<String, Integer> maxes,
+           final LinkedHashMap<String, Boolean> channels) {
+
       studio_ = studio;
       theWindow_ = theWindow;
       newName_ = newName;
       mins_ = mins;
       maxes_ = maxes;
+      channels_ = channels;
    }
 
    @Override
@@ -92,20 +98,18 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
       for (String axis : oldStore.getAxes()) {
          newSizeCoordsBuilder.index(axis, oldStore.getNextIndex(axis) - 1);
       }
-      SummaryMetadata metadata = oldStore.getSummaryMetadata();
-      List<String> channelNames = metadata.getChannelNameList();
-      if (mins_.containsKey(Coords.CHANNEL)) {
+      SummaryMetadata oldMetadata = oldStore.getSummaryMetadata();
+      List<String> channelNames = oldMetadata.getChannelNameList();
+      if (channels_ != null) {
          List<ChannelDisplaySettings> channelDisplaySettings = new ArrayList<>();
-         int min = mins_.get(Coords.CHANNEL);
-         int max = maxes_.get(Coords.CHANNEL);
          List<String> chNameList = new ArrayList<>();
-         for (int index = min; index <= max; index++) {
-            if (channelNames == null || index >= channelNames.size()) {
-               chNameList.add("channel " + index);
-            } else {
-               chNameList.add(channelNames.get(index));
+         int index = 0;
+         for (Map.Entry<String, Boolean> channel : channels_.entrySet()) {
+            if (channel.getValue()) {
+               chNameList.add(channel.getKey());
                channelDisplaySettings.add(originalDisplaySettings.getChannelSettings(index));
             }
+            index++;
          }
          channelNames = chNameList;
          newDisplaySettingsBuilder.channels(channelDisplaySettings);
@@ -113,6 +117,9 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
       newSizeCoordsBuilder.channel(channelNames.size());
       float  nrToBeCopied = 1;
       for (String axis : oldStore.getAxes()) {
+         if (channels_ != null && channels_.size() > 0) {
+            nrToBeCopied *= channels_.size();
+         }
          if (mins_.containsKey(axis)) {
             int min = mins_.get(axis);
             int max = maxes_.get(axis);
@@ -121,7 +128,7 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
          }
       }
 
-      metadata = metadata.copyBuilder()
+      SummaryMetadata metadata = oldMetadata.copyBuilder()
               .channelNames(channelNames)
               .intendedDimensions(newSizeCoordsBuilder.build())
               .build();
@@ -133,9 +140,22 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
          Iterable<Coords> unorderedImageCoords = oldStore.getUnorderedImageCoords();
          int nrCopied = 0;
          for (Coords oldCoord : unorderedImageCoords) {
-            boolean copy = true;
+            List<String> oldAxes = oldStore.getAxes();
+            boolean copy = !oldAxes.contains(Coords.CHANNEL);
             for (String axis : oldStore.getAxes()) {
-               if (mins_.containsKey(axis) && maxes_.containsKey(axis)) {
+               if (axis.equals(Coords.CHANNEL)) {
+                  int index = 0;
+                  for (Map.Entry<String, Boolean> channel : channels_.entrySet()) {
+                     if (channel.getValue() && oldCoord.getIndex(axis) == index) {
+                        copy = true;
+                        continue;
+                     }
+                     index++;
+                  }
+               }
+            }
+            for (String axis : oldStore.getAxes()) {
+               if (copy && mins_.containsKey(axis) && maxes_.containsKey(axis)) {
                   if (oldCoord.getIndex(axis) < (mins_.get(axis))) {
                      copy = false;
                   }
@@ -147,6 +167,18 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
             if (copy) {
                Coords.CoordsBuilder newCoordBuilder = oldCoord.copyBuilder();
                for (String axis : oldCoord.getAxes()) {
+                  if (axis.equals(Coords.CHANNEL)) {
+                     if (channels_ != null && channels_.size() > 0) {
+                        int chIndex = oldCoord.getIndex(axis);
+                        if (chIndex < oldMetadata.getChannelNameList().size()) {
+                           String channelName = oldMetadata.getChannelNameList().get(chIndex);
+                           if (channelNames.contains(channelName)) {
+                              int newIndex = channelNames.indexOf(channelName);
+                              newCoordBuilder.index(axis, newIndex);
+                           }
+                        }
+                     }
+                  }
                   if (mins_.containsKey(axis)) {
                      newCoordBuilder.index(axis, oldCoord.getIndex(axis) - mins_.get(axis));
                   }
@@ -156,19 +188,6 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
                Image newImgShallow = img.copyAtCoords(newCoords);
                if (roi != null) {
                   ImageProcessor ip = studio_.data().ij().createProcessor(img);
-                  /*
-                  ImageProcessor ip = null;
-                  if (img.getImageJPixelType() == ImagePlus.GRAY8) {
-                     ip = new ByteProcessor(
-                          img.getWidth(), img.getHeight(), (byte[]) img.getRawPixels());
-                  } else 
-                     if (img.getImageJPixelType() == ImagePlus.GRAY16) {
-                        ip = new ShortProcessor(
-                        img.getWidth(), img.getHeight() );
-                        ip.setPixels((short[]) img.getRawPixels());
-                  }
-
-                   */
                   if (ip != null) {
                      ip.setRoi(roi);
                      ImageProcessor copyIp = ip.crop();


### PR DESCRIPTION
Previously, only ranges of axes could be selected.  That proved to be cumbersome when desiring to select a sub-set of channels.  

Also added the ability to save directly to any of the formats supported by MM.