### PR TITLE
Studio: Adress flickering of Overlays.  

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/MMImageCanvas.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/MMImageCanvas.java
@@ -22,7 +22,6 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Window;
-import java.awt.image.BufferedImage;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.HierarchyEvent;
@@ -34,6 +33,7 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
+import java.awt.image.BufferedImage;
 import javax.swing.SwingUtilities;
 import org.micromanager.internal.utils.MustCallOnEDT;
 


### PR DESCRIPTION
Create image and overlays in a separate buffer and blit to the screen in one operation. Issue raised by Kyle Doiuglass on image.sc (https://forum.image.sc/t/overlay-performance-and-stability-issues-on-the-micro-manager-live-view/119378), but we should have addressed this much earlier;). 