### PR TITLE
Add Ant targets to display Ivy report/graphs

### DIFF
--- a/buildscripts/fetchdeps.xml
+++ b/buildscripts/fetchdeps.xml
@@ -54,4 +54,12 @@
 			 Needed to prevent downstream errors. -->
 		<mkdir dir="${mm.ivy.lib.dir}/optional"/>
 	</target>
+
+	<target name="show-deps" depends="resolve">
+		<ivy:dependencytree/>
+	</target>
+
+	<target name="ivy-report" depends="resolve">
+		<ivy:report todir="${mm.ivy.lib.dir}/ivy-report" graph="true"/>
+	</target>
 </project>


### PR DESCRIPTION
`ant -f buildscripts/fetchdeps.xml show-deps`: print dependency graph

`ant -f buildscripts/fetchdeps.xml ivy-report`: generate HTML report, also including graphs