### PR TITLE
Studio: Make CoreEventCallback aware of the current acquisition engine.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
@@ -26,7 +26,7 @@ import javax.swing.SwingUtilities;
 import mmcorej.CMMCore;
 import mmcorej.MMEventCallback;
 import org.micromanager.Studio;
-import org.micromanager.acquisition.internal.AcquisitionWrapperEngine;
+import org.micromanager.acquisition.AcquisitionManager;
 
 /**
  * Callback to update Java layer when a change happens in the MMCore. This
@@ -37,7 +37,7 @@ public final class CoreEventCallback extends MMEventCallback {
 
    private final CMMCore core_;
    private final Studio studio_;
-   private final AcquisitionWrapperEngine engine_;
+   private final AcquisitionManager acquisitionManager_;
    private volatile boolean ignoreCoreEvents_;
 
    /**
@@ -46,21 +46,21 @@ public final class CoreEventCallback extends MMEventCallback {
     * ignoreEvents_ flag.
     *
     * @param studio Our main Studio object (usually a singleton)
-    * @param engine Acquisition engine object
+    * @param acquisitionManager Acquisition manager abstracts access to engine object
     */
    @SuppressWarnings("LeakingThisInConstructor")
-   public CoreEventCallback(Studio studio, AcquisitionWrapperEngine engine) {
+   public CoreEventCallback(Studio studio, AcquisitionManager acquisitionManager) {
       super();
       studio_ = studio;
       core_ = studio.core();
-      engine_ = engine;
+      acquisitionManager_ = acquisitionManager;
       core_.registerCallback(this);
    }
 
    @Override
    public void onPropertiesChanged() {
       // TODO: remove test once acquisition engine is fully multithreaded
-      if (engine_ != null && engine_.isAcquisitionRunning()) {
+      if (acquisitionManager_ != null && acquisitionManager_.isAcquisitionRunning()) {
          core_.logMessage("Notification from MMCore ignored because acquisition is running!", true);
       } else if (ignoreCoreEvents_) {
          core_.logMessage("Notification from MMCore ignored", true);

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -391,6 +391,12 @@ public final class MMStudio implements Studio {
 
       org.micromanager.internal.diagnostics.gui.ProblemReportController.startIfInterruptedOnExit();
 
+      acquisitionManager_ = new DefaultAcquisitionManager(
+              this, ui_.getAcquisitionWindow());
+
+      // This entity is a class property to avoid garbage collection.
+      coreCallback_ = new CoreEventCallback(studio_, acquisitionManager_);
+
       // Load hardware configuration
       // Note that this also initializes Autofocus plugins.
       if (sysConfigFile_ != null) {  // we do allow running Micro-Manager without a config file!
@@ -399,12 +405,6 @@ public final class MMStudio implements Studio {
             // TODO Do we still need to turn errors off to prevent spurious error messages?
          }
       }
-
-      acquisitionManager_ = new DefaultAcquisitionManager(
-            this, ui_.getAcquisitionWindow());
-
-      // This entity is a class property to avoid garbage collection.
-      coreCallback_ = new CoreEventCallback(studio_, acquisitionManager_);
 
       try {
          core_.setCircularBufferMemoryFootprint(settings().getCircularBufferSize());


### PR DESCRIPTION
Should fix issue #1948.

CoreEventCallBack was never told about the current acquisition engine.  My only worry is that the changed order of initialization in MMStudio may cause unforeseen problems.   Hope that Mark can review.

Closes #1948.