### PR TITLE
Fix missing Z position metadata in deskewed full volume output

### DIFF
--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/CliJDeskewProcessor.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/CliJDeskewProcessor.java
@@ -167,7 +167,8 @@ public class CliJDeskewProcessor implements Processor {
                   ImageProcessor ip1 = resultStack.getProcessor(i + 1);
                   Image image1 = studio_.data().ij().createImage(ip1,
                            coordsNoZPossiblyNoT.copyBuilder().z(i).build(),
-                           image.getMetadata());
+                           image.getMetadata().copyBuilderWithNewUUID()
+                                    .zPositionUm(i * newZSizeUm_).build());
                   if (fullVolumeStore_ == null) {
                      String prefix = inputSummaryMetadata_.getPrefix().isEmpty()
                               ? "Untitled" : inputSummaryMetadata_.getPrefix();

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewProcessor.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewProcessor.java
@@ -294,9 +294,12 @@ public class DeskewProcessor implements Processor {
             try {
                short[][] reconstructedVolume = fullVolumeResamplers_.get(coordsNoZ)
                         .getReconstructedVolumeZYX();
+               double newZStep = fullVolumeResamplers_.get(
+                        coordsNoZ).getReconstructionVoxelSizeUm();
                for (int z = 0; z < reconstructedVolume.length; z++) {
                   Image img = new DefaultImage(reconstructedVolume[z], format, cb.z(z).build(),
-                           image.getMetadata().copyBuilderWithNewUUID().build());
+                           image.getMetadata().copyBuilderWithNewUUID()
+                                    .zPositionUm(z * newZStep).build());
                   fullVolumeStore_.putImage(img);
                }
             } catch (IOException e) {


### PR DESCRIPTION
Both CPU (DeskewProcessor) and GPU (CliJDeskewProcessor) processors were copying the original image's metadata unchanged for every output Z slice, resulting in identical zPositionUm values across all planes. This caused viewers (MM image viewer, ClearVolume) to show a flat volume. Set zPositionUm on each output slice to z * newZStep so that the reconstructed volume has correct per-plane Z positions.