### PR TITLE
Studio: Greatly reduced cost of function getAnyImage for StorageRAM and SinglePlaneTIffSeries.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageRAM.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -123,9 +124,11 @@ public final class StorageRAM implements RewritableStorage {
    @Override
    public Image getAnyImage() {
       synchronized (this) {
-         if (coordsToImage_ != null && coordsToImage_.size() > 0) {
-            Coords coords = new ArrayList<>(coordsToImage_.keySet()).get(0);
-            return coordsToImage_.get(coords);
+         if (coordsToImage_ != null && !coordsToImage_.isEmpty()) {
+            Iterator<Image> valueIterator = coordsToImage_.values().iterator();
+            if (valueIterator.hasNext()) {
+               return valueIterator.next();
+            }
          }
       }
       return null;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
@@ -46,8 +46,10 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -317,8 +319,11 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
       if (coordsToFilename_.isEmpty()) {
          return null;
       }
-      Coords coords = new ArrayList<>(coordsToFilename_.keySet()).get(0);
-      return getImage(coords);
+      Enumeration<Coords> keyEnumerator = coordsToFilename_.keys();
+      if (keyEnumerator.hasMoreElements()) {
+         return getImage(keyEnumerator.nextElement());
+      }
+      return null;
    }
 
    @Override


### PR DESCRIPTION
Studio: Greatly reduced cost of function getAnyImage for StorageRAM and SinglePlaneTIffSeries. Only changes RAM store.  It would previously stall out at 45000 images, but now tested to not slow down up to 110000 images.
