### PR TITLE
Remove DPI awareness settings for Windows

### DIFF
--- a/bindist/x64/ImageJ.cfg
+++ b/bindist/x64/ImageJ.cfg
@@ -1,4 +1,4 @@
 .
 .\jre\bin\javaw.exe
--Dsun.java2d.dpiaware=false -Xmx2000m -XX:MaxDirectMemorySize=1000g -XX:+UseG1GC -cp ij.jar ij.ImageJ
+-Xmx2000m -XX:MaxDirectMemorySize=1000g -XX:+UseG1GC -cp ij.jar ij.ImageJ
 

--- a/buildscripts/installer_Windows.iss
+++ b/buildscripts/installer_Windows.iss
@@ -194,6 +194,3 @@ Name: {commondesktop}\Micro-Manager 2.0; Filename: {app}\ImageJ.exe; Tasks: desk
 
 [Run]
 Filename: "{app}\ImageJ.exe"; WorkingDir: "{app}"; Description: {cm:LaunchProgram,Micro-Manager-2.0}; Flags: nowait postinstall skipifsilent
-
-[Registry]
-Root: HKLM; Subkey: "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers"; ValueType: string; ValueName: "{app}\ImageJ.exe"; ValueData: "~ DPIUNAWARE";


### PR DESCRIPTION
These should not be needed with JDK >= 9, and we are now shipping 11.