### PR TITLE
Studio: Add auto-update callbacks to Autofocus Properties window

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -386,7 +386,8 @@ public final class AutofocusPropertyEditor extends JDialog {
                }
 
                // For C++ autofocus devices, PropertyChangedEvent will be triggered automatically
-               // For Java autofocus plugins, manually update the value since they don't trigger events
+               // For Java autofocus plugins, manually update the value since they don't trigger
+               // events
                item.value = value.toString();
                fireTableCellUpdated(row, col);
 


### PR DESCRIPTION
## Summary
Implements automatic property updates in the Autofocus Properties window by adding PropertyChangedEvent callback handling, matching the behavior of the Device Property Browser.

## Changes
- Added PropertyChangedEvent subscription to monitor property changes from the autofocus device
- Implemented selective `updateProperty()` method for efficient single-property updates
- Optimized `setValueAt()` to avoid unnecessary full table refreshes
- Added documentation explaining behavior differences between C++ and Java autofocus plugins

## Benefits
- **Real-time updates**: Properties now automatically update when changed externally (scripts, Device Property Browser, etc.)
- **Better performance**: Uses selective cell updates instead of refreshing the entire table
- **Consistent UX**: Matches the auto-update behavior of the Device Property Browser
- **Backward compatible**: Refresh button still works as a manual fallback

## Technical Details
The implementation follows the same callback pattern used in `PropertyEditor.java` (Device Property Browser):
- C++ autofocus devices automatically trigger PropertyChangedEvent via MMCore
- Java autofocus plugins are handled through manual updates in setValueAt()
- Thread-safe: Events are posted on EDT via SwingUtilities.invokeLater

Fixes #2236

🤖 Generated with [Claude Code](https://claude.com/claude-code)