### PR TITLE
Duplicator: now works with snap-live image data

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -809,7 +809,10 @@ public final class SnapLiveManager extends DataViewerListener
          try {
             store_.setSummaryMetadata(store_.getSummaryMetadata().copyBuilder()
                   .channelGroup(core_.getChannelGroup())
-                  .channelNames(channelNames).build());
+                  .channelNames(channelNames)
+                  .imageWidth((int) core_.getImageWidth())
+                  .imageHeight((int) core_.getImageHeight())
+                  .build());
          } catch (DatastoreFrozenException e) {
             ReportingUtils.logError(e,
                   "Unable to update store summary metadata");

--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorExecutor.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorExecutor.java
@@ -198,8 +198,20 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
          }
       }
 
-      int width = roi == null ? oldMetadata.getImageWidth() : roi.getBounds().width;
-      int height = roi == null ? oldMetadata.getImageHeight() : roi.getBounds().height;
+      Integer width = oldMetadata.getImageWidth();
+      if (roi != null) {
+         width = roi.getBounds().width;
+      }
+      Integer height = oldMetadata.getImageHeight();
+      if (roi != null) {
+         height = roi.getBounds().height;
+      }
+      //int width = roi == null ? oldMetadata.getImageWidth() : roi.getBounds().width;
+      //int height = roi == null ? oldMetadata.getImageHeight() : roi.getBounds().height;
+
+      if (width == null || height == null) {
+         throw new DuplicatorException("Width and/or height is unexpectedly null");
+      }
 
       SummaryMetadata metadata = oldMetadata.copyBuilder()
               .channelNames(channelNames)

--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorExecutor.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorExecutor.java
@@ -209,19 +209,20 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
       //int width = roi == null ? oldMetadata.getImageWidth() : roi.getBounds().width;
       //int height = roi == null ? oldMetadata.getImageHeight() : roi.getBounds().height;
 
-      if (width == null || height == null) {
-         throw new DuplicatorException("Width and/or height is unexpectedly null");
-      }
-
-      SummaryMetadata metadata = oldMetadata.copyBuilder()
-              .channelNames(channelNames)
-              .imageWidth(width)
-              .imageHeight(height)
-              .intendedDimensions(newSizeCoordsBuilder.build())
-              .build();
-
       CloseViewerListener closeListener = null;
+
       try {
+         if (width == null || height == null) {
+            throw new DuplicatorException("Width and/or height is unexpectedly null");
+         }
+
+         SummaryMetadata metadata = oldMetadata.copyBuilder()
+                 .channelNames(channelNames)
+                 .imageWidth(width)
+                 .imageHeight(height)
+                 .intendedDimensions(newSizeCoordsBuilder.build())
+                 .build();
+
          newStore.setSummaryMetadata(metadata);
          // The implementations of the store set SummaryMetadata on another thread.
          // This can lead to disasters, so we have to poll to make sure SummaryMetadata is


### PR DESCRIPTION
Turns out the Duplicator plugin would silently crash on summary image metadata missing size information.  This PR both fixes that issue, and adds width and height info for the Snap/Live code path,