### PR TITLE
Studio-NDTiffAdapter: Simplifies function getImagesMatching()

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/ndtiff/NDTiffAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/ndtiff/NDTiffAdapter.java
@@ -249,7 +249,7 @@ public class NDTiffAdapter implements Storage {
    @Override
    public List<Image> getImagesIgnoringAxes(
            Coords coords, String... ignoreTheseAxes) throws IOException {
-      // I don't see how this should do anything different than the above one...
+      // This is obviously wrong, but not quite sure what to do at this point....
 
       return getImagesMatching(coords);
    }


### PR DESCRIPTION
so that it does no longer go through the complete dataset.  This may lead to problems in certain cases, but at least makes virtual datasets readable again.
Closes #1839 