### PR TITLE
Many improvements in AcqEngJ compat layer

### DIFF
--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -46,7 +46,7 @@
       <dependency org="org.micro-manager.pyjavaz" name="PyJavaZ" rev="1.0.0">
          <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
       </dependency>
-      <dependency org="org.micro-manager.acqengj" name="AcqEngJ" rev="0.34.4">
+      <dependency org="org.micro-manager.acqengj" name="AcqEngJ" rev="0.37.1">
          <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
       </dependency>
 		<dependency org="org.micro-manager.ndviewer" name="NDViewer" rev="0.10.2">

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -607,22 +607,23 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          @Override
          public AcquisitionEvent run(AcquisitionEvent event) {
             if (sequenceSettings.acqOrderMode() == AcqOrderMode.POS_TIME_CHANNEL_SLICE
-                  || sequenceSettings.acqOrderMode() == AcqOrderMode.POS_TIME_SLICE_CHANNEL
-                  && event.getAxisPosition("position") != null) {
-               if (startTime_ == 0) {
-                  startTime_ = System.currentTimeMillis();
-               }
-
-               int thisPosition = (int) event.getAxisPosition("position");
-               if (thisPosition != lastPositionIndex_) {
-                  relativePositionStartTime_ =  System.currentTimeMillis() - startTime_;
-                  lastPositionIndex_ = (int) event.getAxisPosition("position");
-                  positionMoved_ = true;
-               }
-               if (positionMoved_) {
-                  long relativeStartTime = relativePositionStartTime_
-                        + event.getMinimumStartTimeAbsolute() - startTime_;
-                  event.setMinimumStartTime(relativeStartTime);
+                  || sequenceSettings.acqOrderMode() == AcqOrderMode.POS_TIME_SLICE_CHANNEL) {
+               Object pPos = event.getAxisPosition("position");
+               if (pPos != null && pPos instanceof Integer) {
+                  if (startTime_ == 0) {
+                     startTime_ = System.currentTimeMillis();
+                  }
+                  int thisPosition = (int) event.getAxisPosition("position");
+                  if (thisPosition != lastPositionIndex_) {
+                     relativePositionStartTime_ = System.currentTimeMillis() - startTime_;
+                     lastPositionIndex_ = (int) event.getAxisPosition("position");
+                     positionMoved_ = true;
+                  }
+                  if (positionMoved_ && event.getMinimumStartTimeAbsolute() != null) {
+                     long relativeStartTime = relativePositionStartTime_
+                             + event.getMinimumStartTimeAbsolute() - startTime_;
+                     event.setMinimumStartTime(relativeStartTime);
+                  }
                }
             }
             if (event.getMinimumStartTimeAbsolute() != null) {

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -262,7 +262,7 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
                   AcquisitionAPI.AFTER_EXPOSURE_HOOK);
          }
 
-         // These hooks make sure that continuousfocus is off when running a Z stack.
+         // These hooks make sure that continuous-focus is off when running a Z stack.
          if (studio_.core().isContinuousFocusEnabled()) {
             currentAcquisition_.addHook(continuousFocusHookBefore(acquisitionSettings),
                   AcquisitionAPI.BEFORE_HARDWARE_HOOK);
@@ -270,9 +270,9 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
                   AcquisitionAPI.AFTER_EXPOSURE_HOOK);
          }
 
-         // These hooks implement Autofocus
-         // TODO: does this give the correct behavior?  This should run after the XY stage
-         // reaches its new position, but before the z stage is moved from its current position
+         // These hooks implement Autofocus.
+         // This runs after the XY stage reaches its new position, but before the z stage
+         // is moved from its current position (tested on hardware).
          if (sequenceSettings_.useAutofocus()) {
             currentAcquisition_.addHook(autofocusHookBefore(sequenceSettings_.skipAutofocusCount()),
                   AcquisitionAPI.BEFORE_HARDWARE_HOOK);
@@ -1622,6 +1622,14 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
       if (event.getStore().equals(curStore_)) {
          curStore_ = null;
          curPipeline_ = null;
+         if (currentAcquisition_ != null) {
+            try {
+               currentAcquisition_.checkForExceptions();
+            } catch (Exception ex) {
+               studio_.logs().logError(ex);
+               studio_.logs().showMessage("Acquisition problem: " + ex.getMessage());
+            }
+         }
          currentAcquisition_ = null;
          studio_.events().unregisterForEvents(this);
       }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -271,13 +271,13 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          }
 
          // These hooks implement Autofocus.
-         // Autofocus needs to run after the XY stage and opional other stages have been set to
+         // Autofocus needs to run after the XY stage and optionally other stages have been set to
          // the correct position, but before the Z-drive moves to its first position of a Z stack.
          // AcqEngJ does not have hooks for this, so move the XY stage and other stages in the positionlist
          // ourselves inside the autofocusHookBefore function.
          if (sequenceSettings_.useAutofocus()) {
             currentAcquisition_.addHook(autofocusHookBefore(sequenceSettings_.skipAutofocusCount()),
-                  AcquisitionAPI.BEFORE_HARDWARE_HOOK);
+                  AcquisitionAPI.BEFORE_Z_DRIVE_HOOK);
          }
 
          // Hooks to keep shutter open between channel and/or slices if desired
@@ -771,21 +771,6 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
                   return event;
                }
                try {
-                  // this hook is called before the engine changes the hardware
-                  // since we want to leave the system in a focussed state, first
-                  // move the XY stage to where we want to image, then autofocus.
-                  if (event.getXPosition() != null && event.getYPosition() != null) {
-                     studio_.core().setXYPosition(event.getXPosition(), event.getYPosition());
-                  }
-                  // Also move all other devices listed in the position list
-                  if (event.getStageDeviceNames() != null) {
-                     for (String stage : event.getStageDeviceNames()) {
-                        if (!stage.equals(core_.getXYStageDevice())) {
-                           double pos = event.getStageSingleAxisStagePosition(stage);
-                           core_.setPosition(stage, pos);
-                        }
-                     }
-                  }
                   studio_.getAutofocusManager().getAutofocusMethod().fullFocus();
                   // TODO: Read back the position of the focus drive, and somehow perpetuate it back
                   // to the StagePositionList that is in use.

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -27,7 +27,11 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.function.Function;
 import javax.swing.JOptionPane;
 import mmcorej.CMMCore;
@@ -275,13 +279,13 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          // These hooks implement Autofocus.
          // Autofocus needs to run after the XY stage and optionally other stages have been set to
          // the correct position, but before the Z-drive moves to its first position of a Z stack.
-         // AcqEngJ does not have hooks for this, so move the XY stage and other stages in the positionlist
-         // ourselves inside the autofocusHookBefore function.
+         // AcqEngJ does not have hooks for this, so move the XY stage and other stages in the
+         // positionlist ourselves inside the autofocusHookBefore function.
          if (sequenceSettings_.useAutofocus()) {
             currentAcquisition_.addHook(autofocusHook(sequenceSettings_.skipAutofocusCount()),
                   AcquisitionAPI.BEFORE_Z_DRIVE_HOOK);
-            // add a hook to update the Z drive positions based on the position found in the previous round
-            // after autofocussing.
+            // add a hook to update the Z drive positions based on the position found in the i
+            // previous round after autofocussing.
             currentAcquisition_.addHook(adjustZDrivesHook(), AcquisitionAPI.BEFORE_HARDWARE_HOOK);
          }
 
@@ -314,23 +318,24 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
             if (zDevice != null && !zDevice.isEmpty()) {
                msp.add(StagePosition.create1D(zDevice, core_.getPosition(zDevice)));
             }
-            // assume that all positions in the list use the same stages, we eventually could go through all of them
-            // to pick up unique stages, but lets keep it simpler for now
+            // assume that all positions in the list use the same stages, we eventually could go
+            // through all of them to pick up unique stages, but lets keep it simpler for now
             MultiStagePosition msp0 = posList_.getPosition(0);
-            for (int i = 0;i < msp.size(); i++) {
+            for (int i = 0; i < msp.size(); i++) {
                StagePosition sp = msp0.get(0);
                String stageDevice = sp.getStageDeviceLabel();
                if (sp.is1DStagePosition() && !stageDevice.equals(zDevice)) {
                   msp.add(StagePosition.create1D(stageDevice, core_.getPosition(stageDevice)));
                }
-               // Multiple XY stages are not supported yet by the acq engine.  Add them here to avoid
-               // forgetting about it in the future.
+               // Multiple XY stages are not supported yet by the acq engine.  Add them here to
+               // avoid forgetting about it in the future.
                if (sp.is2DStagePosition() && !stageDevice.equals(xyStageDevice)) {
                   msp.add(StagePosition.create2D(stageDevice, core_.getXPosition(stageDevice),
                           core_.getYPosition(stageDevice)));
                }
             }
-            currentAcquisition_.addHook(restorePositionHook(msp), AcquisitionAPI.AFTER_EXPOSURE_HOOK);
+            currentAcquisition_.addHook(restorePositionHook(msp),
+                    AcquisitionAPI.AFTER_EXPOSURE_HOOK);
          }
 
          // Read for events
@@ -804,8 +809,9 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
 
    /**
     * Hook function that updates the stagePositions in this event with the stage positions last set
-    * by autofocus.  Will only run if autofocus is enabled.  Look for the positionLabel in the event's
-    * tags, see if we have that in our positionMap_, and if so, update the stage positions in the event
+    * by autofocus.  Will only run if autofocus is enabled.  Look for the positionLabel in the
+    * event's tags, see if we have that in our positionMap_, and if so, update the stage
+    * positions in the event.
     */
    public AcquisitionHook adjustZDrivesHook() {
       return new AcquisitionHook() {

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -133,7 +133,7 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
 
    // this is where the work happens
    private Datastore runAcquisition(SequenceSettings sequenceSettings) {
-      SequenceSettings.Builder sb = sequenceSettings.copyBuilder();
+      final SequenceSettings.Builder sb = sequenceSettings.copyBuilder();
       //Make sure computer can write to selected location and there is enough space to do so
       if (sequenceSettings.save()) {
          File root = new File(sequenceSettings.root());
@@ -470,14 +470,6 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
     */
    private Iterator<AcquisitionEvent> createAcqEventIterator(SequenceSettings acquisitionSettings)
          throws Exception {
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> channels = null;
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> zStack = null;
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> positions = null;
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> timelapse = null;
-
-      ArrayList<Function<AcquisitionEvent, Iterator<AcquisitionEvent>>> acqFunctions
-            = new ArrayList<>();
-
       // Select channels that we are actually using
       List<ChannelSpec> chSpecs = new ArrayList<>();
       for (ChannelSpec chSpec : acquisitionSettings.channels()) {
@@ -486,6 +478,7 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          }
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> zStack = null;
       if (acquisitionSettings.useSlices()) {
          double origin = acquisitionSettings.slices().get(0);
          if (acquisitionSettings.relativeZSlice()) {
@@ -499,6 +492,7 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
                null);
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> channels = null;
       if (acquisitionSettings.useChannels()) {
          if (chSpecs.size() > 0) {
             Integer middleSliceIndex = (acquisitionSettings.slices().size() - 1) / 2;
@@ -506,8 +500,9 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          }
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> positions = null;
       if (acquisitionSettings.usePositionList()) {
-         positions = MDAAcqEventModules.positions(posList_, null);
+         positions = MDAAcqEventModules.positions(posList_, null, core_);
          // TODO: is acq engine supposed to move multiple stages?
          // Yes: when moving to a new position, all stages in the MultiStagePosition instance
          // should be moved to the desired location
@@ -516,12 +511,15 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          // whatever is asked to do.
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> timelapse = null;
       if (acquisitionSettings.useFrames()) {
          timelapse = MDAAcqEventModules.timelapse(acquisitionSettings.numFrames(),
                acquisitionSettings.intervalMs(), null);
          // TODO custom time intervals
       }
 
+      ArrayList<Function<AcquisitionEvent, Iterator<AcquisitionEvent>>> acqFunctions
+              = new ArrayList<>();
       if (acquisitionSettings.acqOrderMode() == AcqOrderMode.POS_TIME_CHANNEL_SLICE) {
          if (acquisitionSettings.usePositionList()) {
             acqFunctions.add(positions);

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/MDAAcqEventModules.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/MDAAcqEventModules.java
@@ -237,11 +237,7 @@ public class MDAAcqEventModules {
                         // API does not handle non-default XY stages
                      }
                   } else {
-                     //if (sp.getStageDeviceLabel().equals(core.getFocusDevice())) {
-                     //   posEvent.setZ(null, sp.get1DPosition());
-                     //} else {
                      posEvent.setStageCoordinate(sp.getStageDeviceLabel(), sp.get1DPosition());
-                     //}
                   }
                }
                HashMap<String, String> tags = posEvent.getTags();

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/MDAAcqEventModules.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/MDAAcqEventModules.java
@@ -7,8 +7,10 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import mmcorej.CMMCore;
 import org.micromanager.MultiStagePosition;
 import org.micromanager.PositionList;
+import org.micromanager.StagePosition;
 import org.micromanager.acqj.internal.Engine;
 import org.micromanager.acqj.main.AcqEngMetadata;
 import org.micromanager.acqj.main.AcquisitionEvent;
@@ -71,7 +73,7 @@ public class MDAAcqEventModules {
                Integer chIndex = (Integer) event.getAxisPosition("channel");
                if (chIndex != null) {
                   if (!chSpecs.get(chIndex).doZStack()) {
-                     zPos = zOrigin + (stopSliceIndex - startSliceIndex) / 2 * zStep;
+                     zPos = zOrigin + ((stopSliceIndex - startSliceIndex) / 2) * zStep;
                   }
                }
                AcquisitionEvent sliceEvent = event.copy();
@@ -133,7 +135,7 @@ public class MDAAcqEventModules {
     *                    the channels that are actually used.
     * @param middleSliceIndex Only used when use ZStack is not checked, indicates index
     *                         of the middle slice
-    * @return
+    * @return Function with AcquisitionEvent and Iterator
     */
    public static Function<AcquisitionEvent, Iterator<AcquisitionEvent>> channels(
          List<ChannelSpec> channelList, Integer middleSliceIndex,
@@ -210,10 +212,10 @@ public class MDAAcqEventModules {
     *
     * @param positionList MM PositionList used in this acquisition
     * @param extraTags - Key Value pairs that will be added to Image Metadata
-    * @return
+    * @return Function with AcquisitionEvent and Iterator
     */
    public static Function<AcquisitionEvent, Iterator<AcquisitionEvent>> positions(
-         PositionList positionList, HashMap<String, String> extraTags) {
+         PositionList positionList, HashMap<String, String> extraTags, CMMCore core) {
       return (AcquisitionEvent event) -> {
          Stream.Builder<AcquisitionEvent> builder = Stream.builder();
          if (positionList == null || positionList.getNumberOfPositions() == 0) {
@@ -223,8 +225,25 @@ public class MDAAcqEventModules {
                AcquisitionEvent posEvent = event.copy();
 
                MultiStagePosition msp = positionList.getPosition(index);
-               posEvent.setX(msp.getX());
-               posEvent.setY(msp.getY());
+               for (int s = 0; s < msp.size(); s++) {
+                  StagePosition sp = msp.get(s);
+                  if (sp.is2DStagePosition()) {
+                     // we will run into trouble when there is more than 1 XY stage.
+                     // for now, assume it is always the core XY stage
+                     if (sp.getStageDeviceLabel().equals(core.getXYStageDevice())) {
+                        posEvent.setX(msp.getX());
+                        posEvent.setY(msp.getY());
+                     } else {
+                        // API does not handle non-default XY stages
+                     }
+                  } else {
+                     //if (sp.getStageDeviceLabel().equals(core.getFocusDevice())) {
+                     //   posEvent.setZ(null, sp.get1DPosition());
+                     //} else {
+                     posEvent.setStageCoordinate(sp.getStageDeviceLabel(), sp.get1DPosition());
+                     //}
+                  }
+               }
                HashMap<String, String> tags = posEvent.getTags();
                tags.put(AcqEngMetadata.POS_NAME, msp.getLabel());
                if (extraTags != null) {

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
@@ -255,7 +255,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
 
          // These hooks implement Autofocus
          if (basicSettings.useAutofocus()) {
-            currentMultiMDA_.addHook(autofocusHookBefore(basicSettings.skipAutofocusCount()),
+            currentMultiMDA_.addHook(autofocusHook(basicSettings.skipAutofocusCount()),
                   AcquisitionAPI.BEFORE_HARDWARE_HOOK);
          }
 

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
@@ -361,10 +361,6 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
          SequenceSettings acquisitionSettings, PositionList positionList, int acqIndex,
          int timeIndex, long minimumStartTime)
          throws Exception {
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> channels = null;
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> zStack = null;
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> positions = null;
-
       // Select channels that we are actually using
       List<ChannelSpec> chSpecs = new ArrayList<>();
       for (ChannelSpec chSpec : acquisitionSettings.channels()) {
@@ -376,9 +372,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       HashMap<String, String> tag = new HashMap<>(1);
       tag.put(ACQ_IDENTIFIER, String.valueOf(acqIndex));
 
-      ArrayList<Function<AcquisitionEvent, Iterator<AcquisitionEvent>>> acqFunctions =
-            new ArrayList<>();
-
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> zStack = null;
       if (acquisitionSettings.useSlices()) {
          double origin = acquisitionSettings.slices().get(0);
          if (acquisitionSettings.relativeZSlice()) {
@@ -392,6 +386,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
                tag);
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> channels = null;
       if (acquisitionSettings.useChannels()) {
          Integer middleSliceIndex = (acquisitionSettings.slices().size() - 1) / 2;
          channels = MDAAcqEventModules.channels(chSpecs, middleSliceIndex, tag);
@@ -400,10 +395,13 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
          //TODO: z stack off for channel
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> positions = null;
       if (acquisitionSettings.usePositionList()) {
-         positions = MDAAcqEventModules.positions(positionList, tag);
+         positions = MDAAcqEventModules.positions(positionList, tag, core_);
       }
 
+      ArrayList<Function<AcquisitionEvent, Iterator<AcquisitionEvent>>> acqFunctions =
+              new ArrayList<>();
       if (acquisitionSettings.acqOrderMode() == AcqOrderMode.TIME_POS_CHANNEL_SLICE) {
          if (acquisitionSettings.usePositionList()) {
             acqFunctions.add(positions);
@@ -541,6 +539,12 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       return numPositions;
    }
 
+   /**
+    * Returns the number of slices in this acquisition.
+    *
+    * @param sequenceSettings The settings for the acquisition
+    * @return Number of slices in this acquisition.
+    */
    public static int getNumSlices(SequenceSettings sequenceSettings) {
       if (!sequenceSettings.useSlices()) {
          return 1;
@@ -699,6 +703,11 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       return true;
    }
 
+   /**
+    * Check if an abort has been requested.
+    *
+    * @return true if an abort has been requested, false otherwise
+    */
    public boolean abortRequested() {
       if (currentMultiMDA_ != null) {
          return currentMultiMDA_.isAbortRequested();
@@ -710,6 +719,11 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       stop(true);
    }
 
+   /**
+    * Pause the acquisition.
+    *
+    * @param state true to pause, false to resume
+    */
    public void setPause(boolean state) {
       if (currentMultiMDA_ != null) {
          currentMultiMDA_.setPaused(state);
@@ -717,6 +731,12 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
    }
 
    //// State Queries /////////////////////////////////////////////////////
+
+   /**
+    * Check if the acquisition is running.
+    *
+    * @return true if the acquisition is running, false otherwise
+    */
    public boolean isAcquisitionRunning() {
       // Even after the acquisition finishes, if the pipeline is still "live",
       // we should consider the acquisition to be running.
@@ -735,6 +755,11 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       }
    }
 
+   /**
+    * Checks if the acquisition is finished.
+    *
+    * @return true if the acquisition is finished, false otherwise
+    */
    public boolean isFinished() {
       if (currentMultiMDA_ != null) {
          return currentMultiMDA_.areEventsFinished();
@@ -759,6 +784,11 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       posList_ = posList;
    }
 
+   /**
+    * Adds the Studio object.
+    *
+    * @param parent The Studio object
+    */
    public void setParentGUI(Studio parent) {
       studio_ = parent;
       core_ = studio_.core();
@@ -871,6 +901,12 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
    }
 
 
+   /**
+    * Creates a human-readable summary of the acquisition.
+    *
+    * @param sequenceSettings The settings for the acquisition
+    * @return A human-readable summary of the acquisition
+    */
    public String getVerboseSummary(SequenceSettings sequenceSettings) {
       final int numFrames = getNumFrames(sequenceSettings);
       final int numSlices = getNumSlices(sequenceSettings);
@@ -996,6 +1032,11 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       return false;
    }
 
+   /**
+    * Returns the available preset groups.
+    *
+    * @return Array with the available preset groups
+    */
    public String[] getAvailableGroups() {
       StrVector groups;
       try {
@@ -1014,6 +1055,11 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       return strGroups.toArray(new String[0]);
    }
 
+   /**
+    * Returns the current Z position.
+    *
+    * @return The current Z position
+    */
    public double getCurrentZPos() {
       if (isFocusStageAvailable()) {
          double z = 0.0;
@@ -1029,6 +1075,11 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       return 0;
    }
 
+   /**
+    * Queries if the acquisition is currenly paused.
+    *
+    * @return true if the acquisition is paused, false otherwise
+    */
    public boolean isPaused() {
       if (currentMultiMDA_ != null) {
          return currentMultiMDA_.isPaused();

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/testacquisition/TestAcqAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/testacquisition/TestAcqAdapter.java
@@ -471,14 +471,6 @@ public class TestAcqAdapter implements AcquisitionEngine, MMAcquistionControlCal
     */
    private Iterator<AcquisitionEvent> createAcqEventIterator(SequenceSettings acquisitionSettings)
            throws Exception {
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> channels = null;
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> zStack = null;
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> positions = null;
-      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> timelapse = null;
-
-      ArrayList<Function<AcquisitionEvent, Iterator<AcquisitionEvent>>> acqFunctions
-              = new ArrayList<>();
-
       // Select channels that we are actually using
       List<ChannelSpec> chSpecs = new ArrayList<>();
       for (ChannelSpec chSpec : acquisitionSettings.channels()) {
@@ -487,6 +479,7 @@ public class TestAcqAdapter implements AcquisitionEngine, MMAcquistionControlCal
          }
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> zStack = null;
       if (acquisitionSettings.useSlices()) {
          double origin = acquisitionSettings.slices().get(0);
          if (acquisitionSettings.relativeZSlice()) {
@@ -500,6 +493,7 @@ public class TestAcqAdapter implements AcquisitionEngine, MMAcquistionControlCal
                  null);
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> channels = null;
       if (acquisitionSettings.useChannels()) {
          if (chSpecs.size() > 0) {
             Integer middleSliceIndex = (acquisitionSettings.slices().size() - 1) / 2;
@@ -507,8 +501,9 @@ public class TestAcqAdapter implements AcquisitionEngine, MMAcquistionControlCal
          }
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> positions = null;
       if (acquisitionSettings.usePositionList()) {
-         positions = MDAAcqEventModules.positions(posList_, null);
+         positions = MDAAcqEventModules.positions(posList_, null, core_);
          // TODO: is acq engine supposed to move multiple stages?
          // Yes: when moving to a new position, all stages in the MultiStagePosition instance
          // should be moved to the desired location
@@ -517,12 +512,15 @@ public class TestAcqAdapter implements AcquisitionEngine, MMAcquistionControlCal
          // whatever is asked to do.
       }
 
+      Function<AcquisitionEvent, Iterator<AcquisitionEvent>> timelapse = null;
       if (acquisitionSettings.useFrames()) {
          timelapse = MDAAcqEventModules.timelapse(acquisitionSettings.numFrames(),
                  acquisitionSettings.intervalMs(), null);
          // TODO custom time intervals
       }
 
+      ArrayList<Function<AcquisitionEvent, Iterator<AcquisitionEvent>>> acqFunctions
+              = new ArrayList<>();
       if (acquisitionSettings.acqOrderMode() == AcqOrderMode.POS_TIME_CHANNEL_SLICE) {
          if (acquisitionSettings.usePositionList()) {
             acqFunctions.add(positions);


### PR DESCRIPTION
Should only be merged after AcqEngJ 0.37.0 is released.  
- Repositions stages at the end of acquisition
- Actually shows error, rather than silently doing nothing.
- When using position list, moves all drives rather than only XY drives
- When using position list, updates positions after autofocus, so those are used at the next time point.