### PR TITLE
Adds Window Position Key to DisplaySettings and uses it in MDA, Album and Preview

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayManager.java
@@ -156,6 +156,22 @@ public interface DisplayManager extends EventPublisher {
                                DisplayWindowControlsFactory factory);
 
    /**
+    * Create a new DisplayWindow for the specified DataProvider and return it.
+    * This version allows you to specify the DisplaySettings to use for the
+    * DisplayWindow. Set the DisplayWindowControlsFactory to null if you do not
+    * use custom controls.
+    *
+    * @param provider        The DataProvider whose data should be displayed.
+    * @param factory         A ControlsFactory used to create custom controls for
+    *                        the DisplayWindow. May be null.
+    * @param displaySettings The initial DisplaySettings to use for the DisplayWindow.
+    * @return The created DisplayWindow.
+    */
+   DisplayWindow createDisplay(DataProvider provider,
+                                      DisplayWindowControlsFactory factory,
+                                      DisplaySettings displaySettings);
+
+   /**
     * Create a new Inspector window that shows information for the specified
     * DataViewer, or for the topmost window if the DataViewer is null.
     *

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -129,6 +129,15 @@ public interface DisplaySettings {
       Builder channels(Iterable<ChannelDisplaySettings> channelSettings);
 
       /**
+       * Adds a key to the DisplaySettings that will be used to position the Windows.
+       *
+       * @param key Key to use for positioning the DisplayWindow. New DisplayWindows with the
+       *            same key will be positioned at the same position
+       * @return builder instance to enable chaining commands
+       */
+      Builder windowPositionKey(String key);
+
+      /**
        * Number of ChannelDisplaySettings in this builder.  Not sure why a builder needs this...
        *
        * @return Number of ChannelDisplaySettings in this Builder.
@@ -246,6 +255,8 @@ public interface DisplaySettings {
    List<Boolean> getAllChannelVisibilities();
 
    boolean isChannelVisible(int channel);
+
+   String getWindowPositionKey();
 
    Builder copyBuilder();
 

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -38,6 +38,13 @@ import java.util.List;
 public interface DisplaySettings {
 
    /**
+    * Keys used by Studio for Window positioning.
+    */
+   static final String ALBUM_DISPLAY = "ALBUM_DISPLAY";
+   static final String PREVIEW_DISPLAY = "PREVIEW_DISPLAY";
+   static final String MDA_DISPLAY = "MDA_DISPLAY";
+
+   /**
     * Builder for DisplaySettings.  Get an instance using the
     * {@link org.micromanager.display.DisplayManager} displaySettingsBuilder()
     * method or by using one of the copy() methods of an existing DisplaySettings instance.

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -270,9 +270,16 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
       return ret;
    }
 
-   // Evaluate a version that includes display settings.
-   // This reduces cpu cycles by current code creating display settings that
-   // are over-written later.
+   /**
+    * Preferred version of createDisplay.  This allows the caller to include
+    * initial display settings that can be used during display creation
+    * (currently to place the window), but also reduces CPU cycles since
+    * the called code will not need to construct a default set of display setting.
+    *
+    * @param provider The DataProvider to use for this display
+    * @param factory  The DisplayWindowControlsFactory to use for this display
+    * @return The created DisplayWindow
+    */
    @Override
    public DisplayWindow createDisplay(DataProvider provider,
                                       DisplayWindowControlsFactory factory,

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayManager.java
@@ -259,15 +259,29 @@ public final class DefaultDisplayManager extends DataViewerListener implements D
       return ret;
    }
 
-   // TODO: Evaluate a version that includes display settings.
-   // This reduce cpu cycles by current code creating display settings that
-   // are over-written later.
 
    @Override
    public DisplayWindow createDisplay(DataProvider provider,
                                       DisplayWindowControlsFactory factory) {
       DisplayWindow ret = new DisplayController.Builder(provider)
             .linkManager(linkManager_).controlsFactory(factory).build(studio_);
+      addViewer(ret);
+      ret.show();
+      return ret;
+   }
+
+   // Evaluate a version that includes display settings.
+   // This reduces cpu cycles by current code creating display settings that
+   // are over-written later.
+   @Override
+   public DisplayWindow createDisplay(DataProvider provider,
+                                      DisplayWindowControlsFactory factory,
+                                      DisplaySettings displaySettings) {
+      DisplayWindow ret = new DisplayController.Builder(provider)
+               .linkManager(linkManager_)
+               .controlsFactory(factory)
+               .displaySettings(displaySettings)
+               .build(studio_);
       addViewer(ret);
       ret.show();
       return ret;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -58,6 +58,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    private final boolean histogramLogarithmic_;
    private final boolean ignoreZeros_;
    private final List<ChannelDisplaySettings> channelSettings_;
+   private final String windowPositionKey_;
 
    private static class Builder implements DisplaySettings.Builder {
       private double zoom_ = 1.0;
@@ -70,6 +71,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       private double extremaQuantile_ = 0.001;
       private boolean ignoreZeros_ = false;
       private List<ChannelDisplaySettings> channelSettings_ = new ArrayList<>();
+      private String windowPositionKey_ = null;
 
       private Builder() {
          channelSettings_.add(DefaultChannelDisplaySettings.builder().build());
@@ -165,6 +167,12 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       }
 
       @Override
+      public Builder windowPositionKey(String key) {
+         windowPositionKey_ = key;
+         return this;
+      }
+
+      @Override
       public Builder channel(int channel) {
          Preconditions.checkArgument(channel >= 0);
          while (channelSettings_.size() <= channel) {
@@ -223,6 +231,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       histogramLogarithmic_ = builder.histogramLogarithmic_;
       channelSettings_ =
             new ArrayList<>(builder.channelSettings_);
+      windowPositionKey_ = builder.windowPositionKey_;
    }
 
    @Override
@@ -278,6 +287,11 @@ public final class DefaultDisplaySettings implements DisplaySettings {
    @Override
    public int getNumberOfChannels() {
       return channelSettings_.size();
+   }
+
+   @Override
+   public String getWindowPositionKey() {
+      return windowPositionKey_;
    }
 
    @Override
@@ -865,6 +879,7 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             .autostretch(autostretch_)
             .roiAutoscale(useROI_)
             .histogramLogarithmic(histogramLogarithmic_)
+            .windowPositionKey(windowPositionKey_)
             .autoscaleIgnoredQuantile(extremaQuantile_)
             .autoscaleIgnoringZeros(ignoreZeros_);
       for (int i = 0; i < getNumberOfChannels(); ++i) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
@@ -203,6 +203,11 @@ public final class DisplayController extends DisplayWindowAPIAdapter
          return this;
       }
 
+      public Builder displaySettings(DisplaySettings displaySettings) {
+         displaySettings_ = displaySettings;
+         return this;
+      }
+
       @MustCallOnEDT
       public DisplayController build(Studio studio) {
          return DisplayController.create(studio, this);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -286,7 +286,8 @@ public final class DisplayUIController implements Closeable, WindowListener,
                getClass().getResource("/org/micromanager/icons/microscope.gif")));
          frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
          frame.setBounds(320, 320, 480, 320);
-         WindowPositioning.setUpBoundsMemory(frame, frame.getClass(), null);
+         displayController_.getDisplaySettings().getKey();
+         WindowPositioning.setUpBoundsMemory(frame, DisplayUIController.class, key);
 
          // TODO Determine initial window bounds using a CascadingWindowPositioner:
          // - (Setting canvas zoom has been handled by DisplayController (ImageJLink))

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -286,7 +286,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
                getClass().getResource("/org/micromanager/icons/microscope.gif")));
          frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
          frame.setBounds(320, 320, 480, 320);
-         displayController_.getDisplaySettings().getKey();
+         String key = displayController_.getDisplaySettings().getWindowPositionKey();
          WindowPositioning.setUpBoundsMemory(frame, DisplayUIController.class, key);
 
          // TODO Determine initial window bounds using a CascadingWindowPositioner:

--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultAlbum.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultAlbum.java
@@ -121,8 +121,6 @@ public final class DefaultAlbum implements Album {
             studio_.logs().logError(e, "Unable to set summary of newly-created datastore");
          }
          studio_.displays().manage(store_);
-         display_ = studio_.displays().createDisplay(store_);
-         display_.setCustomTitle("Album");
          DisplaySettings ds = DefaultDisplaySettings.restoreFromProfile(
                studio_.profile(),
                PropertyKey.ALBUM_DISPLAY_SETTINGS.key());
@@ -137,7 +135,10 @@ public final class DefaultAlbum implements Album {
                         store_.getSummaryMetadata().getSafeChannelName(ch),
                         Color.white)).build();
          }
-         display_.setDisplaySettings(ds);
+         ds = ds.copyBuilder().windowPositionKey(DisplaySettings.ALBUM_DISPLAY).build();
+         display_ = studio_.displays().createDisplay(store_, null, ds);
+         display_.setCustomTitle("Album");
+
 
          curTime_ = null;
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -497,10 +497,6 @@ public final class SnapLiveManager extends DataViewerListener
    }
 
    private void createDisplay() {
-      DisplayWindowControlsFactory controlsFactory =
-            (DisplayWindow display) -> createControls();
-      display_ = new DisplayController.Builder(store_)
-            .controlsFactory(controlsFactory).build(mmStudio_);
       DisplaySettings ds = DefaultDisplaySettings.restoreFromProfile(
             mmStudio_.profile(),
             PropertyKey.SNAP_LIVE_DISPLAY_SETTINGS.key());
@@ -515,6 +511,11 @@ public final class SnapLiveManager extends DataViewerListener
                      store_.getSummaryMetadata().getSafeChannelName(ch),
                      Color.white)).build();
       }
+      ds = ds.copyBuilder().windowPositionKey(DisplaySettings.PREVIEW_DISPLAY).build();
+      final DisplayWindowControlsFactory controlsFactory =
+               (DisplayWindow display) -> createControls();
+      display_ = new DisplayController.Builder(store_)
+            .controlsFactory(controlsFactory).displaySettings(ds).build(mmStudio_);
 
       display_.setDisplaySettings(ds);
       mmStudio_.displays().addViewer(display_);

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -517,7 +517,6 @@ public final class SnapLiveManager extends DataViewerListener
       display_ = new DisplayController.Builder(store_)
             .controlsFactory(controlsFactory).displaySettings(ds).build(mmStudio_);
 
-      display_.setDisplaySettings(ds);
       mmStudio_.displays().addViewer(display_);
 
       display_.registerForEvents(this);


### PR DESCRIPTION
This PR needs a minor version update of the Studio version since it adds a function (and 3 static variables) to DisplaySettings and it adds a function to DisplayManager.

DisplaySettings now can be provided with a key that will be used in WindowPositioning.  For this to take effect, a method for the calling code to provide initial displaySettings was needed.  Since all the calling code was already providing DisplaySettings right after constructing the display, it made sense to add that function in any case.   
