### PR TITLE
Windows installer: delete previous JRE

### DIFF
--- a/buildscripts/installer_Windows.iss
+++ b/buildscripts/installer_Windows.iss
@@ -172,7 +172,14 @@ Source: {#MMStageDir}\MMConfig_demo.cfg; DestDir: {app}; Flags: ignoreversion
 ; MATLAB utility script
 Source: {#MMStageDir}\StartMMStudio.m; DestDir: {app}; Flags: ignoreversion
 
-; Java Runtime
+;;
+;; Java Runtime
+;;
+
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\jre"
+
+[Files]
 Source: {#MMStageDir}\jre\*; DestDir: {app}\jre; Flags: ignoreversion recursesubdirs createallsubdirs
 
 


### PR DESCRIPTION
The current JRE 11 installed over an existing version with JRE 8 fails to launch, so delete before installing.

Closes #2122.