### PR TITLE
Update mscOS C++ dependency build

### DIFF
--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -75,7 +75,7 @@ if [ "$do_download" = yes ]; then
    [ -f FreeImage3180.zip ] || curl -LO http://downloads.sourceforge.net/freeimage/FreeImage3180.zip
    [ -f libdc1394-2.2.1.tar.gz ] || curl -L -o libdc1394-2.2.1.tar.gz http://sourceforge.net/projects/libdc1394/files/libdc1394-2/2.2.1/libdc1394-2.2.1.tar.gz/download
    [ -f opencv-2.4.13.6.zip ] || curl -L -o opencv-2.4.13.6.zip https://github.com/opencv/opencv/archive/refs/tags/2.4.13.6.zip
-   [ -f msgpack-cxx-4.1.3.tar.gz ] || curl -LO https://github.com/msgpack/msgpack-c/releases/download/cpp-4.1.3/msgpack-cxx-4.1.3.tar.gz
+   [ -f msgpack-cxx-7.0.0.tar.gz ] || curl -LO https://github.com/msgpack/msgpack-c/releases/download/cpp-7.0.0/msgpack-cxx-7.0.0.tar.gz
 fi
 
 cat >sha1sums <<EOF
@@ -89,7 +89,7 @@ a52219b12dbc8d33fc096468591170fda71316c0  libexif-0.6.21.tar.bz2
 38daa9d8f1bca2330a2eaa42ec66fbe6ede7dce9  FreeImage3180.zip
 b92c9670b68c4e5011148f16c87532bef2e5b808  libdc1394-2.2.1.tar.gz
 a6c3d6ac8091e3311fc44125e017dd1e88e74825  opencv-2.4.13.6.zip
-451d83b5d0302c88b69e3100be020fe3236391a2  msgpack-cxx-4.1.3.tar.gz
+37bbdbf69ef44392c7af215b9cb419891a9e1c9c  msgpack-cxx-7.0.0.tar.gz
 EOF
 shasum -c sha1sums || { echo "SHA1 checksum mismatch or missing file; remove file and rerun with -d flag"; exit 1; }
 
@@ -559,8 +559,8 @@ popd
 # msgpack-c
 #
 
-tar xzf ../downloads/msgpack-cxx-4.1.3.tar.gz
-pushd msgpack-cxx-4.1.3
+tar xzf ../downloads/msgpack-cxx-7.0.0.tar.gz
+pushd msgpack-cxx-7.0.0
 mkdir -p build-for-mm && cd build-for-mm
 cmake \
 -DBUILD_SHARED_LIBS=OFF \

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -70,7 +70,7 @@ if [ "$do_download" = yes ]; then
    [ -f libusb-compat-0.1.5.tar.bz2 ] || curl -LO http://sourceforge.net/projects/libusb/files/libusb-compat-0.1/libusb-compat-0.1.5/libusb-compat-0.1.5.tar.bz2
    [ -f hidapi-0.8.0-rc1.tar.gz ] || curl -LO https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz
    [ -f libexif-0.6.21.tar.bz2 ] || curl -L -o libexif-0.6.21.tar.bz2 http://sourceforge.net/projects/libexif/files/libexif/0.6.21/libexif-0.6.21.tar.bz2/download
-   [ -f libtool-2.4.7.tar.gz ] || curl -LO https://ftpmirror.gnu.org/libtool/libtool-2.4.7.tar.gz
+   [ -f libtool-2.5.4.tar.gz ] || curl -LO https://ftpmirror.gnu.org/libtool/libtool-2.5.4.tar.gz
    [ -f libgphoto2-2.5.2.tar.bz2 ] || curl -L -o libgphoto2-2.5.2.tar.bz2 http://sourceforge.net/projects/gphoto/files/libgphoto/2.5.2/libgphoto2-2.5.2.tar.bz2/download
    [ -f FreeImage3154.zip ] || curl -LO http://downloads.sourceforge.net/freeimage/FreeImage3154.zip
    [ -f libdc1394-2.2.1.tar.gz ] || curl -L -o libdc1394-2.2.1.tar.gz http://sourceforge.net/projects/libdc1394/files/libdc1394-2/2.2.1/libdc1394-2.2.1.tar.gz/download
@@ -84,7 +84,7 @@ ed58c632befe0d299b39f9e23de1fc20d03870d7  boost_1_85_0.tar.bz2
 062319276d913c753a4b1341036e6a2e42abccc9  libusb-compat-0.1.5.tar.bz2
 5e72a4c7add8b85c8abcdd360ab8b1e1421da468  hidapi-0.8.0-rc1.tar.gz
 a52219b12dbc8d33fc096468591170fda71316c0  libexif-0.6.21.tar.bz2
-d3f2d5399f4bf5cbd974b812ebaca28d6492ca65  libtool-2.4.7.tar.gz
+77227188ead223ed8ba447301eda3761cb68ef57  libtool-2.5.4.tar.gz
 6b70ff6feec62a955bef1fc9a2b16dd07f0e277a  libgphoto2-2.5.2.tar.bz2
 1d30057a127b2016cf9b4f0f8f2ba92547670f96  FreeImage3154.zip
 b92c9670b68c4e5011148f16c87532bef2e5b808  libdc1394-2.2.1.tar.gz
@@ -189,8 +189,8 @@ popd
 # libtool
 #
 
-tar xzf ../downloads/libtool-2.4.7.tar.gz
-pushd libtool-2.4.7
+tar xzf ../downloads/libtool-2.5.4.tar.gz
+pushd libtool-2.5.4
 eval ./configure $MM_DEPS_CONFIGUREFLAGS --enable-shared --disable-static --enable-ltdl-install
 make $MM_PARALLELMAKEFLAG
 make install

--- a/buildscripts/nightly/nightlybuild_macOS_deps.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_deps.sh
@@ -462,6 +462,37 @@ popd
 
 unzip -oq ../downloads/opencv-2.4.13.6.zip
 pushd opencv-2.4.13.6
+
+patch -p1 <<'END_OF_PATCH'
+--- opencv-2.4.13.6/CMakeLists.txt	2018-02-21 12:27:31.000000000 -0600
++++ opencv-patched/CMakeLists.txt	2025-05-09 22:29:23.007048086 -0500
+@@ -36,23 +36,12 @@
+ # --------------------------------------------------------------
+ # Top level OpenCV project
+ # --------------------------------------------------------------
+-if(CMAKE_GENERATOR MATCHES Xcode AND XCODE_VERSION VERSION_GREATER 4.3)
+-  cmake_minimum_required(VERSION 3.0)
+-elseif(IOS)
+-  cmake_minimum_required(VERSION 3.0)
+-else()
+-  cmake_minimum_required(VERSION 2.8.12.2)
+-endif()
++cmake_minimum_required(VERSION 3.5)
+ 
+ if(POLICY CMP0026)
+   cmake_policy(SET CMP0026 NEW)
+ endif()
+ 
+-if (POLICY CMP0042)
+-  # silence cmake 3.0+ warnings about MACOSX_RPATH
+-  cmake_policy(SET CMP0042 OLD)
+-endif()
+-
+ # must go before the project command
+ set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Configs" FORCE)
+ if(DEFINED CMAKE_BUILD_TYPE AND CMAKE_VERSION VERSION_GREATER "2.8")
+END_OF_PATCH
+
 # OpenCV modules: highgui depends on imgproc; imgproc depends on core; OpenCVgrabber requires highgui and core
 mkdir -p build-for-mm && cd build-for-mm
 PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig cmake \

--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -114,7 +114,7 @@ $EVAL ./configure \
    "JAVA_HOME=\"$MM_JDK_HOME\"" \
    "JNI_CPPFLAGS=\"-I$MM_JDK_HOME/include -I$MM_JDK_HOME/include/darwin\"" \
    "JAVACFLAGS=\"-Xlint:all,-path,-serial -source 1.8 -target 1.8\"" \
-   "OPENCV_LDFLAGS=\"-framework Cocoa -framework QTKit -framework QuartzCore -framework AppKit\"" \
+   "OPENCV_LDFLAGS=\"-framework QuartzCore -framework CoreVideo -framework CoreMedia -framework CoreGraphics -framework AVFoundation -framework Accelerate -framework Cocoa\"" \
    "OPENCV_LIBS=\"$MM_DEPS_PREFIX/lib/libopencv_highgui.a $MM_DEPS_PREFIX/lib/libopencv_imgproc.a $MM_DEPS_PREFIX/lib/libopencv_core.a -lz $MM_DEPS_PREFIX/lib/libdc1394.la\"" \
    PKG_CONFIG_PATH=$MM_DEPS_PREFIX/lib/pkgconfig \
    "LIBUSB_0_1_LDFLAGS=\"-framework IOKit -framework CoreFoundation\"" \


### PR DESCRIPTION
Make the build work with the latest Apple toolchain.

Closes #2102.

Before merging, I should test correct loading of:
- [x] OpenCVgrabber
- [x] Gphoto (just in case -- `./configure` should have checked for missing symbols)
- [x] SequenceTester (just in case)