### PR TITLE
Missing line continuation in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,7 +135,7 @@ SUBDIRS = \
 	$(JAVA_APP_DIRS) \
 	mmCoreAndDevices/DeviceAdapters \
 	$(SECRETDEVICEADAPTERS) \
-	$(SYSTEMTEST_DIR)
+	$(SYSTEMTEST_DIR) \
 	bindist
 
 


### PR DESCRIPTION
Not sure how this stayed unnoticed since 2014
(5385af40ecc6e2168c88830dafe55103c1e5a6a3)...