### PR TITLE
NavigationByMap: Cache images so that not every paint invokes a bilinear interpolation.

### DIFF
--- a/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/NavigationByMap.java
+++ b/plugins/NavigationByMap/src/main/java/org/micromanager/navigationbymap/NavigationByMap.java
@@ -75,7 +75,7 @@ public class NavigationByMap implements SciJavaPlugin, MenuPlugin {
     */
    @Override
    public String getName() {
-      return "Navigation Plugin";
+      return "Navigation By Map";
    }
 
    @Override


### PR DESCRIPTION
Enormous performance improvement when loading large images.