### PR TITLE
Avoid double caching

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
@@ -372,7 +372,7 @@ public final class ConfigGroupPad extends JScrollPane {
             ReportingUtils.logMessage("Refreshing config group table");
             for (StateItem item : groupList_) {
                if (item.singleProp) {
-                  item.config = core_.getProperty(item.device, item.name);
+                  item.config = core_.getPropertyFromCache(item.device, item.name);
                } else {
                   item.config = core_.getCurrentConfigFromCache(item.group);
                   // set descr to current situation so that Tooltips get updated

--- a/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
@@ -355,7 +355,9 @@ public class MMUIManager {
             configureBinningCombo();
             frame_.updateAutofocusButton(
                   studio_.getAutofocusManager().getAutofocusMethod() != null);
-            updateGUI(true);
+            // Since the load system configuration event already updated the cache,
+            // we do not need to do it again.
+            updateGUI(true, true);
          }
       } catch (Exception e) {
          ReportingUtils.showError(e);

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -387,8 +387,8 @@ public final class MainFrame extends JFrame {
       JButton refreshButton = createButton("Refresh", "arrow_refresh.png",
             "Refresh all GUI controls directly from the hardware", () -> {
                mmStudio_.live().setSuspended(true);
-               core_.updateSystemStateCache();
-               mmStudio_.uiManager().updateGUI(true);
+               // Let updateGUI refresh the core cache
+               mmStudio_.uiManager().updateGUI(true, false);
                mmStudio_.live().setSuspended(false);
             });
       subPanel.add(refreshButton, BIGBUTTON_SIZE);

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/ToolsMenu.java
@@ -51,8 +51,8 @@ public final class ToolsMenu {
 
       GUIUtils.addMenuItem(toolsMenu, "Refresh GUI",
             "Refresh all GUI controls directly from the hardware", () -> {
-               core_.updateSystemStateCache();
-               mmStudio_.uiManager().updateGUI(true);
+               // let updateGUI also update the core cache
+               mmStudio_.uiManager().updateGUI(true, false);
             },
             "arrow_refresh.png");
 


### PR DESCRIPTION
This PR identified a few places where subsequent function calls would update the System Cache.  This led to slow down in the UI, especially when the hardware was slow to respond.  

On such such occurrence was changing a Configuration Preset in the UI, which used to cause two subsequent updates of the cache.  After this merge, such updates should feel a bit snappier.   