### PR TITLE
Studio: Wait for shutter to be not busy when either our code or the core opens or closes it. 

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -940,6 +940,7 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
                   if (event.getZIndex() != null
                         && event.getZIndex() == sequenceSettings.slices().size() - 1) {
                      if (!event.isZSequenced() && sequenceSettings.useChannels()
+                           && event.getAxisPosition(AcqEngMetadata.CHANNEL_AXIS) != null
                              && (sequenceSettings.acqOrderMode()
                                        == AcqOrderMode.TIME_POS_SLICE_CHANNEL
                              || sequenceSettings.acqOrderMode()

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultShutterManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultShutterManager.java
@@ -79,6 +79,7 @@ public final class DefaultShutterManager implements ShutterManager {
     */
    private void repostShutterState() {
       try {
+         studio_.core().waitForDevice(studio_.core().getShutterDevice());
          boolean isOpen = getShutter();
          if (isOpen != isOpen_) {
             // Shutter state changed; notify everyone.
@@ -103,6 +104,7 @@ public final class DefaultShutterManager implements ShutterManager {
          setAutoShutter(false);
       }
       studio_.core().setShutterOpen(isOpen);
+      studio_.core().waitForDevice(studio_.core().getShutterDevice());
       studio_.events().post(new DefaultShutterEvent(isOpen));
       isOpen_ = isOpen;
       return isAutoOn;

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -255,6 +255,9 @@ public final class SnapLiveManager extends DataViewerListener
          amStartingSequenceAcquisition_ = true;
          core_.startContinuousSequenceAcquisition(0);
          amStartingSequenceAcquisition_ = false;
+         if (core_.getAutoShutter()) {
+            core_.waitForDevice(core_.getShutterDevice());
+         }
       } catch (Exception e) {
          ReportingUtils.showError(e, "Couldn't start live mode sequence acquisition");
          // Give up on starting live mode.
@@ -385,6 +388,9 @@ public final class SnapLiveManager extends DataViewerListener
          }
          while (core_.isSequenceRunning()) {
             core_.sleep(2);
+         }
+         if (core_.getAutoShutter()) {
+            core_.waitForDevice(core_.getShutterDevice());
          }
       } catch (Exception e) {
          ReportingUtils.showError(e,


### PR DESCRIPTION
 This prevents downstream strangeness