### PR TITLE
Pixel config: UI for new core pixel Size config functions

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/Application.java
+++ b/mmstudio/src/main/java/org/micromanager/Application.java
@@ -150,7 +150,7 @@ public interface Application {
 
    /**
     * Shows a background window, that hides potentially cluttered desktops and
-    * provides a better look for the applictions
+    * provides a better look for the application.
     */
    void showBackgroundWindow(boolean show);
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -682,7 +682,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
       setZStepButton_.addActionListener((final ActionEvent e) -> useProposedZStep());
       slicesPanel_.add(setZStepButton_, buttonSize);
 
-      proposedZStepLabel_ = new JLabel("0.643");
+      proposedZStepLabel_ = new JLabel(getOptimalZStep(true));
       proposedZStepLabel_.setFont(DEFAULT_FONT);
       slicesPanel_.add(proposedZStepLabel_, "split 2, alignx center");
       JLabel label = new JLabel("\u00b5m"); // Micro Sign
@@ -1579,8 +1579,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
    @Subscribe
    public void onPixelSizeChangedEvent(PixelSizeChangedEvent psce) {
-      proposedZStepLabel_.setText(NumberUtils.doubleToDisplayString(
-               psce.getNewPixelSizeUm() * 5.0));
+      proposedZStepLabel_.setText(getOptimalZStep(true));
    }
 
 
@@ -2277,6 +2276,20 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
             checkBox.removeActionListener(l);
          }
       }
+   }
+
+   private String getOptimalZStep(boolean cached) {
+      try {
+         double optimalZ = mmStudio_.core().getPixelSizeOptimalZUm(cached);
+         if (optimalZ == 0.0) {
+            double pixelSize = mmStudio_.core().getPixelSizeUm(cached);
+            optimalZ = 4.0 * pixelSize;
+         }
+         return NumberUtils.doubleToDisplayString(optimalZ);
+      } catch (Exception ex) {
+         mmStudio_.logs().logError(ex, "Failed to get optimalZ step from core");
+      }
+      return "1.0";
    }
 
    public static boolean getShouldSyncExposure() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AffineEditorPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AffineEditorPanel.java
@@ -2,6 +2,7 @@ package org.micromanager.internal.dialogs;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.geom.AffineTransform;
 import java.text.NumberFormat;
@@ -57,6 +58,8 @@ public class AffineEditorPanel extends JPanel {
       final DoubleVector affineTransform_ = affineTransform;
       final DoubleVector originalAffineTransform = copyDoubleVector(affineTransform);
 
+      final Font plain = new Font("Arial", Font.PLAIN, 12);
+
       format_ = NumberFormat.getInstance();
       format_.setMaximumFractionDigits(PRECISION);
       format_.setMinimumFractionDigits(PRECISION);
@@ -79,8 +82,10 @@ public class AffineEditorPanel extends JPanel {
       for (int col = 0; col < table.getColumnModel().getColumnCount(); col++) {
          table.getColumnModel().getColumn(col).setMaxWidth(75);
       }
-      super.add(new JLabel("<html><center>Affine transforms define the relation between <br> "
-            + "camera and stage movement</center></html>"), " span 2, center, wrap");
+      JLabel affineText = new JLabel("<html>Affine transforms define the relation between <br> "
+            + "camera and stage movement</html>");
+      affineText.setFont(plain);
+      super.add(affineText, "span 2, left, wrap");
       table.setFillsViewportHeight(true);
 
       super.add(table);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AffineEditorPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AffineEditorPanel.java
@@ -11,8 +11,6 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTable;
-import javax.swing.border.Border;
-import javax.swing.border.EtchedBorder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 import mmcorej.DoubleVector;
@@ -111,9 +109,7 @@ public class AffineEditorPanel extends JPanel {
             atm_.setAffineTransform(originalAffineTransform));
       super.add(resetButton, "center, width 90!");
 
-      Border clbb = BorderFactory.createEtchedBorder(EtchedBorder.LOWERED);
-      super.setBorder(clbb);
-
+      setBorder(BorderFactory.createTitledBorder("Affine Transform (Rotation and Scaling)"));
    }
 
    public DoubleVector getAffineTransform() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CalibrationListDlg.java
@@ -363,7 +363,7 @@ public final class CalibrationListDlg extends JDialog {
             MMStudio mmStudio = (MMStudio) studio_;
             if (mmStudio.hasConfigChanged()) {
                Object[] options = {"Yes", "No"};
-               int userFeedback = JOptionPane.showOptionDialog(null,
+               int userFeedback = JOptionPane.showOptionDialog(this,
                      "Save Changed Pixel Configuration?", "Micro-Manager",
                      JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
                      null, options, options[0]);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
@@ -193,6 +193,8 @@ public abstract class ConfigDialog extends JDialog {
    }
 
    protected void initializeWidgets() {
+      final Font plain = new Font("Arial", Font.PLAIN, 12);
+      final Font bold = new Font("Arial", Font.BOLD, 12);
 
       if (showFlagsPanelVisible_) {
          flags_.load(ConfigDialog.class);
@@ -214,7 +216,7 @@ public abstract class ConfigDialog extends JDialog {
             new MigLayout("flowx, insets 0 6 0 0, gap 2"));
 
       instructionsTextArea_ = new JTextArea();
-      instructionsTextArea_.setFont(new Font("Arial", Font.PLAIN, 12));
+      instructionsTextArea_.setFont(plain);
       instructionsTextArea_.setWrapStyleWord(true);
       instructionsTextArea_.setText(instructionsText_);
       instructionsTextArea_.setEditable(false);
@@ -222,11 +224,11 @@ public abstract class ConfigDialog extends JDialog {
       topMidPanel.add(instructionsTextArea_, "gaptop 2, wrap");
 
       nameFieldLabel_ = new JLabel(nameFieldLabelText_);
-      nameFieldLabel_.setFont(new Font("Arial", Font.BOLD, 12));
-      topMidPanel.add(nameFieldLabel_, "split 2, alignx right");
+      nameFieldLabel_.setFont(bold);
+      topMidPanel.add(nameFieldLabel_, "alignx left");
 
       nameField_ = new JTextField();
-      nameField_.setFont(new Font("Arial", Font.PLAIN, 12));
+      nameField_.setFont(plain);
       // nameField_.setFont(new Font("Arial", Font.BOLD, 16));
       // should consider increasing font size for entry field for readability,
       // but would want to do it in multiple places for consistency
@@ -239,11 +241,11 @@ public abstract class ConfigDialog extends JDialog {
 
       if (showPixelSize_) {
          JLabel pixelSizeFieldLabel = new JLabel(pixelSizeFieldLabelText_);
-         pixelSizeFieldLabel.setFont(new Font("Arial", Font.BOLD, 12));
-         topMidPanel.add(pixelSizeFieldLabel, "split 2, alignx right");
+         pixelSizeFieldLabel.setFont(bold);
+         topMidPanel.add(pixelSizeFieldLabel, "alignx left");
 
          pixelSizeField_ = new JTextField();
-         pixelSizeField_.setFont(new Font("Arial", Font.PLAIN, 12));
+         pixelSizeField_.setFont(plain);
          pixelSizeField_.setText(pixelSize_);
          pixelSizeField_.setEditable(true);
          pixelSizeField_.setSelectionStart(0);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ConfigDialog.java
@@ -32,6 +32,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
+import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -93,7 +94,7 @@ public abstract class ConfigDialog extends JDialog {
    protected String nameFieldLabelText_ = "GroupOrPreset Name";
    protected String initName_ = "";
 
-   // following only used when showPixelSize_ is true
+   // following only used when showPixelSize_ is true (which currently is always true)
    protected boolean showPixelSize_ = false;
    protected String pixelSizeFieldLabelText_ = "Pixel Size (um):";
    protected JTextField pixelSizeField_;
@@ -214,14 +215,7 @@ public abstract class ConfigDialog extends JDialog {
 
       final JPanel topMidPanel = new JPanel(
             new MigLayout("flowx, insets 0 6 0 0, gap 2"));
-
-      instructionsTextArea_ = new JTextArea();
-      instructionsTextArea_.setFont(plain);
-      instructionsTextArea_.setWrapStyleWord(true);
-      instructionsTextArea_.setText(instructionsText_);
-      instructionsTextArea_.setEditable(false);
-      instructionsTextArea_.setOpaque(false);
-      topMidPanel.add(instructionsTextArea_, "gaptop 2, wrap");
+      topMidPanel.setBorder(BorderFactory.createTitledBorder(instructionsText_));
 
       nameFieldLabel_ = new JLabel(nameFieldLabelText_);
       nameFieldLabel_.setFont(bold);
@@ -236,10 +230,10 @@ public abstract class ConfigDialog extends JDialog {
       nameField_.setEditable(true);
       nameField_.setSelectionStart(0);
       nameField_.setSelectionEnd(nameField_.getText().length());
-      int fieldWidth = showPixelSize_ ? 90 : 180;
+      int fieldWidth = 180;
       topMidPanel.add(nameField_, "width " + fieldWidth + "!, gaptop 2, wrap");
 
-      if (showPixelSize_) {
+      if (showPixelSize_) { // always true?
          JLabel pixelSizeFieldLabel = new JLabel(pixelSizeFieldLabelText_);
          pixelSizeFieldLabel.setFont(bold);
          topMidPanel.add(pixelSizeFieldLabel, "alignx left");
@@ -269,8 +263,8 @@ public abstract class ConfigDialog extends JDialog {
       cancelButton_.addActionListener(e -> dispose());
       topRightPanel.add(cancelButton_, "width 90!");
 
-      add(topMidPanel, "flowx, split 2");
-      add(topRightPanel, "gapleft push, flowx");
+      add(topMidPanel, "flowx, split 2, gapright push");
+      add(topRightPanel, "flowx");
 
       // Override x button to make it have same behavior as Cancel button
       this.addWindowListener(new WindowAdapter() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
@@ -26,7 +26,6 @@ import java.awt.geom.AffineTransform;
 import java.text.ParseException;
 import mmcorej.StrVector;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.dialogs.introdialogparts.PixelConfigExtraPanel;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.PropertyItem;

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigEditor.java
@@ -26,6 +26,7 @@ import java.awt.geom.AffineTransform;
 import java.text.ParseException;
 import mmcorej.StrVector;
 import org.micromanager.internal.MMStudio;
+import org.micromanager.internal.dialogs.introdialogparts.PixelConfigExtraPanel;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.PropertyItem;
@@ -44,6 +45,7 @@ public class PixelConfigEditor extends ConfigDialog implements PixelSizeProvider
 
    protected String pixelSize_;
    private final AffineEditorPanel affineEditorPanel_;
+   private final PixelConfigExtraPanel pixelConfigExtraPanel_;
    private final CalibrationListDlg parent_;
 
    /**
@@ -80,6 +82,7 @@ public class PixelConfigEditor extends ConfigDialog implements PixelSizeProvider
       parent_ = parent;
       affineEditorPanel_ = new AffineEditorPanel(parent.getStudio(), this,
             AffineUtils.noTransform());
+      pixelConfigExtraPanel_ = new PixelConfigExtraPanel(parent.getStudio(), this);
       super.initialize();
       super.setIconImage(Toolkit.getDefaultToolkit().getImage(
             getClass().getResource("/org/micromanager/icons/microscope.gif")));
@@ -149,6 +152,12 @@ public class PixelConfigEditor extends ConfigDialog implements PixelSizeProvider
          pixelSize_ = pixelSizeField_.getText();
          core_.setPixelSizeUm(newName, NumberUtils.displayStringToDouble(pixelSize_));
          core_.setPixelSizeAffine(newName, affineEditorPanel_.getAffineTransform());
+         core_.setPixelSizedxdz(newName, NumberUtils.displayStringToDouble(
+                  pixelConfigExtraPanel_.getdxdz()));
+         core_.setPixelSizedydz(newName, NumberUtils.displayStringToDouble(
+                  pixelConfigExtraPanel_.getdydz()));
+         core_.setPixelSizeOptimalZUm(newName, NumberUtils.displayStringToDouble(
+                  pixelConfigExtraPanel_.getPreferredZStepUm()));
       } catch (Exception e) {
          ReportingUtils.logError(e);
       }
@@ -178,6 +187,7 @@ public class PixelConfigEditor extends ConfigDialog implements PixelSizeProvider
    @Override
    protected void initializeBetweenWidgetsAndTable() {
       add(affineEditorPanel_, "growx, center");
+      add(pixelConfigExtraPanel_, "growx, center");
    }
 
    @Override
@@ -194,6 +204,84 @@ public class PixelConfigEditor extends ConfigDialog implements PixelSizeProvider
    @Override
    public void setAffineTransform(AffineTransform aft) {
       affineEditorPanel_.setAffineTransform(AffineUtils.affineToDouble(aft));
+   }
+
+   /**
+    * Returns the dx/dy value as currently known by the PixelSizeProvider.
+    *
+    * @return - dx/dy value as currently known by the PixelSizeProvider
+    */
+   @Override
+   public Double getdxdz() {
+      try {
+         NumberUtils.displayStringToDouble(pixelConfigExtraPanel_.getdxdz());
+      } catch (ParseException ex) {
+         studio_.logs().showError("dx/dz is not a valid Number");
+         pixelConfigExtraPanel_.requestFocus();
+      }
+      return 0.0;
+   }
+
+   /**
+    * Sets the dx/dy value as known by the provider.
+    *
+    * @param dxdz angle between camera and Z stage
+    */
+   @Override
+   public void setdxdz(double dxdz) {
+      pixelConfigExtraPanel_.setdxdz(dxdz);
+   }
+
+   /**
+    * Returns the dy/dz value as currently known by the PixelSizeProvider.
+    *
+    * @return - dy/dz value as currently known by the PixelSizeProvider
+    */
+   @Override
+   public Double getdydz() {
+      try {
+         NumberUtils.displayStringToDouble(pixelConfigExtraPanel_.getdydz());
+      } catch (ParseException ex) {
+         studio_.logs().showError("dy/dz is not a valid Number");
+         pixelConfigExtraPanel_.requestFocus();
+      }
+      return 0.0;
+   }
+
+   /**
+    * Sets the dy/dz value as known by the provider.
+    *
+    * @param dydz angle between camera and Z stage
+    */
+   @Override
+   public void setdydz(double dydz) {
+      pixelConfigExtraPanel_.setdydz(dydz);
+   }
+
+   /**
+    * Returns the preferred step size in Z as currently known by the PixelSizeProvider.
+    *
+    * @return - preferred step size in Z as currently known by the PixelSizeProvider
+    */
+   @Override
+   public Double getPreferredZStepUm() {
+      try {
+         NumberUtils.displayStringToDouble(pixelConfigExtraPanel_.getPreferredZStepUm());
+      } catch (ParseException ex) {
+         studio_.logs().showError("Preferred Z step size is not a valid Number");
+         pixelConfigExtraPanel_.requestFocus();
+      }
+      return 0.0;
+   }
+
+   /**
+    * Sets the preferred step size in Z as known by the provider.
+    *
+    * @param stepSizeUm preferred step size in Z
+    */
+   @Override
+   public void setPreferredZStepUm(double stepSizeUm) {
+      pixelConfigExtraPanel_.setPreferredZStepUm(stepSizeUm);
    }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigExtraPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelConfigExtraPanel.java
@@ -1,4 +1,4 @@
-package org.micromanager.internal.dialogs.introdialogparts;
+package org.micromanager.internal.dialogs;
 
 import java.awt.Font;
 import java.text.NumberFormat;
@@ -6,12 +6,8 @@ import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.Border;
-import javax.swing.border.EtchedBorder;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
-import org.micromanager.internal.dialogs.PixelSizeProvider;
-
 
 
 /**
@@ -74,8 +70,7 @@ public class PixelConfigExtraPanel extends JPanel {
       preferredZStepUmField_.setFont(plain);
       super.add(preferredZStepUmField_, "wrap");
 
-      Border clbb = BorderFactory.createEtchedBorder(EtchedBorder.LOWERED);
-      super.setBorder(clbb);
+      setBorder(BorderFactory.createTitledBorder("Light Sheet Settings"));
    }
 
    public String getdxdz() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
@@ -30,7 +30,6 @@ import mmcorej.Configuration;
 import mmcorej.DoubleVector;
 import org.micromanager.Studio;
 import org.micromanager.internal.MMStudio;
-import org.micromanager.internal.dialogs.introdialogparts.PixelConfigExtraPanel;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.CalibrationList;
 import org.micromanager.internal.utils.NumberUtils;

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelSizeProvider.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelSizeProvider.java
@@ -60,4 +60,46 @@ public interface PixelSizeProvider {
     * @param aft - new affine transform
     */
    void setAffineTransform(AffineTransform aft);
+
+   /**
+    * Returns the dx/dy value as currently known by the PixelSizeProvider.
+    *
+    * @return - dx/dy value as currently known by the PixelSizeProvider
+    */
+   Double getdxdz();
+
+   /**
+    * Sets the dx/dy value as known by the provider.
+    *
+    * @param dxdz angle between camera and Z stage
+    */
+   void setdxdz(double dxdz);
+
+   /**
+    * Returns the dy/dz value as currently known by the PixelSizeProvider.
+    *
+    * @return - dy/dz value as currently known by the PixelSizeProvider
+    */
+   Double getdydz();
+
+   /**
+    * Sets the dy/dz value as known by the provider.
+    *
+    * @param dydz angle between camera and Z stage
+    */
+   void setdydz(double dydz);
+
+   /**
+    * Returns the preferred step size in Z as currently known by the PixelSizeProvider.
+    *
+    * @return - preferred step size in Z as currently known by the PixelSizeProvider
+    */
+   Double getPreferredZStepUm();
+
+   /**
+    * Sets the preferred step size in Z as known by the provider.
+    *
+    * @param stepSizeUm preferred step size in Z
+    */
+   void setPreferredZStepUm(double stepSizeUm);
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/introdialogparts/PixelConfigExtraPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/introdialogparts/PixelConfigExtraPanel.java
@@ -1,0 +1,104 @@
+package org.micromanager.internal.dialogs.introdialogparts;
+
+import java.awt.Font;
+import java.text.NumberFormat;
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.Border;
+import javax.swing.border.EtchedBorder;
+import net.miginfocom.swing.MigLayout;
+import org.micromanager.Studio;
+import org.micromanager.internal.dialogs.PixelSizeProvider;
+
+
+
+/**
+ * Panel for configuring pixel config related settings.
+ * Currently, the angles between camera and Z stage (dx/dz and dy/dz) as
+ * well as the preferred step size in Z are configurable.
+ */
+public class PixelConfigExtraPanel extends JPanel {
+   private final Studio studio_;
+   private final PixelSizeProvider pixelSizeProvider_;
+   private static final int PRECISION = 5;
+   private final NumberFormat format_;
+   protected JTextField dxdzField_;
+   protected JTextField dydzField_;
+   protected JTextField preferredZStepUmField_;
+
+
+   public PixelConfigExtraPanel(Studio studio, PixelSizeProvider pixelSizeProvider) {
+      super(new MigLayout("align center, flowx"));
+
+      studio_ = studio;
+      pixelSizeProvider_ = pixelSizeProvider;
+      final Font plain = new Font("Arial", Font.PLAIN, 12);
+      final Font bold = new Font("Arial", Font.BOLD, 12);
+
+      format_ = NumberFormat.getInstance();
+      format_.setMaximumFractionDigits(PRECISION);
+      format_.setMinimumFractionDigits(PRECISION);
+
+      JLabel angleText = new JLabel("<html><left>Angles between camera and Z-stage. "
+               + "Light Sheet Only. Set 0.0 unless needed."
+               + "</left></html>");
+      angleText.setFont(plain);
+      super.add(angleText, "span 2, left, wrap");
+
+      JLabel dxdzLabel = new JLabel("dx/dz (ratio)");
+      dxdzLabel.setFont(bold);
+      super.add(dxdzLabel);
+      //dxdzField_ = new JTextField(format_.format(pixelSizeProvider_.getdxdz()), 5);
+      dxdzField_ = new JTextField(format_.format(0.0), 5);
+      dxdzField_.setFont(plain);
+      super.add(dxdzField_, "wrap");
+
+      JLabel dydzLabel = new JLabel("dy/dz (ratio)");
+      dydzLabel.setFont(bold);
+      super.add(dydzLabel);
+      dydzField_ = new JTextField(format_.format(0.0), 5);
+      dydzField_.setFont(plain);
+      super.add(dydzField_, "wrap 15px");
+
+      JLabel optimalText = new JLabel("<html><left>Optimal Z step for this Pixel"
+               + "Size configuration.  Shown in the MDA window.</left></html>");
+      optimalText.setFont(plain);
+      super.add(optimalText, "span 2, left, wrap");
+
+      JLabel preferredZLabel = new JLabel("Preferred Z step size (um)");
+      preferredZLabel.setFont(bold);
+      super.add(preferredZLabel);
+      preferredZStepUmField_ = new JTextField(format_.format(0.0), 5);
+      preferredZStepUmField_.setFont(plain);
+      super.add(preferredZStepUmField_, "wrap");
+
+      Border clbb = BorderFactory.createEtchedBorder(EtchedBorder.LOWERED);
+      super.setBorder(clbb);
+   }
+
+   public String getdxdz() {
+      return dxdzField_.getText();
+   }
+
+   public void setdxdz(double dxdz) {
+      dxdzField_.setText(format_.format(dxdz));
+   }
+
+   public String getdydz() {
+      return dydzField_.getText();
+   }
+
+   public void setdydz(double dydz) {
+      dydzField_.setText(format_.format(dydz));
+   }
+
+   public String getPreferredZStepUm() {
+      return preferredZStepUmField_.getText();
+   }
+
+   public void setPreferredZStepUm(double stepSizeUm) {
+      preferredZStepUmField_.setText(format_.format(stepSizeUm));
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigPreset.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/ConfigPreset.java
@@ -37,6 +37,9 @@ public final class ConfigPreset {
    // belongs to the pixelSize group
    private double pixelSizeUm_ = 0.0;
    private DoubleVector affineTransform_;
+   private double dxdz_ = 0.0;
+   private double dydz_ = 0.0;
+   private double optimalZUm_ = 0.0;
 
    public ConfigPreset() {
       name_ = "Undefined";
@@ -118,6 +121,30 @@ public final class ConfigPreset {
 
    public DoubleVector getAffineTransform() {
       return affineTransform_;
+   }
+
+   public void setPixelSizedxdz(double dxdz) {
+      dxdz_ = dxdz;
+   }
+
+   public double getPixelSizedxdz() {
+      return dxdz_;
+   }
+
+   public void setPixelSizedydz(double dydz) {
+      dydz_ = dydz;
+   }
+
+   public double getPixelSizedydz() {
+      return dydz_;
+   }
+
+   public void setPixelSizeOptimalZUm(double z) {
+      optimalZUm_ = z;
+   }
+
+   public double getPixelSizeOptimalZUm() {
+      return optimalZUm_;
    }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/MicroscopeModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/MicroscopeModel.java
@@ -204,7 +204,7 @@ public final class MicroscopeModel {
 
          // assign available devices
          availableDevices_ = new Device[0];
-         ArrayList<Device> hubs = new ArrayList<>();
+         final ArrayList<Device> hubs = new ArrayList<>();
          badLibraries_ = new Vector<>();
 
          StrVector libs = core.getDeviceAdapterNames();
@@ -493,6 +493,9 @@ public final class MicroscopeModel {
             ConfigPreset p = new ConfigPreset(pixelSizeConfigs.get(j));
             p.setPixelSizeUm(core.getPixelSizeUmByID(pixelSizeConfigs.get(j)));
             p.setAffineTransform(core.getPixelSizeAffineByID(pixelSizeConfigs.get(j)));
+            p.setPixelSizedxdz(core.getPixelSizedxdz(pixelSizeConfigs.get(j)));
+            p.setPixelSizedydz(core.getPixelSizedydz(pixelSizeConfigs.get(j)));
+            p.setPixelSizeOptimalZUm(core.getPixelSizeOptimalZUm(pixelSizeConfigs.get(j)));
             for (int k = 0; k < pcfg.size(); k++) {
                PropertySetting ps = pcfg.getSetting(k);
                Setting s = new Setting(ps.getDeviceLabel(),
@@ -704,6 +707,50 @@ public final class MicroscopeModel {
                      throw new MMConfigFileException(
                            "Invalid number of parameters (3 or 8 required):\n" + line);
                   }
+               }
+            } else if (tokens[0].contentEquals(new StringBuffer()
+                     .append(MMCoreJ.getG_CFGCommand_PixelSizedxdz()))) {
+               if (tokens.length == 3) {
+                  ConfigPreset cp = pixelSizeGroup_.findConfigPreset(tokens[1]);
+                  if (cp != null) {
+                     cp.setPixelSizedxdz(Double.parseDouble(tokens[2]));
+                  }
+               }
+            } else if (tokens[0].contentEquals(new StringBuffer()
+                     .append(MMCoreJ.getG_CFGCommand_PixelSizedydz()))) {
+               if (tokens.length == 3) {
+                  ConfigPreset cp = pixelSizeGroup_.findConfigPreset(tokens[1]);
+                  if (cp != null) {
+                     cp.setPixelSizedydz(Double.parseDouble(tokens[2]));
+                  }
+               }
+            } else if (tokens[0].contentEquals(new StringBuffer()
+                     .append(MMCoreJ.getG_CFGCommand_PixelSizeOptimalZUm()))) {
+               if (tokens.length == 3) {
+                  ConfigPreset cp = pixelSizeGroup_.findConfigPreset(tokens[1]);
+                  if (cp != null) {
+                     cp.setPixelSizeOptimalZUm(Double.parseDouble(tokens[2]));
+                  }
+               }
+            } else if (tokens[0].contentEquals(new StringBuffer()
+                     .append(MMCoreJ.getG_CFGCommand_ConfigGroup()))) {
+               // -------------------------------------------------------------
+               // "ConfigGroup" commands
+               // -------------------------------------------------------------
+               if (!(tokens.length == 6 || tokens.length == 5)) {
+                  throw new MMConfigFileException(
+                        "Invalid number of parameters (6 required):\n" + line);
+
+               }
+               addConfigGroup(tokens[1]);
+               ConfigGroup cg = findConfigGroup(tokens[1]);
+               if (tokens.length == 6) {
+                  cg.addConfigSetting(tokens[2], tokens[3], tokens[4],
+                        tokens[5]);
+
+               } else {
+                  cg.addConfigSetting(tokens[2], tokens[3], tokens[4], "");
+
                }
             } else if (tokens[0].contentEquals(new StringBuffer()
                   .append(MMCoreJ.getG_CFGCommand_Delay()))) {
@@ -1076,11 +1123,25 @@ public final class MicroscopeModel {
             if (aft != null) {
                out.write(MMCoreJ.getG_CFGCommand_PixelSizeAffine() + ","
                      + preset.getName());
-
                for (int i = 0; i < aft.size(); i++) {
                   out.write("," + aft.get(i));
                }
+               out.newLine();
             }
+            // write dxdz
+            out.write(MMCoreJ.getG_CFGCommand_PixelSizedxdz() + ","
+                     + preset.getName() + ","
+                     + preset.getPixelSizedxdz());
+            out.newLine();
+            // write dydz
+            out.write(MMCoreJ.getG_CFGCommand_PixelSizedydz() + ","
+                     + preset.getName() + ","
+                     + preset.getPixelSizedydz());
+            out.newLine();
+            // write optimal z
+            out.write(MMCoreJ.getG_CFGCommand_PixelSizeOptimalZUm() + ","
+                     + preset.getName() + ","
+                     + preset.getPixelSizeOptimalZUm());
             out.newLine();
          }
          out.newLine();

--- a/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pixelcalibrator/PixelCalibratorDialog.java
@@ -46,7 +46,7 @@ import org.micromanager.internal.utils.WindowPositioning;
 /**
  * Displays the Pixel Calibrator Dialog.
  *
- * @author arthur, Nico
+ * @author Arthur Edelstein, Nico Stuurman
  */
 public class PixelCalibratorDialog extends JFrame {
 


### PR DESCRIPTION
Adds dxdz, dydz, and OptimalZUm to the pixel Size configuration dialog, and saves these settings in the config file.  Should only be merged after the corresponding PR for mmCoreAndDevices has been merged.

I hope the UI is still workable for people:

![image](https://github.com/user-attachments/assets/de359276-f072-4e56-9a6b-fcc4ae698241)

