### PR TITLE
Remember ChannelDisplaySettings upon any change in settings.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -296,14 +296,15 @@ public final class MMAcquisition extends DataViewerListener {
          ReportingUtils.logError("MMAcquisition: received callback from unknown viewer");
          return true;
       }
+      // NS 20241128: I do not understand the logic here.
+      // If this is not out Datastore or viewer, why deal with it?
       if (callbacks_.getAcquisitionDatastore() != viewer.getDataProvider()) {
          if (display_.getDisplaySettings() instanceof DefaultDisplaySettings) {
-            ((DefaultDisplaySettings) display_.getDisplaySettings()).saveToProfile(
-                  studio_.profile(), PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key());
+            DefaultDisplaySettings ds = (DefaultDisplaySettings) display_.getDisplaySettings();
+            ds.saveToProfile(studio_.profile(), PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key());
          }
          display_.removeListener(this);
          display_ = null;
-         // not our problem;)
          return true;
       }
       boolean result = callbacks_.abortRequest();
@@ -311,8 +312,8 @@ public final class MMAcquisition extends DataViewerListener {
          if (viewer instanceof DisplayWindow && viewer.equals(display_)) {
             // saving settings (again) may not be needed
             if (display_.getDisplaySettings() instanceof DefaultDisplaySettings) {
-               ((DefaultDisplaySettings) display_.getDisplaySettings()).saveToProfile(
-                     studio_.profile(), PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key());
+               DefaultDisplaySettings ds = (DefaultDisplaySettings) display_.getDisplaySettings();
+               ds.saveToProfile(studio_.profile(), PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key());
             }
             display_.removeListener(this);
             display_ = null;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
@@ -73,7 +73,6 @@ import org.micromanager.internal.utils.CoalescentEDTRunnablePool.CoalescentRunna
 import org.micromanager.internal.utils.MustCallOnEDT;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.internal.utils.performance.PerformanceMonitor;
-import org.micromanager.internal.utils.performance.gui.PerformanceMonitorUI;
 
 /**
  * Main controller for the standard image viewer.
@@ -135,8 +134,6 @@ public final class DisplayController extends DisplayWindowAPIAdapter
 
    private PerformanceMonitor perfMon_
          = PerformanceMonitor.createWithTimeConstantMs(1000.0);
-   private final PerformanceMonitorUI perfMonUI_
-         = PerformanceMonitorUI.create(perfMon_, "Display Performance");
 
 
    //This static counter makes sure that each object has it's own unique id during runtime.
@@ -1120,10 +1117,12 @@ public final class DisplayController extends DisplayWindowAPIAdapter
          // attempt to save Display Settings
          // TODO: Are there problems with multiple viewers on one Datastore?
          if (dataProvider_ instanceof Datastore) {
-            Datastore ds = (Datastore) dataProvider_;
-            if (ds.getSavePath() != null) {
-               ((DefaultDisplaySettings) getDisplaySettings()).save(ds.getSavePath());
+            Datastore store = (Datastore) dataProvider_;
+            if (store.getSavePath() != null) {
+               ((DefaultDisplaySettings) getDisplaySettings()).save(store.getSavePath());
             }
+            // Since every change in ChannelDisplaySettings is already stored in
+            // RememberedDisplaySettings we do not need to do it again here
          }
          dataProvider_.unregisterForEvents(this);
          try {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1056,7 +1056,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
             RememberedDisplaySettings.storeChannel(studio_,
                   channelSettings.getGroupName(),
                   channelSettings.getName(),
-                  rememberedSettings.copyBuilder().color(channelSettings.getColor()).build());
+                  channelSettings);
 
             ComponentDisplaySettings componentSettings =
                   channelSettings.getComponentSettings(0);

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -900,12 +900,6 @@ public final class SnapLiveManager extends DataViewerListener
       if (display_.getDisplaySettings() instanceof DefaultDisplaySettings) {
          DefaultDisplaySettings ds = (DefaultDisplaySettings) display_.getDisplaySettings();
          ds.saveToProfile(mmStudio_.profile(), PropertyKey.SNAP_LIVE_DISPLAY_SETTINGS.key());
-         for (int ch = 0; ch < store_.getSummaryMetadata().getChannelNameList().size(); ch++) {
-            RememberedDisplaySettings.storeChannel(mmStudio_,
-                  store_.getSummaryMetadata().getChannelGroup(),
-                  store_.getSummaryMetadata().getSafeChannelName(ch),
-                  ds.getChannelSettings(ch));
-         }
       }
    }
 


### PR DESCRIPTION
This not only simplifies the code, but also makes displaysetting behave more consistent.  

Closes #2029