### PR TITLE
Studio: MultipageTiff reader: re-use ByteBuffer instead of allocating a new one for each image. 

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/ImageByteBuffer.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/ImageByteBuffer.java
@@ -1,0 +1,52 @@
+package org.micromanager.data.internal.multipagetiff;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * A simple class to hold a ByteBuffer and its size.
+ */
+public final class ImageByteBuffer {
+   private final ByteBuffer buffer_;
+   private final int size_;
+   private final ByteOrder byteOrder_;
+
+   /**
+    * Create a new ImageByteBuffer.
+    *
+    * @param size The size of the buffer.
+    * @param byteOrder The byte order of the buffer.
+    */
+   public ImageByteBuffer(int size, ByteOrder byteOrder) {
+      buffer_ = ByteBuffer.allocateDirect(size).order(byteOrder);
+      size_ = size;
+      byteOrder_ = byteOrder;
+   }
+
+   /**
+    * Get the ByteBuffer.
+    *
+    * @return The ByteBuffer.
+    */
+   public ByteBuffer getBuffer() {
+      return buffer_;
+   }
+
+   /**
+    * Get the size of the buffer.
+    *
+    * @return The size of the buffer.
+    */
+   public int getSize() {
+      return size_;
+   }
+
+   /**
+    * Get the byte order of the buffer.
+    *
+    * @return The byte order of the buffer.
+    */
+   public ByteOrder getByteOrder() {
+      return byteOrder_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -89,6 +89,7 @@ public final class MultipageTiffReader {
    private PropertyMap imageFormatReadFromSummary_;
 
    private HashMap<Coords, Long> coordsToOffset_;
+   private ImageByteBuffer imageByteBuffer_;
 
    /**
     * This constructor is used for a file that is currently being written.
@@ -421,8 +422,8 @@ public final class MultipageTiffReader {
       return (DefaultImage) readImage(data);
    }
 
-   private Image readImage(IFDData data) throws IOException {
-      ByteBuffer pixelBuffer = ByteBuffer.allocate((int) data.bytesPerImage).order(byteOrder_);
+   private synchronized Image readImage(IFDData data) throws IOException {
+      ByteBuffer pixelBuffer = getByteBuffer((int) data.bytesPerImage, byteOrder_);
       ByteBuffer mdBuffer = ByteBuffer.allocate((int) data.mdLength).order(byteOrder_);
       fileChannel_.read(pixelBuffer, data.pixelOffset);
       fileChannel_.read(mdBuffer, data.mdOffset);
@@ -518,6 +519,17 @@ public final class MultipageTiffReader {
          // can be thrown when meatadata are bad, todo: report
          return null;
       }
+   }
+
+   private ByteBuffer getByteBuffer(int length, ByteOrder byteOrder) {
+      if (imageByteBuffer_ != null
+              && imageByteBuffer_.getSize() == length
+              && imageByteBuffer_.getByteOrder() == byteOrder) {
+         return imageByteBuffer_.getBuffer();
+      } else {
+         imageByteBuffer_ = new ImageByteBuffer(length, byteOrder);
+      }
+      return imageByteBuffer_.getBuffer();
    }
 
    private IFDEntry readDirectoryEntry(int offset, ByteBuffer buffer) throws IOException {


### PR DESCRIPTION
Also uses allocateDirect rather than allocate.
2250 x 255
Testing AllocateDirect versus Allocate on a dataset of 192 images 2250 x 2250 x 2 bytes (i.e. 192 * 10.125MB = 192 MB) with the script: "

```
start = System.currentTimeMillis();
mm.data().loadData("C:\\Users\\Nico Stuurman\\IMages\\imageData", false);
end = System.currentTimeMillis();
mm.scripter().message("It took: " + (end - start) + " ms");
```

10 times for each gave:

Old code: 6.2 +- 0.3 seconds
Allocate: 6.2 +- 0.9 seconds
AllocateDirect: 6.0 +- 0.83 seconds

Interestingly when run under the debugger in IntelliJ, Allocate was much slower than Allocate Direct (9.1 +- 2.0 seconds).

Not a huge difference, but the more images are in the dataset, the higher the performance improvement should be.  Also, this should create less work for the garbage collector.  Lastly, this seems an obvious thing to do, with the possible downside that it does not allow for multiple simultaneous calls to readImage (which seems a dangerous, untested thing to do in any case, so making this function synchronized may even be helpful).