### PR TITLE
Studio: MainFrame: Only do weird menu thing on Mac.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -181,49 +181,35 @@ public final class MainFrame extends JFrame {
    }
 
    private void setupWindowHandlers() {
+      addWindowListener(new WindowAdapter() {
+         // Shut down when this window is closed.
+         @Override
+         public void windowClosing(WindowEvent event) {
+            if (mmStudio_.closeSequence(false)) {
+               if (exitOnClose_) {
+                  System.exit(0);
+               } else {
+                  dispose();
+               }
+            }
+         }
+      });
+
       if (JavaUtils.isMac()) {
+         // HACK: on OSX, some kind of system bug can disable the entire
+         // menu bar at times (it has something to do with modal dialogs and
+         // possibly with errors resulting from the code that handles their
+         // output). Calling setEnabled() on the MenuBar does *not* fix the
+         // enabled-ness of the menus. However, through experimentation, I've
+         // figured out that setting the menubar to null and then back again
+         // does fix the issue for all menus *except* the Help menu. Note that
+         // if we named our Help menu e.g. "Help2" then it would behave
+         // properly, so this is clearly something special to do with OSX.
          addWindowListener(new WindowAdapter() {
-            // HACK: on OSX, some kind of system bug can disable the entire
-            // menu bar at times (it has something to do with modal dialogs and
-            // possibly with errors resulting from the code that handles their
-            // output). Calling setEnabled() on the MenuBar does *not* fix the
-            // enabled-ness of the menus. However, through experimentation, I've
-            // figured out that setting the menubar to null and then back again
-            // does fix the issue for all menus *except* the Help menu. Note that
-            // if we named our Help menu e.g. "Help2" then it would behave
-            // properly, so this is clearly something special to do with OSX.
             @Override
             public void windowActivated(WindowEvent event) {
-               // This is a workaround for a bug in Java on OSX that causes
-               // the menu bar to be disabled.
                setJMenuBar(null);
                setJMenuBar(getJMenuBar());
-            }
-
-            // Shut down when this window is closed.
-            @Override
-            public void windowClosing(WindowEvent event) {
-               if (mmStudio_.closeSequence(false)) {
-                  if (exitOnClose_) {
-                     System.exit(0);
-                  } else {
-                     dispose();
-                  }
-               }
-            }
-         });
-      } else { // Windows/Linux
-         addWindowListener(new WindowAdapter() {
-            // Shut down when this window is closed.
-            @Override
-            public void windowClosing(WindowEvent event) {
-               if (mmStudio_.closeSequence(false)) {
-                  if (exitOnClose_) {
-                     System.exit(0);
-                  } else {
-                     dispose();
-                  }
-               }
             }
          });
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -24,7 +24,6 @@ package org.micromanager.internal;
 import com.bulenkov.iconloader.IconLoader;
 import com.google.common.eventbus.Subscribe;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Insets;
@@ -77,7 +76,6 @@ import org.micromanager.internal.dialogs.OptionsDlg;
 import org.micromanager.internal.dialogs.StageControlFrame;
 import org.micromanager.internal.utils.DragDropUtil;
 import org.micromanager.internal.utils.GUIUtils;
-import org.micromanager.internal.utils.JavaUtils;
 import org.micromanager.internal.utils.MMKeyDispatcher;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
@@ -194,25 +192,6 @@ public final class MainFrame extends JFrame {
             }
          }
       });
-
-      if (JavaUtils.isMac()) {
-         // HACK: on OSX, some kind of system bug can disable the entire
-         // menu bar at times (it has something to do with modal dialogs and
-         // possibly with errors resulting from the code that handles their
-         // output). Calling setEnabled() on the MenuBar does *not* fix the
-         // enabled-ness of the menus. However, through experimentation, I've
-         // figured out that setting the menubar to null and then back again
-         // does fix the issue for all menus *except* the Help menu. Note that
-         // if we named our Help menu e.g. "Help2" then it would behave
-         // properly, so this is clearly something special to do with OSX.
-         addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowActivated(WindowEvent event) {
-               setJMenuBar(null);
-               setJMenuBar(getJMenuBar());
-            }
-         });
-      }
    }
 
    public void initializeConfigPad() {


### PR DESCRIPTION
This allows MM to work on Windows under Java 11 and is probably a good thing in any case.