### PR TITLE
Studio: Redo Reuse of ByteBuffer in MultiPageTIffReader.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/ImageByteBuffer.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/ImageByteBuffer.java
@@ -1,0 +1,52 @@
+package org.micromanager.data.internal.multipagetiff;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * A simple class to hold a ByteBuffer and its size.
+ */
+public final class ImageByteBuffer {
+   private final ByteBuffer buffer_;
+   private final int size_;
+   private final ByteOrder byteOrder_;
+
+   /**
+    * Create a new ImageByteBuffer.
+    *
+    * @param size The size of the buffer.
+    * @param byteOrder The byte order of the buffer.
+    */
+   public ImageByteBuffer(int size, ByteOrder byteOrder) {
+      buffer_ = ByteBuffer.allocateDirect(size).order(byteOrder);
+      size_ = size;
+      byteOrder_ = byteOrder;
+   }
+
+   /**
+    * Get the ByteBuffer.
+    *
+    * @return The ByteBuffer.
+    */
+   public ByteBuffer getBuffer() {
+      return buffer_;
+   }
+
+   /**
+    * Get the size of the buffer.
+    *
+    * @return The size of the buffer.
+    */
+   public int getSize() {
+      return size_;
+   }
+
+   /**
+    * Get the byte order of the buffer.
+    *
+    * @return The byte order of the buffer.
+    */
+   public ByteOrder getByteOrder() {
+      return byteOrder_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -89,6 +89,7 @@ public final class MultipageTiffReader {
    private PropertyMap imageFormatReadFromSummary_;
 
    private HashMap<Coords, Long> coordsToOffset_;
+   private ImageByteBuffer imageByteBuffer_;
 
    /**
     * This constructor is used for a file that is currently being written.
@@ -421,8 +422,20 @@ public final class MultipageTiffReader {
       return (DefaultImage) readImage(data);
    }
 
+   private ByteBuffer getByteBuffer(int length, ByteOrder byteOrder) {
+      if (imageByteBuffer_ != null
+            && imageByteBuffer_.getSize() == length
+            && imageByteBuffer_.getByteOrder() == byteOrder) {
+      return imageByteBuffer_.getBuffer();
+      } else {
+         imageByteBuffer_ = new ImageByteBuffer(length, byteOrder);
+         return imageByteBuffer_.getBuffer();
+      }
+   }
+
    private Image readImage(IFDData data) throws IOException {
-      ByteBuffer pixelBuffer = ByteBuffer.allocate((int) data.bytesPerImage).order(byteOrder_);
+      ByteBuffer pixelBuffer = getByteBuffer((int)data.bytesPerImage, byteOrder_);
+      pixelBuffer.rewind();
       ByteBuffer mdBuffer = ByteBuffer.allocate((int) data.mdLength).order(byteOrder_);
       fileChannel_.read(pixelBuffer, data.pixelOffset);
       fileChannel_.read(mdBuffer, data.mdOffset);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -422,19 +422,8 @@ public final class MultipageTiffReader {
       return (DefaultImage) readImage(data);
    }
 
-   private ByteBuffer getByteBuffer(int length, ByteOrder byteOrder) {
-      if (imageByteBuffer_ != null
-            && imageByteBuffer_.getSize() == length
-            && imageByteBuffer_.getByteOrder() == byteOrder) {
-      return imageByteBuffer_.getBuffer();
-      } else {
-         imageByteBuffer_ = new ImageByteBuffer(length, byteOrder);
-         return imageByteBuffer_.getBuffer();
-      }
-   }
-
    private Image readImage(IFDData data) throws IOException {
-      ByteBuffer pixelBuffer = getByteBuffer((int)data.bytesPerImage, byteOrder_);
+      ByteBuffer pixelBuffer = getByteBuffer((int) data.bytesPerImage, byteOrder_);
       pixelBuffer.rewind();
       ByteBuffer mdBuffer = ByteBuffer.allocate((int) data.mdLength).order(byteOrder_);
       fileChannel_.read(pixelBuffer, data.pixelOffset);
@@ -530,6 +519,17 @@ public final class MultipageTiffReader {
 
          // can be thrown when meatadata are bad, todo: report
          return null;
+      }
+   }
+
+   private ByteBuffer getByteBuffer(int length, ByteOrder byteOrder) {
+      if (imageByteBuffer_ != null
+              && imageByteBuffer_.getSize() == length
+              && imageByteBuffer_.getByteOrder() == byteOrder) {
+         return imageByteBuffer_.getBuffer();
+      } else {
+         imageByteBuffer_ = new ImageByteBuffer(length, byteOrder);
+         return imageByteBuffer_.getBuffer();
       }
    }
 


### PR DESCRIPTION
Realized that all that was missing was a rewind of the ByteBUffer. Redoing, since this should greatly reduce memory footprint, as the FileChannels are hodling on the to the ByteBuffers they are reading in (at least in the JVM we are currently using).