### PR TITLE
Studio: Fix Stage Control polling and state issues

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
@@ -128,7 +128,8 @@ public final class ConfigGroupPad extends JScrollPane {
    public void refreshGroup(String groupName, String configName) {
       if (data_ != null) {
          data_.refreshGroup(groupName, configName);
-         data_.fireTableStructureChanged();
+         // Use fireTableDataChanged() to preserve selection during updates
+         data_.fireTableDataChanged();
          table_.repaint();
       }
    }


### PR DESCRIPTION
## Summary
Fixes multiple issues with the Stage Control window related to polling behavior, configuration reload, and UI state management.

## Issues Fixed
Fixes #2225 - Three reported issues plus bonus fix:
1. ✅ Polling during configuration reload
2. ✅ Loss of stage display state  
3. ✅ Focus loss from polling updates
4. ✅ "No device with label" exceptions during polling

## Changes

### ConfigGroupPad.java (line 131)
- Changed `fireTableStructureChanged()` to `fireTableDataChanged()` in `refreshGroup()`
- **Effect**: Preserves Configuration Group selection during polling updates
- **Why**: `fireTableDataChanged()` doesn't clear selection, while `fireTableStructureChanged()` does

### StageControlFrame.java - Configuration Reload (lines 939-949)
- Stop polling immediately when configuration reload starts
- Use `SwingUtilities.invokeLater()` for thread-safe deferred initialization
- Always call `initialize()` to update display to reflect current configuration state
- **Effect**: 
  - Polling doesn't interfere with config reload
  - Display immediately shows "No drives" message for configs without stages
  - Display immediately shows available stages when they exist

### StageControlFrame.java - Device Validation (lines 845-852, 863-869)
- Added null/empty checks in `getXYPosLabelFromCore()` before querying XY stage position
- Added null/empty checks in `getZPosLabelFromCore()` before querying Z stage position
- **Effect**: Eliminates "No device with label" exceptions in logs during polling

## Behavior Improvements
- Stage Control window now correctly displays "No XY or Z drive found. Nothing to control." immediately after loading a configuration without stage devices
- Configuration Group selections remain stable during Stage Control polling updates
- No more exception stack traces in logs when polling with no stage devices configured
- Configuration reload process is cleaner and more thread-safe

## Testing
- ✅ Load config with stages → Stage Control shows stages correctly
- ✅ Load config without stages → Stage Control shows "No drives" message immediately
- ✅ Polling enabled → Configuration Group selection preserved
- ✅ Polling with no stages → No exceptions in logs
- ✅ Config reload → Polling stops during reload, resumes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)