### PR TITLE
No reload when saving the configuration file

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
@@ -111,6 +111,9 @@ public final class ConfigGroupPad extends JScrollPane {
       if (data_ != null) {
          data_.rebuildModel(fromCache);
          data_.fireTableStructureChanged();
+         if (table_.getCellEditor() != null) {
+            table_.getCellEditor().stopCellEditing();
+         }
          table_.repaint();
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultApplication.java
@@ -183,7 +183,9 @@ public class DefaultApplication implements Application {
          model.createSetupConfigsFromHardware(studio_.core());
          model.createResolutionsFromHardware(studio_.core());
          model.saveToFile(path);
-         ((MMStudio) studio_).setSysConfigFile(path);
+         // MM used to reload the config file here.  That takes time and I can not
+         // think of a good reason to do this (other than to fail fast).
+         ((MMStudio) studio_).setSysConfigFile(path, false);
          ((MMStudio) studio_).setConfigChanged(false);
       } catch (MMConfigFileException e) {
          ReportingUtils.showError(e);

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import mmcorej.CMMCore;
@@ -547,10 +548,34 @@ public final class MMStudio implements Studio {
     * @param newFile path to system configuration file.
     */
    public void setSysConfigFile(String newFile) {
+      setSysConfigFile(newFile, true);
+   }
+
+   /**
+    * Given a path to a file, will set the file as the
+    * new system configuration file.
+    * Set load to false when saving an already loaded configuration to
+    * another file.
+    *
+    * @param newFile path to system configuration file.
+    * @param load whether to load this configuraton file.
+    */
+   public void setSysConfigFile(String newFile, boolean load) {
       sysConfigFile_ = newFile;
       configChanged_ = false;
       ui_.frame().setConfigSaveButtonStatus(configChanged_);
-      loadSystemConfiguration();
+      if (load) {
+         loadSystemConfiguration();
+      }
+      // make sure everyone knows we are basing ourselves of a new file,
+      // even if we did not actually load it (to save time).
+      HardwareConfigurationManager.create(profile(), this)
+            .setNewConfiguration(sysConfigFile_);
+      FileDialogs.storePath(FileDialogs.MM_CONFIG_FILE, new File(sysConfigFile_));
+      // only to update display of currently used config file
+      uiManager().updateGUI(true, true);
+      SwingUtilities.invokeLater(() -> studio_.events().post(
+               new DefaultSystemConfigurationLoadedEvent()));
    }
 
    protected void changeBinning(String mode) {

--- a/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
@@ -262,7 +262,7 @@ public class MMUIManager {
    /**
     * Updates the GUI with the hardware state.
     *
-    * @param updateConfigPadStructure Whether or not to update the Config Pad.
+    * @param updateConfigPadStructure Whether to update the Config Pad.
     * @param fromCache                When true, use the cache in the core, otherwise, ask
     *                                 the hardware (which will update the cache).
     */

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -612,7 +612,7 @@ public final class MainFrame extends JFrame {
    /**
     * Bit superfluous.  Sets the exit strategy.
     *
-    * @param exitOnClose whether or not to quit the app when closing the window.
+    * @param exitOnClose whether to quit the app when closing the window.
     *                    When running as a Fiji plugin it is strange to exit the app,
     *                    whereas Micro-Manager users are used to it.
     */

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ConfigMenu.java
@@ -20,10 +20,12 @@ import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.profile.internal.gui.HardwareConfigurationManager;
 
+/**
+ * Implements the Main Window menu item "Devices".
+ */
 public final class ConfigMenu {
 
    private final JMenu switchConfigurationMenu_;
-
    private final MMStudio mmStudio_;
    private final CMMCore core_;
 
@@ -90,7 +92,7 @@ public final class ConfigMenu {
       File configFile = FileDialogs.openFile(mmStudio_.uiManager().frame(),
             "Load a Configuration File", FileDialogs.MM_CONFIG_FILE);
       if (configFile != null) {
-         mmStudio_.setSysConfigFile(configFile.getAbsolutePath());
+         mmStudio_.setSysConfigFile(configFile.getAbsolutePath(), true);
       }
    }
 
@@ -145,7 +147,7 @@ public final class ConfigMenu {
          GUIUtils.preventDisplayAdapterChangeExceptions();
 
          // re-initialize the system with the new configuration file
-         mmStudio_.setSysConfigFile(cfg.getFileName());
+         mmStudio_.setSysConfigFile(cfg.getFileName(), true);
 
          GUIUtils.preventDisplayAdapterChangeExceptions();
       } catch (Exception e) {
@@ -177,7 +179,7 @@ public final class ConfigMenu {
          }
          GUIUtils.addMenuItem(switchConfigurationMenu_,
                label, null,
-               () -> mmStudio_.setSysConfigFile(configFile));
+               () -> mmStudio_.setSysConfigFile(configFile, true));
          seenConfigs.add(configFile);
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/profile/internal/gui/HardwareConfigurationManager.java
+++ b/mmstudio/src/main/java/org/micromanager/profile/internal/gui/HardwareConfigurationManager.java
@@ -128,6 +128,19 @@ public class HardwareConfigurationManager {
       loadConfigImpl(file);
    }
 
+   /**
+    * Used when saving a config file where it is not needed to reload.
+    * Ensures that we remember the new config file.
+    *
+    * @param filename Full path to the new config file.
+    */
+   public void setNewConfiguration(String filename) {
+      File file = new File(filename);
+      if (file.exists()) {
+         rememberLoadedConfig(file);
+      }
+   }
+
    public void reloadHardwareConfiguration() throws Exception {
       File file = currentConfiguration_;
       rememberLoadedConfig(file);


### PR DESCRIPTION
So far, the Micro-Manager UI has always unloaded the existing configuration and reloaded it from file when saving a configuration.  Depending on the hardware, this can be a time-consuming action.  Thinking about speeding up some of the UI components, I realized there is no need for this except possibly to check quickly whether the new configuration file is faulty (please correct me if I am wrong in this assumption).  Over the many years using this, I have never found a problem.  

This PR keeps the existing configuration in memory after saving a new config file.  In limited testing with hardware, I have not found a problem, and it does speed things up quite a bit.  