### PR TITLE
fix AF working with z stack when using AcqEngJ

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -907,8 +907,13 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
                         // because at this point in code the event was already generated
                         // and event.zPos has already been set using old (un-adjusted)
                         // event's stage coordinate event.sp.get1DPosition()
-                        // hence, adjusting coordinate using setStageCoordinate doesn't affect event's zPos
-                        event.setZ(event.getZIndex(), event.getZPosition() - event.getStageSingleAxisStagePosition(sp.getStageDeviceLabel()) + sp.get1DPosition());
+                        // hence, adjusting coordinate using setStageCoordinate
+                        // doesn't affect event's zPos
+                        event.setZ(event.getZIndex(),
+                            event.getZPosition() -
+                            event.getStageSingleAxisStagePosition(sp.getStageDeviceLabel()) +
+                            sp.get1DPosition()
+                           );
                         event.setStageCoordinate(sp.getStageDeviceLabel(), sp.get1DPosition());
                      }
                   }


### PR DESCRIPTION
**Issue**
When using New engine (AcqEngJ) there is a problem applying AF during MDA with Z stack.
The core is that `adjustZDrivesHook` is called after the acquisition event was initialized. This hook is suppose to adjust event's Z position to match the Z found during autofocus hook, however adjustZDrivesHook adjusts event's setStageCoordinate and not the position. The position is calculated from stageCoordinate when event is created (see MDAAcqEventModules#zStack.next()) but it's too late to update it when` adjustZDrivesHook` is called.

**Solution**
Manually adjust Z position of the event based on previous position and recently found AF position

This PR addresses threeissues:
1. update actual Z position of the acquisition event
2. move Z drive hook to be happening after AF routine (otherwise it is not called when doing AF for the second time point)
3. remove double-calling of the `adjustZDrivesHook`

NB: this feels very hacky solution and is working so far in MDA when using Z stack or Channels with offsets. Positions can be checked or unchecked
