### PR TITLE
macOS: disable bundling of JRE

### DIFF
--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -214,7 +214,8 @@ find $MM_STAGEDIR -name .svn -prune -exec rm -rf {} +
 
 # The 'jre' directory is preferred over system-installed JREs by the launcher.
 rm -rf $MM_STAGEDIR/jre
-cp -R $(cjdk --arch $MM_ARCH -j temurin-jre:11 java-home) $MM_STAGEDIR/jre
+# cp -R $(cjdk --arch $MM_ARCH -j temurin-jre:11 java-home) $MM_STAGEDIR/jre
+# ^ Disabled until we figure out codesigning issues
 
 
 ##


### PR DESCRIPTION
Unfortunately #2146 did not work: the resulting build fails to launch (apparently after invoking `java`).
Disable bundling the JRE for now.

I believe the reason is that I forgot to add the correct entitlements when code-signing (the JVM requires these to enable things like JIT), but I have not yet found a configuration that works. So let's revert for now.