### PR TITLE
Require VS2022 for Windows Ant build

### DIFF
--- a/buildscripts/Ant/windowsprops.xml
+++ b/buildscripts/Ant/windowsprops.xml
@@ -141,16 +141,10 @@
 			<echo file="${run_msbuild}">
 				$SavePwd = pwd
 
-				# We require exactly Visual Studio 2019 (16.x); 2022 may fail.
-				$VsInstPath = &amp; 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' '-version' '[16.0,17.0)' '-property' 'installationPath'
+				$VsInstPath = &amp; 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' '-version' '[17.0,18.0)' '-property' 'installationPath'
 				if (-not $VsInstPath) {
-					echo 'Cannot find Visual Studio 2019 installation path'
-					echo 'Attempting fallback to VS2022 (requires VS2019 build tools)'
-					$VsInstPath = &amp; 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' '-version' '[17.0,18.0)' '-property' 'installationPath'
-					if (-not $VsInstPath) {
-						echo 'Cannot find Visual Studio 2019 or 2022 installation path'
-						exit 1
-					}
+					echo 'Cannot find Visual Studio 2022 installation path'
+					exit 1
 				}
 
 				# Works better when run from the file location


### PR DESCRIPTION
Before this: use VS2019 if found; else VS2022
After this: use VS2022 or fail

This prepares us for switching to the VS2022 (v143) toolset for our C++ projects (https://github.com/micro-manager/mmCoreAndDevices/pull/626).