### PR TITLE
Multi-page Tiff Reader, avoid direct memory to fill up.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -216,12 +216,6 @@ public final class DefaultDataManager implements DataManager {
       if (!dirFile.isDirectory()) {
          directory = dirFile.getParent();
       }
-      // when stored with multiple positions, we need to go one level up
-      // check by looking for a comments file
-      File tmpDirFile = new File(directory);
-      if ((new File(tmpDirFile.getParent() + File.separator + "comments.txt")).exists()) {
-         directory = tmpDirFile.getParent();
-      }
 
       DefaultDatastore result = new DefaultDatastore(studio_);
       // TODO: future additional file formats will need to be handled here.

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -216,6 +216,13 @@ public final class DefaultDataManager implements DataManager {
       if (!dirFile.isDirectory()) {
          directory = dirFile.getParent();
       }
+      // when stored with multiple positions, we need to go one level up
+      // check by looking for a comments file
+      File tmpDirFile = new File(directory);
+      if ((new File(tmpDirFile.getParent() + File.separator + "comments.txt")).exists()) {
+         directory = tmpDirFile.getParent();
+      }
+
       DefaultDatastore result = new DefaultDatastore(studio_);
       // TODO: future additional file formats will need to be handled here.
       // For now we just choose between StorageMultipageTiff and

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -33,7 +33,6 @@ import org.micromanager.data.Coords;
 import org.micromanager.data.DataProviderHasNewSummaryMetadataEvent;
 import org.micromanager.data.Datastore;
 import org.micromanager.data.Image;
-import org.micromanager.data.ImagesDifferInSizeException;
 import org.micromanager.data.RewritableStorage;
 import org.micromanager.data.SummaryMetadata;
 import org.micromanager.internal.utils.ReportingUtils;
@@ -185,8 +184,10 @@ public final class StorageRAM implements RewritableStorage {
          // otherwise, the search will be very expensive (which will  be the case for other
          // axes) and result in noticaeble slowodwns with large datasetsz
          if (ignoreTheseAxes[0].equals(Coords.CHANNEL)) {
-            for (Coords tmpCoords : coordsIndexedMissingC_.get(coords)) {
-               result.add(coordsToImage_.get(tmpCoords));
+            if (coordsIndexedMissingC_.get(coords) != null) {
+               for (Coords tmpCoords : coordsIndexedMissingC_.get(coords)) {
+                  result.add(coordsToImage_.get(tmpCoords));
+               }
             }
          } else {
             // Brute force it.  This will be slow with large data sets

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/ImageByteBuffer.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/ImageByteBuffer.java
@@ -18,7 +18,7 @@ public final class ImageByteBuffer {
     * @param byteOrder The byte order of the buffer.
     */
    public ImageByteBuffer(int size, ByteOrder byteOrder) {
-      buffer_ = ByteBuffer.allocateDirect(size).order(byteOrder);
+      buffer_ = ByteBuffer.allocate(size).order(byteOrder);
       size_ = size;
       byteOrder_ = byteOrder;
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -423,7 +423,7 @@ public final class MultipageTiffReader {
          return null;
       }
       long byteOffset = coordsToOffset_.get(coords);
-      if (raFile_ == null) {
+      if (fileChannel_ == null) {
          createFileChannel(false);
       }
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -617,6 +617,7 @@ public final class MultipageTiffReader {
          raFile_ = null;
       }
    }
+
    /**
     * Closes this MultipageTIffReader. Saves comments.
     *

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -112,6 +112,7 @@ public final class StorageMultipageTiff implements Storage {
 
    // Map of image Coords to files
    private Map<Coords, MultipageTiffReader> coordsToReader_;
+   private MultipageTiffReader lastReader_;
    private Map<Coords, List<Coords>> coordsIndexedMissingC_;
    // Cache the axes that are in use
    private final Set<String> axesInUse_;
@@ -1009,7 +1010,13 @@ public final class StorageMultipageTiff implements Storage {
          return null;
       }
       try {
-         return coordsToReader_.get(coords).readImage(coords);
+         MultipageTiffReader mptReader = coordsToReader_.get(coords);
+         if (lastReader_ != null && mptReader != lastReader_) {
+            // this could be optional.  Not doing it can result in large memory leaks.
+            lastReader_.pause();
+         }
+         lastReader_ = mptReader;
+         return mptReader.readImage(coords);
       } catch (IOException ex) {
          ReportingUtils.logError(ex, "Failed to read image at " + coords);
          return null;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -1011,7 +1011,7 @@ public final class StorageMultipageTiff implements Storage {
       }
       try {
          MultipageTiffReader mptReader = coordsToReader_.get(coords);
-         if (lastReader_ != null && mptReader != lastReader_) {
+         if (!amInWriteMode_ && lastReader_ != null && mptReader != lastReader_) {
             // this could be optional.  Not doing it can result in large memory leaks.
             lastReader_.pause();
          }


### PR DESCRIPTION
While opening a Multipage Tiff dataset consisting of a few hundred 4GB files, the computer ran out of its 256GB of memory.  Researching this issue showed that this memory was associated with the FileChannel and/or File not closing.  I do not know if this is bug in the version of the JVM we are using, or a general problem, but it makes it impossible to go through large datasets that were opened in virtual mode.  This PR (branch is poorly named) changes the way MultipageTIffReader works, by closing the FileChannel and FileHandle whenever the Reader switches to another File.  I was afraid that closing and opening File Handles would be costly, but do not see significant slowdown on my systems.

This PR also switches back from using Direct Buffers to non-direct.  Direct Buffers do not open 8-bit and RGB images correctly, so it will be good to merge this PR soon.