### PR TITLE
Studio: live mode used to get the current configuration

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -634,12 +634,14 @@ public final class SnapLiveManager extends DataViewerListener
          shouldReset = true;
          store_ = null;
       }
-      // NS-20241128: not quite sure if this serves any function anymore.  Delete?
+      // THis code checks the current channel and adjusts the names for the images from multiple
+      // cameras accordingly.
       if (store_ != null && !store_.isFrozen()) {
          List<String> channelNames = store_.getSummaryMetadata().getChannelNameList();
          String curChannel = "";
          try {
-            curChannel = core_.getCurrentConfig(core_.getChannelGroup());
+            // if not from cache, we will slow down live mode
+            curChannel = core_.getCurrentConfigFromCache(core_.getChannelGroup());
          } catch (Exception e) {
             ReportingUtils.logError(e, "Error getting current channel");
          }


### PR DESCRIPTION
of the channelgroup from the actual hardware. Now uses the cache instead to avoid slowing down live mode.
We still need to get this data in case of multiple cameras, wgere the name of the channel is pre-pended to the camera name. Also likely needed in case acquisitions.

Closes #1915 