### PR TITLE
SplitView: adds new image sizes to the Summarymetadata.

### DIFF
--- a/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewProcessor.java
+++ b/plugins/SplitView/src/main/java/org/micromanager/splitview/SplitViewProcessor.java
@@ -84,7 +84,20 @@ public class SplitViewProcessor implements Processor {
             newNames[i * numSplits_ + j] = base + channelSuffixes_.get(j);
          }
       }
-      return summary.copyBuilder().channelNames(newNames).build();
+      SummaryMetadata.Builder sb = summary.copyBuilder().channelNames(newNames);
+
+      if (summary.getImageWidth() != null && summary.getImageHeight() != null) {
+         int width = summary.getImageWidth();
+         int height = summary.getImageHeight();
+         if (orientation_.equals(SplitViewFrame.TB)) {
+            height /= numSplits_;
+         } else {
+            width /= numSplits_;
+         }
+         sb.imageWidth(width).imageHeight(height);
+      }
+
+      return sb.build();
    }
 
    @Override


### PR DESCRIPTION
Closes #1874. The Datastores now better enforce correct size information, which should be provided by the Image processors in the Summarymetadata.  So, this change fixes a regression.