### PR TITLE
Ensure Windows Ant build uses VS2019 only

### DIFF
--- a/buildscripts/Ant/windowsprops.xml
+++ b/buildscripts/Ant/windowsprops.xml
@@ -135,39 +135,40 @@
 			<property name="msbuild.params"
 				value="@{project} /t:@{target} /p:Configuration=${mm.configuration} /p:Platform=${mm.architecture} /v:@{verbosity} /flp:LogFile=${msbuild.log} ${msbuild.flag.parallel}"/>
 
-			<!-- Find the bat file that activates the Visual Studio environment -->
-			<local name="vsDevCmdBat"/>
-			<!-- Use vswhere to find the location of the most recent VSDevCmd.bat installed -->
-			<echo file="temp.bat">
-				@echo off
-				for /f "usebackq delims=#" %%a in (`"%programfiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -latest -property installationPath`) do set VsDevCmd_Path=%%a\Common7\Tools\VsDevCmd.bat
-				echo %VsDevCmd_Path%
-			</echo>
-			<exec executable="cmd" outputproperty="vsDevCmdBat">
-				<arg value="/c"/>
-				<arg value="temp.bat"/>
-			</exec>
-			<delete file="temp.bat"/>
+			<local name="run_msbuild"/>
+			<tempfile property="run_msbuild"
+				prefix="run_msbuild" suffix=".ps1" destdir="${mm.intdir}"/>
+			<echo file="${run_msbuild}">
+				$SavePwd = pwd
 
-			<fail message="Cannot locate VsDevCmd.bat from Visual Studio">
-				<condition>
-					<not><available file="${vsDevCmdBat}"/></not>
-				</condition>
-			</fail>
-			
-			<local name="temp.bat"/>
-			<tempfile property="temp.bat" prefix="msbuild" suffix=".bat" destdir="${mm.intdir}"/>
-			<echo file="${temp.bat}">
-				@echo off
-				call "${vsDevCmdBat}"
-				if errorlevel 1 exit /b
+				# We require exactly Visual Studio 2019 (16.x); 2022 may fail.
+				$VsInstPath = &amp; 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' '-version' '[16.0,17.0)' '-property' 'installationPath'
+				if (-not $VsInstPath) {
+					echo 'Cannot find Visual Studio 2019 installation path'
+					exit 1
+				}
+
+				# Works better when run from the file location
+				cd $VsInstPath\Common7\Tools
+				.\Launch-VsDevShell.ps1
+				if (-not $?) {
+					echo 'Failed to set up Visual Studio dev env'
+					exit 1
+				}
+
+				# Restore dir (note that Launch-VsDevShell also changes it)
+				cd $SavePwd
 				msbuild ${msbuild.params}
+				if (-not $?) {
+					echo 'msbuild exited with error'
+					exit 1
+				}
 			</echo>
-			<exec executable="cmd" failonerror="@{failonerror}">
-				<arg value="/c"/>
-				<arg value="${temp.bat}"/>
+			<exec executable="powershell" failonerror="@{failonerror}">
+				<arg line="-ExecutionPolicy bypass"/>
+				<arg line="-File ${run_msbuild}"/>
 			</exec>
-			<delete file="${temp.bat}"/>
+			<delete file="${run_msbuild}"/>
 		</sequential>
 	</macrodef>
 </project>


### PR DESCRIPTION
Previously the build either failed, or incorrectly ran the VS2022 msbuild, when both VS2019 and VS2022 are installed.

(Using the VS2022 msbuild is a problem because the build currently happens to fail in that case.)

This fix ensures that the VS2019 msbuild is always used when building from Ant.

Also eliminate the impossible-to-maintain batch file syntax from this mechanism and replace with a single PowerShell script.