### PR TITLE
mm1.4 handle XYStage offset and mirror operations in sequences and scanning

### DIFF
--- a/DeviceAdapters/ASITiger/ASIXYStage.h
+++ b/DeviceAdapters/ASITiger/ASIXYStage.h
@@ -47,7 +47,7 @@ public:
    // XYStageBase uses these functions to move the stage
    // the step size is the programming unit for dimensions and is integer
    // see http://micro-manager.3463995.n2.nabble.com/what-are-quot-steps-quot-for-stages-td7580724.html
-   double GetStepSizeXUm() {return stepSizeYUm_;}
+   double GetStepSizeXUm() {return stepSizeXUm_;}
    double GetStepSizeYUm() {return stepSizeYUm_;}
    int GetPositionSteps(long& x, long& y);
    int SetPositionSteps(long x, long y);

--- a/MMDevice/DeviceBase.h
+++ b/MMDevice/DeviceBase.h
@@ -1835,16 +1835,11 @@ public:
       this->AddAllowedValue(MM::g_Keyword_Transpose_MirrorY, "1");
    }
 
-
-   virtual int SetPositionUm(double x, double y)
+   
+   virtual int CalculatePositionSteps(long& xSteps, long& ySteps, double x, double y)
    {
       bool mirrorX, mirrorY;
       GetOrientation(mirrorX, mirrorY);
-      double xPos = x;
-      double yPos = y;
-
-      long xSteps = 0;
-      long ySteps = 0;
 
       if (mirrorX)
          xSteps = originXSteps_ - nint (x / this->GetStepSizeXUm());
@@ -1855,7 +1850,22 @@ public:
       else
          ySteps = originYSteps_ + nint (y / this->GetStepSizeYUm());
 
-      int ret = this->SetPositionSteps(xSteps, ySteps);
+      return DEVICE_OK;     
+   }
+
+
+   virtual int SetPositionUm(double x, double y)
+   {
+      double xPos = x;
+      double yPos = y;
+      long xSteps = 0;
+      long ySteps = 0;
+
+      int ret = CalculatePositionSteps(xSteps, ySteps, x, y);
+      if (ret != DEVICE_OK)
+         return ret;
+      
+      ret = this->SetPositionSteps(xSteps, ySteps);
       if (ret == DEVICE_OK) {
          xPos_ = xPos;
          yPos_ = yPos;

--- a/plugins/ASIdiSPIM/src/org/micromanager/asidispim/ASIdiSPIM.java
+++ b/plugins/ASIdiSPIM/src/org/micromanager/asidispim/ASIdiSPIM.java
@@ -46,7 +46,7 @@ public class ASIdiSPIM implements MMPlugin {
    public static final boolean SCOPE = false;
    public static final boolean singleView = (oSPIM || SCOPE);  // true for SCOPE and oSPIM (and possibly other situations?)
    public static final boolean doubleXYZ = false;
-   public final static String versionString = " 20250101";
+   public final static String versionString = " 20250528";
    
    public final static String menuName = "ASI " 
          + (SCOPE ? "SCOPE" : (oSPIM ? "oSPIM" : "diSPIM") ) 

--- a/plugins/ASIdiSPIM/src/org/micromanager/asidispim/Data/Cameras.java
+++ b/plugins/ASIdiSPIM/src/org/micromanager/asidispim/Data/Cameras.java
@@ -262,6 +262,11 @@ public class Cameras {
             
             props_.setPropValue(devKey,
                   Properties.Keys.HAMAMATSU_LINE_INTERVAL, (float)Math.max(rowTime, lowerLimit));
+
+            // setting this seems to be required to force the camera to re-calculate something
+            // this works around an apparent bug in the device adapter
+            props_.setPropValue(devKey, Properties.Keys.HAMAMATSU_LINE_SPEED, 0.01f);
+
             break;
          case LEVEL:
             props_.setPropValue(devKey,
@@ -781,8 +786,11 @@ public class Cameras {
          }
          break;
       case LIGHT_SHEET:
-         if (camLibrary == Devices.Libraries.HAMCAM && props_.getPropValueString(camKey, Properties.Keys.CAMERA_BUS).equals(Properties.Values.USB3.toString())) {
-            readoutTimeMs = 10000;  // absurdly large, light sheet mode over USB3 isn't supported by Flash4 but we are set up to decide available modes by device library and not a property
+         if (camLibrary == Devices.Libraries.HAMCAM && !isFusion(camKey)
+            && props_.getPropValueString(camKey, Properties.Keys.CAMERA_BUS).equals(Properties.Values.USB3.toString())) {
+            // absurdly large, light sheet mode over USB3 isn't supported by Flash4 but we are set up to decide available modes by device library and not a property
+            // Fusion does seem to support light sheet mode over USB3
+            readoutTimeMs = 10000;
          } else if (camLibrary == Devices.Libraries.PVCAM) {
             readoutTimeMs = (float) props_.getPropValueInteger(camKey, Properties.Keys.PVCAM_READOUT_TIME) / 1e6f;
          } else {

--- a/plugins/ASIdiSPIM/src/org/micromanager/asidispim/Data/Cameras.java
+++ b/plugins/ASIdiSPIM/src/org/micromanager/asidispim/Data/Cameras.java
@@ -248,7 +248,7 @@ public class Cameras {
                   Properties.Values.EDGE);
             double rowTime = getRowReadoutTime(devKey) * 
                   props_.getPropValueFloat(Devices.Keys.PLUGIN, Properties.Keys.PLUGIN_LS_SHUTTER_SPEED);
-            
+
             // get the lower limit from the camera (0.0098 for Flash4)
             double lowerLimit = 0.0;
             final String deviceName = devices_.getMMDevice(Devices.Keys.CAMERAA);
@@ -259,13 +259,19 @@ public class Cameras {
             	// ignore => will set the HAMAMATSU_LINE_INTERVAL property  
             	// to the rowTime without considering the lower limit
             }
-            
-            props_.setPropValue(devKey,
-                  Properties.Keys.HAMAMATSU_LINE_INTERVAL, (float)Math.max(rowTime, lowerLimit));
 
-            // setting this seems to be required to force the camera to re-calculate something
-            // this works around an apparent bug in the device adapter
-            props_.setPropValue(devKey, Properties.Keys.HAMAMATSU_LINE_SPEED, 0.01f);
+            final float shutterSpeed = props_.getPropValueFloat(
+                    Devices.Keys.PLUGIN, Properties.Keys.PLUGIN_LS_SHUTTER_SPEED);
+
+            props_.setPropValue(devKey,
+                    Properties.Keys.HAMAMATSU_LINE_INTERVAL, (float)Math.max(rowTime, lowerLimit));
+
+            if (prefs_.getBoolean(MyStrings.PanelNames.SETTINGS.toString(),
+                 Properties.Keys.PLUGIN_USE_TOOLSET, false)) {
+               // setting this seems to be required to force the camera to re-calculate something
+               // this works around an apparent bug in the device adapter
+               props_.setPropValue(devKey, Properties.Keys.HAMAMATSU_LINE_SPEED, 0.1f / shutterSpeed);
+            }
 
             break;
          case LEVEL:
@@ -593,6 +599,7 @@ public class Cameras {
    public double getRowReadoutTime(Devices.Keys camKey) {
       switch(devices_.getMMDeviceLibrary(camKey)) {
       case HAMCAM:
+         // TODO changes this for LIGHT_SHEET mode?
          if (isFusion(camKey)) {
             String mode = props_.getPropValueString(camKey, Properties.Keys.SCAN_MODE);
             if (mode.equals("3")) {

--- a/plugins/ASIdiSPIM/src/org/micromanager/asidispim/Data/Properties.java
+++ b/plugins/ASIdiSPIM/src/org/micromanager/asidispim/Data/Properties.java
@@ -169,6 +169,7 @@ public class Properties {
       SCAN_MODE("ScanMode"),              // for Hamamatsu, for Flash4: 1 = slow scan, 2 = fast scan, for Fusion 1 = slow scan, 2 = standard scan, 3 = fast scan
       CAMERA_BUS("Camera Bus"),           // for Hamamatsu interface type, USB3 or ??
       HAMAMATSU_LINE_INTERVAL("INTERNAL LINE INTERVAL"), // for Hamamatsu
+      HAMAMATSU_LINE_SPEED("INTERNAL LINE SPEED"), // for Hamamatsu
       TRIGGER_MODE_PCO("Triggermode"),         // for PCO
       PIXEL_RATE("PixelRate"),                 // for PCO
       CAMERA_TYPE("CameraType"),               // for PCO


### PR DESCRIPTION
We have discussed this on the forum at https://forum.image.sc/t/device-adapter-for-xy-stage-handling-mirroring-and-offsets.

We can treat this commit to the mm1.4 branch (used only by ASI I think) as a trial run.

The API in MMDevice.h creates an optional offset and mirroring between hardware units ("steps") and units displayed by MM.  Notably these are used in the HCS plugin.  As long as you only are using positions via the following 3 API calls everything is fine.

```
int SetPositionUm(double x, double y);
int SetRelativePositionUm(double dx, double dy);
int GetPositionUm(double& x, double& y);
```

However the ASITiger device adapter uses positions it at least 2 other places, and these didn't previously take into account the disconnect between hardware units and the displayed units. 
- sequence positions
- scan positions (set with properties in units of millimeters)

So we need a method to do the same calculations as the the get/set position methods do so that other places in the device adapter can send correct information to the controller.

My solution is to add a new method to MMDevice.h under XY stage that is code extracted from `SetPositionUm(...)` and exposed separately (and now `SetPositionUm(...)' calls this method internally).

`int CalculatePositionSteps(long& xSteps, long& ySteps, double x, double y);`

I use this method in my device adapter so that sequence positions and scan positions calculate the correct hardware positions before sending anything to the controller.