### PR TITLE
Exclude net.coremem#coremem dependency

### DIFF
--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -96,7 +96,11 @@
 
 
       <!-- ClearVolume dependencies -->
-      <dependency org="net.clearvolume" name="clearvolume" rev="1.4.3"/>
+      <dependency org="net.clearvolume" name="clearvolume" rev="1.4.3">
+         <!-- coremem 0.4.4 no longer available from maven.scijava.org
+         (0.4.5 wins anyway) -->
+         <exclude org="net.coremem" name="coremem"/>
+      </dependency>
       <dependency org="net.clearvolume" name="cleargl" rev="2.2.6"/>
       <!-- <dependency org="net.clearvolume" name="clearcuda" rev="0.9.4"/> -->
       <dependency org="net.clearcontrol" name="clearcl" rev="0.6.0"/>


### PR DESCRIPTION
Closes #2278.

After some artifacts became unavailable from maven.scijava.org in June 2025 (https://forum.image.sc/t/unplanned-server-outage-for-maven-scijava-org/113683) I reuploaded (with @ctrueden's help) a few dependencies (for which we had JARs and POMs in our Ivy cache) but apparently missed some. (At the time we uploaded `net.clearcontrol#clearcl;0.6.0`, `net.clearcontrol#coremem;0.4.5`, and `net.clearvolume#clearaudio;1.0.2`.)

`net.clearvolume#clearcl;0.5.2` was being reported missing by Ivy (probably not caught until now because of caches on our local and build machines and the fact that we have Ant set not to fail by default on unresolved dependencies). Thanks to @paulmenzel for [reporting](https://github.com/micro-manager/micro-manager/issues/2278#issuecomment-3801911742).

So I uploaded JAR and POM for clearcl-0.5.2. Then its dependency `net.coremem#coremem;0.4.4` was missing, but unfortunately we do not have the JAR for this; only the POM, because the JAR was not actually being used (coremem 0.4.5 wins over it) and thus is not in any of my caches. (I uploaded the POM but Ivy still displayed an error because the JAR that it doesn't need is missing.)

There was also both `net.coremem#coremem;0.4.5` and `net.clearcontrol#coremem;0.4.5`. It looks like our builds were shipping the latter (by chance?). Yes, they are different, and neither is a strict superset of the other, but it looks like the net.coremem one contains added test classes whereas the net.clearcontrol one contains a few additional non-test classes, so the latter is probably the safe bet. (I also uploaded `net.coremem#coremem;0.4.5` JAR & POM just to preserve it.)

So this PR excludes `net.coremem#coremem` entirely. `net.clearcontrol#coremem;0.4.5` is already explicitly listed as a dependency, so all should be good (and nothing should change in our actual builds).