### PR TITLE
Studio: when reading from a large read-only multipage tiff

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
@@ -23,6 +23,7 @@ package org.micromanager.data.internal;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import org.micromanager.PropertyMap;
 import org.micromanager.PropertyMaps;
@@ -98,9 +99,11 @@ public final class DefaultAnnotation implements Annotation {
       }
       File file = new File(store_.getSavePath() + File.separator + filename_);
       if (!file.exists()) {
-         file.createNewFile();
+         if (!file.createNewFile()) {
+            throw new IOException("Can not save Annotation.  File does not exist and can not be created.");
+         }
       }
-      if (!file.canWrite()) {
+      if (!Files.isWritable(file.toPath())) {
          throw new IOException("Can not save Annotation.  File is not writeable.");
       }
       PropertyMap.Builder builder = PropertyMaps.builder();

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultAnnotation.java
@@ -100,7 +100,8 @@ public final class DefaultAnnotation implements Annotation {
       File file = new File(store_.getSavePath() + File.separator + filename_);
       if (!file.exists()) {
          if (!file.createNewFile()) {
-            throw new IOException("Can not save Annotation.  File does not exist and can not be created.");
+            throw new IOException(
+                    "Can not save Annotation.  File does not exist and can not be created.");
          }
       }
       if (!Files.isWritable(file.toPath())) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -583,8 +583,13 @@ public final class MultipageTiffReader {
          raFile_ = null;
       }
       if (masterStorage_ != null) {
-         CommentsHelper.saveComments(masterStorage_.getDatastore());
-         masterStorage_ = null;
+         try {
+            CommentsHelper.saveComments(masterStorage_.getDatastore());
+         } catch (IOException e) {
+            throw e;
+         } finally {
+            masterStorage_ = null;
+         }
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -1044,11 +1044,17 @@ public final class StorageMultipageTiff implements Storage {
          }
       }
       // For files we read from disk.
+      int errorCounter = 0;
       for (MultipageTiffReader reader : coordsToReader_.values()) {
          try {
             reader.close();
          } catch (IOException e) {
+            errorCounter++;
             ReportingUtils.logError(e, "Error cleaning up open file descriptor");
+            if (errorCounter > 10) {
+               ReportingUtils.logError("Too many errors closing file descriptors");
+               return;
+            }
          }
       }
    }


### PR DESCRIPTION
data set, various problems arise on exit, delaying exit for hours. This PR uses a valid method to establish whether the annotations file can be written to.  It also gives up trying to write to file handles that can not be written to after 10 tries.  This gives a great performance boost. It should be evaluated if there are edge cases where this approach is detrimental.