### PR TITLE
Studio: prevent crash on shutdown when PropertyEditor is open.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -191,7 +191,7 @@ public final class PropertyEditor extends JFrame {
    public void onShutdownCommencing(ShutdownCommencingEvent event) {
       if (!event.isCanceled()) {
          flags_.save(PropertyEditor.class);
-         dispose();
+         this.dispose();
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlags.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlags.java
@@ -67,12 +67,14 @@ public final class ShowFlags {
 
    public void save(Class<?> c) {
       UserProfile profile = studio_.getUserProfile();
-      profile.getSettings(c).putBoolean(SHOW_CAMERAS, cameras_);
-      profile.getSettings(c).putBoolean(SHOW_SHUTTERS, shutters_);
-      profile.getSettings(c).putBoolean(SHOW_STAGES, stages_);
-      profile.getSettings(c).putBoolean(SHOW_STATE, state_);
-      profile.getSettings(c).putBoolean(SHOW_OTHER, other_);
-      profile.getSettings(c).putBoolean(SHOW_READONLY, readonly_);
-      profile.getSettings(c).putString(SEARCH_FILTER, searchFilter_);
+      if (profile != null) {
+         profile.getSettings(c).putBoolean(SHOW_CAMERAS, cameras_);
+         profile.getSettings(c).putBoolean(SHOW_SHUTTERS, shutters_);
+         profile.getSettings(c).putBoolean(SHOW_STAGES, stages_);
+         profile.getSettings(c).putBoolean(SHOW_STATE, state_);
+         profile.getSettings(c).putBoolean(SHOW_OTHER, other_);
+         profile.getSettings(c).putBoolean(SHOW_READONLY, readonly_);
+         profile.getSettings(c).putString(SEARCH_FILTER, searchFilter_);
+      }
    }
 }


### PR DESCRIPTION
I still do not fully understand why this happens, but this prevents it from happening.