### PR TITLE
ASI CRISP: fix MS-2000 device detection, improve plugin responsiveness with multithreading

### DIFF
--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPFrame.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPFrame.java
@@ -104,7 +104,7 @@ public class CRISPFrame extends JFrame {
       spinnerPanel.setAxisLabelText(crisp.getAxisString());
 
       // the timer task updates the status panel
-      timer.createTimerTask(statusPanel);
+      timer.setStatusPanel(statusPanel);
 
       // load settings before the polling check
       // but after we created the timer task we need

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/CRISPPlugin.java
@@ -14,15 +14,15 @@ import org.scijava.plugin.Plugin;
 import org.scijava.plugin.SciJavaPlugin;
 
 // The original plugin was created by Nico Stuurman, rewritten by Vikram Kopuri, 
-// and then once again rewritten by the current maintainer.
+// and then once again rewritten by the current maintainer, Brandon Simpson.
 @Plugin(type = MenuPlugin.class)
 public class CRISPPlugin implements MenuPlugin, SciJavaPlugin {
 
-   public static final String copyright = "Applied Scientific Instrumentation (ASI), 2014-2024";
+   public static final String copyright = "Applied Scientific Instrumentation (ASI), 2014-2025";
    public static final String description =
            "An interface to control the ASI CRISP Autofocus device.";
    public static final String menuName = "ASI CRISP Control";
-   public static final String version = "2.5.3";
+   public static final String version = "2.6.0";
 
    private Studio studio;
    private CRISPFrame frame;

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/StatusPanel.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/StatusPanel.java
@@ -52,7 +52,7 @@ public class StatusPanel extends Panel {
       lblSumValue = new JLabel("###");
       lblOffsetValue = new JLabel("###");
 
-      // TODO: tooltips based on firmware version? extra x vs lk t for example
+      // TODO: tooltips based on firmware version? EXTRA X? vs LK T? for example
 
       // tooltips for labels
       // "Property:" is the associated Micro-Manager property name
@@ -97,12 +97,16 @@ public class StatusPanel extends Panel {
     * after CRISP enters the Log Cal state for several ticks.
     */
    public void update() {
+      //final long startTime = System.nanoTime();
       final String state = crisp.getState();
       final String error = crisp.getDitherError();
       final String snr = crisp.getSNR();
       final String agc = crisp.getAGC();
       final String sum = crisp.getSum();
       final String offset = crisp.getOffsetString();
+      //final long endTime = System.nanoTime();
+      //final double durationMs = (endTime - startTime) / 1_000_000.0;
+      //System.out.println("duration: " + durationMs + " ms");
       EventQueue.invokeLater(() -> {
          setLabelText(lblStateValue, state);
          setLabelText(lblErrorValue, error);

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/StatusPanel.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/panels/StatusPanel.java
@@ -10,6 +10,7 @@ package com.asiimaging.crisp.panels;
 import com.asiimaging.devices.crisp.CRISP;
 import com.asiimaging.ui.Panel;
 import java.awt.Dimension;
+import java.awt.EventQueue;
 import java.util.Objects;
 import javax.swing.JLabel;
 import net.miginfocom.swing.MigLayout;
@@ -51,8 +52,7 @@ public class StatusPanel extends Panel {
       lblSumValue = new JLabel("###");
       lblOffsetValue = new JLabel("###");
 
-      // TODO: finish tooltips for agc, sum, and offset
-      //   (tooltips based on firmware version? extra x vs lk t for example)
+      // TODO: tooltips based on firmware version? extra x vs lk t for example
 
       // tooltips for labels
       // "Property:" is the associated Micro-Manager property name
@@ -97,12 +97,20 @@ public class StatusPanel extends Panel {
     * after CRISP enters the Log Cal state for several ticks.
     */
    public void update() {
-      setLabelText(lblStateValue, crisp.getState());
-      setLabelText(lblErrorValue, crisp.getDitherError());
-      setLabelText(lblSNRValue, crisp.getSNR());
-      setLabelText(lblAGCValue, crisp.getAGC());
-      setLabelText(lblSumValue, crisp.getSum());
-      setLabelText(lblOffsetValue, crisp.getOffsetString());
+      final String state = crisp.getState();
+      final String error = crisp.getDitherError();
+      final String snr = crisp.getSNR();
+      final String agc = crisp.getAGC();
+      final String sum = crisp.getSum();
+      final String offset = crisp.getOffsetString();
+      EventQueue.invokeLater(() -> {
+         setLabelText(lblStateValue, state);
+         setLabelText(lblErrorValue, error);
+         setLabelText(lblSNRValue, snr);
+         setLabelText(lblAGCValue, agc);
+         setLabelText(lblSumValue, sum);
+         setLabelText(lblOffsetValue, offset);
+      });
    }
 
    /**
@@ -112,11 +120,7 @@ public class StatusPanel extends Panel {
     * @param label The label to update.
     */
    private void setLabelText(final JLabel label, final String text) {
-      if (text.isEmpty()) {
-         label.setText("read error");
-      } else {
-         label.setText(text);
-      }
+      label.setText(text.isEmpty() ? "read error" : text);
    }
 
    /**

--- a/plugins/CRISP/src/main/java/com/asiimaging/crisp/plot/PlotFrame.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/crisp/plot/PlotFrame.java
@@ -140,8 +140,7 @@ public class PlotFrame extends JFrame {
          try {
             FileUtils.saveFile(data.toCSV(), file.toString(), ".csv");
          } catch (IOException ex) {
-            // TODO: log or show the error
-            //DialogUtils.showMessage(btnSaveData, "Failed to save the data.");
+            MMStudio.getInstance().logs().showError("Failed to save the data.");
          }
       });
    }
@@ -159,8 +158,8 @@ public class PlotFrame extends JFrame {
          final File file = new File(filepath);
          ChartUtils.saveChartAsPNG(file, chart, size.width, size.height);
       } catch (IOException e) {
-         // TODO: log or show error
-         //ReportingUtils.showError("Could not save the plot as a PNG file.");
+         MMStudio.getInstance().logs().showError(
+               "Could not save the plot as a PNG file.");
       }
    }
 }

--- a/plugins/CRISP/src/main/java/com/asiimaging/devices/crisp/CRISP.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/devices/crisp/CRISP.java
@@ -86,7 +86,7 @@ public class CRISP {
     */
    private static final class Description {
       public static final String TIGER = "ASI CRISP AutoFocus";
-      public static final String MS2000 = "ASI CRISP Autofocus adapter";
+      public static final String MS2000 = "ASI CRISP Autofocus";
    }
 
    /**
@@ -201,7 +201,7 @@ public class CRISP {
                break;
             }
          } else if (deviceLibrary.equals(DeviceLibrary.MS2000)) {
-            if (getDescription(device).equals(Description.MS2000)) {
+            if (getDescription(device).startsWith(Description.MS2000)) {
                deviceType = ControllerType.MS2000;
                deviceName = device;
                found = true;

--- a/plugins/CRISP/src/main/java/com/asiimaging/devices/crisp/CRISPFocus.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/devices/crisp/CRISPFocus.java
@@ -11,8 +11,6 @@ import com.asiimaging.crisp.plot.FocusData;
 import com.asiimaging.crisp.plot.FocusDataSet;
 import com.asiimaging.devices.zstage.ZStage;
 
-// TODO: consider whether or not to just add "LR F?" to the device adapter ("C Z?" too?)
-
 /**
  * A helper class to generate a focus curve in software using CRISP and ZStage for
  * Tiger controllers.
@@ -28,6 +26,7 @@ public class CRISPFocus {
       final double countsMM = Double.parseDouble(rawCounts[1].split(" ")[0]);
       //System.out.println("countsMM = " + countsMM);
 
+      // TODO: use "Calibration Range" property?
       crisp.sendSerialCommand("LR F?");
       final String[] rawCalRange = crisp.getSerialResponse().split("=");
       final double calRange = Double.parseDouble(rawCalRange[1]);

--- a/plugins/CRISP/src/main/java/com/asiimaging/devices/crisp/CRISPTimer.java
+++ b/plugins/CRISP/src/main/java/com/asiimaging/devices/crisp/CRISPTimer.java
@@ -8,7 +8,6 @@
 package com.asiimaging.devices.crisp;
 
 import com.asiimaging.crisp.panels.StatusPanel;
-
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.SwingWorker;


### PR DESCRIPTION
Refactor CRISPTimer to use a SwingWorker instead of a SwingTimer, this allows the CRISP query commands to run a worker thread rather than making the queries on the EDT (Event Dispatch Thread).

The ASIStage device adapter recently had a change to the CRISP device description which broke device detection in the CRISP plugin.

Device detection relies the device description, so a small change makes that work again.