### PR TITLE
Studio: Bug fix in AcqEngJWrapper.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -221,10 +221,10 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          loadRunnables(acquisitionSettings);
 
          summaryMetadataJSON_ = currentAcquisition_.getSummaryMetadata();
+         addMMSummaryMetadata(summaryMetadataJSON_, sequenceSettings, posList_, studio_);
          SummaryMetadata summaryMetadata =  DefaultSummaryMetadata.fromPropertyMap(
                   NonPropertyMapJSONFormats.summaryMetadata().fromJSON(
                            summaryMetadataJSON_.toString()));
-         addMMSummaryMetadata(summaryMetadataJSON_, sequenceSettings, posList_, studio_);
          MMAcquisition acq = new MMAcquisition(studio_, summaryMetadata, this,
                acquisitionSettings);
          curStore_ = acq.getDatastore();


### PR DESCRIPTION
SummaryMetadata were incomplete.  First add MM Metadata, then convert from JSON to SummaryMetadata class.  Noticed this, because animations did not work in data acquired with AcqEngJ.