### PR TITLE
Add ZMQ port command line option

### DIFF
--- a/buildscripts/launchers/micromanager.in
+++ b/buildscripts/launchers/micromanager.in
@@ -42,4 +42,5 @@ echo "class path = $CLASSPATH" 1>&2
    -Dorg.micromanager.autofocus.path="@mmautofocusdir@" \
    -Dorg.micromanager.default.config.file="@mmdatadir@/MMConfig_demo.cfg" \
    -Dorg.micromanager.corelog.dir=/tmp \
-   org.micromanager.internal.MMStudio
+   org.micromanager.internal.MMStudio \
+   $@

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -189,7 +189,17 @@ public final class MMStudio implements Studio {
                ReportingUtils.showError(
                      "Micro-Manager received no value for the `-profile` startup argument.");
             }
-         } else {
+         }
+	 else if (args[i].equals("-zmqport")){
+            if (i < args.length - 1) {
+               i++;
+	       ZMQServer.STARTING_PORT_NUMBER = Integer.parseInt(args[i]);
+            } else {
+               ReportingUtils.showError(
+                     "Micro-Manager received no value for the `-zmqport` startup argument.");
+            }
+	 }
+	 else {
             ReportingUtils.showError("Micro-Manager received unknown startup argument: " + args[i]);
          }
       }


### PR DESCRIPTION
This adds a 'zmqport' command line option that can be used to change the ZMQ port used by pycro-manager at startup, for example:

`./micromanager -zmqport 9010`

It also fixes an issue on linux where the `micromanager` shell script command line arguments were not getting passed to MM.