### PR TITLE
Adds option to only show display once images arrive.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/DisplayWindow.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayWindow.java
@@ -324,4 +324,11 @@ public interface DisplayWindow extends DataViewer, Closeable {
     * construction, and after attaching listeners as needed, to show the Window.
     */
    void show();
+
+   /**
+    * DisplayWindows are not shown by default.  Call this function after
+    * construction, and after attaching listeners as needed, to show the Window.
+    * This version will only show the display window once there are images available.
+    */
+   void showOnceThereAreImages();
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -269,7 +269,7 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
       DisplayWindow ret = new DisplayController.Builder(provider)
             .linkManager(linkManager_).controlsFactory(factory).build(studio_);
       addViewer(ret);
-      ret.show();
+      ret.showOnceThereAreImages();
       return ret;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
@@ -139,9 +139,10 @@ public final class DisplayController extends DisplayWindowAPIAdapter
          = PerformanceMonitorUI.create(perfMon_, "Display Performance");
 
 
-   //This static counter makes sure that each object has it's own unique id during runtime.
+   //This static counter makes sure that each object has its own unique id during runtime.
    private static final AtomicInteger counter = new AtomicInteger();
    private final Integer uid = counter.getAndIncrement();
+   private boolean showOnceThereAreImages_ = false;
 
    @Override
    public void addListener(DataViewerListener listener, int priority) {
@@ -321,6 +322,17 @@ public final class DisplayController extends DisplayWindowAPIAdapter
       toFront();
    }
 
+   @Override
+   public void showOnceThereAreImages() {
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(this::showOnceThereAreImages);
+      }
+      if (dataProvider_.getNumImages() > 0) {
+         show();
+         return;
+      }
+      showOnceThereAreImages_ = true;
+   }
 
    //
    // Scheduling images for display
@@ -924,6 +936,10 @@ public final class DisplayController extends DisplayWindowAPIAdapter
          if (closeCompleted_) {
             return;
          }
+      }
+      if (showOnceThereAreImages_) {
+         showOnceThereAreImages_ = false;
+         show();
       }
 
       // Generally we want to display new images (if not instructed otherwise


### PR DESCRIPTION
This PR is prompted by the recent addition of the Deskew plugin.  The Deskew plugin is a Processor in the on-the-fly-processor pipeline that uses images to create its own Datastores, and optionally does not propagate images to original Datasink.  This works well, but does create display windows that never receive images, which is a bit of a bad user experience.

This PR is more of a discussion piece.  It adds an option to the API to only show the display once images actually arrive.  It works well for the use case described.  Another option would be to leave the API unchanged, and change the behavior of the current method "show()", so that displays are always only shown once images actually arrive.

I am not quite sure what happens to these "orphaned" displays and associated Datastores.  Are they garbage collected?  I currently do not have a Java Profiler working, so it is a bit hard to investigate. 

Looking for suggestions for the best path forward.