### PR TITLE
Studio: ConfigChangedCallback: add constructor that

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
@@ -109,7 +109,7 @@ public final class CoreEventCallback extends MMEventCallback {
       } else {
          // see OnPropertyChanged for reasons to run this on the EDT
          SwingUtilities.invokeLater(() -> studio_.events().post(
-               new DefaultConfigGroupChangedEvent(groupName, newConfig)));
+               new DefaultConfigGroupChangedEvent(studio_, groupName, newConfig)));
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/events/internal/DefaultConfigGroupChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/DefaultConfigGroupChangedEvent.java
@@ -1,5 +1,6 @@
 package org.micromanager.events.internal;
 
+import org.micromanager.Studio;
 import org.micromanager.events.ConfigGroupChangedEvent;
 
 /**
@@ -14,6 +15,18 @@ public class DefaultConfigGroupChangedEvent implements ConfigGroupChangedEvent {
    public DefaultConfigGroupChangedEvent(String groupName, String newConfig) {
       groupName_ = groupName;
       newConfig_ = newConfig;
+   }
+
+   public DefaultConfigGroupChangedEvent(Studio studio, String groupName, String newConfig) {
+      groupName_ = groupName;
+      String config  = newConfig;
+      // check config with core cache.  It may have changed after this callback landed on the EDT:
+      try {
+         config = studio.core().getCurrentConfigFromCache(groupName);
+      } catch (Exception e) {
+         studio.logs().logError(e, "Exception in constructor of DefaultConfigGroupChangedEvent.");
+      }
+      newConfig_ = config;
    }
 
    /**


### PR DESCRIPTION
checks with the core cache what the current config is.  This is a cheap call, and avoids stale callbacks overwriting the actual state.