### PR TITLE
HCS plugin: Fix problems in load save calibration code.

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -178,10 +178,14 @@ public class CalibrationFrame extends JFrame {
             if (loadCalibration != null) {
                try {
                   PropertyMap propertyMap = PropertyMaps.loadJSON(loadCalibration);
-                  if (propertyMap.containsDouble(OFFSETX) && propertyMap.containsDouble(OFFSETY)) {
+                  if (propertyMap.containsDouble(OFFSETX) && propertyMap.containsDouble(OFFSETY)
+                           && propertyMap.containsString(calibrationMethod)) {
                      Point2D.Double offset = new Point2D.Double(propertyMap.getDouble(OFFSETX, 0.0),
                            propertyMap.getDouble(OFFSETY, 0.0));
                      siteGenerator.applyOffset(offset);
+                     settings.putString(calibrationMethod, propertyMap.getString(
+                           calibrationMethod, calibrationRecommended));
+                     siteGenerator.finishCalibration(offset);
                      this.dispose();
                   }
                } catch (IOException ioe) {
@@ -198,6 +202,8 @@ public class CalibrationFrame extends JFrame {
             DefaultPropertyMap.Builder builder = new DefaultPropertyMap.Builder();
             builder.putDouble(OFFSETX, offset.getX());
             builder.putDouble(OFFSETY, offset.getY());
+            builder.putString(calibrationMethod,
+                  settings.getString(calibrationMethod, calibrationRecommended));
             File saveCalibration = FileDialogs.save(this, "Save calibration", OFFSET_FILE);
             if (saveCalibration != null) {
                try {


### PR DESCRIPTION
Previous code did not actually apply the offset to user's settings.  This also adds the calibration method.  Saving and loading calibrations remains tricky, but in the absence of a more general mechanism to share certain settings between profiles, I am not quite sure what would be better.