### PR TITLE
fix gamepad plugin to be compatible with Java11

### DIFF
--- a/plugins/Gamepad/src/main/java/com/asiimaging/asigamepad/AsiGamepadFrame.java
+++ b/plugins/Gamepad/src/main/java/com/asiimaging/asigamepad/AsiGamepadFrame.java
@@ -293,7 +293,7 @@ public class AsiGamepadFrame extends JFrame {
          Vector<? extends Vector<?>> rowData = (Vector<? extends Vector<?>>) in.readObject();
          DefaultTableModel model = (DefaultTableModel) btnTable.table.getModel();
          model.setDataVector(rowData, getColumnNames(btnTable.table));
-         rowData = (Vector<? extends Vector<?>>) in.readObject(); // cast must match the variable type
+         rowData = (Vector<? extends Vector<?>>) in.readObject();
          model = (DefaultTableModel) axisTable.table_.getModel();
          model.setDataVector(rowData, getColumnNames(axisTable.table_));
 


### PR DESCRIPTION
in Java8 original code compiles, but with JDK11/21 there is an error due to stricter anonymous type checks.
This PR fixes that

Error when doing `ant build-java` on original code with JDK 21:

```
compile:
    [mkdir] Created dir: C:\Users\AndreyAndreev\Documents\GitHub\micro-manager-emi\build\intermediates\Classes\plugins\Gamepad
 [mm-javac] Compiling 8 source files to C:\Users\AndreyAndreev\Documents\GitHub\micro-manager-emi\build\intermediates\Classes\plugins\Gamepad
 [mm-javac] warning: [options] bootstrap class path not set in conjunction with -source 8
 [mm-javac] warning: [options] source value 8 is obsolete and will be removed in a future release
 [mm-javac] warning: [options] target value 8 is obsolete and will be removed in a future release
 [mm-javac] warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
 [mm-javac] Note: Annotation processing is enabled because one or more processors were found
 [mm-javac]   on the class path. A future release of javac may disable annotation processing
 [mm-javac]   unless at least one processor is specified by name (-processor), or a search
 [mm-javac]   path is specified (--processor-path, --processor-module-path), or annotation
 [mm-javac]   processing is enabled explicitly (-proc:only, -proc:full).
 [mm-javac]   Use -Xlint:-options to suppress this message.
 [mm-javac]   Use -proc:none to disable annotation processing.
 [mm-javac] warning: No processor claimed any of these annotations: org.scijava.plugin.Plugin
 [mm-javac] C:\Users\AndreyAndreev\Documents\GitHub\micro-manager-emi\plugins\Gamepad\src\main\java\com\asiimaging\asigamepad\AsiGamepadFrame.java:295: error: no suitable method found for setDataVector(Vector<CAP#1>,Vector<String>)
 [mm-javac]          model.setDataVector(rowData, getColumnNames(btnTable.table));
 [mm-javac]               ^
 [mm-javac]     method DefaultTableModel.setDataVector(Vector<? extends Vector>,Vector<?>) is not applicable
 [mm-javac]       (argument mismatch; Vector<CAP#1> cannot be converted to Vector<? extends Vector>)
 [mm-javac]     method DefaultTableModel.setDataVector(Object[][],Object[]) is not applicable
 [mm-javac]       (argument mismatch; Vector<CAP#1> cannot be converted to Object[][])
 [mm-javac]   where CAP#1 is a fresh type-variable:
 [mm-javac]     CAP#1 extends Object from capture of ?
 [mm-javac] C:\Users\AndreyAndreev\Documents\GitHub\micro-manager-emi\plugins\Gamepad\src\main\java\com\asiimaging\asigamepad\AsiGamepadFrame.java:298: error: no suitable method found for setDataVector(Vector<CAP#1>,Vector<String>)
 [mm-javac]          model.setDataVector(rowData, getColumnNames(axisTable.table_));
 [mm-javac]               ^
 [mm-javac]     method DefaultTableModel.setDataVector(Vector<? extends Vector>,Vector<?>) is not applicable
 [mm-javac]       (argument mismatch; Vector<CAP#1> cannot be converted to Vector<? extends Vector>)
 [mm-javac]     method DefaultTableModel.setDataVector(Object[][],Object[]) is not applicable
 [mm-javac]       (argument mismatch; Vector<CAP#1> cannot be converted to Object[][])
 [mm-javac]   where CAP#1 is a fresh type-variable:
 [mm-javac]     CAP#1 extends Object from capture of ?

```

Core of the issue is that in Swing, DefaultTableModel#setDataVector is declared as:

```
public void setDataVector(Vector<? extends Vector> dataVector,
                          Vector<?> columnIdentifiers)
```

And `Vector<?>` (vector of something) is not the same as `Vector<? extends Vector>` (vector of vectors), JDK11 is more strict to enforce that difference
