### PR TITLE
MultipageTiff writer: warn against killing MM while filesets are being closed.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/FileSet.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/FileSet.java
@@ -21,6 +21,7 @@
 
 package org.micromanager.data.internal.multipagetiff;
 
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -38,6 +39,7 @@ import org.micromanager.data.internal.DefaultCoords;
 import org.micromanager.data.internal.DefaultMetadata;
 import org.micromanager.data.internal.DefaultSummaryMetadata;
 import org.micromanager.internal.propertymap.NonPropertyMapJSONFormats;
+import org.micromanager.internal.utils.ProgressBar;
 import org.micromanager.internal.utils.ReportingUtils;
 
 
@@ -112,9 +114,20 @@ class FileSet {
       // only need to finish last one here because previous ones in set are finished
       // as they fill up with images
       tiffWriters_.getLast().finish();
-      //  close all
+      //  close all, this can be time-consuming ,so use a ProgressBar
+      ProgressBar pb = null;
+      if (!GraphicsEnvironment.isHeadless() && tiffWriters_.size() > 4) {
+         pb = new ProgressBar(null, "Closing files", 0, tiffWriters_.size());
+      }
+      int count = 0;
       for (MultipageTiffWriter w : tiffWriters_) {
          w.close(omeXML, ijDescription);
+         if (pb != null) {
+            pb.setProgress(count++);
+         }
+      }
+      if (pb != null) {
+         pb.setVisible(false);
       }
       omeMetadata_ = null;
       masterStorage_ = null;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/FileSet.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/FileSet.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.UUID;
+import javax.swing.SwingUtilities;
 import org.micromanager.PropertyMap;
 import org.micromanager.data.Coords;
 import org.micromanager.data.Image;
@@ -38,6 +39,7 @@ import org.micromanager.data.internal.DefaultCoords;
 import org.micromanager.data.internal.DefaultMetadata;
 import org.micromanager.data.internal.DefaultSummaryMetadata;
 import org.micromanager.internal.propertymap.NonPropertyMapJSONFormats;
+import org.micromanager.internal.utils.ProgressBar;
 import org.micromanager.internal.utils.ReportingUtils;
 
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/FileSet.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/FileSet.java
@@ -30,7 +30,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.UUID;
-import javax.swing.SwingUtilities;
 import org.micromanager.PropertyMap;
 import org.micromanager.data.Coords;
 import org.micromanager.data.Image;
@@ -39,7 +38,6 @@ import org.micromanager.data.internal.DefaultCoords;
 import org.micromanager.data.internal.DefaultMetadata;
 import org.micromanager.data.internal.DefaultSummaryMetadata;
 import org.micromanager.internal.propertymap.NonPropertyMapJSONFormats;
-import org.micromanager.internal.utils.ProgressBar;
 import org.micromanager.internal.utils.ReportingUtils;
 
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -524,7 +524,6 @@ public final class StorageMultipageTiff implements Storage {
                filename = p.getCurrentFilename();
                p.finished(fullOMEXMLMetadata, ijDescription);
                master = p;
-               count++;
                break;
             }
          }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ProgressBar.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ProgressBar.java
@@ -34,8 +34,7 @@ import javax.swing.SwingUtilities;
 /**
  * Utility class to show a ProgressBar.
  * Construction of the ProgressBar is done on the EDT, on the first call of
- * SetProgress.  Thus, it is safe to call this class from any thread, with the
- * possible exception of a call to setVisible(false) from a non-EDT thread.
+ * SetProgress.  Thus, it is safe to call this class from any thread.
  */
 public final class ProgressBar extends JPanel {
    private static final long serialVersionUID = 1L;
@@ -122,7 +121,12 @@ public final class ProgressBar extends JPanel {
          });
          return;
       }
-      frame_.setVisible(visible);
+      if (visible && frame_ == null) {
+         initialize();
+      }
+      if (frame_ != null) {
+         frame_.setVisible(visible);
+      }
    }
 
    public void setRange(int min, int max) {


### PR DESCRIPTION
Tested under various scenarios, looks OK.