### PR TITLE
macOS: Bundle the JRE

### DIFF
--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -209,6 +209,15 @@ find $MM_STAGEDIR -name .svn -prune -exec rm -rf {} +
 
 
 ##
+## Bundle JRE
+##
+
+# The 'jre' directory is preferred over system-installed JREs by the launcher.
+rm -rf $MM_STAGEDIR/jre
+cp -R $(cjdk --arch $MM_ARCH -j temurin-jre:11 java-home) $MM_STAGEDIR/jre
+
+
+##
 ## Temporarily unpack JARs for processing; remove other archs
 ##
 


### PR DESCRIPTION
Closes #1402.

Draft for now because `cjdk` needs to be available on the build machine before merging.