### PR TITLE
Revert "Allow explore acquisition to zoom before data"

### DIFF
--- a/plugins/Magellan/src/main/java/org/micromanager/magellan/internal/magellanacq/MagellanAcqUIAndStorage.java
+++ b/plugins/Magellan/src/main/java/org/micromanager/magellan/internal/magellanacq/MagellanAcqUIAndStorage.java
@@ -333,11 +333,6 @@ public class MagellanAcqUIAndStorage
    }
 
    @Override
-   public void increaseMaxResolutionLevel(int newMaxResolutionLevel) {
-      storage_.increaseMaxResolutionLevel(newMaxResolutionLevel);
-   }
-
-   @Override
    public String getDiskLocation() {
       return storage_.getDiskLocation();
    }


### PR DESCRIPTION
Reverts micro-manager/micro-manager#1734 since that code did not compile and MicroMagellan no longer worked.