### PR TITLE
Deskew plugin: fix problem with processing existing data.

### DIFF
--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
@@ -569,20 +569,35 @@ public class DeskewFrame extends JFrame implements ProcessorConfigurator {
             orderedImageCoords.add(c);
          }
          final List<String> axisOrder = source.getSummaryMetadata().getOrderedAxes();
-         Collections.reverse(axisOrder);
-
-         Collections.sort(orderedImageCoords, new Comparator<Coords>() {
-            @Override
-            public int compare(Coords o1, Coords o2) {
-               for (String axis : axisOrder) {
-                  if (o1.getIndex(axis)  < o2.getIndex(axis)) {
-                     return -1;
-                  }  else if (o1.getIndex(axis) > o2.getIndex(axis)) {
-                     return 1;
+         // We need to ensure that the z axis is last:
+         if (!axisOrder.get(axisOrder.size() - 1).equals(Coords.Z)) {
+            if (axisOrder.get(0).equals(Coords.Z)) {
+               Collections.reverse(axisOrder);
+            } else {
+               if (axisOrder.contains(Coords.Z)) {
+                  int zIndex = axisOrder.indexOf(Coords.Z);
+                  // Move Z to the end of the axis order
+                  axisOrder.remove(zIndex);
+                  // If the axis order is empty, we need to add Z as the only axis
+                  if (axisOrder.isEmpty()) {
+                     axisOrder.add(Coords.Z);
+                  } else {
+                     // Otherwise, we add Z to the end of the axis order
+                     axisOrder.add(Coords.Z);
                   }
                }
-               return 0;
             }
+         }
+
+         orderedImageCoords.sort((Coords o1, Coords o2) -> {
+            for (String axis : axisOrder) {
+               if (o1.getIndex(axis) < o2.getIndex(axis)) {
+                  return -1;
+               } else if (o1.getIndex(axis) > o2.getIndex(axis)) {
+                  return 1;
+               }
+            }
+            return 0;
          });
 
          int i = 0;

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
@@ -578,13 +578,8 @@ public class DeskewFrame extends JFrame implements ProcessorConfigurator {
                   int zIndex = axisOrder.indexOf(Coords.Z);
                   // Move Z to the end of the axis order
                   axisOrder.remove(zIndex);
-                  // If the axis order is empty, we need to add Z as the only axis
-                  if (axisOrder.isEmpty()) {
-                     axisOrder.add(Coords.Z);
-                  } else {
-                     // Otherwise, we add Z to the end of the axis order
-                     axisOrder.add(Coords.Z);
-                  }
+                  // Always add Z to the end of the axis order after removing it
+                  axisOrder.add(Coords.Z);
                }
             }
          }


### PR DESCRIPTION
Apperently, the Coords were sorted in the wrong order, so that processing would not start until the complete dataset was read in.  I can not fully wrap my head around the sort order, but the data seem to sort correctly now.