### PR TITLE
Optimizes Storage:getImagesIgnoringAxes implementations.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -128,11 +128,14 @@ public final class StorageRAM implements RewritableStorage {
 
    @Override
    public synchronized List<Image> getImagesMatching(Coords coords) {
-      if (coordsToImage_ == null) {
-         return null;
+      List<String> ignoredAxes = new ArrayList<>();
+      for (String axis : axesInUse_) {
+         if (!coords.getAxes().contains(axis)) {
+            ignoredAxes.add(axis);
+         }
       }
       try {
-         return getImagesIgnoringAxes(coords, coords.getAxes().toArray(new String[0]));
+         return getImagesIgnoringAxes(coords, ignoredAxes.toArray(new String[0]));
       } catch (IOException ex) {
          ReportingUtils.logError(ex, "Failed to read image at " + coords);
          return null;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -131,12 +131,8 @@ public final class StorageRAM implements RewritableStorage {
          return null;
       }
       List<Image> results = new ArrayList<>();
-      for (Image image : coordsToImage_.values()) {
-         // TODO figure out why subSpace was used and fix problems by not doing it
-         //  if (image.getCoords().isSubspaceCoordsOf(coords)) {
-         if (image.getCoords().equals(coords)) {
-            results.add(image);
-         }
+      if (coordsToImage_.containsKey(coords)) {
+         results.add(coordsToImage_.get(coords));
       }
       return results;
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -166,7 +166,7 @@ public final class StorageRAM implements RewritableStorage {
       for (String axis : ignoreTheseAxes) {
          if (axesInUse_.contains(axis)) {
             haveIgnoredAxes = true;
-            continue;
+            break;
          }
       }
       if (!haveIgnoredAxes) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -35,6 +35,7 @@ import org.micromanager.data.Image;
 import org.micromanager.data.ImagesDifferInSizeException;
 import org.micromanager.data.RewritableStorage;
 import org.micromanager.data.SummaryMetadata;
+import org.micromanager.internal.utils.ReportingUtils;
 
 
 /**
@@ -130,11 +131,12 @@ public final class StorageRAM implements RewritableStorage {
       if (coordsToImage_ == null) {
          return null;
       }
-      List<Image> results = new ArrayList<>();
-      if (coordsToImage_.containsKey(coords)) {
-         results.add(coordsToImage_.get(coords));
+      try {
+         return getImagesIgnoringAxes(coords, coords.getAxes().toArray(new String[0]));
+      } catch (IOException ex) {
+         ReportingUtils.logError(ex, "Failed to read image at " + coords);
+         return null;
       }
-      return results;
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -924,8 +924,14 @@ public final class StorageMultipageTiff implements Storage {
 
    @Override
    public List<Image> getImagesMatching(Coords coords) {
+      List<String> ignoredAxes = new ArrayList<>();
+      for (String axis : axesInUse_) {
+         if (!coords.getAxes().contains(axis)) {
+            ignoredAxes.add(axis);
+         }
+      }
       try {
-         return getImagesIgnoringAxes(coords, coords.getAxes().toArray(new String[0]));
+         return getImagesIgnoringAxes(coords, ignoredAxes.toArray(new String[0]));
       } catch (IOException ex) {
          ReportingUtils.logError(ex, "Failed to read image at " + coords);
          return null;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -924,22 +924,12 @@ public final class StorageMultipageTiff implements Storage {
 
    @Override
    public List<Image> getImagesMatching(Coords coords) {
-      HashSet<Image> result = new HashSet<>();
-      synchronized (coordsToPendingImage_) {
-         for (Coords imageCoords : coordsToPendingImage_.keySet()) {
-            if (imageCoords.equals(coords)) {
-               result.add(coordsToPendingImage_.get(imageCoords));
-            }
-         }
+      try {
+         return getImagesIgnoringAxes(coords, coords.getAxes().toArray(new String[0]));
+      } catch (IOException ex) {
+         ReportingUtils.logError(ex, "Failed to read image at " + coords);
+         return null;
       }
-      if (coordsToReader_.containsKey(coords)) {
-         try {
-            result.add(coordsToReader_.get(coords).readImage(coords));
-         } catch (IOException ex) {
-            ReportingUtils.logError("Failed to read image at " + coords);
-         }
-      }
-      return new ArrayList<>(result);
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -932,13 +932,11 @@ public final class StorageMultipageTiff implements Storage {
             }
          }
       }
-      for (Coords imageCoords : coordsToReader_.keySet()) {
-         if (imageCoords.equals(coords)) {
-            try {
-               result.add(coordsToReader_.get(imageCoords).readImage(imageCoords));
-            } catch (IOException ex) {
-               ReportingUtils.logError("Failed to read image at " + imageCoords);
-            }
+      if (coordsToReader_.containsKey(coords)) {
+         try {
+            result.add(coordsToReader_.get(coords).readImage(coords));
+         } catch (IOException ex) {
+            ReportingUtils.logError("Failed to read image at " + coords);
          }
       }
       return new ArrayList<>(result);
@@ -964,7 +962,7 @@ public final class StorageMultipageTiff implements Storage {
       for (String axis : ignoreTheseAxes) {
          if (axesInUse_.contains(axis)) {
             haveIgnoredAxes = true;
-            continue;
+            break;
          }
       }
       if (!haveIgnoredAxes) {


### PR DESCRIPTION
Closes #1858. The implementations of the function Storage:getImagesIgnoringAxes would iterate over all known coords to check if they match or not.  This is an expensive operation, especially for large datasets.  Our code only uses this function with the axis Channels as the ignored axes, so I added code to store those in a HashMap for fast retrieval.  This change avoids the slow down in display speed for large datasets.

The function GetImagesMatching appears to be almost the same in intent.  I changed its implementations to call getImageIgnoringAxes wherever appropriate.   

There is quite a bit of redundancy in this code.  I played with creating a special class for handling Coords for all Storage implementations, but this was not very pleasant either.  