### PR TITLE
add Keep shutter open? flag to OughtaFocus plugin

### DIFF
--- a/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
+++ b/autofocus/src/main/java/org/micromanager/autofocus/OughtaFocus.java
@@ -90,7 +90,7 @@ public class OughtaFocus extends AutofocusBase implements AutofocusPlugin, SciJa
    private boolean displayGraph_ = false;
    private double cropFactor_ = 1;
    private String optimizer_ = OPTIMIZERS[0];
-   private boolean keepShutterOpen_ = true;
+   private boolean keepShutterOpen_ = false;
 
    /**
     * Constructor for the OughtaFocus class. This is the most versatible autofocus plugin.


### PR DESCRIPTION
This PR adds a setting to OughtaFocus KeepShutterOpen? with yes/no options

When selected to Yes the plugin will disable `autoshutter` and open the shutter during auto-focusing, reversing the action after AF complete
When selected to No, the Core will decide what to do with the shutter, e.g. if it is manual and closed then it will stay closed during AF process

Similar to default AF plugin the shutter should stay open for the duration of autofocusing, see this code: https://github.com/micro-manager/micro-manager/blob/c1edcdcb4e66d3a4df5fd02f2febf3f98e6736ab/autofocus/src/main/java/org/micromanager/autofocus/Autofocus.java#L150C24-L150C36