### PR TITLE
Studio: now actually saves MDA Settings in file.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -709,7 +709,7 @@ public enum PropertyKey {
       }
    },
 
-   MDA_SETTINGS("MdaSettings", SequenceSettings.class){
+   MDA_SETTINGS("MdaSettings", SequenceSettings.class) {
       @Override
       protected void convertFromGson(JsonElement je, PropertyMap.Builder dest) {
          dest.putString(key(), je.getAsString());

--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -709,7 +709,20 @@ public enum PropertyKey {
       }
    },
 
-   MDA_SETTINGS("MdaSettings", SequenceSettings.class),
+   MDA_SETTINGS("MdaSettings", SequenceSettings.class){
+      @Override
+      protected void convertFromGson(JsonElement je, PropertyMap.Builder dest) {
+         dest.putString(key(), je.getAsString());
+      }
+
+      @Override
+      protected JsonElement convertToGson(PropertyMap pmap) {
+         if (pmap.containsKey(key())) {
+            return new JsonPrimitive(pmap.getString(key(), null));
+         }
+         return null;
+      }
+   },
 
    METADATA_VERSION("MetadataVersion", SummaryMetadata.class) {
       @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/propertymap/NonPropertyMapJSONFormats.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/propertymap/NonPropertyMapJSONFormats.java
@@ -24,6 +24,7 @@ import static org.micromanager.data.internal.PropertyKey.INTENDED_DIMENSIONS;
 import static org.micromanager.data.internal.PropertyKey.INTERVAL_MS;
 import static org.micromanager.data.internal.PropertyKey.KEEP_SHUTTER_OPEN_CHANNELS;
 import static org.micromanager.data.internal.PropertyKey.KEEP_SHUTTER_OPEN_SLICES;
+import static org.micromanager.data.internal.PropertyKey.MDA_SETTINGS;
 import static org.micromanager.data.internal.PropertyKey.METADATA_VERSION;
 import static org.micromanager.data.internal.PropertyKey.MICRO_MANAGER_VERSION;
 import static org.micromanager.data.internal.PropertyKey.MULTI_STAGE_POSITION__DEFAULT_XY_STAGE;
@@ -275,6 +276,7 @@ public abstract class NonPropertyMapJSONFormats {
                STAGE_POSITIONS,
                KEEP_SHUTTER_OPEN_SLICES,
                KEEP_SHUTTER_OPEN_CHANNELS,
+               MDA_SETTINGS,
                PIXEL_TYPE, // Needed due to MultipageTiffReader design
                USER_DATA)) {
             key.extractFromGsonObject(je.getAsJsonObject(), builder);
@@ -309,6 +311,7 @@ public abstract class NonPropertyMapJSONFormats {
                STAGE_POSITIONS,
                KEEP_SHUTTER_OPEN_SLICES,
                KEEP_SHUTTER_OPEN_CHANNELS,
+               MDA_SETTINGS,
                PIXEL_TYPE, // compat
                WIDTH, // compat
                HEIGHT, // compat


### PR DESCRIPTION
I wonder about the representation.  It would be nicer to store them as a propertymap rather than a string, will need to look into that before merging. Since these data have not been stored yet (will need to check format of MDA Settings stored from MDA window), that may still be possible without backward compatibility issues.