### PR TITLE
Snap on move improvements

### DIFF
--- a/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/ConfigFrame.java
+++ b/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/ConfigFrame.java
@@ -1,4 +1,4 @@
-// Snap-on-Move Preview for Micro-Manager
+// Snap-on-Move for Micro-Manager
 //
 // Author: Mark A. Tsuchida
 //
@@ -76,14 +76,12 @@ final class ConfigFrame extends JFrame {
 
    public ConfigFrame(final MainController controller) {
 
-      setTitle("Snap-on-Move Preview");
+      setTitle("Snap-on-Move");
       setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
       setLayout(new MigLayout("fill",
             "[]rel[]rel[grow, fill]rel[]", "[]rel[]unrel[]unrel[]rel[grow, fill]"));
 
-      add(new JLabel("Make sure to stop before starting MDA!"), "span 2, wrap");
-
-      add(new JLabel("Snap-on-Move Preview: "));
+      add(new JLabel("Snap-on-Move: "));
 
       final JButton enableButton = new JButton(ENABLE_BUTTON);
       enableButton.setText(controller.isEnabled() ? DISABLE_BUTTON : ENABLE_BUTTON);

--- a/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/MainController.java
+++ b/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/MainController.java
@@ -52,8 +52,7 @@ import org.micromanager.alerts.UpdatableAlert;
 import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.events.StagePositionChangedEvent;
 import org.micromanager.events.XYStagePositionChangedEvent;
-import org.micromanager.internal.propertymap.DefaultPropertyMap;
-import org.micromanager.internal.propertymap.MM1JSONSerializer;
+import org.micromanager.internal.propertymap.PropertyMapJSONSerializer;
 
 /**
  * The main control code for Snap-on-Move.
@@ -121,7 +120,7 @@ class MainController {
       if (criteriaJSON != null) {
          PropertyMap listPm = null;
          try {
-            listPm = MM1JSONSerializer.fromJSON(criteriaJSON);
+            listPm = PropertyMapJSONSerializer.fromJSON(criteriaJSON);
          } catch (IOException ignore) {
             studio.logs().logError(ignore);
          }
@@ -167,14 +166,13 @@ class MainController {
          cc.serialize(pmb);
          listPmb.putPropertyMap(Integer.toString(i), pmb.build());
       }
-      // TODO We shouldn't use internal class DefaultPropertyMap
-      String json = ((DefaultPropertyMap) listPmb.build()).toJSON();
+      String json = listPmb.build().toJSON();
       studio_.profile().getSettings(this.getClass()).putString(
             PROFILE_KEY_CHANGE_CRITERIA, json);
    }
 
    synchronized List<ChangeCriterion> getChangeCriteria() {
-      return new ArrayList<ChangeCriterion>(changeCriteria_);
+      return new ArrayList<>(changeCriteria_);
    }
 
    synchronized void setEnabled(boolean f) {

--- a/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/MainController.java
+++ b/plugins/SnapOnMove/src/main/java/org/micromanager/plugins/snaponmove/MainController.java
@@ -72,27 +72,23 @@ class MainController {
    // Although we frequently search for matching MonitoredItem, we just
    // use a list since the number of items is small and order preservation
    // is important.
-   private final List<ChangeCriterion> changeCriteria_ =
-         new ArrayList<ChangeCriterion>();
+   private final List<ChangeCriterion> changeCriteria_ = new ArrayList<>();
 
    // The most recent known values. For asynchonously notified items, the last
    // notified value. For polled items, the last polled value.
    // Synchronized by its own monitor, since it is accessed from notification
    // handlers.
-   private final Map<MonitoredItem, MonitoredValue> latestValues_ =
-         new HashMap<MonitoredItem, MonitoredValue>();
+   private final Map<MonitoredItem, MonitoredValue> latestValues_ = new HashMap<>();
 
    // Values at the time of the last snap, for use as a basis for detecting
    // movement. Only accessed from monitoring thread while monitoring thread
    // is running.
-   private final Map<MonitoredItem, MonitoredValue> lastSnapValues_ =
-         new HashMap<MonitoredItem, MonitoredValue>();
+   private final Map<MonitoredItem, MonitoredValue> lastSnapValues_ = new HashMap<>();
 
    // Use string elements (stage device name) for prototype; should change to
    // objects
    private final LinkedBlockingQueue<Map.Entry<MonitoredItem, MonitoredValue>>
-         eventQueue_ =
-         new LinkedBlockingQueue<Map.Entry<MonitoredItem, MonitoredValue>>();
+         eventQueue_ = new LinkedBlockingQueue<>();
 
    // The monitoring thread; null when not running (disabled)
    private Thread monitorThread_;
@@ -121,8 +117,8 @@ class MainController {
          PropertyMap listPm = null;
          try {
             listPm = PropertyMapJSONSerializer.fromJSON(criteriaJSON);
-         } catch (IOException ignore) {
-            studio.logs().logError(ignore);
+         } catch (IOException ioe) {
+            studio.logs().logError(ioe);
          }
          if (listPm != null) {
             for (int i = 0; ; ++i) {
@@ -285,7 +281,7 @@ class MainController {
       long remainingMs = Math.max(0, deadlineMs - System.currentTimeMillis());
       do {
          final Map<MonitoredItem, MonitoredValue> events =
-               new HashMap<MonitoredItem, MonitoredValue>();
+               new HashMap<>();
 
          Map.Entry<MonitoredItem, MonitoredValue> event =
                eventQueue_.poll(remainingMs, TimeUnit.MILLISECONDS);
@@ -401,7 +397,7 @@ class MainController {
          synchronized (latestValues_) {
             latestValues_.put(item, value);
          }
-         eventQueue_.put(new AbstractMap.SimpleEntry<MonitoredItem, MonitoredValue>(item, value));
+         eventQueue_.put(new AbstractMap.SimpleEntry<>(item, value));
       } catch (InterruptedException unexpected) {
          Thread.currentThread().interrupt();
       }
@@ -425,7 +421,7 @@ class MainController {
          synchronized (latestValues_) {
             latestValues_.put(item, value);
          }
-         eventQueue_.put(new AbstractMap.SimpleEntry<MonitoredItem, MonitoredValue>(item, value));
+         eventQueue_.put(new AbstractMap.SimpleEntry<>(item, value));
       } catch (InterruptedException unexpected) {
          Thread.currentThread().interrupt();
       }


### PR DESCRIPTION
Closes #1823.  Now remembers movement criteria between MM invocations.  Also automatically stops operation while an acquisition is running.

@marktsuchida, could you check if the way I handle pausing the monitoring thread is correct?  It works OK with the demo config.

I'd be happy to move this out of the beta menu item, probably into "Device Control".