### PR TITLE
Studio; Display bug: it only displayed the first image,

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -817,15 +817,20 @@ public final class DisplayUIController implements Closeable, WindowListener,
          }
       }
 
-      // Early exit if nothing changed - KEY OPTIMIZATION
+      // Skip expensive UI rebuilding if axes haven't changed
+      // But always ensure ImageJ knows about axis extents (critical for display updates)
       if (!axesChanged) {
          if (perfMon_ != null) {
             perfMon_.sampleTimeInterval("expandDisplayedRange early exit - no change");
          }
-         return; // Skip expensive sorting and UI updates
+         // Still need to ensure ImageJ is informed about axis extents
+         if (ijBridge_ != null) {
+            ijBridge_.mm2ijEnsureDisplayAxisExtents();
+         }
+         return;
       }
 
-
+      // Axes changed - rebuild scrollbar panel and update UI
       List<String> scrollableAxes = new ArrayList<>();
       Map<String, Integer> scrollableLengths = new HashMap<>();
       for (int i = 0; i < displayedAxes_.size(); ++i) {


### PR DESCRIPTION
This was caused by mm2ijEndsureDisplayAxisExtent not being called This commit makes sure that part is always called, but other optimizations are still in place.

Critical Fix!  Builds without this will be disappointing to people.