### PR TITLE
Studio-HCW: Cleaner response to removing devices from the configuration.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/FinishPage.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/FinishPage.java
@@ -147,7 +147,10 @@ public final class FinishPage extends PagePanel {
             }
          }
          setFilePath(f);
-         model_.removeInvalidConfigurations();
+         // Call model_.removeInvalidConfigurations() to go back to previous behavior.
+         // checkConfigurations() is a new method that keeps everythings that can be kept
+         // rather than remove configurations containing no longer available devices wholesale.
+         model_.checkConfigurations();
          model_.saveToFile(fileNameField_.getText());
       } catch (Exception e) {
          ReportingUtils.showError(e);

--- a/mmstudio/src/main/java/org/micromanager/internal/hcwizard/MicroscopeModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/hcwizard/MicroscopeModel.java
@@ -1461,6 +1461,17 @@ public final class MicroscopeModel {
       modified_ = true;
    }
 
+   public void removePropertyFromGroup(String group, String preset) {
+      ConfigGroup cg = findConfigGroup(group);
+      if (cg != null) {
+         ConfigPreset cp = cg.findConfigPreset(preset);
+         if (cp != null) {
+            cg.removePreset(preset);
+            modified_ = true;
+         }
+      }
+   }
+
    public void removeGroup(String name) {
       configGroups_.remove(name);
       modified_ = true;
@@ -1490,6 +1501,36 @@ public final class MicroscopeModel {
          }
       }
    }
+
+
+   /**
+    * Checks all configurations.  Removes properties that are no longer available from presets.
+    * If no properties are left, the preset is removed.
+    * If no presets are left, the group is removed.
+    */
+   public void checkConfigurations() {
+      Object[] groups = configGroups_.values().toArray();
+      for (Object o : groups) {
+         ConfigGroup group = (ConfigGroup) o;
+         ConfigPreset[] presets = group.getConfigPresets();
+         for (ConfigPreset preset : presets) {
+            for (int k = 0; k < preset.getNumberOfSettings(); k++) {
+               Setting s = preset.getSetting(k);
+               // check if device is available
+               if (null == findDevice(s.deviceName_)) {
+                  preset.removeSetting(s);
+               }
+            }
+            if (preset.getNumberOfSettings() == 0) {
+               group.removePreset(preset.getName());
+            }
+         }
+         if (group.getConfigPresets().length == 0) {
+            removeGroup(group.name_);
+         }
+      }
+   }
+
 
    /**
     * Remove configurations which refer to non existent devices. This situation


### PR DESCRIPTION
When a device is removed, no longer delete all configuration groups that contained presets with that device, but remove all properties referring to the device from the group.  Will remove presets and groups if they no longer contain members.

Closes #2050.