### PR TITLE
Studio: ups the number of Z stages in the StageControlFrame to 8.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -83,7 +83,7 @@ public final class StageControlFrame extends JFrame {
    private final UiMovesStageManager uiMovesStageManager_;
    private final MutablePropertyMapView settings_;
 
-   private static final int MAX_NUM_Z_PANELS = 5;
+   private static final int MAX_NUM_Z_PANELS = 8;
    private static final int FRAME_X_DEFAULT_POS = 100;
    private static final int FRAME_Y_DEFAULT_POS = 100;
 
@@ -281,6 +281,9 @@ public final class StageControlFrame extends JFrame {
       // mailing list report 12/31/2019 encounters nrZPanels == 0, workaround:
       if (nrZPanels <= 0 && nrZDrives > 0) {
          nrZPanels = 1;
+      }
+      if (nrZPanels > nrZDrives) {
+         nrZPanels = nrZDrives;
       }
       settings_.putInteger(key, nrZPanels);
       for (int idx = 1; idx < MAX_NUM_Z_PANELS; ++idx) {


### PR DESCRIPTION
Also deals with a funny situation that can occur by removing Z drives from a configuration.