### PR TITLE
Fixed unwanted behavior of Album button in the Snap/Live window

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/DefaultAlbum.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/DefaultAlbum.java
@@ -204,11 +204,11 @@ public final class DefaultAlbum implements Album {
                .channel(image.getCoords().getChannel())
                .t(curTime_)
                .build();
-         java.util.List<Image> existingImageList = store_.getImagesIgnoringAxes(matcher,"");
-         if (!existingImageList.isEmpty() ) {
+         java.util.List<Image> existingImageList = store_.getImagesIgnoringAxes(matcher, "");
+         if (!existingImageList.isEmpty()) {
             if (existingImageList.get(0) != null) {
-                // Have an image at this time/channel pair already.
-                curTime_++;
+               // Have an image at this time/channel pair already.
+               curTime_++;
             }
          }
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java
@@ -608,12 +608,14 @@ public final class SnapLiveManager extends DataViewerListener
       toAlbumButton.setFont(GUIUtils.buttonFont);
       toAlbumButton.setMargin(zeroInsets);
       toAlbumButton.addActionListener((ActionEvent event) -> {
-         // Disable Application Processors so that images from the live window aren't sent through the pipeline again
-         java.util.List<ProcessorConfigurator> pcList = mmStudio_.data().getApplicationPipelineConfigurators(true);
+         // Disable Application Processors so that images from the live window
+         // aren't sent through the pipeline again
+         java.util.List<ProcessorConfigurator> pcList =
+               mmStudio_.data().getApplicationPipelineConfigurators(true);
          boolean[] pcEnabled = new boolean[pcList.size()]; 
-         for (int a=0; a < pcList.size(); a++) {
-             pcEnabled[a] = mmStudio_.data().isApplicationPipelineStepEnabled(a);
-             mmStudio_.data().setApplicationPipelineStepEnabled(a,false);
+         for (int a = 0; a < pcList.size(); a++) {
+            pcEnabled[a] = mmStudio_.data().isApplicationPipelineStepEnabled(a);
+            mmStudio_.data().setApplicationPipelineStepEnabled(a, false);
          }
          
          // Send all images at current channel to the album.
@@ -623,7 +625,7 @@ public final class SnapLiveManager extends DataViewerListener
             builder.channel(i);
             try {
                mmStudio_.album().addImages(store_.getImagesIgnoringAxes(
-                     builder.build(),""));
+                     builder.build(), ""));
                hadChannels = true;
             } catch (IOException e) {
                ReportingUtils.showError(e, "There was an error grabbing the images");
@@ -639,8 +641,8 @@ public final class SnapLiveManager extends DataViewerListener
          }
          
          // Re-enable Application Processors
-         for (int b=0; b < pcList.size(); b++) {
-             mmStudio_.data().setApplicationPipelineStepEnabled(b,pcEnabled[b]);
+         for (int b = 0; b < pcList.size(); b++) {
+            mmStudio_.data().setApplicationPipelineStepEnabled(b, pcEnabled[b]);
          }
       });
       controls.add(toAlbumButton);


### PR DESCRIPTION
In the DefaultAlbum code, there is the following comment: 

// When users press the Album button in the viewer, this code will 
// send the image through the pipeline for a second time.  That can 
// never be the intent of the user.  So, it would be best to have 
// a "use pipeline" parameter in the addImage function.  At this point,
// I do not want to touch the API.  As a work-around use the 
// MDA pipeline ratehr than the LivePipeline.  That gives the user
// the ability to uncouple the Live and Album pipelines (albeit in 
// an obscure way.

I encountered this exact issue, and it posed a problem for my workflow.  So I am proposing this fix.  The new code saves a list of processors in the application pipeline and which are active; disables them all; sends the snapped image through the (now inactive) pipeline so that they are not processed again; and then resets the application pipeline to its original state. 

To get this to work properly, I found I also had to replace the deprecated store().getImagesMatching(Coords), which was returning incorrect values. 

Mark, Nico, thanks for all your great work - looking forward to your feedback on this proposed change. 