### PR TITLE
Studio: Fixes memory leak in Multipage Tiff writer.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
@@ -320,6 +320,7 @@ public final class MultipageTiffWriter {
       return allocateByteBuffer(capacity);
    }
 
+
    private static void tryRecycleLargeBuffer(ByteBuffer b) {
       // Keep up to BUFFER_POOL_SIZE direct buffers of the current size
       if (BUFFER_POOL_SIZE == 0 || !b.isDirect()) {
@@ -437,6 +438,13 @@ public final class MultipageTiffWriter {
       ByteBuffer indexMapNumEntries = allocateByteBuffer(4);
       indexMapNumEntries.putInt(0, numImages);
       fileChannelWrite(indexMapNumEntries, indexMapFirstEntry_ - 4);
+      // no more data will be written, clear the buffers to free up memory.
+      if (BUFFER_POOL_SIZE == 0) {
+         return;
+      }
+      synchronized (MultipageTiffWriter.class) {
+         pooledBuffers_.clear();
+      }
    }
 
    /**


### PR DESCRIPTION
Each tif file has its own MultipageTiffWriter.  Each MultipageTIffwriter has a buffer pool of up to 3 images.  When the file approaches 4GB in size, the MultipageTiffWriter is no longer used, and a new one is created to continue writing to a new file.  However, its bufferPool was never released.  This caused major problems with a dataset with extremely large images, but more generally, this was an unnecessary memory leak. This commit clears the pool when the finish() function is called (which happens when the file approaches 4GB and a new one is created).
