### PR TITLE
Add macOS disk images to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ bin
 .vs/
 .vscode/
 
+# macOS packaging (with the nightly script)
+/*.dmg
+/*.sparseimage


### PR DESCRIPTION
These are created by the nightly build script.