### PR TITLE
Set macOS target to 11.0

### DIFF
--- a/buildscripts/nightly/nightlybuild_macOS_defs.sh
+++ b/buildscripts/nightly/nightlybuild_macOS_defs.sh
@@ -10,8 +10,7 @@ MM_STAGEDIR="$MM_BUILDDIR/stage"
 # backward-compatible binaries. Omitting this will produce binaries that will
 # only run on the macOS version of the build host or newer. Also, mixing
 # different minimum versions may cause C++ linking issues.
-# 10.9 is the oldest deployment target that uses libc++ (vs libstdc++).
-MM_MACOSX_VERSION_MIN=10.9
+MM_MACOSX_VERSION_MIN=11.0
 
 # We don't use a fixed macOS SDK version, but need a fixed path to the SDK.
 MM_MACOSX_SDKROOT=$(xcode-select --print-path)/SDKs/MacOSX.sdk


### PR DESCRIPTION
macOS 11.0 (Big Sur) was released Nov 2020, end of support Sep 2023. The version before, 10.15 (Catalina) was released Oct 2019, end of support Sep 2022.

Xcode 26 tools do not support building for older than 11.0.

Closes micro-manager/mmCoreAndDevices#772.