### PR TITLE
Fix exceptions and errors when there is no shutter

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultShutterManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultShutterManager.java
@@ -73,13 +73,20 @@ public final class DefaultShutterManager implements ShutterManager {
       repostShutterState();
    }
 
+   private void waitForShutter() throws Exception {
+      String shutter = studio_.core().getShutterDevice();
+      if (shutter != null && !shutter.isEmpty()) {
+         studio_.core().waitForDevice(shutter);
+      }
+   }
+
    /**
     * Check the current shutter state, and post events if it has changed
     * compared to our cached values.
     */
    private void repostShutterState() {
       try {
-         studio_.core().waitForDevice(studio_.core().getShutterDevice());
+         waitForShutter();
          boolean isOpen = getShutter();
          if (isOpen != isOpen_) {
             // Shutter state changed; notify everyone.
@@ -104,7 +111,7 @@ public final class DefaultShutterManager implements ShutterManager {
          setAutoShutter(false);
       }
       studio_.core().setShutterOpen(isOpen);
-      studio_.core().waitForDevice(studio_.core().getShutterDevice());
+      waitForShutter();
       studio_.events().post(new DefaultShutterEvent(isOpen));
       isOpen_ = isOpen;
       return isAutoOn;

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -232,6 +232,13 @@ public final class SnapLiveManager extends DataViewerListener
       }
    }
 
+   private void waitForShutter() throws Exception {
+      String shutter = core_.getShutterDevice();
+      if (shutter != null && !shutter.isEmpty()) {
+         core_.waitForDevice(shutter);
+      }
+   }
+
    private void startLiveMode() {
       if (amStartingSequenceAcquisition_) {
          // HACK: if startContinuousSequenceAcquisition results in a core
@@ -256,7 +263,7 @@ public final class SnapLiveManager extends DataViewerListener
          core_.startContinuousSequenceAcquisition(0);
          amStartingSequenceAcquisition_ = false;
          if (core_.getAutoShutter()) {
-            core_.waitForDevice(core_.getShutterDevice());
+            waitForShutter();
          }
       } catch (Exception e) {
          ReportingUtils.showError(e, "Couldn't start live mode sequence acquisition");
@@ -390,7 +397,7 @@ public final class SnapLiveManager extends DataViewerListener
             core_.sleep(2);
          }
          if (core_.getAutoShutter()) {
-            core_.waitForDevice(core_.getShutterDevice());
+            waitForShutter();
          }
       } catch (Exception e) {
          ReportingUtils.showError(e,


### PR DESCRIPTION
Fix Live, which would result in errors when there is no current shutter and autoshutter is enabled.

Prevent exceptions from being logged at startup, when shutter is manually opened/closed in the main window, and at the end of Live, when there is no current shutter.

These were introduced in #2139 and the fix is just to avoid waiting for the shutter when there is no shutter.