### PR TITLE
Fix bug displaying wrong channel names in Inspector Window

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -218,6 +218,10 @@ public final class MMAcquisition extends DataViewerListener {
                                           ? acquisitionSettings.channels().get(channelIndex).color()
                                           : null));
             }
+         } else {
+            int tmpNrChannels = summaryMetadata.getChannelNameList().size();
+            studio_.logs().logError("nrChannel in MMAcquisition was unexpectedly zero");
+
          }
 
          display_ = studio_.displays().createDisplay(store_,

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/MMAcquisition.java
@@ -192,10 +192,11 @@ public final class MMAcquisition extends DataViewerListener {
 
          // Use settings of last closed acquisition viewer
          DisplaySettings.Builder displaySettingsBuilder = null;
-         if (studio_.displays().displaySettingsFromProfile(
-                           PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key()) != null) {
-            displaySettingsBuilder = studio_.displays().displaySettingsFromProfile(
-                     PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key()).copyBuilder();
+         DisplaySettings tmpDisplaySettings =
+               studio_.displays().displaySettingsFromProfile(
+                        PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key());
+         if (tmpDisplaySettings != null) {
+            displaySettingsBuilder = tmpDisplaySettings.copyBuilder();
          }
          if (displaySettingsBuilder == null) {
             displaySettingsBuilder = DefaultDisplaySettings.builder();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayController.java
@@ -1196,7 +1196,8 @@ public final class DisplayController extends DisplayWindowAPIAdapter
          for (String axis : dataProvider_.getAxes()) {
             cb.index(axis, dataProvider_.getNextIndex(axis) - 1);
          }
-         uiController_.expandDisplayedRangeToInclude(cb.build());
+         SwingUtilities.invokeLater(() ->
+               uiController_.expandDisplayedRangeToInclude(cb.build()));
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/MDScrollBarPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/MDScrollBarPanel.java
@@ -117,12 +117,6 @@ public class MDScrollBarPanel extends JPanel implements AdjustmentListener {
     */
    @MustCallOnEDT
    void setAxes(List<String> axes) {
-      if (!SwingUtilities.isEventDispatchThread()) {
-         SwingUtilities.invokeLater(() -> {
-            setAxes(axes);
-         });
-         return;
-      }
       if (axes_.equals(axes)) {
          return;
       }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/MDScrollBarPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/MDScrollBarPanel.java
@@ -25,6 +25,7 @@ import javax.swing.BoundedRangeModel;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JScrollBar;
+import javax.swing.SwingUtilities;
 import net.miginfocom.layout.CC;
 import net.miginfocom.layout.LC;
 import net.miginfocom.swing.MigLayout;
@@ -116,6 +117,12 @@ public class MDScrollBarPanel extends JPanel implements AdjustmentListener {
     */
    @MustCallOnEDT
    void setAxes(List<String> axes) {
+      if (!SwingUtilities.isEventDispatchThread()) {
+         SwingUtilities.invokeLater(() -> {
+            setAxes(axes);
+         });
+         return;
+      }
       if (axes_.equals(axes)) {
          return;
       }

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewAcqManager.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewAcqManager.java
@@ -1,5 +1,6 @@
 package org.micromanager.deskew;
 
+import java.awt.Color;
 import java.io.IOException;
 import java.util.EnumMap;
 import org.micromanager.PropertyMap;
@@ -11,6 +12,7 @@ import org.micromanager.data.SummaryMetadata;
 import org.micromanager.data.internal.PropertyKey;
 import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.DisplayWindow;
+import org.micromanager.display.internal.RememberedDisplaySettings;
 
 /**
  * This class manages the test datastores and data viewers for the Deskew plugin.
@@ -176,6 +178,27 @@ public class DeskewAcqManager {
       } else {
          displaySettingsBuilder = displaySettings.copyBuilder();
       }
+      final int nrChannels = store.getSummaryMetadata().getChannelNameList().size();
+      if (nrChannels > 0) { // I believe this will always be true, but just in case...
+         if (nrChannels == 1) {
+            displaySettingsBuilder.colorModeGrayscale();
+         } else {
+            displaySettingsBuilder.colorModeComposite();
+         }
+         for (int channelIndex = 0; channelIndex < nrChannels; channelIndex++) {
+            displaySettingsBuilder.channel(channelIndex,
+                     RememberedDisplaySettings.loadChannel(studio_,
+                              store.getSummaryMetadata().getChannelGroup(),
+                              store.getSummaryMetadata().getChannelNameList().get(channelIndex),
+                              displaySettings != null
+                                       ? displaySettings.getChannelColor(channelIndex)
+                                       : Color.WHITE));
+         }
+      } else {
+         int tmpNrChannels = summaryMetadata.getChannelNameList().size();
+         studio_.logs().logError("nrChannel in MMAcquisition was unexpectedly zero");
+      }
+
       if ((settings.containsKey(DeskewFrame.SHOW) && settings.getBoolean(DeskewFrame.SHOW, false))
                || (settings.containsKey(DeskewFrame.OUTPUT_OPTION)
                && (settings.getString(DeskewFrame.OUTPUT_OPTION, "").equals(DeskewFrame.OPTION_RAM)

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewAcqManager.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewAcqManager.java
@@ -195,7 +195,6 @@ public class DeskewAcqManager {
                                        : Color.WHITE));
          }
       } else {
-         int tmpNrChannels = summaryMetadata.getChannelNameList().size();
          studio_.logs().logError("nrChannel in MMAcquisition was unexpectedly zero");
       }
 

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewAcqManager.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewAcqManager.java
@@ -195,7 +195,7 @@ public class DeskewAcqManager {
                                        : Color.WHITE));
          }
       } else {
-         studio_.logs().logError("nrChannel in MMAcquisition was unexpectedly zero");
+         studio_.logs().logError("nrChannel in DeskewAcqManager was unexpectedly zero");
       }
 
       if ((settings.containsKey(DeskewFrame.SHOW) && settings.getBoolean(DeskewFrame.SHOW, false))


### PR DESCRIPTION
This was mainly due to Datastore SummaryMetadata not being set synchronously.