### PR TITLE
Read bad mp tiff files, and better UI feedback in Duplicator plugin

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -444,6 +444,10 @@ public final class MultipageTiffReader {
       fileChannel_.read(mdBuffer, data.mdOffset);
 
       String mdJSON = getString(mdBuffer);
+      String tmp = mdJSON.substring(mdJSON.length() - 3);
+      if (!tmp.substring(0,2).equals("\"}")) {
+         mdJSON = (new StringBuilder(mdJSON.substring(0, mdJSON.length() -3))).append("\"}").toString();
+      }
       JsonParser parser = new JsonParser();
       JsonReader reader = new JsonReader(new StringReader(mdJSON));
       reader.setLenient(true);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -445,8 +445,9 @@ public final class MultipageTiffReader {
 
       String mdJSON = getString(mdBuffer);
       String tmp = mdJSON.substring(mdJSON.length() - 3);
-      if (!tmp.substring(0,2).equals("\"}")) {
-         mdJSON = (new StringBuilder(mdJSON.substring(0, mdJSON.length() -3))).append("\"}").toString();
+      if (!tmp.substring(0, 2).equals("\"}")) {
+         mdJSON = (new StringBuilder(mdJSON.substring(0, mdJSON.length() - 3))).append("\"}")
+                 .toString();
       }
       JsonParser parser = new JsonParser();
       JsonReader reader = new JsonReader(new StringReader(mdJSON));

--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorExecutor.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorExecutor.java
@@ -208,6 +208,7 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
       }
 
       CloseViewerListener closeListener = null;
+      int nrCopied = 0;
 
       try {
          if (width == null || height == null) {
@@ -271,7 +272,6 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
             }
          });
 
-         int nrCopied = 0;
          for (Coords oldCoord : orderedImageCoords) {
             List<String> oldAxes = oldStore.getAxes();
             boolean copy = !oldAxes.contains(Coords.CHANNEL);
@@ -347,6 +347,9 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
                
             }
          }
+         if (nrCopied == 0) {
+            copyDisplay.close();
+         }
       } catch (DatastoreFrozenException ex) {
          studio_.logs().showError("Can not add data to frozen datastore");
       } catch (DatastoreRewriteException ex) {
@@ -362,6 +365,10 @@ public class DuplicatorExecutor extends SwingWorker<Void, Void> {
          newStore.freeze();
       } catch (IOException ioe) {
          studio_.logs().showError(ioe, "IOException freezing store in Duplicator plugin");
+      }
+      if (nrCopied == 0) {
+         studio_.logs().showError("Found no images in the requested range", theWindow_.getWindow());
+         return null;
       }
       studio_.displays().manage(newStore);
       return null;

--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
@@ -232,11 +232,14 @@ public class DuplicatorPluginFrame extends JDialog {
                   }
                   maxes.put(axis, (Integer) maxSpinner.getValue() - 1);
                   try {
+                     if (ourWindow_.getDisplayedImages().isEmpty()) {
+                        return;
+                     }
                      Coords coord = ourWindow_.getDisplayedImages().get(0).getCoords();
                      coord = coord.copyBuilder().index(axis, maxes.get(axis)).build();
                      ourWindow_.setDisplayPosition(coord);
                   } catch (IOException ioe) {
-                     studio_.logs().logError(ioe, "IOException in DuplcatorPlugin");
+                     studio_.logs().logError(ioe, "IOException in DuplicatorPlugin");
                   }
                });
                super.add(maxSpinner, "wmin 60, wrap");


### PR DESCRIPTION
We encountered Micro-Manager data where some of the image metadata json was not terminated with `"}`.  It would be ideal to figure out how that happened and ensure this will never happen again, but to be able to still read this data I added code to terminate the json string if not properly terminated.  This will have a tiny performance penalty, but save other data too.  Please advice whether or not this should be included. 

The other half of the PR give user feedback when the Duplicator plugin finds nothing to duplicate.  Sorry to bring these unrelated things together in one PR, can split out if that works better.

