### PR TITLE
No longer produce many metadata.txt files with identical content.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -438,7 +438,7 @@ public final class StorageMultipageTiff implements Storage {
       if (!positionToFileSet_.containsKey(fileSetIndex)) {
          positionToFileSet_.put(fileSetIndex,
                new FileSet(image, this, omeMetadata_,
-                     splitByXYPosition_, separateMetadataFile_));
+                     splitByXYPosition_, fileSetIndex == 0 && separateMetadataFile_));
       }
       FileSet set = positionToFileSet_.get(fileSetIndex);
 


### PR DESCRIPTION
For multi-position acquisitions with separate files per position and saving metadata.txt files, only produce one metadata.txt rathern producing identical copies with the name of each tiff file.