### PR TITLE
Studio: Fixes recent bug in reading single page Tiffs.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -65,6 +65,7 @@ public final class StorageRAM implements RewritableStorage {
       maxIndex_ = new DefaultCoords.Builder().build();
       axesInUse_ = new TreeSet<>();
       summaryMetadata_ = (new DefaultSummaryMetadata.Builder()).build();
+      coordsIndexedMissingC_ = new HashMap<>();
       // It is imperative that we be notified of new images before anyone who
       // wants to retrieve the images from the store is notified.
       ((DefaultDatastore) store).registerForEvents(this, 0);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
@@ -122,6 +122,7 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
       axesInUse_ = new TreeSet<>();
       maxIndices_ = new DefaultCoords.Builder().build();
       amLoading_ = false;
+      coordsIndexedMissingC_ = new HashMap<>();
       isMultiPosition_ = true;
 
       // Note: this will throw an error if there is no existing data set


### PR DESCRIPTION
This was caused by uninitialized HashMap coordsIndexedMissingC_.  These type of errors really should be picked up by automated testing, but setting that up correctly will involve some effort.

Closes #1884