### PR TITLE
Adds ability to read Sequence Settings from data in Viewer and apply to MDA window.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/SequenceSettings.java
@@ -849,6 +849,9 @@ public final class SequenceSettings {
       try {
          Gson gson = new Gson();
          SequenceSettings result = gson.fromJson(stream, SequenceSettings.class);
+         if (result == null) {
+            return null;
+         }
          double version = result.getVersion();
          if (version <= Version) {
             return result;

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/AcquisitionWrapperEngine.java
@@ -214,6 +214,8 @@ public final class AcquisitionWrapperEngine implements AcquisitionEngine,
          SummaryMetadata summaryMetadata =  DefaultSummaryMetadata.fromPropertyMap(
                            NonPropertyMapJSONFormats.summaryMetadata().fromJSON(
                                     summaryMetadataJSON_.toString()));
+         summaryMetadata = summaryMetadata.copyBuilder().sequenceSettings(
+                  acquisitionSettings).build();
          MMAcquisition acq = new MMAcquisition(studio_, summaryMetadata,
                   this, acquisitionSettings);
          curStore_ = acq.getDatastore();

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -225,6 +225,8 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          SummaryMetadata summaryMetadata =  DefaultSummaryMetadata.fromPropertyMap(
                   NonPropertyMapJSONFormats.summaryMetadata().fromJSON(
                            summaryMetadataJSON_.toString()));
+         summaryMetadata = summaryMetadata.copyBuilder().sequenceSettings(
+                  acquisitionSettings).build();
          MMAcquisition acq = new MMAcquisition(studio_, summaryMetadata, this,
                acquisitionSettings);
          curStore_ = acq.getDatastore();


### PR DESCRIPTION
Fixes some issue adding SequenceSettings to the SummaryMetadata (previously only in User data?).  The MDA window now checks each DataViewer that became active and enables/disables the ReUse button based on the ability to apply the SequenceSettings.  It checks Sequence settings by seeing if the Channel Group and Channel names match the currently loaded configuration.  More check could (should?) be added.