### PR TITLE
Studio: Avoid deadlock in DefaultDatastore.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -387,13 +387,15 @@ public class DefaultDatastore implements Datastore {
    }
 
    @Override
-   public synchronized void freeze() throws IOException {
+   public void freeze() throws IOException {
       if (!isFrozen_) {
          isFrozen_ = true;
-         if (storage_ != null) {
-            storage_.freeze();
+         synchronized(this) {
+            if (storage_ != null) {
+               storage_.freeze();
+            }
+            bus_.post(new DefaultDatastoreFrozenEvent());
          }
-         bus_.post(new DefaultDatastoreFrozenEvent());
       }
    }
 


### PR DESCRIPTION
This PR addresses an issue where the UI would lock up when the user closes a display window on a Datastore that is in the process of being frozen.  With TB large datasets written as Multipage Tiffs, the "freezing" can literally take 30 minutes or more.  Locking up the UI for all that time is not right.  By checking the isFrozen_ flag outside of the lock, the second tread calling freeze on the Datastore can continue, while the first will actually feeze the store.  Of course, it would be much more preferable that freezing does not take 30 minutes, but that is another project.