### PR TITLE
Fix calibration property name in the pgFocus plugin

### DIFF
--- a/plugins/pgFocus/src/main/java/edu/umassmed/pgfocus/PGFocusFrame.java
+++ b/plugins/pgFocus/src/main/java/edu/umassmed/pgfocus/PGFocusFrame.java
@@ -415,7 +415,7 @@ public class PGFocusFrame extends JFrame {
       }
 
       private boolean updateValues() {
-         String curve = getStringProperty("Calibration curve");
+         String curve = getStringProperty("Calibration Curve");
 
          try {
             if (curve.length() > 0) {
@@ -1054,4 +1054,3 @@ public class PGFocusFrame extends JFrame {
 
 
 }
-


### PR DESCRIPTION
This fixes the error described in #2075 in the pgFocus plugin. The plugin uses a property name for the `Calibration Curve` property that differs from the one defined in the device adapter in the case of only a single letter.

https://github.com/micro-manager/mmCoreAndDevices/blob/a9b83246ca9154c4e20b125df72a40027de2d8c8/DeviceAdapters/pgFocus/pgFocus.h#L117

I am guessing that this previously worked because getting properties from the core by name used to be case insensitive; this likely changed sometime after 2018.