### PR TITLE
Navigation plugin - Use a map image to navigate 

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -31,7 +31,7 @@ nobase_mmplugin_DATA = \
 	Mist.jar \
 	MultiAndor.jar \
 	MultiChannelShading.jar \
-	NavigationPlugin.jar
+	NavigationByMap.jar
 	PTCTools.jar \
 	PipelineSaver.jar \
 	PointAndShootAnalysis.jar \

--- a/plugins/NavigationByMap/build.xml
+++ b/plugins/NavigationByMap/build.xml
@@ -1,3 +1,3 @@
-<project name="NavigationPlugin" default="jar">
+<project name="NavigationByMap" default="jar">
     <import file="../javapluginbuild.xml"/>
 </project>

--- a/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/CalibrationPoint.java
+++ b/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/CalibrationPoint.java
@@ -7,7 +7,7 @@
  * <p>LICENSE:      This file is distributed under the BSD license.
  */
 
-package org.micromanager.navigationplugin;
+package org.micromanager.navigationbymap;
 
 import java.awt.geom.Point2D;
 

--- a/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/ImagePanel.java
+++ b/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/ImagePanel.java
@@ -7,7 +7,7 @@
  * <p>lLICENSE: This file is distributed under the BSD license.
  */
 
-package org.micromanager.navigationplugin;
+package org.micromanager.navigationbymap;
 
 import java.awt.BasicStroke;
 import java.awt.Color;

--- a/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/NavigationByMap.java
+++ b/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/NavigationByMap.java
@@ -21,7 +21,7 @@
  * @copyright Regents of the University of California, 2026
  */
 
-package org.micromanager.navigationplugin;
+package org.micromanager.navigationbymap;
 
 import com.google.common.eventbus.Subscribe;
 import org.micromanager.MenuPlugin;
@@ -32,7 +32,7 @@ import org.scijava.plugin.Plugin;
 import org.scijava.plugin.SciJavaPlugin;
 
 @Plugin(type = MenuPlugin.class)
-public class NavigationPlugin implements SciJavaPlugin, MenuPlugin {
+public class NavigationByMap implements SciJavaPlugin, MenuPlugin {
    private static final String NAVIGATION_FRAME_OPEN = "NavigationFrameOpen";
 
    private Studio studio_;

--- a/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/NavigationFrame.java
+++ b/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/NavigationFrame.java
@@ -7,7 +7,7 @@
  * <p>LICENSE: This file is distributed under the BSD license.
  */
 
-package org.micromanager.navigationplugin;
+package org.micromanager.navigationbymap;
 
 import com.google.common.eventbus.Subscribe;
 import java.awt.BorderLayout;

--- a/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/NavigationState.java
+++ b/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/NavigationState.java
@@ -7,7 +7,7 @@
  * <p>LICENSE: This file is distributed under the BSD license.
  */
 
-package org.micromanager.navigationplugin;
+package org.micromanager.navigationbymap;
 
 import java.awt.geom.AffineTransform;
 import java.awt.geom.NoninvertibleTransformException;


### PR DESCRIPTION
The idea of this plugin was born from problems finding samples with our single objective light sheet.  It has high magnification and the 30 degree slice makes it hard to understand where in the sample one is location.
This plugin can load an image taken anywhere (in fact, it loads png, jpg, and tif).  The microscope operator needs to find 3 points that match between the map image and the current microscope. Once those calibration points are established, one can navigate to any point in the map directly.  The map image can be large as the operator can zoom in and pan the image around.  