### PR TITLE
Allow Ant build scripts to use VS2022

### DIFF
--- a/buildscripts/Ant/windowsprops.xml
+++ b/buildscripts/Ant/windowsprops.xml
@@ -145,7 +145,12 @@
 				$VsInstPath = &amp; 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' '-version' '[16.0,17.0)' '-property' 'installationPath'
 				if (-not $VsInstPath) {
 					echo 'Cannot find Visual Studio 2019 installation path'
-					exit 1
+					echo 'Attempting fallback to VS2022 (requires VS2019 build tools)'
+					$VsInstPath = &amp; 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' '-version' '[17.0,18.0)' '-property' 'installationPath'
+					if (-not $VsInstPath) {
+						echo 'Cannot find Visual Studio 2019 or 2022 installation path'
+						exit 1
+					}
 				}
 
 				# Works better when run from the file location


### PR DESCRIPTION
If the computer does not have VS2019 installed, use VS2022 for the build.

For now, it will still required that VS2022 is installed with the option "MSVC v142 - VS 2019 C++ x64/x86 build tools".

This will facilitate migrating the actual build to VS2022 tools.