### PR TITLE
Studio-Navigation: make panel work without camera calibration.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -459,13 +459,13 @@ public final class StageControlFrame extends JFrame {
             int dy = 0;
             switch (index / 3) {
                case 0:
-                  dy = -1;
+                  dy = 1;
                   break;
                case 1:
                   dx = -1;
                   break;
                case 2:
-                  dx = 1;
+                  dx = -1;
                   break;
                case 3:
                   dy = 1;
@@ -784,7 +784,7 @@ public final class StageControlFrame extends JFrame {
    }
 
    private void setRelativeXYStagePosition(double x, double y) {
-      uiMovesStageManager_.getXYNavigator().moveSampleOnDisplayUm(x, y);
+      uiMovesStageManager_.getXYNavigator().moveSampleUm(x, y);
       if (settings_.getBoolean(SNAP, false)) {
          try {
             core_.waitForDevice(core_.getXYStageDevice());

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
@@ -135,6 +135,26 @@ public class XYNavigator {
    }
 
    /**
+    * Moves the stage the requested distance.  If there is a camera, and the
+    * affine transform is known, it will use that to determine the movement.
+    *
+    * @param tmpXUm amount (in microns) the sample should move in the x direction
+    * @param tmpYUm amount (in microns) the sample should move in the y direction
+    */
+   public void moveSampleUm(final double tmpXUm, final double tmpYUm) {
+      String xyStage = studio_.core().getXYStageDevice();
+      if (xyStage == null || xyStage.equals("")) {
+         return;
+      }
+      double pixSizeUm = studio_.core().getPixelSizeUm(true);
+      if (pixSizeUm > 0.0) {
+         moveSampleOnDisplayUm(tmpXUm, tmpYUm);
+         return;
+      }
+      moveXYStageUm(xyStage, tmpXUm, tmpYUm);
+   }
+
+   /**
     * Move the XYStage in such a manner that the sample as displayed in the
     * viewer will move in an absolute Carthesian coordinate system.
     * For instance, moving 1 micron in x will move the stage so that the
@@ -144,7 +164,7 @@ public class XYNavigator {
     * @param tmpXUm amount (in microns) the sample should move in the x direction
     * @param tmpYUm amount (in microns) the sample should move in the y direction
     */
-   public void moveSampleOnDisplayUm(final double tmpXUm, final double tmpYUm) {
+   private void moveSampleOnDisplayUm(final double tmpXUm, final double tmpYUm) {
       double pixSizeUm = studio_.core().getPixelSizeUm(true);
       if (!(pixSizeUm > 0.0)) {
          JOptionPane.showMessageDialog(null,

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
@@ -111,19 +111,19 @@ public final class XYZKeyListener {
             }
             switch (e.getKeyCode()) {
                case KeyEvent.VK_LEFT:
-                  xyNavigator_.moveSampleOnDisplayUm(-xMicron, 0);
+                  xyNavigator_.moveSampleUm(-xMicron, 0);
                   consumed = true;
                   break;
                case KeyEvent.VK_RIGHT:
-                  xyNavigator_.moveSampleOnDisplayUm(xMicron, 0);
+                  xyNavigator_.moveSampleUm(xMicron, 0);
                   consumed = true;
                   break;
                case KeyEvent.VK_UP:
-                  xyNavigator_.moveSampleOnDisplayUm(0, yMicron);
+                  xyNavigator_.moveSampleUm(0, yMicron);
                   consumed = true;
                   break;
                case KeyEvent.VK_DOWN:
-                  xyNavigator_.moveSampleOnDisplayUm(0, -yMicron);
+                  xyNavigator_.moveSampleUm(0, -yMicron);
                   consumed = true;
                   break;
                default:


### PR DESCRIPTION
Closes #1812.  Also, change polarity of Y-buttons.  Up is now positive (as one expect it should be).  This needs some checking with an actual, calibrated camera to see if things are moving in the right direction.