### PR TITLE
Studio: AcqEngJ: fixed null pointer exception.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -734,7 +734,8 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
                         || (Integer) event.getAxisPosition(MDAAcqEventModules.POSITION_AXIS) == 0)
                   && (event.getAxisPosition(AcqEngMetadata.CHANNEL_AXIS) == null
                         || (Integer) event.getAxisPosition(AcqEngMetadata.CHANNEL_AXIS) == 0)) {
-               if (event.getTIndex() != null && event.getTIndex() % skipFrames != 0) {
+               if (event.getTIndex() != null && skipFrames != 0
+                       && event.getTIndex() % skipFrames != 0) {
                   return event;
                }
                try {


### PR DESCRIPTION
Not sure why this did not show up before, but skipFrames=0 (more or less the default) cause a divide by null exception.  Wondering if this also fixes #1891.