### PR TITLE
Studio-AcqControlDlg: Remove Actionlisteners every time we touch the ChannelGroup Combo box.  

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1302,7 +1302,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    public void updateGroupsCombo() {
       String[] groups = getAcquisitionEngine().getAvailableGroups();
       ActionListener[] als = channelGroupCombo_.getActionListeners();
-      for (ActionListener al: als) {
+      for (ActionListener al : als) {
          channelGroupCombo_.removeActionListener(al);
       }
       if (groups.length != 0) {
@@ -1313,7 +1313,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
          channelGroupCombo_.setSelectedItem(getAcquisitionEngine().getChannelGroup());
       }
-      for (ActionListener al: als) {
+      for (ActionListener al : als) {
          channelGroupCombo_.addActionListener(al);
       }
    }


### PR DESCRIPTION
There is a hard to reproduce situation where these ActionListeners lead to a sequence of circular calls that never stops.  Removing them does not seem to adversely affect the behavior.