### PR TITLE
Fewer warnings in mmstudio code

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -130,7 +130,7 @@ public final class MMAcquisition extends DataViewerListener {
                         SequenceSettings acquisitionSettings) {
       studio_ = studio;
       callbacks_ = callbacks;
-      show_ = acquisitionSettings.shouldDisplayImages;
+      show_ = acquisitionSettings.shouldDisplayImages();
       store_ = new DefaultDatastore(studio);
       pipeline_ = studio_.data().copyApplicationPipeline(store_, false);
       if (acquisitionSettings.save() && acquisitionSettings.root() != null) {

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -105,6 +105,7 @@ public final class MMAcquisition extends DataViewerListener {
     *                        viewer should be shown.
     * @deprecated Use the constructor that takes a SummaryMetadata object instead.
     */
+   @Deprecated
    @SuppressWarnings("LeakingThisInConstructor")
    public MMAcquisition(Studio studio, String dir, String prefix, JSONObject summaryMetadata,
                         MMAcquistionControlCallbacks callbacks, SequenceSettings acqSettings)

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
@@ -232,14 +232,14 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
          // These hooks implement Autofocus
          if (basicSettings.useAutofocus()) {
             currentMultiMDA_.addHook(autofocusHookBefore(basicSettings.skipAutofocusCount()),
-                  currentMultiMDA_.BEFORE_HARDWARE_HOOK);
+                  AcquisitionAPI.BEFORE_HARDWARE_HOOK);
          }
 
          for (int i = 0; i < sequenceSettings.size(); i++) {
             // Hook to move back the ZStage to its original position after a Z stack
             if (sequenceSettings.get(i).useSlices()) {
                currentMultiMDA_.addHook(zPositionHook(sequenceSettings.get(i),
-                           Acquisition.BEFORE_HARDWARE_HOOK, i),
+                           AcquisitionAPI.BEFORE_HARDWARE_HOOK, i),
                      AcquisitionAPI.BEFORE_HARDWARE_HOOK);
                currentMultiMDA_.addHook(zPositionHook(sequenceSettings.get(i),
                            Acquisition.AFTER_EXPOSURE_HOOK, i),

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultSummaryMetadata.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultSummaryMetadata.java
@@ -477,7 +477,7 @@ public final class DefaultSummaryMetadata implements SummaryMetadata {
 
    @Override
    public SequenceSettings getSequenceSettings() {
-      return SequenceSettings.fromJSONStream(pmap_.getString(MDA_SETTINGS.key()));
+      return SequenceSettings.fromJSONStream(pmap_.getString(MDA_SETTINGS.key(), ""));
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultSummaryMetadata.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultSummaryMetadata.java
@@ -401,7 +401,7 @@ public final class DefaultSummaryMetadata implements SummaryMetadata {
 
    @Override
    public List<Double> getCustomIntervalsMsList() {
-      return pmap_.getDoubleList(CUSTOM_INTERVALS_MS.key(), (List) null);
+      return pmap_.getDoubleList(CUSTOM_INTERVALS_MS.key(), (List<Double>) null);
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/OMEMetadata.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/OMEMetadata.java
@@ -50,7 +50,7 @@ import org.micromanager.data.Image;
 import org.micromanager.data.Metadata;
 import org.micromanager.data.SummaryMetadata;
 import org.micromanager.data.internal.CommentsHelper;
-import org.micromanager.internal.utils.MDUtils;
+import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 
 public final class OMEMetadata {
@@ -207,7 +207,7 @@ public final class OMEMetadata {
                //make sure each tiffdata entry is present. If it is missing, link Tiffdata entry
                //to a a preveious IFD
                Integer tiffDataIndex =
-                     tiffDataIndexMap_.get(MDUtils.generateLabel(channel, slice, frame, position));
+                     tiffDataIndexMap_.get(generateLabel(channel, slice, frame, position));
                if (tiffDataIndex == null) {
                   // this plane was never added, so link to another IFD
                   // find substitute channel, frame, slice
@@ -220,22 +220,22 @@ public final class OMEMetadata {
                   // point missing, go back until image is found
                   while (tiffDataIndex == null) {
                      tiffDataIndex = tiffDataIndexMap_
-                           .get(MDUtils.generateLabel(channel, s, frameSearchIndex, position));
+                           .get(generateLabel(channel, s, frameSearchIndex, position));
                      if (tiffDataIndex != null) {
                         break;
                      }
 
                      if (backIndex >= 0) {
-                        tiffDataIndex = tiffDataIndexMap_.get(MDUtils
-                              .generateLabel(channel, backIndex, frameSearchIndex, position));
+                        tiffDataIndex = tiffDataIndexMap_.get(generateLabel(
+                                 channel, backIndex, frameSearchIndex, position));
                         if (tiffDataIndex != null) {
                            break;
                         }
                         backIndex--;
                      }
                      if (forwardIndex < numSlices_) {
-                        tiffDataIndex = tiffDataIndexMap_.get(MDUtils
-                              .generateLabel(channel, forwardIndex, frameSearchIndex, position));
+                        tiffDataIndex = tiffDataIndexMap_.get(generateLabel(
+                                 channel, forwardIndex, frameSearchIndex, position));
                         if (tiffDataIndex != null) {
                            break;
                         }
@@ -339,7 +339,7 @@ public final class OMEMetadata {
                "Multipage Tiff storage only supports images in increasing order, t=0, t=2, etc.."));
       }
       tiffDataIndexMap_
-            .put(MDUtils.generateLabel(channel, slice, frame, position), indices.tiffDataIndex_);
+            .put(generateLabel(channel, slice, frame, position), indices.tiffDataIndex_);
       metadata_.setTiffDataPlaneCount(new NonNegativeInteger(1), position, indices.tiffDataIndex_);
 
       metadata_.setPlaneTheZ(new NonNegativeInteger(slice), position, indices.planeIndex_);
@@ -439,4 +439,12 @@ public final class OMEMetadata {
          }
       }
    }
+
+   public static String generateLabel(int channel, int slice, int frame, int position) {
+      return NumberUtils.intToCoreString(channel) + "_"
+               + NumberUtils.intToCoreString(slice) + "_"
+               + NumberUtils.intToCoreString(frame) + "_"
+               + NumberUtils.intToCoreString(position);
+   }
+
 }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/InspectorController.java
@@ -76,7 +76,7 @@ public final class InspectorController
    private JPanel headerPanel_;
    private JScrollPane scrollPane_;
    private VerticalMultiSplitPane sectionsPane_;
-   private JComboBox viewerComboBox_;
+   private JComboBox<Object> viewerComboBox_;
    private Object viewerComboBoxSelection_;
    private JButton viewerToFrontButton_;
    private DataViewer viewer_;
@@ -158,7 +158,7 @@ public final class InspectorController
             new LC().fill().insets("0").gridGap("0", "0")));
       headerPanel_.add(new JLabel("Inspect:"),
             new CC().gapBefore("rel").split(3));
-      viewerComboBox_ = new JComboBox();
+      viewerComboBox_ = new JComboBox<>();
       viewerComboBox_.setToolTipText("Select the image window to inspect");
       viewerComboBox_.setRenderer(
             ComboBoxSeparatorRenderer.create(viewerComboBox_.getRenderer()));

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
@@ -164,7 +164,7 @@ public final class IntegerComponentStats {
       if (histogram_ == null) {
          return 0;
       }
-      return getHistogramBinWidth() * getHistogramBinCount() - 1;
+      return (long) getHistogramBinWidth() * getHistogramBinCount() - 1;
    }
 
    public long getPixelCount() {
@@ -208,7 +208,7 @@ public final class IntegerComponentStats {
    public long getAutoscaleMinForQuantile(double q) {
       if (q >= 0.5) {
          // Safe, in-range value that is less than max
-         return Math.max(0L, (long) Math.round(getQuantile(0.5)) - 1L);
+         return Math.max(0L, Math.round(getQuantile(0.5)) - 1L);
       }
       return Math.round(getQuantile(q));
    }
@@ -216,7 +216,7 @@ public final class IntegerComponentStats {
    public long getAutoscaleMinForQuantileIgnoringZeros(double q) {
       if (q >= 0.5) {
          // Safe, in-range value that is less than max
-         return Math.max(0L, (long) Math.round(getQuantileIgnoringZeros(0.5)) - 1L);
+         return Math.max(0L, Math.round(getQuantileIgnoringZeros(0.5)) - 1L);
       }
       return Math.round(getQuantileIgnoringZeros(q));
    }
@@ -224,7 +224,7 @@ public final class IntegerComponentStats {
    public long getAutoscaleMaxForQuantile(double q) {
       if (q >= 0.5) {
          // Safe, in-range value that is greater than min
-         return Math.max(1L, (long) Math.round(getQuantile(0.5)));
+         return Math.max(1L, Math.round(getQuantile(0.5)));
       }
       return Math.round(getQuantile(1.0 - q)) - 1L;
    }
@@ -232,7 +232,7 @@ public final class IntegerComponentStats {
    public long getAutoscaleMaxForQuantileIgnoringZeros(double q) {
       if (q >= 0.5) {
          // Safe, in-range value that is greater than min
-         return Math.max(1L, (long) Math.round(getQuantileIgnoringZeros(0.5)));
+         return Math.max(1L, Math.round(getQuantileIgnoringZeros(0.5)));
       }
       return Math.round(getQuantileIgnoringZeros(1.0 - q)) - 1L;
    }
@@ -281,7 +281,7 @@ public final class IntegerComponentStats {
             (long) Math.floor(countBelowQuantile));
 
       int binWidth = getHistogramBinWidth();
-      long leftEdge = (binIndex - 1) * binWidth;
+      long leftEdge = (long) (binIndex - 1) * binWidth;
       double binFraction =
             (countBelowQuantile - cumDistrib[binIndex - 1])
                   / (cumDistrib[binIndex] - cumDistrib[binIndex - 1]);
@@ -321,7 +321,7 @@ public final class IntegerComponentStats {
       }
 
       int binIndex;
-      // The binary seatch will find _a_ bin with the desired cumulative count,
+      // The binary search will find _a_ bin with the desired cumulative count,
       // but it may not be the _only_ such bin, if the histogram contains bins
       // with zero count. This is not an issue when 0 < q < 1 (for our use of
       // the quantile for limiting scaling range), but when q = 0 or q = 1, we
@@ -336,7 +336,7 @@ public final class IntegerComponentStats {
             (long) Math.floor(countBelowQuantile));
 
       int binWidth = getHistogramBinWidth();
-      long leftEdge = (binIndex - 1) * binWidth;
+      long leftEdge = (long) (binIndex - 1) * binWidth;
       double binFraction =
              (countBelowQuantile - cumDistrib[binIndex - 1])
                  / (cumDistrib[binIndex] - cumDistrib[binIndex - 1]);

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -362,31 +362,31 @@ public final class PipelineFrame extends JFrame
     * Set whether or not a configurator is enabled.
     */
    public void setConfiguratorEnabled(int row, boolean enabled) {
-      int column = getTableModel().ENABLED_COLUMN;
+      int column = PipelineTableModel.ENABLED_COLUMN;
       getTableModel().setValueAt(enabled, row, column);
    }
 
    /**
-    * Set whether or not a configurator is enabled for live mode.
+    * Set whether a configurator is enabled for live mode.
     */
    public void setConfiguratorEnabledLive(int row, boolean enabled) {
-      int column = getTableModel().ENABLED_LIVE_COLUMN;
+      int column = PipelineTableModel.ENABLED_LIVE_COLUMN;
       getTableModel().setValueAt(enabled, row, column);
    }
 
    /**
-    * Get whether or not a configurator is enabled.
+    * Get whether a configurator is enabled.
     */
    public boolean getConfiguratorEnabled(int row) {
-      int column = getTableModel().ENABLED_COLUMN;
+      int column = PipelineTableModel.ENABLED_COLUMN;
       return (boolean) getTableModel().getValueAt(row, column);
    }
 
    /**
-    * Get whether or not a configurator is enabled for live mode.
+    * Get whether a configurator is enabled for live mode.
     */
    public boolean getConfiguratorEnabledLive(int row) {
-      int column = getTableModel().ENABLED_LIVE_COLUMN;
+      int column = PipelineTableModel.ENABLED_LIVE_COLUMN;
       return (boolean) getTableModel().getValueAt(row, column);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
@@ -51,7 +51,7 @@ public final class DefaultPluginManager implements PluginManager {
 
    // List of the types of plugins we allow.
    // TODO Remove this list and just load all MMGenericPlugin instances
-   private static final ArrayList<Class> VALID_CLASSES = new ArrayList<>();
+   private static final ArrayList<Class<?>> VALID_CLASSES = new ArrayList<>();
 
    static {
       VALID_CLASSES.add(AcquisitionDialogPlugin.class);
@@ -75,7 +75,7 @@ public final class DefaultPluginManager implements PluginManager {
    public DefaultPluginManager(Studio studio) {
       studio_ = studio;
 
-      for (Class classType : VALID_CLASSES) {
+      for (Class<?> classType : VALID_CLASSES) {
          pluginTypeToPlugins_.put(classType, new ArrayList<>());
       }
       loadingThread_ = new Thread(this::loadPlugins, "Plugin loading thread");
@@ -134,8 +134,8 @@ public final class DefaultPluginManager implements PluginManager {
     * Insert the provided plugins into the pluginTypeToPlugins_ structure,
     * instantiate them, add them to menus, etc.
     */
-   private void loadPlugins(List<Class> pluginClasses) {
-      for (Class pluginClass : pluginClasses) {
+   private void loadPlugins(List<Class<?>> pluginClasses) {
+      for (Class<?> pluginClass : pluginClasses) {
          try {
             // Ignore any SciJava plugins that are not MM plugins.
             if (!MMGenericPlugin.class.isAssignableFrom(pluginClass)) {
@@ -165,7 +165,7 @@ public final class DefaultPluginManager implements PluginManager {
       if (plugin instanceof MMPlugin) { // Legacy plugin base class
          ((MMPlugin) plugin).setContext(studio_);
       }
-      for (Class pluginClass : VALID_CLASSES) {
+      for (Class<?> pluginClass : VALID_CLASSES) {
          if (pluginClass.isInstance(plugin)) {
             pluginTypeToPlugins_.get(pluginClass).add(plugin);
          }

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/PluginFinder.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/PluginFinder.java
@@ -70,8 +70,8 @@ public final class PluginFinder {
     * indicates that they're annotated with the @Plugin annotation, and return
     * a list of the corresponding annotated classes.
     */
-   public static List<Class> findPlugins(String root) {
-      ArrayList<Class> result = new ArrayList<>();
+   public static List<Class<?>> findPlugins(String root) {
+      ArrayList<Class<?>> result = new ArrayList<>();
       List<URL> jarURLs = new ArrayList<>();
       for (String jarPath : findPaths(root, ".jar")) {
          try {
@@ -101,12 +101,12 @@ public final class PluginFinder {
       return result;
    }
 
-   public static List<Class> findPluginsWithLoader(ClassLoader loader) {
-      ArrayList<Class> result = new ArrayList<>();
+   public static List<Class<?>> findPluginsWithLoader(ClassLoader loader) {
+      ArrayList<Class<?>> result = new ArrayList<>();
       DefaultPluginFinder finder = new DefaultPluginFinder(loader);
       PluginIndex index = new PluginIndex(finder);
       index.discover();
-      for (PluginInfo info : index.getAll()) {
+      for (PluginInfo<?> info : index.getAll()) {
          try {
             result.add(info.loadClass());
          } catch (InstantiableException e) {

--- a/mmstudio/src/test/java/org/micromanager/data/internal/VersionCompatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/VersionCompatTest.java
@@ -405,7 +405,7 @@ public class VersionCompatTest {
             Assert.assertNotNull("Non-null user data", userData);
             for (String key : userData.getKeys()) {
                Assert.assertEquals(key + " for " + coords,
-                       userData.getString(key), DEVICE_PROPERTIES.get(key));
+                       userData.getString(key, null), DEVICE_PROPERTIES.get(key));
             }
          } catch (IOException io) {
             Assert.fail("Failed to open image from datastore");

--- a/mmstudio/src/test/java/org/micromanager/display/internal/animate/DataCoordsAnimationStateTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/animate/DataCoordsAnimationStateTest.java
@@ -106,14 +106,13 @@ public class DataCoordsAnimationStateTest {
 
    @Test
    public void testGetSetAdvance() {
-      mockAxes_ = Arrays.asList(DefaultCoords.TIME, DefaultCoords.CHANNEL);
+      mockAxes_ = Arrays.asList(DefaultCoords.TIME_POINT, DefaultCoords.CHANNEL);
       for (int t = 0; t < 10; ++t) {
          for (int ch = 0; ch < 3; ++ch) {
-            mockDataset_.put(new DefaultCoords.Builder().
-                  time(t).channel(ch).build(), Boolean.TRUE);
+            mockDataset_.put(new DefaultCoords.Builder().t(t).channel(ch).build(), Boolean.TRUE);
          }
       }
-      mockAnimatedAxes_ = Collections.singleton(DefaultCoords.TIME);
+      mockAnimatedAxes_ = Collections.singleton(DefaultCoords.TIME_POINT);
 
       DataCoordsAnimationState instance =
             DataCoordsAnimationState.create(mockCoordsProvider_);
@@ -122,9 +121,9 @@ public class DataCoordsAnimationStateTest {
       Coords c = instance.getAnimationPosition();
       List<String> axes = c.getAxes();
       assertEquals(2, axes.size());
-      assertTrue(axes.contains(DefaultCoords.TIME));
+      assertTrue(axes.contains(DefaultCoords.TIME_POINT));
       assertTrue(axes.contains(DefaultCoords.CHANNEL));
-      assertEquals(0, c.getTime());
+      assertEquals(0, c.getT());
       assertEquals(0, c.getChannel());
 
       // Set coords should be recovered, preserving unset axes
@@ -132,23 +131,23 @@ public class DataCoordsAnimationStateTest {
       c = instance.getAnimationPosition();
       axes = c.getAxes();
       assertEquals(axes.size(), 2);
-      assertTrue(axes.contains(DefaultCoords.TIME));
+      assertTrue(axes.contains(DefaultCoords.TIME_POINT));
       assertTrue(axes.contains(DefaultCoords.CHANNEL));
-      assertEquals(3, c.getTime());
+      assertEquals(3, c.getT());
       assertEquals(0, c.getChannel());
 
       // Set coords should be recovered, preserving unset axes
       instance.setAnimationPosition(new DefaultCoords.Builder().channel(1).build());
       c = instance.getAnimationPosition();
       assertEquals(2, c.getAxes().size());
-      assertEquals(3, c.getTime());
+      assertEquals(3, c.getT());
       assertEquals(1, c.getChannel());
 
       // Advance by one should advance time (animated) but not channel (not
       // animated)
       c = instance.advanceAnimationPosition(1.0);
       assertEquals(2, c.getAxes().size());
-      assertEquals(4, c.getTime());
+      assertEquals(4, c.getT());
       assertEquals(1, c.getChannel());
 
       mockAnimatedAxes_ = new HashSet<String>(Arrays.asList(
@@ -157,27 +156,27 @@ public class DataCoordsAnimationStateTest {
       // Advance by many; should end up in expected coords
       c = instance.advanceAnimationPosition(11.0);
       assertEquals(2, c.getAxes().size());
-      assertEquals(8, c.getTime());
+      assertEquals(8, c.getT());
       assertEquals(0, c.getChannel());
 
-      mockDataset_.put(new DefaultCoords.Builder().time(8).channel(1).build(),
+      mockDataset_.put(new DefaultCoords.Builder().t(8).channel(1).build(),
             Boolean.FALSE);
 
       // Check skipping of nonexistent coords
       c = instance.advanceAnimationPosition(1.0);
       assertEquals(2, c.getAxes().size());
-      assertEquals(8, c.getTime());
+      assertEquals(8, c.getT());
       assertEquals(2, c.getChannel());
 
       for (int ch = 0; ch < 3; ++ch) {
-         mockDataset_.put(new DefaultCoords.Builder().time(9).channel(ch).build(),
+         mockDataset_.put(new DefaultCoords.Builder().t(9).channel(ch).build(),
                Boolean.FALSE);
       }
 
       // Another test for skipping
       c = instance.advanceAnimationPosition(1.0);
       assertEquals(2, c.getAxes().size());
-      assertEquals(0, c.getTime());
+      assertEquals(0, c.getT());
       assertEquals(0, c.getChannel());
    }
 


### PR DESCRIPTION
Most remaining have to do with raw types, where I really do not know how to fix them, or the use of deprecated code (such as MDUtils), for which there is not really an alternative.  Trying to reduce the number of warnings to make it easier to spot errors (and to find potentially unintended behavior)