### PR TITLE
Added option to copy to the system clipboard to the export images as displayed gear menu.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ImageExporter.java
@@ -52,7 +52,11 @@ public interface ImageExporter {
        * Output as an ImageJ stack, which will open in a new window; this
        * "format" does not create any files on disk.
        */
-      OUTPUT_IMAGEJ
+      OUTPUT_IMAGEJ,
+      /**
+       * Output to the System Clipboard, will only work for a single image
+       */
+      OUTPUT_CLIPBOARD
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/CopyAsDisplayed.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/CopyAsDisplayed.java
@@ -1,0 +1,49 @@
+package org.micromanager.display.internal.displaywindow;
+
+import java.awt.event.ActionEvent;
+import java.io.IOException;
+import javax.swing.AbstractAction;
+import org.micromanager.Studio;
+import org.micromanager.data.Coords;
+import org.micromanager.display.ImageExporter;
+import org.micromanager.display.internal.gearmenu.DefaultImageExporter;
+
+/**
+ * Utility that copies the current image as displayed to the System Clipboard.
+ * Initialized by the DisplayUIController.
+ */
+public class CopyAsDisplayed extends AbstractAction {
+   private final Studio studio_;
+   private final DisplayUIController displayUIController_;
+
+   /**
+    * Constructor, gets access to Studio and the DisplayUIController
+    * (from which it uses the DisplayController).
+    *
+    * @param studio Used for logging
+    * @param displayUIController DisplayUIController owns the RootPane, and
+    *                            has access to the DisplayController.
+    */
+   public CopyAsDisplayed(Studio studio, DisplayUIController displayUIController) {
+      studio_ = studio;
+      displayUIController_ = displayUIController;
+   }
+
+   @Override
+   public void actionPerformed(ActionEvent e) {
+      ImageExporter exporter = new DefaultImageExporter(studio_.getLogManager());
+      exporter.setOutputFormat(ImageExporter.OutputFormat.OUTPUT_CLIPBOARD);
+      exporter.setDisplay(displayUIController_.getDisplayController());
+      Coords displayedImage = displayUIController_.getDisplayController().getDisplayPosition();
+      for (String axis : displayUIController_.getDisplayController().getDataProvider().getAxes()) {
+         exporter.loop(axis, displayedImage.getIndex(axis), displayedImage.getIndex(axis));
+      }
+      try {
+         exporter.export();
+      } catch (IOException | IllegalArgumentException exc) {
+         studio_.logs().logError(exc, "MMKeyDispatcher: error should never happen");
+      }
+   }
+
+
+}

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -32,6 +32,7 @@ import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -61,8 +62,10 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
+import javax.swing.JRootPane;
 import javax.swing.JSpinner;
 import javax.swing.JToggleButton;
+import javax.swing.KeyStroke;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
@@ -309,6 +312,12 @@ public final class DisplayUIController implements Closeable, WindowListener,
          frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
       }
       setTitle(frame);
+      JRootPane rootPane = frame.getRootPane();
+      String copyText = "Copy";
+      KeyStroke copyKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_C,
+            Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
+      rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(copyKeyStroke, copyText);
+      rootPane.getActionMap().put(copyText, new CopyAsDisplayed(studio_, this));
       return frame;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/DefaultImageExporter.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/DefaultImageExporter.java
@@ -27,6 +27,10 @@ import ij.ImageStack;
 import ij.process.ColorProcessor;
 import java.awt.Dimension;
 import java.awt.Graphics;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -247,6 +251,9 @@ public final class DefaultImageExporter implements ImageExporter {
                            currentImage_.getHeight());
                   }
                   addToStack(stack_, currentImage_);
+               } else if (format_ == OutputFormat.OUTPUT_CLIPBOARD) {
+                  TransferableImage transferable = new TransferableImage(currentImage_);
+                  Toolkit.getDefaultToolkit().getSystemClipboard().setContents(transferable, null);
                } else {
                   // Save the image to disk in appropriate format.
                   String label = createImageLabel(lastDrawnCoords_);
@@ -342,7 +349,7 @@ public final class DefaultImageExporter implements ImageExporter {
          // Nothing to do.
          return coords;
       }
-      if (format_ != OutputFormat.OUTPUT_IMAGEJ) {
+      if (format_ == OutputFormat.OUTPUT_JPG || format_ == OutputFormat.OUTPUT_PNG) {
          if (directory_ == null || prefix_ == null) {
             // Can't save.
             throw new IllegalArgumentException(String.format(
@@ -380,7 +387,7 @@ public final class DefaultImageExporter implements ImageExporter {
     * @return directory/prefixlabel.suffix
     */
    private String getOutputFilename(String label) {
-      if (format_ == OutputFormat.OUTPUT_IMAGEJ) {
+      if (format_ == OutputFormat.OUTPUT_IMAGEJ || format_ == OutputFormat.OUTPUT_CLIPBOARD) {
          throw new RuntimeException("Asked for output filename when exporting in ImageJ format.");
       }
       String suffix = (format_ == OutputFormat.OUTPUT_PNG) ? "png" : "jpg";
@@ -521,6 +528,40 @@ public final class DefaultImageExporter implements ImageExporter {
    public void waitForExport() throws InterruptedException {
       while (!doneFlag_.get()) {
          Thread.sleep(100);
+      }
+   }
+
+   private class TransferableImage implements Transferable {
+      private java.awt.Image img;
+
+      public TransferableImage(java.awt.Image i) {
+         this.img = i;
+      }
+
+      public Object getTransferData(DataFlavor flavor)
+            throws UnsupportedFlavorException, IOException {
+         if (flavor.equals(DataFlavor.imageFlavor) && img != null)  {
+            return img;
+         } else {
+            throw new UnsupportedFlavorException(flavor);
+         }
+      }
+
+      public DataFlavor[] getTransferDataFlavors() {
+         DataFlavor[] flavors = new DataFlavor[ 1 ];
+         flavors[ 0 ] = DataFlavor.imageFlavor;
+         return flavors;
+      }
+
+      public boolean isDataFlavorSupported(DataFlavor flavor) {
+         DataFlavor[] flavors = getTransferDataFlavors();
+         for (int i = 0; i < flavors.length; i++) {
+            if (flavor.equals(flavors[i])) {
+               return true;
+            }
+         }
+
+         return false;
       }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
@@ -78,8 +78,9 @@ public final class ExportMovieDlg extends JDialog {
    private static final String FORMAT_PNG = "PNG";
    private static final String FORMAT_JPEG = "JPEG";
    private static final String FORMAT_IMAGEJ = "ImageJ stack window";
+   private static final String FORMAT_SYSTEM_CLIPBOARD = "System Clipboard";
    private static final String[] OUTPUT_FORMATS = {
-         FORMAT_PNG, FORMAT_JPEG, FORMAT_IMAGEJ
+         FORMAT_PNG, FORMAT_JPEG, FORMAT_IMAGEJ, FORMAT_SYSTEM_CLIPBOARD
    };
    private static final String DEFAULT_USE_LABEL = "Use Label";
    private static final Boolean USE_LABEL = true;
@@ -385,6 +386,8 @@ public final class ExportMovieDlg extends JDialog {
          suffix = "jpg";
       } else if (mode.contentEquals(FORMAT_IMAGEJ)) {
          format = ImageExporter.OutputFormat.OUTPUT_IMAGEJ;
+      } else if (mode.contentEquals(FORMAT_SYSTEM_CLIPBOARD)) {
+         format = ImageExporter.OutputFormat.OUTPUT_CLIPBOARD;
       }
       String[] fss = {suffix};
       exporter.setOutputFormat(format);
@@ -402,7 +405,7 @@ public final class ExportMovieDlg extends JDialog {
                .getString(EXPORT_LOCATION, base);
       }
       File path = new File(base);
-      if (!mode.equals(FORMAT_IMAGEJ)) {
+      if (mode.equals(FORMAT_JPEG) || mode.equals(FORMAT_PNG)) {
          File outputDir = FileDialogs.promptForFile(this,
                "Export as",
                path,

--- a/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/gearmenu/ExportMovieDlg.java
@@ -265,6 +265,11 @@ public final class ExportMovieDlg extends JDialog {
       display_ = display;
       provider_ = display.getDataProvider();
       axisPanels_ = new ArrayList<>();
+      AxisPanel ap = null;
+      if (!getNonZeroAxes().isEmpty()) {
+         ap = createAxisPanel();
+      }
+      final AxisPanel axisPanel = ap;
 
       File file = new File(display.getName());
       String shortName = file.getName();
@@ -288,6 +293,7 @@ public final class ExportMovieDlg extends JDialog {
 
       jpegQualitySpinner_ = new JSpinner();
       jpegQualitySpinner_.setModel(new SpinnerNumberModel(getJPEGQuality(), 1, 100, 1));
+      final JCheckBox useLabel = new JCheckBox("Use label in filename");
 
       contentsPanel_.add(new JLabel("Output format: "),
             "split 4, flowx");
@@ -301,8 +307,19 @@ public final class ExportMovieDlg extends JDialog {
          } else {
             jpegPanel_.removeAll();
          }
-         prefixLabel_.setEnabled(!selection.equals(FORMAT_IMAGEJ));
-         prefixText_.setEnabled(!selection.equals(FORMAT_IMAGEJ));
+         boolean usePrefix = selection.equals(FORMAT_PNG) || selection.equals(FORMAT_JPEG);
+         prefixLabel_.setEnabled(usePrefix);
+         prefixLabel_.setVisible(usePrefix);
+         prefixText_.setEnabled(usePrefix);
+         prefixText_.setVisible(usePrefix);
+         useLabel.setVisible(usePrefix);
+         if (axisPanel != null) {
+            if (selection.equals(FORMAT_SYSTEM_CLIPBOARD)) {
+               axisPanel.setVisible(false);
+            } else {
+               axisPanel.setVisible(true);
+            }
+         }
          pack();
       });
       contentsPanel_.add(outputFormatSelector_);
@@ -324,7 +341,7 @@ public final class ExportMovieDlg extends JDialog {
                new JLabel("There is only one image available to export."),
                "align center");
       } else {
-         contentsPanel_.add(createAxisPanel());
+         contentsPanel_.add(axisPanel);
       }
 
       // Dropdown menu with all axes (except channel when in composite mode)
@@ -335,7 +352,6 @@ public final class ExportMovieDlg extends JDialog {
       // for single-axis datasets just auto-fill the one axis
       // Future req: add ability to export to ImageJ as RGB stack
 
-      JCheckBox useLabel = new JCheckBox("Use label in filename");
       useLabel.setSelected(studio.profile().getSettings(ExportMovieDlg.class)
             .getBoolean(DEFAULT_USE_LABEL, USE_LABEL));
       ChangeListener changeListener = new ChangeListener() {
@@ -432,7 +448,13 @@ public final class ExportMovieDlg extends JDialog {
 
       exporter.setOutputQuality((Integer) jpegQualitySpinner_.getValue());
       exporter.setDisplay(display_);
-      if (axisPanels_.size() > 0) {
+      if (mode.contentEquals(FORMAT_SYSTEM_CLIPBOARD)) {
+         // only copy the currently displayed image, do not loop
+         Coords displayedImage = display_.getDisplayPosition();
+         for (String axis : display_.getDataProvider().getAxes()) {
+            exporter.loop(axis, displayedImage.getIndex(axis), displayedImage.getIndex(axis));
+         }
+      } else if (axisPanels_.size() > 0) {
          axisPanels_.get(0).configureExporter(exporter);
       } else {
          exporter.loop(provider_.getAxes().get(0), 0, 0);

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -157,7 +157,7 @@ public final class MainFrame extends JFrame {
       setupWindowHandlers();
 
       // Add our own keyboard manager that handles Micro-Manager shortcuts
-      MMKeyDispatcher mmKD = new MMKeyDispatcher();
+      MMKeyDispatcher mmKD = new MMKeyDispatcher(mmStudio_);
       KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(mmKD);
       DropTarget dropTarget = new DropTarget(this, new DragDropUtil(mmStudio_));
 

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/MMKeyDispatcher.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/MMKeyDispatcher.java
@@ -92,34 +92,6 @@ public final class MMKeyDispatcher implements KeyEventDispatcher {
       if (ke.getID() != KeyEvent.KEY_PRESSED) {
          return false;
       }
-      // we use Ctrl-C to copy the active image to the clipboard
-      if (ke.isControlDown() && ke.getKeyCode() == 67) {
-         DataViewer activeDataViewer = studio_.displays().getActiveDataViewer();
-         // We would like to know if the activeDataViewer has focus, not sure if this
-         // does the trick
-         if (activeDataViewer != null
-               && activeDataViewer.isVisible()
-               && activeDataViewer instanceof DisplayWindow)  {
-            DisplayWindow dw = (DisplayWindow) activeDataViewer;
-            if (dw.getWindow().isFocused()) {
-               System.out.println(ke.getKeyChar());
-               System.out.println(ke.getKeyCode());
-               ImageExporter exporter = new DefaultImageExporter(studio_.getLogManager());
-               exporter.setOutputFormat(ImageExporter.OutputFormat.OUTPUT_CLIPBOARD);
-               exporter.setDisplay(dw);
-               Coords displayedImage = activeDataViewer.getDisplayPosition();
-               for (String axis : activeDataViewer.getDataProvider().getAxes()) {
-                  exporter.loop(axis, displayedImage.getIndex(axis), displayedImage.getIndex(axis));
-               }
-               try {
-                  exporter.export();
-               } catch (IOException | IllegalArgumentException exc) {
-                  studio_.logs().logError(exc, "MMKeyDispatcher: error should never happen");
-               }
-            }
-         }
-      }
-
       // Since all key events in the application go through here
       // we need to efficiently determine whether or not to deal with this
       // key event will be dealt with.  CheckSource seems relatively expensive


### PR DESCRIPTION
In addition, pressing Ctrl-c in a display window will now copy the currently displayed image to the system clipboard.  This code is in MMKeydispatcher, which is no super elegant.  Suggestions for a better place are welcome, however, copying the currently displayed image with a key combination is super useful.

