### PR TITLE
Datastore close on save

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/Datastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/Datastore.java
@@ -169,6 +169,18 @@ public interface Datastore extends DataProvider {
    void save(SaveMode mode, String path, boolean blocking) throws IOException;
 
    /**
+    * Saves the datastore to the given path using the given format (SaveMode).
+    *
+    * @param mode     File format to save to
+    * @param path     File path used to save the data
+    * @param blocking when true, will block while saving data, otherwise will return
+    *                 immediately
+    * @param closeOnSave when true, will close datastore after saving.
+    * @throws java.io.IOException if an IO error occurs
+    */
+   void save(SaveMode mode, String path, boolean blocking, boolean closeOnSave) throws IOException;
+   
+   /**
     * Sets the name of the Datastore.  Posts a DatastoreNewNameEvent.
     *
     * @param name new name of the Datastore

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
@@ -68,6 +68,11 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
 
    }
    
+   /**
+    * Same as constructor above with closeOnSave parameter
+    * 
+    * @param closeOnSave when true, will close datastore after saving.
+    */
    public DefaultDataSaver(Studio studio,
                            DefaultDatastore store,
                            Datastore.SaveMode mode,

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
@@ -29,6 +29,7 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
    private final String path_;
    private final DefaultDatastore duplicate_;
    private final Storage saver_;
+   private boolean closeOnSave_;
 
    /**
     * Takes care of most of the dirty work saving data to various targets.
@@ -46,6 +47,7 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
       this.studio = studio;
       store_ = store;
       path_ = path;
+      closeOnSave_ = false;
 
       duplicate_ = new DefaultDatastore(this.studio);
 
@@ -65,6 +67,15 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
       }
 
    }
+   
+   public DefaultDataSaver(Studio studio,
+                           DefaultDatastore store,
+                           Datastore.SaveMode mode,
+                           String path,
+                           boolean closeOnSave) throws IOException {
+      this(studio, store, mode, path);
+      closeOnSave_ = closeOnSave;
+      }
 
    @Override
    protected Void doInBackground() throws IOException {
@@ -186,6 +197,9 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
       // may trigger side-effects that "finish" the process of saving.
       store_.setSavePath(path_);
       store_.freeze();
+      if (closeOnSave_) {
+          store_.close();
+      }
       duplicate_.setSavePath(path_);
       duplicate_.freeze();
       duplicate_.close();

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -518,6 +518,16 @@ public class DefaultDatastore implements Datastore {
          ds.execute();
       }
    }
+   
+   @Override
+   public void save(Datastore.SaveMode mode, String path, boolean blocking, boolean closeOnSave) throws IOException {
+      DefaultDataSaver ds = new DefaultDataSaver(studio_, this, mode, path, closeOnSave);
+      if (blocking) {
+         ds.doInBackground();
+      } else {
+         ds.execute();
+      }
+   }
 
    protected Map<String, Annotation> getAnnotations() {
       return annotations_;


### PR DESCRIPTION
RAMDatastore has option to save asynchronously but currently doesn't have an option to close datastore when it is finished. This adds a new save() method to DefaultDatastore class with parameter closeOnSave so that datastore can be deleted without close() calling from the main thread.

Notes: 

I'm not sure if this is an issue only for me because of how I've written our acquisition code with Pycro-Manager. To me, this seems like this would be the default behavior, but I suppose it's not because the displays from MDA are RAMDatastores, and it would be weird to close immediately after saving. 

Anyway, I've tested this with the nightly build and it works as intended--RAMDatastore is closed after saving is completed.