### PR TITLE
Mac build: replace `@rpath` with `@loader-path`

### DIFF
--- a/buildscripts/nightly/mkportableapp_OSX/mkportableapp.py
+++ b/buildscripts/nightly/mkportableapp_OSX/mkportableapp.py
@@ -112,6 +112,11 @@ def process_libs(destdir, staged_seeds, srcdir,
       deps = get_deps_and_arch_status(os.path.join(destdir, staged_lib))
       for dep, arch_status in deps:
          if dep.startswith("@"):
+            # Third-party libs (to be installed by user into MM) may have
+            # @rpath; replace with @loader-path
+            if dep.startswith("@rpath/"):
+               update_dep(os.path.join(destdir, staged_lib), dep,
+                          dep.replace("@rpath/", "@loader-path/", 1))
             continue
 
          dep = os.path.realpath(dep)


### PR DESCRIPTION
Until now, there were no dylibs with dependencies at `@rpath`. Third-party dylibs to be installed by the user may have this. Replace with `@loader-path` so that copying the dependency dylibs into the Micro-Manager folder works.

(Preparation for addressing micro-manager/mmCoreAndDevices#368)