### PR TITLE
Studio: Make it optional to unlock autofocus during Z stack.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -271,7 +271,7 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
 
          // These hooks make sure that continuous-focus is off when running a Z stack.
          if (studio_.core().isContinuousFocusEnabled()
-                 && ((MMStudio) studio_).settings().getUnlockAutofocusInZStack()) {
+                 && ((MMStudio) studio_).settings().getUnlockAutofocusDuringZStack()) {
             currentAcquisition_.addHook(continuousFocusHookBefore(acquisitionSettings),
                   AcquisitionAPI.BEFORE_HARDWARE_HOOK);
             currentAcquisition_.addHook(continuousFocusHookAfter(acquisitionSettings),

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -71,6 +71,7 @@ import org.micromanager.data.internal.PropertyKey;
 import org.micromanager.display.DisplayWindow;
 import org.micromanager.events.NewPositionListEvent;
 import org.micromanager.events.internal.InternalShutdownCommencingEvent;
+import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.propertymap.NonPropertyMapJSONFormats;
 import org.micromanager.internal.utils.AcqOrderMode;
 import org.micromanager.internal.utils.MMException;
@@ -269,7 +270,8 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
          }
 
          // These hooks make sure that continuous-focus is off when running a Z stack.
-         if (studio_.core().isContinuousFocusEnabled()) {
+         if (studio_.core().isContinuousFocusEnabled()
+                 && ((MMStudio) studio_).settings().getUnlockAutofocusInZStack()) {
             currentAcquisition_.addHook(continuousFocusHookBefore(acquisitionSettings),
                   AcquisitionAPI.BEFORE_HARDWARE_HOOK);
             currentAcquisition_.addHook(continuousFocusHookAfter(acquisitionSettings),

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1213,6 +1213,8 @@ public final class MMStudio implements Studio {
             + "before they are written to disk";
       private static final String SHOULD_USE_ACQENGJ
               = "Use new Acquisition Engine";
+      private static final String UNLOCK_AUTOFOCUS_DURING_Z_STACK
+              = "Unlock autofocus during Z stack";
 
       public boolean getShouldDeleteOldCoreLogs() {
          return profile().getSettings(MMStudio.class).getBoolean(
@@ -1271,6 +1273,16 @@ public final class MMStudio implements Studio {
          profile().getSettings(MMStudio.class).putBoolean(
                  SHOULD_USE_ACQENGJ, use);
          acquisitions().setAcquisitionSettings(acqSettings);
+      }
+
+      public boolean getUnlockAutofocusDuringZStack() {
+         return profile().getSettings(MMStudio.class).getBoolean(
+                 UNLOCK_AUTOFOCUS_DURING_Z_STACK, true);
+      }
+
+      public void setUnlockAutofocusDuringZStack(boolean use) {
+         profile().getSettings(MMStudio.class).putBoolean(
+                 UNLOCK_AUTOFOCUS_DURING_Z_STACK, use);
       }
    }
 }


### PR DESCRIPTION
Needed in some unexpected situations.  Use the Options mechanism, but do not expose in Options dialog.