### PR TITLE
Signal pixel size changed when refreshing GUI

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
@@ -280,7 +280,7 @@ public class MMUIManager {
          studio_.cache().refreshValues();
          studio_.getAutofocusManager().refresh();
          double pixSizeUmPost = studio_.cache().getPixelSizeUm();
-         if (pixSizeUmPre != pixSizeUmPost) {
+         if (Double.compare(pixSizeUmPre, pixSizeUmPost) != 0) {
             // Firing this event is only needed for devices that do not notify the core
             // of changed properties.  For those devices, the core will already fire the
             // event.  Since we have no way of knowing, better call one extra time.


### PR DESCRIPTION
Previously, this event would not fire for devices that do not use callbacks to the core to signal state changes.