### PR TITLE
mmstudio: handle registerCallback() exception

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
+++ b/mmstudio/src/main/java/org/micromanager/events/internal/CoreEventCallback.java
@@ -54,7 +54,13 @@ public final class CoreEventCallback extends MMEventCallback {
       studio_ = studio;
       core_ = studio.core();
       acquisitionManager_ = acquisitionManager;
-      core_.registerCallback(this);
+      try {
+         core_.registerCallback(this);
+      } catch (Exception e) {
+         // registerCallback() throws only if we're in a callback (since MMCore
+         // 12.0), which we shouldn't be, so this shouldn't happen.
+         throw new RuntimeException(e);
+      }
    }
 
    @Override


### PR DESCRIPTION
In preparation for MMCore 12.0 (micro-manager/mmCoreAndDevices#877).

Just wrap in unchecked RuntimeException because we don't ever expect an exception here.