### PR TITLE
Improvements in remembering display settings

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -446,6 +446,12 @@ public final class MMAcquisition extends DataViewerListener {
          return true;
       }
       if (callbacks_.getAcquisitionDatastore() != viewer.getDataProvider()) {
+         if (display_.getDisplaySettings() instanceof DefaultDisplaySettings) {
+            ((DefaultDisplaySettings) display_.getDisplaySettings()).saveToProfile(
+                  studio_.profile(), PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key());
+         }
+         display_.removeListener(this);
+         display_ = null;
          // not our problem;)
          return true;
       }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -207,31 +207,6 @@ public final class MMAcquisition extends DataViewerListener {
                   } else {
                      displaySettingsBuilder.colorModeComposite();
                   }
-                  for (int channelIndex = 0; channelIndex < nrChannels; channelIndex++) {
-                     displaySettingsBuilder.channel(channelIndex,
-                           RememberedDisplaySettings.loadChannel(studio_,
-                               store_.getSummaryMetadata().getChannelGroup(),
-                               store_.getSummaryMetadata().getChannelNameList().get(channelIndex),
-                           null));  // TODO: use chColors as default Color?
-                     /*
-                     ChannelDisplaySettings channelSettings
-                             = displaySettingsBuilder.getChannelSettings(channelIndex);
-                     Color chColor = new Color(chColors.getInt(channelIndex));
-                     ChannelDisplaySettings.Builder csb =
-                             channelSettings.copyBuilder().color(chColor);
-                     if (summaryMetadata.has("ChNames")) {
-                        Object chNames = summaryMetadata.get("ChNames");
-                        if (chNames instanceof JSONArray) {
-                           JSONArray jChNames = (JSONArray) chNames;
-                           if (channelIndex < jChNames.length()) {
-                              csb.name(jChNames.getString(channelIndex));
-                           }
-                        }
-                     }
-                     displaySettingsBuilder.channel(channelIndex,csb.build());
-
-                      */
-                  }
                } while (!display_.compareAndSetDisplaySettings(
                         display_.getDisplaySettings(), displaySettingsBuilder.build()));
             } else {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -572,6 +572,8 @@ public enum PropertyKey {
 
    HISTOGRAM_BIT_DEPTH("HistogramBitDepth", ChannelDisplaySettings.class),
 
+   HISTOGRAM_IS_LOGARITHMIC("HistogramIsLogarithmic", DisplaySettings.class),
+
    IGNORE_ZEROS_AUTOSCALE("IgnorZerosAutoscale", DisplaySettings.class),
 
    IJ_TYPE("IJType", Image.class) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -572,6 +572,8 @@ public enum PropertyKey {
 
    HISTOGRAM_BIT_DEPTH("HistogramBitDepth", ChannelDisplaySettings.class),
 
+   IGNORE_ZEROS_AUTOSCALE("IgnorZerosAutoscale", DisplaySettings.class),
+
    IJ_TYPE("IJType", Image.class) {
       @Override
       protected void convertFromGson(JsonElement je, PropertyMap.Builder dest) {

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -88,6 +88,15 @@ public interface DisplaySettings {
       Builder autoscaleIgnoringZeros(boolean ignoreZeros);
 
       /**
+       * Whether the histogram should be shown with a logarithmic (true)
+       * or linear (false) y-axis.
+       *
+       * @param histogramLogarithmic true when y-axis should be logarithmic.
+       * @return builder instance
+       */
+      Builder histogramLogarithmic(boolean histogramLogarithmic);
+
+      /**
        * Increases the number of ChannelDisplaySettings in this Builder to
        * the given number.  DefaultSettings for each channel will be added.
        *
@@ -207,6 +216,13 @@ public interface DisplaySettings {
     * @return Whether zero pixel values are ignored when autoscaling
     */
    boolean isAutoscaleIgnoringZeros();
+
+   /**
+    * Whether the y-axis of the histogram uses a logarithmic or linear scale.
+    *
+    * @return Logarithmic scale when true.
+    */
+   boolean isHistogramLogarithmic();
 
    /**
     * Returns the number of channels in these DisplaySettings

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -719,6 +719,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          histogram_.setGamma(channelSettings
                .getComponentSettings(0)
                .getScalingGamma());
+         histogram_.setLogIntensity(settings.isHistogramLogarithmic());
          // Need to remove actionListeners before setting the histoRangeBox
          ActionListener[] actionListeners = histoRangeComboBox_.getActionListeners();
          for (ActionListener al : actionListeners) {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
@@ -309,6 +309,15 @@ public class IntensityInspectorPanelController
       for (ChannelIntensityController ch : channelControllers_) {
          ch.setHistogramLogYAxis(logarithmic);
       }
+      DisplaySettings oldSettings;
+      DisplaySettings newSettings;
+      do {
+         oldSettings = viewer_.getDisplaySettings();
+         if (oldSettings.isHistogramLogarithmic() == logarithmic) {
+            return;
+         }
+         newSettings = oldSettings.copyBuilder().histogramLogarithmic(logarithmic).build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldSettings, newSettings));
    }
 
    private void handleColorPalette(List<Color> colors) {
@@ -585,6 +594,7 @@ public class IntensityInspectorPanelController
          displaySettingsUpdateSuspended_ = false;
       }
 
+      gearMenuLogYAxisItem_.setSelected(settings.isHistogramLogarithmic());
       gearMenuUseROIItem_.setSelected(settings.isROIAutoscaleEnabled());
       gearMenuIgnoreZerosItem_.setSelected(settings.isAutoscaleIgnoringZeros());
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -259,6 +259,10 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
       return ret;
    }
 
+   // TODO: Evaluate a version that includes display settings.
+   // This reduce cpu cycles by current code creating display settings that
+   // are over-written later.
+
    @Override
    public DisplayWindow createDisplay(DataProvider provider,
                                       DisplayWindowControlsFactory factory) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -1020,7 +1020,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
     * @return PropertyMap containing these DisplaySettings
     */
    public PropertyMap toPropertyMap() {
-      List<PropertyMap> channelSettings = new ArrayList<PropertyMap>();
+      List<PropertyMap> channelSettings = new ArrayList<>();
       for (ChannelDisplaySettings cs : channelSettings_) {
          channelSettings.add(((DefaultChannelDisplaySettings) cs).toPropertyMap());
       }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -1002,6 +1002,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             .putBoolean(PropertyKey.UNIFORM_CHANNEL_SCALING.key(), uniformChannelScaling_)
             .putBoolean(PropertyKey.AUTOSTRETCH.key(), autostretch_)
             .putBoolean(PropertyKey.ROI_AUTOSCALE.key(), useROI_)
+            .putBoolean(PropertyKey.IGNORE_ZEROS_AUTOSCALE.key(), ignoreZeros_)
             .putDouble(PropertyKey.AUTOSCALE_IGNORED_QUANTILE.key(), extremaQuantile_)
             .putPropertyMapList(PropertyKey.CHANNEL_SETTINGS.key(), channelSettings)
             .build();
@@ -1039,6 +1040,10 @@ public final class DefaultDisplaySettings implements DisplaySettings {
          }
          if (pMap.containsBoolean(PropertyKey.ROI_AUTOSCALE.key())) {
             ddsb.roiAutoscale(pMap.getBoolean(PropertyKey.ROI_AUTOSCALE.key(), ddsb.useROI_));
+         }
+         if (pMap.containsBoolean(PropertyKey.IGNORE_ZEROS_AUTOSCALE.key())) {
+            ddsb.autoscaleIgnoringZeros(pMap.getBoolean(PropertyKey.IGNORE_ZEROS_AUTOSCALE.key(),
+                  ddsb.ignoreZeros_));
          }
          if (pMap.containsDouble(PropertyKey.AUTOSCALE_IGNORED_QUANTILE.key())) {
             ddsb.autoscaleIgnoredQuantile(pMap.getDouble(PropertyKey

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -55,6 +55,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    private final boolean autostretch_;
    private final boolean useROI_;
    private final double extremaQuantile_;
+   private final boolean histogramLogarithmic_;
    private final boolean ignoreZeros_;
    private final List<ChannelDisplaySettings> channelSettings_;
 
@@ -65,6 +66,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       private boolean useUniformChannelScaling_ = false;
       private boolean autostretch_ = true;
       private boolean useROI_ = true;
+      private boolean histogramLogarithmic_;
       private double extremaQuantile_ = 0.001;
       private boolean ignoreZeros_ = false;
       private List<ChannelDisplaySettings> channelSettings_ = new ArrayList<>();
@@ -149,6 +151,19 @@ public final class DefaultDisplaySettings implements DisplaySettings {
          return this;
       }
 
+      /**
+       * Whether the histogram should be shown with a logarithmic (true)
+       * or linear (false) y-axis.
+       *
+       * @param histogramLogarithmic true when y-axis should be logarithmic.
+       * @return builder instance
+       */
+      @Override
+      public DisplaySettings.Builder histogramLogarithmic(boolean histogramLogarithmic) {
+         histogramLogarithmic_ = histogramLogarithmic;
+         return this;
+      }
+
       @Override
       public Builder channel(int channel) {
          Preconditions.checkArgument(channel >= 0);
@@ -205,6 +220,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       useROI_ = builder.useROI_;
       extremaQuantile_ = builder.extremaQuantile_;
       ignoreZeros_ = builder.ignoreZeros_;
+      histogramLogarithmic_ = builder.histogramLogarithmic_;
       channelSettings_ =
             new ArrayList<>(builder.channelSettings_);
    }
@@ -252,6 +268,11 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    @Override
    public boolean isAutoscaleIgnoringZeros() {
       return ignoreZeros_;
+   }
+
+   @Override
+   public boolean isHistogramLogarithmic() {
+      return histogramLogarithmic_;
    }
 
    @Override
@@ -308,6 +329,8 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    private static final String SHOULD_AUTOSTRETCH = "shouldAutostretch";
    private static final String SHOULD_SCALE_WITH_ROI = "shouldScaleWithROI";
    private static final String EXTREMA_PERCENTAGE = "extremaPercentage";
+   private static final String IGNORE_ZEROS_AUTOSCALE = "IgnoreZerosWhenAutoscaling";
+   private static final String HISTOGRAM_IS_LOGARITHMIC = "histogramIsLogarithmic";
 
    /**
     * Retrieve the display settings that have been saved in the preferences.
@@ -344,6 +367,10 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       builder.shouldAutostretch(settings.getBoolean(key + SHOULD_AUTOSTRETCH, true));
       builder.shouldScaleWithROI(settings.getBoolean(key + SHOULD_SCALE_WITH_ROI, true));
       builder.extremaPercentage(settings.getDouble(key + EXTREMA_PERCENTAGE, 0.0));
+      builder.autoscaleIgnoringZeros(settings.getBoolean(
+            key + IGNORE_ZEROS_AUTOSCALE, false));
+      builder.histogramLogarithmic(settings.getBoolean(
+            key + HISTOGRAM_IS_LOGARITHMIC, false));
       // Note we don't store user data in the prefs explicitly; let third-party
       // code manually access the prefs if they want.
       return builder.build();
@@ -837,6 +864,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             .uniformChannelScaling(uniformChannelScaling_)
             .autostretch(autostretch_)
             .roiAutoscale(useROI_)
+            .histogramLogarithmic(histogramLogarithmic_)
             .autoscaleIgnoredQuantile(extremaQuantile_)
             .autoscaleIgnoringZeros(ignoreZeros_);
       for (int i = 0; i < getNumberOfChannels(); ++i) {
@@ -870,7 +898,9 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             .uniformChannelScaling(uniformChannelScaling_)
             .autostretch(autostretch_)
             .roiAutoscale(useROI_)
-            .autoscaleIgnoredQuantile(extremaQuantile_);
+            .histogramLogarithmic(histogramLogarithmic_)
+            .autoscaleIgnoredQuantile(extremaQuantile_)
+            .autoscaleIgnoringZeros(ignoreZeros_);
       for (int i = 0; i < getNumberOfChannels(); ++i) {
          ret.channel(i, channelSettings_.get(i));
       }
@@ -1001,6 +1031,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             .putEnumAsString(PropertyKey.COLOR_MODE.key(), mode_)
             .putBoolean(PropertyKey.UNIFORM_CHANNEL_SCALING.key(), uniformChannelScaling_)
             .putBoolean(PropertyKey.AUTOSTRETCH.key(), autostretch_)
+            .putBoolean(PropertyKey.HISTOGRAM_IS_LOGARITHMIC.key(), histogramLogarithmic_)
             .putBoolean(PropertyKey.ROI_AUTOSCALE.key(), useROI_)
             .putBoolean(PropertyKey.IGNORE_ZEROS_AUTOSCALE.key(), ignoreZeros_)
             .putDouble(PropertyKey.AUTOSCALE_IGNORED_QUANTILE.key(), extremaQuantile_)
@@ -1037,6 +1068,10 @@ public final class DefaultDisplaySettings implements DisplaySettings {
          }
          if (pMap.containsBoolean(PropertyKey.AUTOSTRETCH.key())) {
             ddsb.autostretch(pMap.getBoolean(PropertyKey.AUTOSTRETCH.key(), ddsb.autostretch_));
+         }
+         if (pMap.containsBoolean(PropertyKey.HISTOGRAM_IS_LOGARITHMIC.key())) {
+            ddsb.histogramLogarithmic(pMap.getBoolean(PropertyKey.HISTOGRAM_IS_LOGARITHMIC.key(),
+                  ddsb.histogramLogarithmic_));
          }
          if (pMap.containsBoolean(PropertyKey.ROI_AUTOSCALE.key())) {
             ddsb.roiAutoscale(pMap.getBoolean(PropertyKey.ROI_AUTOSCALE.key(), ddsb.useROI_));


### PR DESCRIPTION
This PR was prompted by the "Ignore zero pixel" setting not being remembered (i.e. setting it, closing a window, then opening a new one would not automatically set this checkbox). It turned out that there are various (legacy?) systems to store DisplaySettings, and I surely have not completely untangled these.  However, for Snap and MDA windows, settings (including Channel Display Settings) are now stored in and retrieved from PropertyMaps, which I believe was the goal altogether.  Further clean up (including adding the ability to create a Display while specifying the desired DisplaySettings) is needed, but I believe this is a good step in the right direction until I'll have more time.