### PR TITLE
Studio: Revert ByteBuffer from Direct to normal.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/ImageByteBuffer.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/ImageByteBuffer.java
@@ -18,7 +18,7 @@ public final class ImageByteBuffer {
     * @param byteOrder The byte order of the buffer.
     */
    public ImageByteBuffer(int size, ByteOrder byteOrder) {
-      buffer_ = ByteBuffer.allocateDirect(size).order(byteOrder);
+      buffer_ = ByteBuffer.allocate(size).order(byteOrder);
       size_ = size;
       byteOrder_ = byteOrder;
    }


### PR DESCRIPTION
This should fix bugs with 8-bit and RGB images.  Converting that code to work with Direct Buffers seems to negate any speed advantages with shorts.  Sorry for the mess.   Hopefully, the memory fixes will still work.