### PR TITLE
WIP: macOS: Reenable bundling of JRE and add macOS entitlements

### DIFF
--- a/buildscripts/nightly/macOS-java-entitlements.plist
+++ b/buildscripts/nightly/macOS-java-entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- These 5 entitlements are equal to what Temurin's 'java' ships with -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key> <true/>
+    <key>com.apple.security.cs.allow-jit</key> <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key> <true/>
+    <key>com.apple.security.cs.debugger</key> <true/>
+    <key>com.apple.security.cs.disable-library-validation</key> <true/>
+</dict>
+</plist>

--- a/buildscripts/nightly/nightlybuild_macOS_mm.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_mm.sh
@@ -238,7 +238,17 @@ thin_script="`dirname $0`/macOS-thin-binaries.sh"
 ##
 codesign_script="`dirname $0`/macOS-codesign.sh"
 if [ "$do_codesign" = yes ]; then
-   "$codesign_script" -b "$MM_STAGEDIR"
+   "$codesign_script" -d "$MM_STAGEDIR" --options runtime
+
+   # Temurin JRE has the same 5 entitlements on all executables and dylibs.
+   # Zulu JRE does the same (except for adding audio-input for 'java').
+   # Even though I don't think dylibs need entitlements, let's follow that.
+   "$codesign_script" -d "$MM_STAGEDIR/jre" --options runtime \
+      --force-library-entitlements \
+      --entitlements "`dirname $0`/macOS-java-entitlements.plist"
+
+   # The ImageJ.app launcher bundle (which contains a shell script; no binary)
+   "$codesign_script" -1 "$MM_STAGEDIR/ImageJ.app"
 fi
 
 ##
@@ -289,7 +299,7 @@ hdiutil convert "$sparseimage_name" -format UDBZ -o "$dmg_name"
 
 # Sign the DMG, too
 if [ "$do_codesign" = yes ]; then
-   "$codesign_script" -D "$dmg_name"
+   "$codesign_script" -1 "$dmg_name"
 fi
 
 


### PR DESCRIPTION
This is my work so far to address #1402 again (see #2146, #2147).

This PR signs the (Temurin) JRE binaries with the same entitlements as they originally come with. It passes notarization. However, after downloading from the internet, we get the expected '"ImageJ" is an app downloaded from the Internet' dialog followed by an unexpected 'Apple could not verify "java" is free of malware' dialog.

This is in contrast to #2146 (where I forgot to attach any entitlements to the JRE binaries), where I got two "downloaded from the Internet" dialogs in a row, one for `ImageJ.app` and one for `java`, followed by a crash with no error (as would be expected for insufficient entitlements).

Claude thinks that, when the Hardened Runtime is enabled and a launcher starts an executable that in turn performs JIT, the launcher itself also needs to have `com.apple.security.cs.allow-unsigned-executable-memory` (and possibly the other entitlements that the JVM needs). (Claude also ranted that this is a gap in Apple's documentation.)

If this is true, I don't think we can make it work with our current launcher, because it is a shell script to which we cannot attach entitlements (and the shell executable running it is not under our control). I don't propose shipping our own shell binary.

We might need to do #2142 (at least for macOS) first, after all. Then the launcher will be an executable that we can sign with the entitlements.