### PR TITLE
Expose abort in AcquisitionManager

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionManager.java
@@ -106,9 +106,9 @@ public interface AcquisitionManager {
    void haltAcquisition();
 
    /**
-    * Stop any ongoing acquisition as soon as possible, without user dialog.
+    * Abort any ongoing acquisition as soon as possible, without user dialog.
     */
-   void stopAcqusition();
+   void abortAcquisition();
 
    /**
     * Load a file containing a SequenceSettings object, and apply the settings

--- a/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionManager.java
@@ -100,9 +100,15 @@ public interface AcquisitionManager {
                                         boolean shouldBlock) throws IllegalThreadStateException;
 
    /**
-    * Halt any ongoing acquisition as soon as possible.
+    * Halt any ongoing acquisition as soon as possible, prompting users with a
+    * dialog for confirmation.
     */
    void haltAcquisition();
+
+   /**
+    * Stop any ongoing acquisition as soon as possible, without user dialog.
+    */
+   void stopAcqusition();
 
    /**
     * Load a file containing a SequenceSettings object, and apply the settings

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -175,7 +175,7 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
    }
 
    @Override
-   public void stopAcqusition() {
+   public void abortAcquisition() {
       getAcquisitionEngine().stop(true);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionManager.java
@@ -174,6 +174,11 @@ public final class DefaultAcquisitionManager implements AcquisitionManager {
       getAcquisitionEngine().abortRequest();
    }
 
+   @Override
+   public void stopAcqusition() {
+      getAcquisitionEngine().stop(true);
+   }
+
    /**
     * Loads acquisition settings from file.
     *


### PR DESCRIPTION
Hi!

This PR simply exposes a `stopAcquisition` method in `AcquisitionManager`, allowing to programmatically stop an acquisition without prompting users with a dialog.

This is following a [problem I ran into](https://forum.image.sc/t/stopping-acquisition-programmatically/79056). Alternatively I thought of making the user dialog optional in the `haltAcquisition` method.

Does this break a particularlogic in the current development of the acquisition engine? Obviously this would require the same method in the AcqEngJ wrapper.

I have not yet tested it, running into some issues downloading the 3rdparty stuff before building MM (hopefully in the next days I'll get it running).