### PR TITLE
Adds support for 32bit images to DataViewer and DataStore

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -4,6 +4,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
 import java.util.Arrays;
@@ -29,6 +30,11 @@ public final class BufferTools {
 
    public static IntBuffer directBufferFromInts(int[] ints) {
       return ByteBuffer.allocateDirect(4 * ints.length).order(NATIVE_ORDER).asIntBuffer().put(ints);
+   }
+
+   public static FloatBuffer directBufferFromFloats(float[] floats) {
+      return ByteBuffer.allocateDirect(4 * floats.length).order(NATIVE_ORDER).asFloatBuffer()
+            .put(floats);
    }
 
    /**
@@ -82,6 +88,15 @@ public final class BufferTools {
     * @param buffer Direct Buffer to be copied.
     * @return Copy of the Buffer as a Java array
     */
+   public static float[] floatsFromBuffer(FloatBuffer buffer) {
+      synchronized (buffer) {
+         float[] floats = new float[buffer.capacity()];
+         buffer.rewind();
+         buffer.get(floats);
+         return floats;
+      }
+   }
+
    public static Object arrayFromBuffer(Buffer buffer) {
       synchronized (buffer) {
          if (buffer instanceof ByteBuffer) {
@@ -90,6 +105,8 @@ public final class BufferTools {
             return shortsFromBuffer((ShortBuffer) buffer);
          } else if (buffer instanceof IntBuffer) {
             return intsFromBuffer((IntBuffer) buffer);
+         } else if (buffer instanceof FloatBuffer) {
+            return floatsFromBuffer((FloatBuffer) buffer);
          }
       }
       return null;
@@ -126,6 +143,16 @@ public final class BufferTools {
       } else if (rawPixels instanceof ByteBuffer) {
          byte[] arr = ((ByteBuffer) rawPixels).array();
          return Arrays.copyOf(arr, arr.length);
+      } else if (rawPixels instanceof FloatBuffer) {
+         FloatBuffer buf = (FloatBuffer) rawPixels;
+         buf.rewind();
+         ByteBuffer bb = ByteBuffer.allocate(buf.remaining() * 4);
+         while (buf.hasRemaining()) {
+            bb.putFloat(buf.get());
+         }
+         buf.rewind();
+         byte[] arr = bb.array();
+         return Arrays.copyOf(arr, arr.length);
       } else {
          throw new RuntimeException(("Unhandled Case."));
       }
@@ -144,6 +171,8 @@ public final class BufferTools {
          return directBufferFromShorts((short[]) primitiveArray);
       } else if (primitiveArray instanceof int[]) {
          return directBufferFromInts((int[]) primitiveArray);
+      } else if (primitiveArray instanceof float[]) {
+         return directBufferFromFloats((float[]) primitiveArray);
       }
       return null;
    }
@@ -193,6 +222,9 @@ public final class BufferTools {
             break;
          case 2:
             buffer = ShortBuffer.wrap((short[]) pixels);
+            break;
+         case 4:
+            buffer = FloatBuffer.wrap((float[]) pixels);
             break;
          default:
             throw new UnsupportedOperationException("Unimplemented pixel component size");

--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -217,7 +217,22 @@ public final class BufferTools {
       Buffer buffer;
       switch (bytesPerPixel) {
          case 1:
-            buffer = ByteBuffer.wrap((byte[]) pixels);
+            if (pixels instanceof int[]) {
+               // RGB32 image: convert int[] (0x00RRGGBB per pixel) to 4-byte-per-pixel
+               // byte[] in B-G-R-0 order to match the PixelType.RGB32 component offsets
+               // {2, 1, 0} and the layout expected by the TIFF save path.
+               int[] ints = (int[]) pixels;
+               byte[] bytes = new byte[ints.length * 4];
+               for (int i = 0; i < ints.length; ++i) {
+                  bytes[i * 4]     = (byte) ( ints[i]        & 0xFF); // B (offset 0)
+                  bytes[i * 4 + 1] = (byte) ((ints[i] >>  8) & 0xFF); // G (offset 1)
+                  bytes[i * 4 + 2] = (byte) ((ints[i] >> 16) & 0xFF); // R (offset 2)
+                  bytes[i * 4 + 3] = 0;                                // pad
+               }
+               buffer = ByteBuffer.wrap(bytes);
+            } else {
+               buffer = ByteBuffer.wrap((byte[]) pixels);
+            }
             break;
          case 2:
             buffer = ShortBuffer.wrap((short[]) pixels);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -145,7 +145,6 @@ public final class BufferTools {
          return Arrays.copyOf(arr, arr.length);
       } else if (rawPixels instanceof FloatBuffer) {
          FloatBuffer buf = (FloatBuffer) rawPixels;
-         buf.rewind();
          ByteBuffer bb = ByteBuffer.allocate(buf.remaining() * 4);
          while (buf.hasRemaining()) {
             bb.putFloat(buf.get());

--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -207,32 +207,20 @@ public final class BufferTools {
    }
 
    /**
-    * Wraps a primitive array of either byte[] or short[] into a ByteBuffer.
+    * Wraps a primitive array into a Buffer without copying.
+    * Supported: byte[] (bpc=1), short[] (bpc=2), float[] (bpc=4).
+    * For RGB32 images stored as int[], convert to byte[] first using
+    * {@link #rgb32IntToBytes(int[])}, then call this method with bpc=1.
     *
-    * @param pixels byte[] or short[] array
-    * @param bytesPerPixel 1 for byte[], 2 for short[]
-    * @return Buffer (either ByteBuffer or ShortBuffer).
+    * @param pixels primitive array (byte[], short[], or float[])
+    * @param bytesPerPixel 1 for byte[], 2 for short[], 4 for float[]
+    * @return Buffer wrapping the input array (no copy for byte[]/short[]/float[])
     */
    public static Buffer wrapArray(Object pixels, int bytesPerPixel) {
       Buffer buffer;
       switch (bytesPerPixel) {
          case 1:
-            if (pixels instanceof int[]) {
-               // RGB32 image: convert int[] (0x00RRGGBB per pixel) to 4-byte-per-pixel
-               // byte[] in B-G-R-0 order to match the PixelType.RGB32 component offsets
-               // {2, 1, 0} and the layout expected by the TIFF save path.
-               int[] ints = (int[]) pixels;
-               byte[] bytes = new byte[ints.length * 4];
-               for (int i = 0; i < ints.length; ++i) {
-                  bytes[i * 4]     = (byte) (ints[i]         & 0xFF); // B (offset 0)
-                  bytes[i * 4 + 1] = (byte) ((ints[i] >>  8) & 0xFF); // G (offset 1)
-                  bytes[i * 4 + 2] = (byte) ((ints[i] >> 16) & 0xFF); // R (offset 2)
-                  bytes[i * 4 + 3] = 0;                                // pad
-               }
-               buffer = ByteBuffer.wrap(bytes);
-            } else {
-               buffer = ByteBuffer.wrap((byte[]) pixels);
-            }
+            buffer = ByteBuffer.wrap((byte[]) pixels);
             break;
          case 2:
             buffer = ShortBuffer.wrap((short[]) pixels);
@@ -244,6 +232,26 @@ public final class BufferTools {
             throw new UnsupportedOperationException("Unimplemented pixel component size");
       }
       return buffer;
+   }
+
+   /**
+    * Converts an RGB32 int[] pixel array (ImageJ packed 0x00RRGGBB format) to a
+    * byte[] in B-G-R-0 order (4 bytes per pixel) matching PixelType.RGB32's
+    * component offsets {2, 1, 0}.
+    * This is a copy, not a wrap — call once per image construction, not per frame.
+    *
+    * @param ints packed RGB pixels, one int per pixel (0x00RRGGBB)
+    * @return interleaved byte array, 4 bytes per pixel in B, G, R, 0 order
+    */
+   public static byte[] rgb32IntToBytes(int[] ints) {
+      byte[] bytes = new byte[ints.length * 4];
+      for (int i = 0; i < ints.length; ++i) {
+         bytes[i * 4]     = (byte) ( ints[i]        & 0xFF); // B (offset 0)
+         bytes[i * 4 + 1] = (byte) ((ints[i] >>  8) & 0xFF); // G (offset 1)
+         bytes[i * 4 + 2] = (byte) ((ints[i] >> 16) & 0xFF); // R (offset 2)
+         bytes[i * 4 + 3] = 0;                                // pad
+      }
+      return bytes;
    }
 
 }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -224,7 +224,7 @@ public final class BufferTools {
                int[] ints = (int[]) pixels;
                byte[] bytes = new byte[ints.length * 4];
                for (int i = 0; i < ints.length; ++i) {
-                  bytes[i * 4]     = (byte) ( ints[i]        & 0xFF); // B (offset 0)
+                  bytes[i * 4]     = (byte) (ints[i]         & 0xFF); // B (offset 0)
                   bytes[i * 4 + 1] = (byte) ((ints[i] >>  8) & 0xFF); // G (offset 1)
                   bytes[i * 4 + 2] = (byte) ((ints[i] >> 16) & 0xFF); // R (offset 2)
                   bytes[i * 4 + 3] = 0;                                // pad

--- a/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/BufferTools.java
@@ -246,7 +246,7 @@ public final class BufferTools {
    public static byte[] rgb32IntToBytes(int[] ints) {
       byte[] bytes = new byte[ints.length * 4];
       for (int i = 0; i < ints.length; ++i) {
-         bytes[i * 4]     = (byte) ( ints[i]        & 0xFF); // B (offset 0)
+         bytes[i * 4]     = (byte) (ints[i]         & 0xFF); // B (offset 0)
          bytes[i * 4 + 1] = (byte) ((ints[i] >>  8) & 0xFF); // G (offset 1)
          bytes[i * 4 + 2] = (byte) ((ints[i] >> 16) & 0xFF); // R (offset 2)
          bytes[i * 4 + 3] = 0;                                // pad

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
@@ -173,11 +173,15 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
             Thread.sleep(100);
          } catch (InterruptedException e) {
             timeOut = true;
-            studio.logs().logError(e);
+            if (studio != null) {
+               studio.logs().logError(e);
+            }
          }
       }
       if (timeOut) {
-         studio.logs().showError("Failed to save data");
+         if (studio != null) {
+            studio.logs().showError("Failed to save data");
+         }
          return null;
       }
       for (Coords coords : tmp) {
@@ -208,10 +212,14 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
       try {
          get();
       } catch (ExecutionException | InterruptedException e) {
-         studio.logs().showError(e, "Failed to save to " + path_);
+         if (studio != null) {
+            studio.logs().showError(e, "Failed to save to " + path_);
+         }
       }
 
-      studio.alerts().postAlert("Finished saving", this.getClass(), path_);
+      if (studio != null) {
+         studio.alerts().postAlert("Finished saving", this.getClass(), path_);
+      }
    }
 
 

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataSaver.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import javax.swing.JFrame;
 import javax.swing.SwingWorker;
 import org.micromanager.Studio;
 import org.micromanager.data.Annotation;
@@ -50,7 +51,11 @@ public class DefaultDataSaver extends SwingWorker<Void, Void> {
       duplicate_ = new DefaultDatastore(this.studio);
 
       if (mode == Datastore.SaveMode.MULTIPAGE_TIFF) {
-         saver_ = new StorageMultipageTiff(studio.app().getMainWindow(),
+         JFrame frame = null;
+         if (studio != null) {
+            frame = studio.app().getMainWindow();
+         }
+         saver_ = new StorageMultipageTiff(frame,
                duplicate_,
                path_, true, true,
                StorageMultipageTiff.getShouldSplitPositions());

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -423,8 +423,10 @@ public class DefaultDatastore implements Datastore {
    @Override
    public void close() throws IOException {
       freeze();
-      studio_.events().post(
-            new DefaultDatastoreClosingEvent(this));
+      if (studio_ != null) {
+         studio_.events().post(
+                  new DefaultDatastoreClosingEvent(this));
+      }
       if (copiedFromStore_ != null) {
          try {
             CommentsHelper.copyComments(this, copiedFromStore_);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
@@ -413,7 +413,7 @@ public final class DefaultImage implements Image {
       if (pixelType_ == PixelType.GRAY32) {
          int pixelIndex = y * pixelWidth_ + x;
          float val = ((FloatBuffer) rawPixels_).get(pixelIndex);
-         return String.format("%.6g", val);
+         return String.format(java.util.Locale.US, "%.6g", val);
       }
       if (getNumComponents() == 1) {
          return String.format("%d", getIntensityAt(x, y));

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
@@ -182,13 +182,10 @@ public final class DefaultImage implements Image {
     * Generates a DefaultImage from pixels, minimal image info, and the
     * supplied coords and metadata.
     *
-    * <p>For byte[], short[], and float[] inputs the pixel array is used directly
-    * (wrapped in a Buffer, not copied). For int[] RGB32 inputs the pixels are
-    * converted from packed 0x00RRGGBB format to an interleaved B-G-R-0 byte[]
-    * (one allocation per call); all other array types are zero-copy.
+    * <p>The pixel array is used directly (wrapped in a Buffer, not copied).
     *
-    * @param pixels   Image pixels: byte[] (GRAY8), short[] (GRAY16), float[] (GRAY32),
-    *                 or int[] (RGB32, packed 0x00RRGGBB). Must not be null.
+    * @param pixels   Image pixels: byte[] (GRAY8 or RGB), short[] (GRAY16), float[] (GRAY32).
+    *                 Must not be null.
     * @param coords   Coords to be used for this new image (can be null).
     * @param metadata Metadata to be used this new image (can be null).
     * @throws IllegalArgumentException thrown when pixels is null
@@ -206,13 +203,6 @@ public final class DefaultImage implements Image {
          bpc = 1;
       } else if (pixels instanceof short[]) {
          bpc = 2;
-      } else if (pixels instanceof int[] && bytesPerPixel == 4
-            && numComponents == 3) {
-         // Convert packed 0x00RRGGBB int[] to interleaved B-G-R-0 byte[] so that
-         // wrapArray() gets a plain byte[] and the copy is explicit here, not hidden
-         // inside BufferTools.
-         pixels = BufferTools.rgb32IntToBytes((int[]) pixels);
-         bpc = 1;
       } else if (pixels instanceof float[] && bytesPerPixel == 4
             && numComponents == 1) {
          bpc = 4;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
@@ -182,9 +182,13 @@ public final class DefaultImage implements Image {
     * Generates a DefaultImage from pixels, minimal image info, and the
     * supplied coords and metadata.
     *
-    * <p>Input pixels will be used directly (i.e., they are not copied).
+    * <p>For byte[], short[], and float[] inputs the pixel array is used directly
+    * (wrapped in a Buffer, not copied). For int[] RGB32 inputs the pixels are
+    * converted from packed 0x00RRGGBB format to an interleaved B-G-R-0 byte[]
+    * (one allocation per call); all other array types are zero-copy.
     *
-    * @param pixels   Image pixels.  Should be a Java array of bytes or shorts (not null).
+    * @param pixels   Image pixels: byte[] (GRAY8), short[] (GRAY16), float[] (GRAY32),
+    *                 or int[] (RGB32, packed 0x00RRGGBB). Must not be null.
     * @param coords   Coords to be used for this new image (can be null).
     * @param metadata Metadata to be used this new image (can be null).
     * @throws IllegalArgumentException thrown when pixels is null
@@ -204,6 +208,10 @@ public final class DefaultImage implements Image {
          bpc = 2;
       } else if (pixels instanceof int[] && bytesPerPixel == 4
             && numComponents == 3) {
+         // Convert packed 0x00RRGGBB int[] to interleaved B-G-R-0 byte[] so that
+         // wrapArray() gets a plain byte[] and the copy is explicit here, not hidden
+         // inside BufferTools.
+         pixels = BufferTools.rgb32IntToBytes((int[]) pixels);
          bpc = 1;
       } else if (pixels instanceof float[] && bytesPerPixel == 4
             && numComponents == 1) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultImage.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
 import java.nio.ShortBuffer;
 import mmcorej.TaggedImage;
 import mmcorej.org.json.JSONException;
@@ -204,6 +205,9 @@ public final class DefaultImage implements Image {
       } else if (pixels instanceof int[] && bytesPerPixel == 4
             && numComponents == 3) {
          bpc = 1;
+      } else if (pixels instanceof float[] && bytesPerPixel == 4
+            && numComponents == 1) {
+         bpc = 4;
       } else {
          throw new UnsupportedOperationException("Unsupported pixel data type");
       }
@@ -235,6 +239,8 @@ public final class DefaultImage implements Image {
          bytesPerComponent = 1;
       } else if (source.getRawPixels() instanceof short[]) {
          bytesPerComponent = 2;
+      } else if (source.getRawPixels() instanceof float[]) {
+         bytesPerComponent = 4;
       }
       rawPixels_ = BufferTools.wrapArray(source.getRawPixels(), bytesPerComponent);
 
@@ -249,6 +255,8 @@ public final class DefaultImage implements Image {
          bpc = 1;
       } else if (rawPixels_ instanceof ShortBuffer) {
          bpc = 2;
+      } else if (rawPixels_ instanceof FloatBuffer) {
+         bpc = 4;
       } else {
          throw new UnsupportedOperationException("Unsupported pixel data type");
       }
@@ -317,6 +325,10 @@ public final class DefaultImage implements Image {
          int[] tmp = (int[]) original;
          length = tmp.length;
          copy = new int[length];
+      } else if (original instanceof float[]) {
+         float[] tmp = (float[]) original;
+         length = tmp.length;
+         copy = new float[length];
       } else {
          throw new RuntimeException("Unrecognized pixel type " + original.getClass());
       }
@@ -339,6 +351,8 @@ public final class DefaultImage implements Image {
          result = (Object) new byte[length];
       } else if (rawPixels_ instanceof ShortBuffer) {
          result = (Object) new short[length];
+      } else if (rawPixels_ instanceof FloatBuffer) {
+         result = (Object) new float[length];
       } else {
          ReportingUtils.logError("Unrecognized pixel buffer type.");
          return null;
@@ -349,6 +363,8 @@ public final class DefaultImage implements Image {
             ((byte[]) result)[i] = ((ByteBuffer) rawPixels_).get(sourceIndex);
          } else if (rawPixels_ instanceof ShortBuffer) {
             ((short[]) result)[i] = ((ShortBuffer) rawPixels_).get(sourceIndex);
+         } else if (rawPixels_ instanceof FloatBuffer) {
+            ((float[]) result)[i] = ((FloatBuffer) rawPixels_).get(sourceIndex);
          }
       }
       return result;
@@ -375,6 +391,8 @@ public final class DefaultImage implements Image {
             return ImageUtils.unsignedValue(((ByteBuffer) rawPixels_).get(sampleIndex));
          case 2:
             return ImageUtils.unsignedValue(((ShortBuffer) rawPixels_).get(sampleIndex));
+         case 4:
+            return (long) ((FloatBuffer) rawPixels_).get(sampleIndex);
          default:
             throw new AssertionError("Unimplemented sample size");
       }
@@ -392,15 +410,20 @@ public final class DefaultImage implements Image {
 
    @Override
    public String getIntensityStringAt(int x, int y) {
+      if (pixelType_ == PixelType.GRAY32) {
+         int pixelIndex = y * pixelWidth_ + x;
+         float val = ((FloatBuffer) rawPixels_).get(pixelIndex);
+         return String.format("%.6g", val);
+      }
       if (getNumComponents() == 1) {
          return String.format("%d", getIntensityAt(x, y));
       } else {
          String result = "(";
          for (int i = 0; i < getNumComponents(); ++i) {
-            result += String.format("%d", getComponentIntensityAt(x, y, i));
             if (i != 0) {
                result += ", ";
             }
+            result += String.format("%d", getComponentIntensityAt(x, y, i));
          }
          return result + ")";
       }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/PixelType.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PixelType.java
@@ -26,6 +26,12 @@ public enum PixelType {
          return 1;
       }
    },
+   GRAY32(4, 4, 1) {
+      @Override
+      public int imageJConstant() {
+         return 2; // ImagePlus.GRAY32
+      }
+   },
    /**
     * RGB 888 format.
     *
@@ -115,6 +121,10 @@ public enum PixelType {
             if (bytesPerPixel == 2) {
                return GRAY16;
             }
+         } else if (bytesPerComponent == 4) {
+            if (bytesPerPixel == 4) {
+               return GRAY32;
+            }
          }
       } else if (numberOfComponents == 3) {
          if (bytesPerComponent == 1) {
@@ -140,6 +150,8 @@ public enum PixelType {
             return RGB32;
 
          case 2: // ImagePlus.GRAY32 (float)
+            return GRAY32;
+
          case 3: // ImagePlus.COLOR_256
          default:
             throw new UnsupportedOperationException(

--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -1033,7 +1033,7 @@ public enum PropertyKey {
    PIXEL_TYPE("PixelType", Image.class) {
       @Override
       public String getDescription() {
-         return "The pixel format of the image (GRAY8, GRAY16, or RGB32)";
+         return "The pixel format of the image (GRAY8, GRAY16, GRAY32, or RGB32)";
       }
 
       @Override

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
@@ -35,6 +35,7 @@ import ij.io.FileSaver;
 import ij.io.Opener;
 import ij.process.ByteProcessor;
 import ij.process.ColorProcessor;
+import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
 import ij.process.ShortProcessor;
 import java.io.BufferedWriter;
@@ -296,6 +297,9 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
             numComponents = 1;
          } else if (proc instanceof ShortProcessor) {
             bytesPerPixel = 2;
+            numComponents = 1;
+         } else if (proc instanceof FloatProcessor) {
+            bytesPerPixel = 4;
             numComponents = 1;
          } else if (proc instanceof ColorProcessor) {
             bytesPerPixel = 4;
@@ -561,6 +565,10 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
             // Short
             proc = new ShortProcessor(width, height);
             proc.setPixels((short[]) pixels);
+         } else if (numComponents == 1 && bytesPerPixel == 4) {
+            // Float
+            proc = new FloatProcessor(width, height);
+            proc.setPixels((float[]) pixels);
          } else {
             throw new IllegalArgumentException(String.format(
                   "Unexpected image format with %d bytes per pixel and %d components",

--- a/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/StorageSinglePlaneTiffSeries.java
@@ -305,6 +305,11 @@ public final class StorageSinglePlaneTiffSeries implements Storage {
             return null;
          }
          Object pixels = proc.getPixels();
+         // ColorProcessor.getPixels() returns int[] (packed 0xAARRGGBB).
+         // Convert to interleaved B-G-R-0 byte[] that DefaultImage expects.
+         if (proc instanceof ColorProcessor) {
+            pixels = BufferTools.rgb32IntToBytes((int[]) pixels);
+         }
          return new DefaultImage(pixels, width, height,
                bytesPerPixel, numComponents, coords, metadata);
       } catch (IllegalArgumentException ex) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -627,6 +627,14 @@ public final class MultipageTiffReader {
                img = new DefaultImage(pixelsARGB, formatPmap, coords, metadata);
                break;
             }
+            case GRAY32: {
+               pixelBuffer.rewind();
+               java.nio.FloatBuffer fb = pixelBuffer.order(byteOrder_).asFloatBuffer();
+               float[] pixels32 = new float[fb.capacity()];
+               fb.get(pixels32);
+               img = new DefaultImage(pixels32, formatPmap, coords, metadata);
+               break;
+            }
             default:
                throw new IOException("Unknown pixel type: " + pixelType.name());
          }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -607,22 +607,20 @@ public final class MultipageTiffReader {
                break;
             }
             case RGB32: {
-               byte[] pixelsARGB = new byte[(int) (4 * data.bytesPerImage / 3)];
-               int i = 0;
-               for (byte b : pixelBuffer.array()) {
-                  // need to swap byte 0 and 2: saved order is RGBA, but we want BGRA
-                  if (i % 4 == 0) {
-                     pixelsARGB[i + 2] = b;
-                  } else if (i % 2 == 0) {
-                     pixelsARGB[i - 2] = b;
-                  } else {
-                     pixelsARGB[i] = b;
-                  }
-                  i++;
-                  if ((i + 1) % 4 == 0) {
-                     pixelsARGB[i] = 0;
-                     i++;
-                  }
+               // TIFF stores RGB as 3 bytes/pixel (R, G, B).
+               // Expand to 4 bytes/pixel (B, G, R, 0) to match PixelType.RGB32
+               // component offsets {2, 1, 0}. Use absolute get() rather than array()
+               // so this works with both direct and heap ByteBuffers.
+               int nPixels = (int) (data.bytesPerImage / 3);
+               byte[] pixelsARGB = new byte[nPixels * 4];
+               for (int px = 0; px < nPixels; px++) {
+                  byte r = pixelBuffer.get(px * 3);
+                  byte g = pixelBuffer.get(px * 3 + 1);
+                  byte b = pixelBuffer.get(px * 3 + 2);
+                  pixelsARGB[px * 4]     = b; // offset 0 = B
+                  pixelsARGB[px * 4 + 1] = g; // offset 1 = G
+                  pixelsARGB[px * 4 + 2] = r; // offset 2 = R
+                  pixelsARGB[px * 4 + 3] = 0; // pad
                }
                img = new DefaultImage(pixelsARGB, formatPmap, coords, metadata);
                break;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
@@ -99,6 +99,7 @@ public final class MultipageTiffWriter {
    public static final char X_RESOLUTION = 282;
    public static final char Y_RESOLUTION = 283;
    public static final char RESOLUTION_UNIT = 296;
+   public static final char SAMPLE_FORMAT = 339;
    public static final char IJ_METADATA_BYTE_COUNTS = TiffDecoder.META_DATA_BYTE_COUNTS;
    public static final char IJ_METADATA = TiffDecoder.META_DATA;
    public static final char MM_METADATA = 51123;
@@ -124,6 +125,7 @@ public final class MultipageTiffWriter {
    private final HashMap<Coords, Long> coordsToOffset_;
    private long nextIFDOffsetLocation_ = -1;
    private final boolean rgb_;
+   private final boolean float_;
    private final int byteDepth_;
    private final int imageWidth_;
    private final int imageHeight_;
@@ -158,6 +160,7 @@ public final class MultipageTiffWriter {
       // Obtain information from storage that will be used globally:
       Image repImage = masterStorage_.getAnyImage();
       rgb_ = repImage.getNumComponents() > 1;
+      float_ = !rgb_ && repImage.getBytesPerPixel() == 4 && repImage.getNumComponents() == 1;
       numChannels_ = masterStorage_.getIntendedSize(Coords.CHANNEL);
       numFrames_ = masterStorage_.getIntendedSize(Coords.TIME_POINT);
       numSlices_ = masterStorage_.getIntendedSize(Coords.Z_SLICE);
@@ -645,6 +648,9 @@ public final class MultipageTiffWriter {
       // 1 byte per character of MD string
       // number of bytes for pixels
       char numEntries = ((firstIFD_ ? ENTRIES_PER_IFD + 4 : ENTRIES_PER_IFD));
+      if (float_) {
+         numEntries++;
+      }
       int ifDandBitDepthBytes = 2 + numEntries * 12 + 4 + (rgb_ ? 6 : 0);
 
       ByteBuffer ifdBuffer = allocateByteBuffer(ifDandBitDepthBytes);
@@ -683,6 +689,10 @@ public final class MultipageTiffWriter {
       writeIFDEntry(ifdBuffer, charView, Y_RESOLUTION, (char) 5, 1, tagDataOffset);
       tagDataOffset += 8;
       writeIFDEntry(ifdBuffer, charView, RESOLUTION_UNIT, (char) 3, 1, 3);
+      if (float_) {
+         // SampleFormat=3 means IEEE floating point (TIFF tag 339, type SHORT)
+         writeIFDEntry(ifdBuffer, charView, SAMPLE_FORMAT, (char) 3, 1, 3);
+      }
       if (firstIFD_) {
          ijMetadataCountsTagPosition_ = filePosition_ + bufferPosition_;
          writeIFDEntry(ifdBuffer, charView, IJ_METADATA_BYTE_COUNTS, (char) 4, 0, 0);
@@ -795,6 +805,12 @@ public final class MultipageTiffWriter {
       } else {
          if (byteDepth_ == 1) {
             return ByteBuffer.wrap((byte[]) pixels);
+         } else if (byteDepth_ == 4) {
+            float[] pix = (float[]) pixels;
+            ByteBuffer buffer = getLargeBuffer(pix.length * 4);
+            buffer.asFloatBuffer().put(pix);
+            buffer.rewind();
+            return buffer;
          } else {
             short[] pix = (short[]) pixels;
             ByteBuffer buffer = getLargeBuffer(pix.length * 2);
@@ -900,11 +916,22 @@ public final class MultipageTiffWriter {
       String channelGroup = summary.getChannelGroup();
       DisplaySettings ds = masterStorage_.getDisplaySettings();
       // Store contrast min/max.
-      if (ds == null) {
+      MMStudio studio = MMStudio.getInstance();
+      if (ds != null) {
+         for (int ch = 0; ch < numChannels; ch++) {
+            ChannelDisplaySettings cs = ds.getChannelSettings(ch);
+            // Display Ranges: For each channel, write min then max
+            // TODO: doesn't handle multi-component images.
+            mdBuffer.putDouble(bufferPosition, cs.getComponentSettings(0).getScalingMinimum());
+            bufferPosition += 8;
+            mdBuffer.putDouble(bufferPosition, cs.getComponentSettings(0).getScalingMaximum());
+            bufferPosition += 8;
+         }
+      } else if (studio != null) {
          for (int ch = 0; ch < numChannels; ch++) {
             String name = summary.getSafeChannelName(ch);
             ChannelDisplaySettings cds = RememberedDisplaySettings.loadChannel(
-                  MMStudio.getInstance(), channelGroup, name, null);
+                  studio, channelGroup, name, null);
             // Display Ranges: For each channel, write min then max
             // TODO: doesn't handle multi-component images.
             mdBuffer.putDouble(bufferPosition, (double)
@@ -915,13 +942,11 @@ public final class MultipageTiffWriter {
             bufferPosition += 8;
          }
       } else {
+         // Headless: write zeros for display range
          for (int ch = 0; ch < numChannels; ch++) {
-            ChannelDisplaySettings cs = ds.getChannelSettings(ch);
-            // Display Ranges: For each channel, write min then max
-            // TODO: doesn't handle multi-component images.
-            mdBuffer.putDouble(bufferPosition, cs.getComponentSettings(0).getScalingMinimum());
+            mdBuffer.putDouble(bufferPosition, 0.0);
             bufferPosition += 8;
-            mdBuffer.putDouble(bufferPosition, cs.getComponentSettings(0).getScalingMaximum());
+            mdBuffer.putDouble(bufferPosition, 0.0);
             bufferPosition += 8;
          }
       }
@@ -929,12 +954,14 @@ public final class MultipageTiffWriter {
       // Store LUTs for each channel.
       for (int ch = 0; ch < numChannels; ++ch) {
          Color color;
-         if (ds == null) {
+         if (ds != null) {
+            color = ds.getChannelColor(ch);
+         } else if (studio != null) {
             String name = summary.getSafeChannelName(ch);
             color = RememberedDisplaySettings.loadChannel(
-                  MMStudio.getInstance(), channelGroup, name, null).getColor();
+                  studio, channelGroup, name, null).getColor();
          } else {
-            color = ds.getChannelColor(ch);
+            color = Color.WHITE;
          }
          // Defaulting to a gamma range of 1.0, as display settings
          // aren't available here and that's the only place we can access that
@@ -1047,6 +1074,9 @@ public final class MultipageTiffWriter {
 
       char numEntries = (char) ((firstIFD_ ? ENTRIES_PER_IFD + 2 : ENTRIES_PER_IFD)
             + (firstIFD_ ? 2 : 0));
+      if (float_) {
+         numEntries++;
+      }
 
       int ifdAndBitDepthBytes = 2 + numEntries * 12 + 4 + (rgb_ ? 6 : 0);
 
@@ -1095,6 +1125,9 @@ public final class MultipageTiffWriter {
       writeIFDEntry(ifdBuffer, charView, Y_RESOLUTION, (char) 5, 1, tagDataOffset);
       tagDataOffset += 8;
       writeIFDEntry(ifdBuffer, charView, RESOLUTION_UNIT, (char) 3, 1, 3);
+      if (float_) {
+         writeIFDEntry(ifdBuffer, charView, SAMPLE_FORMAT, (char) 3, 1, 3);
+      }
       if (firstIFD_) {
          ijMetadataCountsTagPosition_ = filePosition_ + bufferPosition_;
          writeIFDEntry(ifdBuffer, charView, IJ_METADATA_BYTE_COUNTS, (char) 4, 0, 0);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
@@ -938,7 +938,7 @@ public final class MultipageTiffWriter {
                   cds.getComponentSettings(0).getScalingMinimum());
             bufferPosition += 8;
             mdBuffer.putDouble(bufferPosition, (double)
-                  cds.getComponentSettings(0).getScalingMinimum());
+                  cds.getComponentSettings(0).getScalingMaximum());
             bufferPosition += 8;
          }
       } else {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -734,6 +734,9 @@ public final class StorageMultipageTiff implements Storage {
     */
    DisplaySettings getDisplaySettings() {
       MMStudio studio = MMStudio.getInstance();
+      if (studio == null) {
+         return null;
+      }
       DataViewer activeDataViewer = studio.displays().getActiveDataViewer();
       try {
          if (activeDataViewer != null && isViewingOurStore(activeDataViewer)) {
@@ -1074,8 +1077,11 @@ public final class StorageMultipageTiff implements Storage {
    }
 
    public static boolean getShouldGenerateMetadataFile() {
-      return MMStudio.getInstance().profile().getSettings(StorageMultipageTiff.class)
-            .getBoolean(SHOULD_GENERATE_METADATA_FILE, true);
+      if (MMStudio.getInstance() != null) {
+         return MMStudio.getInstance().profile().getSettings(StorageMultipageTiff.class)
+                  .getBoolean(SHOULD_GENERATE_METADATA_FILE, true);
+      }
+      return true;
    }
 
    public static void setShouldGenerateMetadataFile(boolean shouldGen) {
@@ -1084,8 +1090,11 @@ public final class StorageMultipageTiff implements Storage {
    }
 
    public static boolean getShouldSplitPositions() {
-      return MMStudio.getInstance().profile().getSettings(StorageMultipageTiff.class)
-            .getBoolean(SHOULD_USE_SEPARATE_FILES_FOR_POSITIONS, true);
+      if (MMStudio.getInstance() != null) {
+         return MMStudio.getInstance().profile().getSettings(StorageMultipageTiff.class)
+                  .getBoolean(SHOULD_USE_SEPARATE_FILES_FOR_POSITIONS, true);
+      }
+      return true;
    }
 
    public static void setShouldSplitPositions(boolean shouldSplit) {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -448,7 +448,21 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          }
          long[] data = componentStats.getInRangeHistogram();
          if (data != null) {
-            int lengthToUse = Math.min(data.length, (1 << rangeBits) - 1);
+            // For 32-bit float images (cameraBits == 32), the histogram is built in
+            // actual pixel-value coordinates with a data-driven number of bins.
+            // Use data.length directly so the X-axis spans the actual pixel range.
+            // For integer images, clamp to (1<<rangeBits)-1 as before, but cap
+            // rangeBits at 30 to avoid Java int-shift overflow (1<<32 == 1).
+            int lengthToUse;
+            if (rangeBits >= 32) {
+               lengthToUse = data.length;
+            } else {
+               int clampedRangeBits = Math.min(rangeBits, 30);
+               lengthToUse = Math.min(data.length, (1 << clampedRangeBits) - 1);
+            }
+            if (lengthToUse <= 0) {
+               lengthToUse = data.length; // safety fallback
+            }
             histogram_.setComponentGraph(component, data, lengthToUse, lengthToUse);
             histogram_.setROIIndicator(componentStats.isROIStats());
          }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -421,9 +421,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          if (settings.isAutoscaleIgnoringZeros()) {
             min = componentStats.getMinIntensityExcludingZeros();
          }
-         intensityStatsPanel_.setMin(min >= 0 ? Long.toString(min) : null);
+         intensityStatsPanel_.setMin(Long.toString(min));
          long max = componentStats.getMaxIntensity();
-         intensityStatsPanel_.setMax(max >= 0 ? Long.toString(max) : null);
+         intensityStatsPanel_.setMax(Long.toString(max));
          long mean = componentStats.getMeanIntensity();
          if (settings.isAutoscaleIgnoringZeros()) {
             mean = componentStats.getMeanIntensityExcludingZeros();
@@ -437,6 +437,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                String.format("%1.2e", stdev));
 
          cameraBits_ = anyImage.getMetadata().getBitDepth(); // can throw IOException
+         updateHistoRangeControlsEnabled();
          ChannelDisplaySettings cSettings = histoRangeComboBoxModel_.getBits(
                viewer_.getDisplaySettings().getChannelSettings(0), cameraBits_);
 
@@ -450,20 +451,25 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          if (data != null) {
             // For 32-bit float images (cameraBits == 32), the histogram is built in
             // actual pixel-value coordinates with a data-driven number of bins.
-            // Use data.length directly so the X-axis spans the actual pixel range.
-            // For integer images, clamp to (1<<rangeBits)-1 as before, but cap
-            // rangeBits at 30 to avoid Java int-shift overflow (1<<32 == 1).
-            int lengthToUse;
+            // For float images (cameraBits == 32): pass actual pixel-value range
+            // [floor(fMin), ceil(fMax)] so the histogram X-axis shows real pixel values.
+            // For integer images: use the bit-depth combo box selection as before,
+            // capping at 30 bits to avoid Java int-shift overflow (1<<32 == 1).
             if (rangeBits >= 32) {
-               lengthToUse = data.length;
+               long rangeMin = componentStats.getHistogramRangeMin();
+               long rangeMax = componentStats.getHistogramRangeMax();
+               if (rangeMax <= rangeMin) {
+                  rangeMax = rangeMin + 1;
+               }
+               histogram_.setComponentGraph(component, data, data.length, rangeMin, rangeMax);
             } else {
                int clampedRangeBits = Math.min(rangeBits, 30);
-               lengthToUse = Math.min(data.length, (1 << clampedRangeBits) - 1);
+               int lengthToUse = Math.min(data.length, (1 << clampedRangeBits) - 1);
+               if (lengthToUse <= 0) {
+                  lengthToUse = data.length;
+               }
+               histogram_.setComponentGraph(component, data, lengthToUse, lengthToUse);
             }
-            if (lengthToUse <= 0) {
-               lengthToUse = data.length; // safety fallback
-            }
-            histogram_.setComponentGraph(component, data, lengthToUse, lengthToUse);
             histogram_.setROIIndicator(componentStats.isROIStats());
          }
 
@@ -493,17 +499,25 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                      .getComponentSettings(component);
          max = Math.min(componentStats.getHistogramRangeMax(),
                componentSettings.getScalingMaximum());
-         min = Math.max(0, Math.min(max - 1,
+         long rangeMin = componentStats.getHistogramRangeMin();
+         min = Math.max(rangeMin, Math.min(max - 1,
                componentSettings.getScalingMinimum()));
       }
       histogram_.setComponentScaling(component, min, max);
    }
 
    @MustCallOnEDT
+   private void updateHistoRangeControlsEnabled() {
+      boolean isFloat = cameraBits_ != null && cameraBits_ >= 32;
+      histoRangeComboBox_.setEnabled(!isFloat);
+      histoRangeDownButton_.setEnabled(!isFloat && histoRangeComboBox_.getSelectedIndex() > 0);
+      histoRangeUpButton_.setEnabled(!isFloat
+            && histoRangeComboBox_.getSelectedIndex() < histoRangeComboBoxModel_.getSize() - 2);
+   }
+
+   @MustCallOnEDT
    private void updateHistoRangeButtonStates() {
-      int index = histoRangeComboBox_.getSelectedIndex();
-      histoRangeDownButton_.setEnabled(index > 0);
-      histoRangeUpButton_.setEnabled(index < histoRangeComboBoxModel_.getSize() - 2);
+      updateHistoRangeControlsEnabled();
       DisplaySettings oldDisplaySettings;
       DisplaySettings newDisplaySettings;
       do {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -449,13 +449,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          }
          long[] data = componentStats.getInRangeHistogram();
          if (data != null) {
-            // For 32-bit float images (cameraBits == 32), the histogram is built in
-            // actual pixel-value coordinates with a data-driven number of bins.
-            // For float images (cameraBits == 32): pass actual pixel-value range
-            // [floor(fMin), ceil(fMax)] so the histogram X-axis shows real pixel values.
-            // For integer images: use the bit-depth combo box selection as before,
+            // For float images: the histogram is built in actual pixel-value coordinates
+            // with a data-driven range [floor(fMin), ceil(fMax)] so the X-axis shows
+            // real pixel values. For integer images: use the bit-depth combo box selection,
             // capping at 30 bits to avoid Java int-shift overflow (1<<32 == 1).
-            if (rangeBits >= 32) {
+            if (componentStats.isFloat()) {
                long rangeMin = componentStats.getHistogramRangeMin();
                long rangeMax = componentStats.getHistogramRangeMax();
                if (rangeMax <= rangeMin) {
@@ -508,7 +506,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    @MustCallOnEDT
    private void updateHistoRangeControlsEnabled() {
-      boolean isFloat = cameraBits_ != null && cameraBits_ >= 32;
+      boolean isFloat = stats_ != null
+            && stats_.getNumberOfComponents() > 0
+            && stats_.getComponentStats(0).isFloat();
       histoRangeComboBox_.setEnabled(!isFloat);
       histoRangeDownButton_.setEnabled(!isFloat && histoRangeComboBox_.getSelectedIndex() > 0);
       histoRangeUpButton_.setEnabled(!isFloat

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -68,6 +68,7 @@ public final class HistogramView extends JPanel {
    // Data state
    private static class ComponentState {
       long[] graph_ = new long[0];
+      long rangeMin_ = 0;
       long rangeMax_ = 0;
       Color color_ = Color.GRAY;
       Color highlightColor_ = Color.YELLOW;
@@ -194,16 +195,22 @@ public final class HistogramView extends JPanel {
    }
 
    public void setComponentGraph(int component, long[] graph, int graphLen, long rangeMax) {
+      setComponentGraph(component, graph, graphLen, 0, rangeMax);
+   }
+
+   public void setComponentGraph(int component, long[] graph, int graphLen,
+                                  long rangeMin, long rangeMax) {
       Preconditions.checkArgument(component >= 0);
       Preconditions.checkArgument(graphLen <= graph.length);
-      Preconditions.checkArgument(rangeMax > 0);
+      Preconditions.checkArgument(rangeMax > rangeMin);
       addComponentIfNecessary(component);
       ComponentState state = componentStates_.get(component);
-      boolean rangeMaxChanged = (rangeMax != state.rangeMax_);
+      boolean rangeChanged = (rangeMin != state.rangeMin_ || rangeMax != state.rangeMax_);
       state.graph_ = Arrays.copyOf(graph, graphLen);
+      state.rangeMin_ = rangeMin;
       state.rangeMax_ = rangeMax;
 
-      if (component == selectedComponent_ && rangeMaxChanged) {
+      if (component == selectedComponent_ && rangeChanged) {
          nullRectsAndMappingPath();
       }
       state.cachedInterpolatedLogScaledGraph_ = null;
@@ -215,6 +222,7 @@ public final class HistogramView extends JPanel {
       nullRectsAndMappingPath();
       for (ComponentState state : componentStates_) {
          state.graph_ = null;
+         state.rangeMin_ = 0;
          state.rangeMax_ = 0;
          state.scalingMin_ = 0;
          state.scalingMax_ = 0;
@@ -363,7 +371,7 @@ public final class HistogramView extends JPanel {
    private float getScalingHandlePos(int component, boolean top) {
       ComponentState state = componentStates_.get(component);
       float intensity = top ? state.scalingMax_ : state.scalingMin_;
-      float xPos = intensityFractionToGraphXPos(intensity / state.rangeMax_);
+      float xPos = intensityFractionToGraphXPos(intensityToFraction(state, intensity));
       return (float) (top ? Math.ceil(xPos) : Math.floor(xPos));
    }
 
@@ -397,9 +405,10 @@ public final class HistogramView extends JPanel {
          int x = (int) getScalingHandlePos(component, top);
 
          boolean drawOnLeftOfHandle = top;
-         if (top && intensity < 0.5 * state.rangeMax_) {
+         double midpoint = 0.5 * (state.rangeMin_ + state.rangeMax_);
+         if (top && intensity < midpoint) {
             drawOnLeftOfHandle = false;
-         } else if (!top && intensity > 0.5 * state.rangeMax_) {
+         } else if (!top && intensity > midpoint) {
             drawOnLeftOfHandle = true;
          }
 
@@ -434,8 +443,8 @@ public final class HistogramView extends JPanel {
    private Rectangle getGammaHandleRect() {
       if (gammaHandleRect_ == null) {
          ComponentState state = componentStates_.get(selectedComponent_);
-         float loX = intensityFractionToGraphXPos((float) state.scalingMin_ / state.rangeMax_);
-         float hiX = intensityFractionToGraphXPos((float) state.scalingMax_ / state.rangeMax_);
+         float loX = intensityFractionToGraphXPos(intensityToFraction(state, state.scalingMin_));
+         float hiX = intensityFractionToGraphXPos(intensityToFraction(state, state.scalingMax_));
          int x = Math.round(0.5f * (loX + hiX));
          float yFrac = (float) Math.pow(0.5, gamma_);
          int y = Math.round(frequencyFractionToGraphYPos(yFrac));
@@ -444,6 +453,14 @@ public final class HistogramView extends JPanel {
          gammaHandleRect_ = new Rectangle(x - s, y - s, 2 * s, 2 * s);
       }
       return gammaHandleRect_;
+   }
+
+   private float intensityToFraction(ComponentState state, float intensity) {
+      long span = state.rangeMax_ - state.rangeMin_;
+      if (span == 0) {
+         return 0.0f;
+      }
+      return (intensity - state.rangeMin_) / (float) span;
    }
 
    private float intensityFractionToGraphXPos(float intensityFraction) {
@@ -468,8 +485,8 @@ public final class HistogramView extends JPanel {
 
    private double graphPosToGamma(float x, float y) {
       ComponentState state = componentStates_.get(selectedComponent_);
-      float loX = intensityFractionToGraphXPos((float) state.scalingMin_ / state.rangeMax_);
-      float hiX = intensityFractionToGraphXPos((float) state.scalingMax_ / state.rangeMax_);
+      float loX = intensityFractionToGraphXPos(intensityToFraction(state, state.scalingMin_));
+      float hiX = intensityFractionToGraphXPos(intensityToFraction(state, state.scalingMax_));
 
       float xFrac = (x + 0.5f - loX) / (hiX - loX);
       float yFrac = graphYPosToFrequencyFraction(y);
@@ -592,8 +609,8 @@ public final class HistogramView extends JPanel {
          return;
       }
       int offset = 2 * component;
-      float loXPos = intensityFractionToGraphXPos((float) state.scalingMin_ / state.rangeMax_);
-      float hiXPos = intensityFractionToGraphXPos((float) state.scalingMax_ / state.rangeMax_);
+      float loXPos = intensityFractionToGraphXPos(intensityToFraction(state, state.scalingMin_));
+      float hiXPos = intensityFractionToGraphXPos(intensityToFraction(state, state.scalingMax_));
 
       Graphics2D g2d = (Graphics2D) g.create();
       g2d.setClip(rect.x, rect.y, rect.width, rect.height);
@@ -616,7 +633,7 @@ public final class HistogramView extends JPanel {
       }
       int offset = 2 * component;
       float xPos = intensityFractionToGraphXPos(
-            (float) state.highlightIntensity_ / state.rangeMax_);
+            intensityToFraction(state, state.highlightIntensity_));
       Rectangle rect = getGraphRect();
 
       Graphics2D g2d = (Graphics2D) g.create();
@@ -680,9 +697,10 @@ public final class HistogramView extends JPanel {
       }
 
       boolean drawOnLeftOfHandle = top;
-      if (top && intensity < 0.5 * state.rangeMax_) {
+      double midpoint2 = 0.5 * (state.rangeMin_ + state.rangeMax_);
+      if (top && intensity < midpoint2) {
          drawOnLeftOfHandle = false;
-      } else if (!top && intensity > 0.5 * state.rangeMax_) {
+      } else if (!top && intensity > midpoint2) {
          drawOnLeftOfHandle = true;
       }
 
@@ -899,8 +917,8 @@ public final class HistogramView extends JPanel {
       if (cachedGammaMappingPath_ == null) {
          ComponentState state = componentStates_.get(component);
          Rectangle rect = getGraphRect();
-         float loX = intensityFractionToGraphXPos((float) state.scalingMin_ / state.rangeMax_);
-         float hiX = intensityFractionToGraphXPos((float) state.scalingMax_ / state.rangeMax_);
+         float loX = intensityFractionToGraphXPos(intensityToFraction(state, state.scalingMin_));
+         float hiX = intensityFractionToGraphXPos(intensityToFraction(state, state.scalingMax_));
          int width = (int) Math.floor(hiX - loX);
 
          cachedGammaMappingPath_ = new Path2D.Float();
@@ -1015,7 +1033,7 @@ public final class HistogramView extends JPanel {
    private void startScalingEdit(final boolean top) {
       final ComponentState state = componentStates_.get(selectedComponent_);
       long intensity = top ? state.scalingMax_ : state.scalingMin_;
-      long min = top ? state.scalingMin_ + 1 : 0;
+      long min = top ? state.scalingMin_ + 1 : state.rangeMin_;
       long max = top ? state.rangeMax_ : state.scalingMax_ - 1;
       // TODO spinner model fails if not min <= value <= max!!!
       final JSpinner scalingSpinner = new JSpinner(
@@ -1044,8 +1062,9 @@ public final class HistogramView extends JPanel {
    private void jumpSetScaling(int mouseX, boolean top) {
       ComponentState state = componentStates_.get(selectedComponent_);
       long intensity = Math.round(
-            graphXPosToIntensityFraction(mouseX) * state.rangeMax_);
-      intensity = Math.max(0, Math.min(state.rangeMax_, intensity));
+            graphXPosToIntensityFraction(mouseX) * (state.rangeMax_ - state.rangeMin_)
+            + state.rangeMin_);
+      intensity = Math.max(state.rangeMin_, Math.min(state.rangeMax_, intensity));
       if (top) {
          intensity = Math.max(state.scalingMin_ + 1, intensity);
          setComponentScaling(selectedComponent_, state.scalingMin_, intensity);
@@ -1089,11 +1108,12 @@ public final class HistogramView extends JPanel {
       long intensity;
       if (getValidDragRect().contains(mousePosition)) {
          float intensityFrac = graphXPosToIntensityFraction(mousePosition.x);
-         intensity = Math.round(intensityFrac * state.rangeMax_);
+         intensity = Math.round(intensityFrac * (state.rangeMax_ - state.rangeMin_)
+               + state.rangeMin_);
       } else {
          intensity = scalingHandleDragOriginalValue_;
       }
-      intensity = Math.max(0, Math.min(state.rangeMax_, intensity));
+      intensity = Math.max(state.rangeMin_, Math.min(state.rangeMax_, intensity));
       if (top) {
          intensity = Math.max(state.scalingMin_ + 1, intensity);
          setComponentScaling(selectedComponent_, state.scalingMin_, intensity);

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -205,7 +205,7 @@ public final class HistogramView extends JPanel {
       Preconditions.checkArgument(rangeMax > rangeMin);
       addComponentIfNecessary(component);
       ComponentState state = componentStates_.get(component);
-      boolean rangeChanged = (rangeMin != state.rangeMin_ || rangeMax != state.rangeMax_);
+      final boolean rangeChanged = (rangeMin != state.rangeMin_ || rangeMax != state.rangeMax_);
       state.graph_ = Arrays.copyOf(graph, graphLen);
       state.rangeMin_ = rangeMin;
       state.rangeMax_ = rangeMax;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1132,10 +1132,13 @@ public final class DisplayUIController implements Closeable, WindowListener,
             // TODO: Remember changes in component display settings?
             ijBridge_.mm2ijSetChannelColor(i, channelSettings.getColor());
             if (!autostretch) {
-               int max = Math.max(1, (int) Math.min(Integer.MAX_VALUE,
-                     componentSettings.getScalingMaximum()));
-               int min = (int) Math.min(max - 1,
-                     componentSettings.getScalingMinimum());
+               int max = (int) Math.min(Integer.MAX_VALUE,
+                     componentSettings.getScalingMaximum());
+               if (max < 1) {
+                  max = 1;
+               }
+               int min = (int) componentSettings.getScalingMinimum();
+               min = Math.min(max - 1, min);
                ijBridge_.mm2ijSetIntensityScaling(i, min, max);
             }
             double gamma = componentSettings.getScalingGamma();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
@@ -11,6 +11,7 @@ import ij.CompositeImage;
 import ij.ImagePlus;
 import ij.process.ByteProcessor;
 import ij.process.ColorProcessor;
+import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
 import ij.process.LUT;
 import ij.process.ShortProcessor;
@@ -69,6 +70,11 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
       }
       if (proc instanceof ColorProcessor) {
          return 255;
+      }
+      if (proc instanceof FloatProcessor) {
+         // Float images don't have a fixed sample max; return a large value
+         // so the LUT range is not clamped when no explicit max is set.
+         return Integer.MAX_VALUE;
       }
       throw new UnsupportedOperationException("Unsupported ImageProcessor type");
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
@@ -187,7 +187,6 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
 
    @Override
    public void applyScaling(int index, int min, int max) {
-      Preconditions.checkArgument(min >= 0);
       Preconditions.checkArgument(max >= min);
       if (minima_.size() <= index) {
          minima_.addAll(Collections.nCopies(index + 1 - minima_.size(), 0));

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
@@ -574,6 +574,8 @@ public final class ImageJBridge {
          blankPixels = new byte[((byte[]) templatePixels).length];
       } else if (templatePixels instanceof short[]) {
          blankPixels = new short[((short[]) templatePixels).length];
+      } else if (templatePixels instanceof float[]) {
+         blankPixels = new float[((float[]) templatePixels).length];
       } else if (templatePixels instanceof int[]) {
          blankPixels = new int[((int[]) templatePixels).length];
       } else if (templatePixels instanceof long[]) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/event/DataViewerMousePixelInfoChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/event/DataViewerMousePixelInfoChangedEvent.java
@@ -26,6 +26,8 @@ public class DataViewerMousePixelInfoChangedEvent {
    private final String[] indexingAxes_;
    private final List<Coords> coords_ = new ArrayList<Coords>();
    private final List<long[]> values_ = new ArrayList<long[]>();
+   // Preformatted intensity strings; null entries mean fall back to formatting values_[i] as longs.
+   private final List<String> valueStrings_ = new ArrayList<String>();
 
    public static DataViewerMousePixelInfoChangedEvent fromImage(int x, int y,
                                                                 Image image) {
@@ -43,6 +45,7 @@ public class DataViewerMousePixelInfoChangedEvent {
 
       List<Coords> coords = new ArrayList<Coords>();
       List<long[]> componentValues = new ArrayList<long[]>();
+      List<String> valueStrings = new ArrayList<String>();
       for (Image image : images) {
          Preconditions.checkNotNull(image);
          Coords c = image.getCoords();
@@ -52,8 +55,12 @@ public class DataViewerMousePixelInfoChangedEvent {
          }
          coords.add(cb.build());
          componentValues.add(image.getComponentIntensitiesAt(x, y));
+         valueStrings.add(image.getIntensityStringAt(x, y));
       }
-      return create(x, y, indexingAxes, coords, componentValues);
+      DataViewerMousePixelInfoChangedEvent event =
+            create(x, y, indexingAxes, coords, componentValues);
+      event.valueStrings_.addAll(valueStrings);
+      return event;
    }
 
    public static DataViewerMousePixelInfoChangedEvent create(int x, int y,
@@ -154,6 +161,10 @@ public class DataViewerMousePixelInfoChangedEvent {
    }
 
    public String getComponentValuesStringForCoords(Coords coords) {
+      int i = coords_.indexOf(coords);
+      if (i >= 0 && i < valueStrings_.size() && valueStrings_.get(i) != null) {
+         return valueStrings_.get(i);
+      }
       long[] values = getComponentValuesForCoords(coords);
       if (values.length == 1) {
          return String.valueOf(values[0]);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -211,10 +211,15 @@ public final class ImageStatsProcessor {
       int width = image.getWidth();
       float fMin = Float.MAX_VALUE;
       float fMax = -Float.MAX_VALUE;
+      float fMinNonZero = Float.MAX_VALUE;
       long count = 0;
+      long countNonZero = 0;
       double sum = 0.0;
+      double sumNonZero = 0.0;
+      double sumOfSquares = 0.0;
 
-      // First pass: find min/max (ignoring NaN, Infinity, and masked-out pixels)
+      // First pass: find min/max, accumulate sum/sumOfSquares/counts
+      // (ignoring NaN, Infinity, and masked-out pixels)
       for (int y = statsBounds.y; y < statsBounds.y + statsBounds.height; y++) {
          for (int x = statsBounds.x; x < statsBounds.x + statsBounds.width; x++) {
             if (maskBytes != null) {
@@ -229,17 +234,28 @@ public final class ImageStatsProcessor {
             }
             count++;
             sum += v;
+            sumOfSquares += (double) v * v;
             if (v < fMin) {
                fMin = v;
             }
             if (v > fMax) {
                fMax = v;
             }
+            if (v != 0.0f) {
+               countNonZero++;
+               sumNonZero += v;
+               if (v < fMinNonZero) {
+                  fMinNonZero = v;
+               }
+            }
          }
       }
       if (count == 0) {
          fMin = 0.0f;
          fMax = 0.0f;
+      }
+      if (countNonZero == 0) {
+         fMinNonZero = 0.0f;
       }
 
       // Second pass: build a 256-bin histogram spanning [fMin, fMax].
@@ -249,7 +265,9 @@ public final class ImageStatsProcessor {
       // ImageJ FloatProcessor LUT. This works for negative fMin as well.
       final int N_BINS = 256;
       final float range = fMax - fMin;
-      final double fBinWidth = (range == 0.0f) ? 1.0 : (double) range / N_BINS;
+      // When all pixels are identical (range == 0), use binWidth=0 as a sentinel so
+      // that getHistogramRangeMax() returns ceil(fMax) rather than fMin + 256.
+      final double fBinWidth = (range == 0.0f) ? 0.0 : (double) range / N_BINS;
 
       // [0]=underflow, [1..N_BINS]=in-range, [N_BINS+1]=overflow
       long[] hist = new long[N_BINS + 2];
@@ -277,18 +295,22 @@ public final class ImageStatsProcessor {
          }
       }
 
+      // sum and sumOfSquares are stored as long in IntegerComponentStats.
+      // Round to the nearest integer so that getMeanIntensity() and
+      // getStandardDeviation() return values that are correct to integer precision,
+      // matching the display which shows mean and stdev rounded to integers.
       IntegerComponentStats stats = IntegerComponentStats.builder()
             .histogram(hist, 0)
             .rangeMin((double) fMin)
             .binWidthFloat(fBinWidth)
             .pixelCount(count)
-            .pixelCountExcludingZeros(count)
+            .pixelCountExcludingZeros(countNonZero)
             .usedROI(useROI)
             .minimum((long) Math.floor(fMin))
-            .minimumExcludingZeros((long) Math.floor(fMin))
+            .minimumExcludingZeros((long) Math.floor(fMinNonZero))
             .maximum((long) Math.ceil(fMax))
-            .sum((long) sum)
-            .sumOfSquares(0L)
+            .sum(Math.round(sum))
+            .sumOfSquares(Math.round(sumOfSquares))
             .build();
       return ImageStats.create(index, stats);
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -194,7 +194,7 @@ public final class ImageStatsProcessor {
                nComponents, bitDepth, binCountPowerOf2,
                useROI, index);
       } else if (bytesPerSample == 4 && nComponents == 1) {
-         result = computeFloatStats(image, statsBounds, useROI, index);
+         result = computeFloatStats(image, statsBounds, maskBytes, maskBounds, useROI, index);
       }
 
       if (perfMon_ != null) {
@@ -205,6 +205,7 @@ public final class ImageStatsProcessor {
    }
 
    private ImageStats computeFloatStats(Image image, java.awt.Rectangle statsBounds,
+                                        byte[] maskBytes, java.awt.Rectangle maskBounds,
                                         boolean useROI, int index) {
       float[] pixels = (float[]) image.getRawPixels();
       int width = image.getWidth();
@@ -213,9 +214,15 @@ public final class ImageStatsProcessor {
       long count = 0;
       double sum = 0.0;
 
-      // First pass: find min/max (ignoring NaN and Infinity)
+      // First pass: find min/max (ignoring NaN, Infinity, and masked-out pixels)
       for (int y = statsBounds.y; y < statsBounds.y + statsBounds.height; y++) {
          for (int x = statsBounds.x; x < statsBounds.x + statsBounds.width; x++) {
+            if (maskBytes != null) {
+               int maskIdx = (y - maskBounds.y) * maskBounds.width + (x - maskBounds.x);
+               if ((maskBytes[maskIdx] & 0xff) < MASK_THRESH) {
+                  continue;
+               }
+            }
             float v = pixels[y * width + x];
             if (Float.isNaN(v) || Float.isInfinite(v)) {
                continue;
@@ -278,6 +285,12 @@ public final class ImageStatsProcessor {
       float range = fMax - fMin;
       for (int y = statsBounds.y; y < statsBounds.y + statsBounds.height; y++) {
          for (int x = statsBounds.x; x < statsBounds.x + statsBounds.width; x++) {
+            if (maskBytes != null) {
+               int maskIdx = (y - maskBounds.y) * maskBounds.width + (x - maskBounds.x);
+               if ((maskBytes[maskIdx] & 0xff) < MASK_THRESH) {
+                  continue;
+               }
+            }
             float v = pixels[y * width + x];
             if (Float.isNaN(v) || Float.isInfinite(v)) {
                continue;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -242,47 +242,17 @@ public final class ImageStatsProcessor {
          fMax = 0.0f;
       }
 
-      // Second pass: build histogram.
-      // For non-negative floats, build in actual pixel-value coordinates so that
-      // bin i covers [i*binWidth, (i+1)*binWidth). This ensures that histogram
-      // bin coordinates equal pixel values, which is what the display framework
-      // assumes when applying the LUT min/max to the ImageJ FloatProcessor.
-      // For negative floats (unusual in microscopy), fall back to a 256-bin
-      // normalized histogram (bin coords differ from pixel values in that case).
+      // Second pass: build a 256-bin histogram spanning [fMin, fMax].
+      // bin width = (fMax - fMin) / N_BINS (floating-point, not power-of-2).
+      // Storing rangeMin_ = fMin and binWidthFloat_ in IntegerComponentStats means
+      // getQuantile() returns actual pixel values, which are passed directly to the
+      // ImageJ FloatProcessor LUT. This works for negative fMin as well.
       final int N_BINS = 256;
-      final boolean nonnegative = (fMin >= 0.0f);
+      final float range = fMax - fMin;
+      final double fBinWidth = (range == 0.0f) ? 1.0 : (double) range / N_BINS;
 
-      final int binWidthPow2;
-      final long histMin;
-      final long histMax;
-      if (nonnegative) {
-         // Choose the smallest power-of-2 bin width that keeps at most N_BINS bins
-         // spanning [0, ceil(fMax)].
-         long intRange = (long) Math.ceil(fMax) + 1;
-         int bw = 0;
-         while (((intRange + ((1L << bw) - 1)) >> bw) > N_BINS) {
-            bw++;
-         }
-         binWidthPow2 = bw;
-         histMin = (long) fMin;
-         histMax = (long) Math.ceil(fMax);
-      } else {
-         binWidthPow2 = 0;
-         histMin = (long) fMin;
-         histMax = (long) Math.ceil(fMax);
-      }
+      long[] hist = new long[N_BINS + 2]; // [0]=underflow, [1..N_BINS]=in-range, [N_BINS+1]=overflow
 
-      int binWidth = 1 << binWidthPow2;
-      int nBins;
-      if (nonnegative) {
-         nBins = (int) (((long) Math.ceil(fMax) + binWidth) >> binWidthPow2);
-         nBins = Math.max(1, Math.min(nBins, N_BINS));
-      } else {
-         nBins = N_BINS;
-      }
-      long[] hist = new long[nBins + 2]; // [0]=underflow, [1..nBins]=in-range, [nBins+1]=overflow
-
-      float range = fMax - fMin;
       for (int y = statsBounds.y; y < statsBounds.y + statsBounds.height; y++) {
          for (int x = statsBounds.x; x < statsBounds.x + statsBounds.width; x++) {
             if (maskBytes != null) {
@@ -296,29 +266,26 @@ public final class ImageStatsProcessor {
                continue;
             }
             int bin;
-            if (nonnegative) {
-               bin = 1 + (int) (v / binWidth);
-               bin = Math.max(1, Math.min(nBins, bin));
+            if (range == 0.0f) {
+               bin = 1;
             } else {
-               if (range == 0.0f) {
-                  bin = 1;
-               } else {
-                  bin = 1 + (int) ((v - fMin) / range * (N_BINS - 1));
-                  bin = Math.max(1, Math.min(N_BINS, bin));
-               }
+               bin = 1 + (int) Math.floor((v - fMin) / fBinWidth);
+               bin = Math.max(1, Math.min(N_BINS, bin));
             }
             hist[bin]++;
          }
       }
 
       IntegerComponentStats stats = IntegerComponentStats.builder()
-            .histogram(hist, binWidthPow2)
+            .histogram(hist, 0)
+            .rangeMin((double) fMin)
+            .binWidthFloat(fBinWidth)
             .pixelCount(count)
             .pixelCountExcludingZeros(count)
             .usedROI(useROI)
-            .minimum(histMin)
-            .minimumExcludingZeros(histMin)
-            .maximum(histMax)
+            .minimum((long) Math.floor(fMin))
+            .minimumExcludingZeros((long) Math.floor(fMin))
+            .maximum((long) Math.ceil(fMax))
             .sum((long) sum)
             .sumOfSquares(0L)
             .build();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -193,6 +193,8 @@ public final class ImageStatsProcessor {
                mask,
                nComponents, bitDepth, binCountPowerOf2,
                useROI, index);
+      } else if (bytesPerSample == 4 && nComponents == 1) {
+         result = computeFloatStats(image, statsBounds, useROI, index);
       }
 
       if (perfMon_ != null) {
@@ -200,6 +202,114 @@ public final class ImageStatsProcessor {
       }
 
       return result; // null if we don't know how to compute (TODO FIX)
+   }
+
+   private ImageStats computeFloatStats(Image image, java.awt.Rectangle statsBounds,
+                                        boolean useROI, int index) {
+      float[] pixels = (float[]) image.getRawPixels();
+      int width = image.getWidth();
+      float fMin = Float.MAX_VALUE;
+      float fMax = -Float.MAX_VALUE;
+      long count = 0;
+      double sum = 0.0;
+
+      // First pass: find min/max (ignoring NaN and Infinity)
+      for (int y = statsBounds.y; y < statsBounds.y + statsBounds.height; y++) {
+         for (int x = statsBounds.x; x < statsBounds.x + statsBounds.width; x++) {
+            float v = pixels[y * width + x];
+            if (Float.isNaN(v) || Float.isInfinite(v)) {
+               continue;
+            }
+            count++;
+            sum += v;
+            if (v < fMin) {
+               fMin = v;
+            }
+            if (v > fMax) {
+               fMax = v;
+            }
+         }
+      }
+      if (count == 0) {
+         fMin = 0.0f;
+         fMax = 0.0f;
+      }
+
+      // Second pass: build histogram.
+      // For non-negative floats, build in actual pixel-value coordinates so that
+      // bin i covers [i*binWidth, (i+1)*binWidth). This ensures that histogram
+      // bin coordinates equal pixel values, which is what the display framework
+      // assumes when applying the LUT min/max to the ImageJ FloatProcessor.
+      // For negative floats (unusual in microscopy), fall back to a 256-bin
+      // normalized histogram (bin coords differ from pixel values in that case).
+      final int N_BINS = 256;
+      final boolean nonnegative = (fMin >= 0.0f);
+
+      final int binWidthPow2;
+      final long histMin;
+      final long histMax;
+      if (nonnegative) {
+         // Choose the smallest power-of-2 bin width that keeps at most N_BINS bins
+         // spanning [0, ceil(fMax)].
+         long intRange = (long) Math.ceil(fMax) + 1;
+         int bw = 0;
+         while (((intRange + ((1L << bw) - 1)) >> bw) > N_BINS) {
+            bw++;
+         }
+         binWidthPow2 = bw;
+         histMin = (long) fMin;
+         histMax = (long) Math.ceil(fMax);
+      } else {
+         binWidthPow2 = 0;
+         histMin = (long) fMin;
+         histMax = (long) Math.ceil(fMax);
+      }
+
+      int binWidth = 1 << binWidthPow2;
+      int nBins;
+      if (nonnegative) {
+         nBins = (int) (((long) Math.ceil(fMax) + binWidth) >> binWidthPow2);
+         nBins = Math.max(1, Math.min(nBins, N_BINS));
+      } else {
+         nBins = N_BINS;
+      }
+      long[] hist = new long[nBins + 2]; // [0]=underflow, [1..nBins]=in-range, [nBins+1]=overflow
+
+      float range = fMax - fMin;
+      for (int y = statsBounds.y; y < statsBounds.y + statsBounds.height; y++) {
+         for (int x = statsBounds.x; x < statsBounds.x + statsBounds.width; x++) {
+            float v = pixels[y * width + x];
+            if (Float.isNaN(v) || Float.isInfinite(v)) {
+               continue;
+            }
+            int bin;
+            if (nonnegative) {
+               bin = 1 + (int) (v / binWidth);
+               bin = Math.max(1, Math.min(nBins, bin));
+            } else {
+               if (range == 0.0f) {
+                  bin = 1;
+               } else {
+                  bin = 1 + (int) ((v - fMin) / range * (N_BINS - 1));
+                  bin = Math.max(1, Math.min(N_BINS, bin));
+               }
+            }
+            hist[bin]++;
+         }
+      }
+
+      IntegerComponentStats stats = IntegerComponentStats.builder()
+            .histogram(hist, binWidthPow2)
+            .pixelCount(count)
+            .pixelCountExcludingZeros(count)
+            .usedROI(useROI)
+            .minimum(histMin)
+            .minimumExcludingZeros(histMin)
+            .maximum(histMax)
+            .sum((long) sum)
+            .sumOfSquares(0L)
+            .build();
+      return ImageStats.create(index, stats);
    }
 
    private <T extends IntegerType<T>> ImageStats compute(

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -251,7 +251,8 @@ public final class ImageStatsProcessor {
       final float range = fMax - fMin;
       final double fBinWidth = (range == 0.0f) ? 1.0 : (double) range / N_BINS;
 
-      long[] hist = new long[N_BINS + 2]; // [0]=underflow, [1..N_BINS]=in-range, [N_BINS+1]=overflow
+      // [0]=underflow, [1..N_BINS]=in-range, [N_BINS+1]=overflow
+      long[] hist = new long[N_BINS + 2];
 
       for (int y = statsBounds.y; y < statsBounds.y + statsBounds.height; y++) {
          for (int x = statsBounds.x; x < statsBounds.x + statsBounds.width; x++) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -301,6 +301,7 @@ public final class ImageStatsProcessor {
       // matching the display which shows mean and stdev rounded to integers.
       IntegerComponentStats stats = IntegerComponentStats.builder()
             .histogram(hist, 0)
+            .isFloat(true)
             .rangeMin((double) fMin)
             .binWidthFloat(fBinWidth)
             .pixelCount(count)

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
@@ -24,6 +24,11 @@ import java.util.Arrays;
 public final class IntegerComponentStats {
    private final long[] histogram_;
    private final int binWidthPowerOf2_;
+   // For float images: actual pixel-value start of bin 1 and width of each bin.
+   // For integer images these default to 0.0 and (1 << binWidthPowerOf2_) respectively,
+   // reproducing the previous behavior exactly.
+   private final double rangeMin_;
+   private final double binWidthFloat_;
    private final long pixelCount_;
    private final long pixelCountExcludingZeros_;
    private final boolean usedROI_;
@@ -37,6 +42,8 @@ public final class IntegerComponentStats {
    public static class Builder {
       private long[] histogram_;
       private int binWidthPowerOf2_;
+      private double rangeMin_ = 0.0;
+      private double binWidthFloat_ = -1.0; // sentinel: -1 → use 1 << binWidthPowerOf2_
       private long pixelCount_;
       private long pixelCountExcludingZeros_;
       private boolean usedROI_;
@@ -53,6 +60,17 @@ public final class IntegerComponentStats {
          Preconditions.checkArgument(binsIncludingOutOfRange.length >= 2);
          histogram_ = binsIncludingOutOfRange;
          binWidthPowerOf2_ = binWidthPowerOf2;
+         return this;
+      }
+
+      public Builder rangeMin(double min) {
+         rangeMin_ = min;
+         return this;
+      }
+
+      public Builder binWidthFloat(double width) {
+         Preconditions.checkArgument(width > 0.0);
+         binWidthFloat_ = width;
          return this;
       }
 
@@ -153,6 +171,8 @@ public final class IntegerComponentStats {
             ? Arrays.copyOf(b.histogram_, b.histogram_.length) :
             null;
       binWidthPowerOf2_ = b.binWidthPowerOf2_;
+      rangeMin_ = b.rangeMin_;
+      binWidthFloat_ = (b.binWidthFloat_ >= 0.0) ? b.binWidthFloat_ : (1 << b.binWidthPowerOf2_);
       pixelCount_ = b.pixelCount_;
       pixelCountExcludingZeros_ = b.pixelCountExcludingZeros_;
       usedROI_ = b.usedROI_;
@@ -199,15 +219,30 @@ public final class IntegerComponentStats {
       return 1 << binWidthPowerOf2_;
    }
 
+   public double getHistogramRangeMinDouble() {
+      return rangeMin_;
+   }
+
    public long getHistogramRangeMin() {
-      return 0;
+      return (long) Math.floor(rangeMin_);
    }
 
    public long getHistogramRangeMax() {
       if (histogram_ == null) {
          return 0;
       }
-      return (long) getHistogramBinWidth() * getHistogramBinCount() - 1;
+      // For integer images (rangeMin_ == 0 and binWidthFloat_ is a power of 2),
+      // the last representable value is binWidth*nBins - 1 (e.g. 255 for 8-bit).
+      // For float images (rangeMin_ or binWidthFloat_ may be fractional), the
+      // histogram covers exactly [rangeMin_, rangeMin_ + binWidthFloat_*nBins],
+      // so the upper bound is ceil(fMax) with no subtraction.
+      double rawMax = rangeMin_ + binWidthFloat_ * getHistogramBinCount();
+      long ceiled = (long) Math.ceil(rawMax);
+      if (rangeMin_ == 0.0 && binWidthFloat_ == (1 << binWidthPowerOf2_)) {
+         // Integer image: last valid sample value is one below the bin-count boundary
+         return ceiled - 1;
+      }
+      return ceiled;
    }
 
    public long getPixelCount() {
@@ -251,7 +286,7 @@ public final class IntegerComponentStats {
    public long getAutoscaleMinForQuantile(double q) {
       if (q >= 0.5) {
          // Safe, in-range value that is less than max
-         return Math.max(0L, Math.round(getQuantile(0.5)) - 1L);
+         return Math.round(getQuantile(0.5)) - 1L;
       }
       return Math.round(getQuantile(q));
    }
@@ -259,7 +294,7 @@ public final class IntegerComponentStats {
    public long getAutoscaleMinForQuantileIgnoringZeros(double q) {
       if (q >= 0.5) {
          // Safe, in-range value that is less than max
-         return Math.max(0L, Math.round(getQuantileIgnoringZeros(0.5)) - 1L);
+         return Math.round(getQuantileIgnoringZeros(0.5)) - 1L;
       }
       return Math.round(getQuantileIgnoringZeros(q));
    }
@@ -301,7 +336,7 @@ public final class IntegerComponentStats {
 
       if (countBelowQuantile <= cumDistrib[0] && cumDistrib[0] > 0) {
          // Quantile is below histogram range
-         return getHistogramRangeMin();
+         return getHistogramRangeMinDouble();
       }
       if (countBelowQuantile > cumDistrib[cumDistrib.length - 2]) {
          // Quantile is above histogram range
@@ -323,12 +358,11 @@ public final class IntegerComponentStats {
       binIndex = binarySearch(cumDistrib, 1, cumDistrib.length - 1,
             (long) Math.floor(countBelowQuantile));
 
-      int binWidth = getHistogramBinWidth();
-      long leftEdge = (long) (binIndex - 1) * binWidth;
+      double leftEdge = rangeMin_ + (binIndex - 1) * binWidthFloat_;
       double binFraction =
             (countBelowQuantile - cumDistrib[binIndex - 1])
                   / (cumDistrib[binIndex] - cumDistrib[binIndex - 1]);
-      return leftEdge + binFraction * binWidth;
+      return leftEdge + binFraction * binWidthFloat_;
    }
 
 
@@ -356,7 +390,7 @@ public final class IntegerComponentStats {
 
       if (countBelowQuantile < cumDistrib[2] && cumDistrib[2] > 0) {
          // Quantile is below histogram range
-         return getHistogramRangeMin() + 1;
+         return getHistogramRangeMinDouble() + binWidthFloat_;
       }
       if (countBelowQuantile > cumDistrib[cumDistrib.length - 2]) {
          // Quantile is above histogram range
@@ -378,12 +412,11 @@ public final class IntegerComponentStats {
       binIndex = binarySearch(cumDistrib, 2, cumDistrib.length - 1,
             (long) Math.floor(countBelowQuantile));
 
-      int binWidth = getHistogramBinWidth();
-      long leftEdge = (long) (binIndex - 1) * binWidth;
+      double leftEdge = rangeMin_ + (binIndex - 1) * binWidthFloat_;
       double binFraction =
              (countBelowQuantile - cumDistrib[binIndex - 1])
                  / (cumDistrib[binIndex] - cumDistrib[binIndex - 1]);
-      return leftEdge + binFraction * binWidth;
+      return leftEdge + binFraction * binWidthFloat_;
    }
 
    private long[] computeCumulativeDistribution() {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
@@ -69,7 +69,7 @@ public final class IntegerComponentStats {
       }
 
       public Builder binWidthFloat(double width) {
-         Preconditions.checkArgument(width > 0.0);
+         Preconditions.checkArgument(width >= 0.0);
          binWidthFloat_ = width;
          return this;
       }
@@ -233,9 +233,12 @@ public final class IntegerComponentStats {
       }
       // For integer images (rangeMin_ == 0 and binWidthFloat_ is a power of 2),
       // the last representable value is binWidth*nBins - 1 (e.g. 255 for 8-bit).
-      // For float images (rangeMin_ or binWidthFloat_ may be fractional), the
-      // histogram covers exactly [rangeMin_, rangeMin_ + binWidthFloat_*nBins],
-      // so the upper bound is ceil(fMax) with no subtraction.
+      // For float images with binWidthFloat_ == 0 (constant image, all pixels identical),
+      // the range collapses to a single point: return ceil(rangeMin_).
+      // For all other float images, the upper bound is ceil(fMax).
+      if (binWidthFloat_ == 0.0) {
+         return (long) Math.ceil(rangeMin_);
+      }
       double rawMax = rangeMin_ + binWidthFloat_ * getHistogramBinCount();
       long ceiled = (long) Math.ceil(rawMax);
       if (rangeMin_ == 0.0 && binWidthFloat_ == (1 << binWidthPowerOf2_)) {
@@ -284,19 +287,21 @@ public final class IntegerComponentStats {
    }
 
    public long getAutoscaleMinForQuantile(double q) {
+      long rangeMin = getHistogramRangeMin();
       if (q >= 0.5) {
          // Safe, in-range value that is less than max
-         return Math.round(getQuantile(0.5)) - 1L;
+         return Math.max(rangeMin, Math.round(getQuantile(0.5)) - 1L);
       }
-      return Math.round(getQuantile(q));
+      return Math.max(rangeMin, Math.round(getQuantile(q)));
    }
 
    public long getAutoscaleMinForQuantileIgnoringZeros(double q) {
+      long rangeMin = getHistogramRangeMin();
       if (q >= 0.5) {
          // Safe, in-range value that is less than max
-         return Math.round(getQuantileIgnoringZeros(0.5)) - 1L;
+         return Math.max(rangeMin, Math.round(getQuantileIgnoringZeros(0.5)) - 1L);
       }
-      return Math.round(getQuantileIgnoringZeros(q));
+      return Math.max(rangeMin, Math.round(getQuantileIgnoringZeros(q)));
    }
 
    public long getAutoscaleMaxForQuantile(double q) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
@@ -29,6 +29,7 @@ public final class IntegerComponentStats {
    // reproducing the previous behavior exactly.
    private final double rangeMin_;
    private final double binWidthFloat_;
+   private final boolean isFloat_;
    private final long pixelCount_;
    private final long pixelCountExcludingZeros_;
    private final boolean usedROI_;
@@ -44,6 +45,7 @@ public final class IntegerComponentStats {
       private int binWidthPowerOf2_;
       private double rangeMin_ = 0.0;
       private double binWidthFloat_ = -1.0; // sentinel: -1 → use 1 << binWidthPowerOf2_
+      private boolean isFloat_ = false;
       private long pixelCount_;
       private long pixelCountExcludingZeros_;
       private boolean usedROI_;
@@ -71,6 +73,11 @@ public final class IntegerComponentStats {
       public Builder binWidthFloat(double width) {
          Preconditions.checkArgument(width >= 0.0);
          binWidthFloat_ = width;
+         return this;
+      }
+
+      public Builder isFloat(boolean isFloat) {
+         isFloat_ = isFloat;
          return this;
       }
 
@@ -142,6 +149,7 @@ public final class IntegerComponentStats {
       int binWidthPow2 = Integer.numberOfTrailingZeros(a.getHistogramBinWidth());
       return builder()
             .histogram(merged, binWidthPow2)
+            .isFloat(a.isFloat() || b.isFloat())
             .pixelCount(a.getPixelCount() + b.getPixelCount())
             .pixelCountExcludingZeros(
                   a.getPixelCountExcludingZeros()
@@ -173,6 +181,7 @@ public final class IntegerComponentStats {
       binWidthPowerOf2_ = b.binWidthPowerOf2_;
       rangeMin_ = b.rangeMin_;
       binWidthFloat_ = (b.binWidthFloat_ >= 0.0) ? b.binWidthFloat_ : (1 << b.binWidthPowerOf2_);
+      isFloat_ = b.isFloat_;
       pixelCount_ = b.pixelCount_;
       pixelCountExcludingZeros_ = b.pixelCountExcludingZeros_;
       usedROI_ = b.usedROI_;
@@ -227,21 +236,25 @@ public final class IntegerComponentStats {
       return (long) Math.floor(rangeMin_);
    }
 
+   public boolean isFloat() {
+      return isFloat_;
+   }
+
    public long getHistogramRangeMax() {
       if (histogram_ == null) {
          return 0;
       }
-      // For integer images (rangeMin_ == 0 and binWidthFloat_ is a power of 2),
-      // the last representable value is binWidth*nBins - 1 (e.g. 255 for 8-bit).
       // For float images with binWidthFloat_ == 0 (constant image, all pixels identical),
       // the range collapses to a single point: return ceil(rangeMin_).
       // For all other float images, the upper bound is ceil(fMax).
+      // For integer images, the last representable value is
+      // binWidth*nBins - 1 (e.g. 255 for 8-bit).
       if (binWidthFloat_ == 0.0) {
          return (long) Math.ceil(rangeMin_);
       }
       double rawMax = rangeMin_ + binWidthFloat_ * getHistogramBinCount();
       long ceiled = (long) Math.ceil(rawMax);
-      if (rangeMin_ == 0.0 && binWidthFloat_ == (1 << binWidthPowerOf2_)) {
+      if (!isFloat_) {
          // Integer image: last valid sample value is one below the bin-count boundary
          return ceiled - 1;
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/propertymap/NonPropertyMapJSONFormats.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/propertymap/NonPropertyMapJSONFormats.java
@@ -246,7 +246,10 @@ public abstract class NonPropertyMapJSONFormats {
             try {
                key.storeInGsonObject(pmap, jo);
             } catch (NullPointerException npe) {
-               MMStudio.getInstance().logs().logError("Null Pointer for Key: " + key);
+               MMStudio studio = MMStudio.getInstance();
+               if (studio != null) {
+                  studio.logs().logError("Null Pointer for Key: " + key);
+               }
             }
          }
       }

--- a/mmstudio/src/test/java/org/micromanager/data/internal/Gray32ImageTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/Gray32ImageTest.java
@@ -7,7 +7,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;

--- a/mmstudio/src/test/java/org/micromanager/data/internal/Gray32ImageTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/Gray32ImageTest.java
@@ -1,0 +1,455 @@
+package org.micromanager.data.internal;
+
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+import org.micromanager.data.Coords;
+import org.micromanager.data.Image;
+import org.micromanager.data.Metadata;
+import org.micromanager.data.internal.multipagetiff.StorageMultipageTiff;
+import org.micromanager.display.internal.imagestats.BoundsRectAndMask;
+import org.micromanager.display.internal.imagestats.ImageStats;
+import org.micromanager.display.internal.imagestats.ImageStatsProcessor;
+import org.micromanager.display.internal.imagestats.ImageStatsRequest;
+import org.micromanager.display.internal.imagestats.ImagesAndStats;
+
+/**
+ * Tests for GRAY32 (32-bit float) image support.
+ * All tests in this class should FAIL before the GRAY32 implementation
+ * and PASS after it.
+ */
+public class Gray32ImageTest {
+
+   // ------------------------------------------------------------------
+   // PixelType enum tests
+   // ------------------------------------------------------------------
+
+   @Test
+   public void testPixelTypeValueFor() {
+      PixelType pt = PixelType.valueFor(4, 4, 1);
+      Assert.assertEquals(PixelType.GRAY32, pt);
+   }
+
+   @Test
+   public void testPixelTypeValueOfImageJConstant() {
+      // ImagePlus.GRAY32 == 2
+      PixelType pt = PixelType.valueOfImageJConstant(2);
+      Assert.assertEquals(PixelType.GRAY32, pt);
+   }
+
+   @Test
+   public void testPixelTypeImageJConstant() {
+      Assert.assertEquals(2, PixelType.GRAY32.imageJConstant());
+   }
+
+   @Test
+   public void testPixelTypeDimensions() {
+      Assert.assertEquals(4, PixelType.GRAY32.getBytesPerPixel());
+      Assert.assertEquals(4, PixelType.GRAY32.getBytesPerComponent());
+      Assert.assertEquals(1, PixelType.GRAY32.getNumberOfComponents());
+   }
+
+   // ------------------------------------------------------------------
+   // DefaultImage construction tests
+   // ------------------------------------------------------------------
+
+   private static float[] makeTestPixels(int w, int h) {
+      float[] px = new float[w * h];
+      // Known values including negative, fractional, zero, and large
+      px[0] = -1.5f;
+      px[1] = 0.001f;
+      px[2] = 0.0f;
+      px[3] = 1000000.0f;
+      px[4] = Float.MAX_VALUE / 2;
+      // Fill rest with pattern
+      for (int i = 5; i < px.length; i++) {
+         px[i] = i * 0.5f;
+      }
+      return px;
+   }
+
+   private static DefaultImage makeFloatImage(int w, int h) {
+      float[] px = makeTestPixels(w, h);
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      return new DefaultImage(px, w, h, 4, 1, coords, metadata);
+   }
+
+   @Test
+   public void testFloatImageConstruction() {
+      // Should not throw
+      DefaultImage img = makeFloatImage(16, 16);
+      Assert.assertNotNull(img);
+   }
+
+   @Test
+   public void testFloatImageGetRawPixelsReturnsFloatArray() {
+      DefaultImage img = makeFloatImage(16, 16);
+      Object pixels = img.getRawPixels();
+      Assert.assertTrue("getRawPixels() should return float[]",
+            pixels instanceof float[]);
+   }
+
+   @Test
+   public void testFloatImageDimensions() {
+      DefaultImage img = makeFloatImage(16, 24);
+      Assert.assertEquals(16, img.getWidth());
+      Assert.assertEquals(24, img.getHeight());
+      Assert.assertEquals(4, img.getBytesPerPixel());
+      Assert.assertEquals(1, img.getNumComponents());
+   }
+
+   @Test
+   public void testFloatImagePixelType() {
+      DefaultImage img = makeFloatImage(16, 16);
+      Assert.assertEquals(PixelType.GRAY32, img.getPixelType());
+   }
+
+   // ------------------------------------------------------------------
+   // Pixel access tests
+   // ------------------------------------------------------------------
+
+   @Test
+   public void testFloatImageGetComponentIntensityAt() {
+      int w = 8, h = 8;
+      float[] px = new float[w * h];
+      px[0] = 42.9f;
+      px[1] = -7.3f;
+      px[w + 3] = 100.0f;
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      DefaultImage img = new DefaultImage(px, w, h, 4, 1, coords, metadata);
+
+      // getComponentIntensityAt returns (long) cast of float value
+      Assert.assertEquals((long) 42.9f, img.getComponentIntensityAt(0, 0, 0));
+      Assert.assertEquals((long) (-7.3f), img.getComponentIntensityAt(1, 0, 0));
+      Assert.assertEquals((long) 100.0f, img.getComponentIntensityAt(3, 1, 0));
+   }
+
+   @Test
+   public void testFloatImageGetIntensityStringContainsDecimalPoint() {
+      int w = 4, h = 4;
+      float[] px = new float[w * h];
+      px[0] = 3.14f;
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      DefaultImage img = new DefaultImage(px, w, h, 4, 1, coords, metadata);
+
+      String s = img.getIntensityStringAt(0, 0);
+      Assert.assertTrue("Intensity string for float image should contain decimal point, got: " + s,
+            s.contains("."));
+   }
+
+   // ------------------------------------------------------------------
+   // Copy tests
+   // ------------------------------------------------------------------
+
+   @Test
+   public void testFloatImageGetRawPixelsCopyReturnsFloatArray() {
+      DefaultImage img = makeFloatImage(8, 8);
+      Object copy = img.getRawPixelsCopy();
+      Assert.assertTrue("getRawPixelsCopy() should return float[]",
+            copy instanceof float[]);
+   }
+
+   @Test
+   public void testFloatImageGetRawPixelsCopyIsIndependent() {
+      float[] original = makeTestPixels(8, 8);
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      DefaultImage img = new DefaultImage(original, 8, 8, 4, 1, coords, metadata);
+
+      float[] copy = (float[]) img.getRawPixelsCopy();
+      Assert.assertNotSame("Copy should be a different array", original, copy);
+      Assert.assertArrayEquals("Copy should have same values", original, copy, 0.0f);
+   }
+
+   // ------------------------------------------------------------------
+   // TIFF round-trip tests
+   // ------------------------------------------------------------------
+
+   @Test
+   public void testFloatImageTiffRoundTrip() throws Exception {
+      int w = 512, h = 512;
+      float[] original = makeTestPixels(w, h);
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      Image image = new DefaultImage(original, w, h, 4, 1, coords, metadata);
+
+      File tempDir = Files.createTempDir();
+      String path = tempDir.getPath() + "/float_test";
+
+      // Write
+      DefaultDatastore writeStore = new DefaultDatastore(null);
+      StorageMultipageTiff writeStorage = new StorageMultipageTiff(
+            null, writeStore, path, true, false, false);
+      writeStore.setStorage(writeStorage);
+      writeStore.setSummaryMetadata(new DefaultSummaryMetadata.Builder().build());
+      writeStore.putImage(image);
+      writeStore.freeze();
+      writeStorage.close();
+
+      // Read back
+      DefaultDatastore readStore = new DefaultDatastore(null);
+      StorageMultipageTiff readStorage = new StorageMultipageTiff(
+            null, readStore, path, false, false, false);
+
+      Image loadedImage = readStorage.getImage(coords);
+      Assert.assertNotNull("Loaded image should not be null", loadedImage);
+      Assert.assertEquals(4, loadedImage.getBytesPerPixel());
+      Assert.assertEquals(1, loadedImage.getNumComponents());
+
+      Object loadedPixels = loadedImage.getRawPixels();
+      Assert.assertTrue("Loaded pixels should be float[]", loadedPixels instanceof float[]);
+
+      float[] loadedFloats = (float[]) loadedPixels;
+      Assert.assertEquals("Pixel count mismatch", original.length, loadedFloats.length);
+      for (int i = 0; i < original.length; i++) {
+         Assert.assertEquals("Pixel " + i + " mismatch", original[i], loadedFloats[i], 0.0f);
+      }
+
+      readStorage.close();
+   }
+
+   @Test
+   public void testFloatTiffHasSampleFormatTag() throws Exception {
+      int w = 512, h = 512;
+      float[] pixels = new float[w * h];
+      for (int i = 0; i < pixels.length; i++) pixels[i] = i;
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      Image image = new DefaultImage(pixels, w, h, 4, 1, coords, metadata);
+
+      File tempDir = Files.createTempDir();
+      String path = tempDir.getPath() + "/sample_format_test";
+
+      DefaultDatastore writeStore = new DefaultDatastore(null);
+      StorageMultipageTiff writeStorage = new StorageMultipageTiff(
+            null, writeStore, path, true, false, false);
+      writeStore.setStorage(writeStorage);
+      writeStore.setSummaryMetadata(new DefaultSummaryMetadata.Builder().build());
+      writeStore.putImage(image);
+      writeStore.freeze();
+      writeStorage.close();
+
+      // Find the TIFF file and scan for SampleFormat tag (339 = 0x0153)
+      File tiffFile = new File(path + "/NDTiff.tif");
+      if (!tiffFile.exists()) {
+         // Try single-file naming
+         File[] files = new File(path).listFiles(
+               f -> f.getName().endsWith(".tif") || f.getName().endsWith(".tiff"));
+         Assert.assertNotNull("No TIFF files found in " + path, files);
+         Assert.assertTrue("No TIFF files found in " + path, files.length > 0);
+         tiffFile = files[0];
+      }
+
+      boolean foundSampleFormat3 = scanTiffForSampleFormat(tiffFile, 3);
+      Assert.assertTrue("TIFF should contain SampleFormat=3 (IEEE float) tag", foundSampleFormat3);
+   }
+
+   /**
+    * Scan a TIFF file's IFDs looking for SampleFormat tag (339) with a given value.
+    * Returns true if found.
+    */
+   private boolean scanTiffForSampleFormat(File file, int expectedValue) throws IOException {
+      try (FileChannel ch = FileChannel.open(file.toPath(), StandardOpenOption.READ)) {
+         ByteBuffer header = ByteBuffer.allocate(8);
+         ch.read(header, 0);
+         header.rewind();
+
+         // Byte order
+         ByteOrder order;
+         short bom = header.getShort();
+         if (bom == 0x4949) {
+            order = ByteOrder.LITTLE_ENDIAN;
+         } else if (bom == 0x4D4D) {
+            order = ByteOrder.BIG_ENDIAN;
+         } else {
+            return false; // Not a TIFF
+         }
+         header.order(order);
+         header.position(4);
+         long ifdOffset = Integer.toUnsignedLong(header.getInt());
+
+         // Walk IFDs
+         while (ifdOffset != 0 && ifdOffset < ch.size()) {
+            ByteBuffer countBuf = ByteBuffer.allocate(2).order(order);
+            ch.read(countBuf, ifdOffset);
+            countBuf.rewind();
+            int numEntries = Short.toUnsignedInt(countBuf.getShort());
+
+            int entrySize = 12;
+            ByteBuffer entries = ByteBuffer.allocate(numEntries * entrySize).order(order);
+            ch.read(entries, ifdOffset + 2);
+            entries.rewind();
+
+            for (int i = 0; i < numEntries; i++) {
+               int tag = Short.toUnsignedInt(entries.getShort());
+               int type = Short.toUnsignedInt(entries.getShort());
+               int count = entries.getInt();
+               int valueOrOffset = entries.getInt();
+
+               // SampleFormat tag = 339 (0x0153); type 3 = SHORT
+               if (tag == 339 && type == 3 && count == 1) {
+                  // For SHORT type with count=1, value is left-justified in the 4-byte field
+                  int value = (order == ByteOrder.LITTLE_ENDIAN)
+                        ? (valueOrOffset & 0xFFFF)
+                        : (valueOrOffset >>> 16);
+                  if (value == expectedValue) {
+                     return true;
+                  }
+               }
+            }
+
+            // Read next IFD offset
+            ByteBuffer nextBuf = ByteBuffer.allocate(4).order(order);
+            ch.read(nextBuf, ifdOffset + 2 + numEntries * entrySize);
+            nextBuf.rewind();
+            ifdOffset = Integer.toUnsignedLong(nextBuf.getInt());
+         }
+      }
+      return false;
+   }
+
+   // ------------------------------------------------------------------
+   // ImageStats tests
+   // ------------------------------------------------------------------
+
+   @Test
+   public void testFloatImageStatsNonNull() throws Exception {
+      int w = 8, h = 8;
+      float[] pixels = new float[w * h];
+      for (int i = 0; i < pixels.length; i++) pixels[i] = i * 10.5f;
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      Image image = new DefaultImage(pixels, w, h, 4, 1, coords, metadata);
+
+      ImageStatsProcessor processor = ImageStatsProcessor.create();
+      try {
+         ImageStatsRequest request = ImageStatsRequest.create(
+               coords,
+               Collections.singletonList(image),
+               BoundsRectAndMask.unselected());
+         ImagesAndStats result = processor.process(1L, request, false);
+         Assert.assertNotNull("process() should return non-null", result);
+         ImageStats stats = result.getResult().get(0);
+         Assert.assertNotNull("ImageStats should not be null for float image", stats);
+         Assert.assertTrue("Pixel count should be > 0",
+               stats.getComponentStats(0).getPixelCount() > 0);
+         Assert.assertEquals("Should have 1 component", 1, stats.getNumberOfComponents());
+      } finally {
+         processor.shutdown();
+      }
+   }
+
+   @Test
+   public void testFloatImageStatsExcludesNaN() throws Exception {
+      int w = 4, h = 4;
+      float[] pixels = new float[w * h];
+      int nanCount = 0;
+      for (int i = 0; i < pixels.length; i++) {
+         if (i % 4 == 0) {
+            pixels[i] = Float.NaN;
+            nanCount++;
+         } else {
+            pixels[i] = i * 1.0f;
+         }
+      }
+      int expectedCount = pixels.length - nanCount;
+
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      Image image = new DefaultImage(pixels, w, h, 4, 1, coords, metadata);
+
+      ImageStatsProcessor processor = ImageStatsProcessor.create();
+      try {
+         ImageStatsRequest request = ImageStatsRequest.create(
+               coords,
+               Collections.singletonList(image),
+               BoundsRectAndMask.unselected());
+         ImagesAndStats result = processor.process(1L, request, false);
+         ImageStats stats = result.getResult().get(0);
+         Assert.assertNotNull(stats);
+         Assert.assertEquals("NaN pixels should be excluded from count",
+               expectedCount, stats.getComponentStats(0).getPixelCount());
+      } finally {
+         processor.shutdown();
+      }
+   }
+
+   // ------------------------------------------------------------------
+   // Regression: existing pixel types still work
+   // ------------------------------------------------------------------
+
+   @Test
+   public void testGray8TiffRoundTrip() throws Exception {
+      byte[] px = new byte[512 * 512];
+      for (int i = 0; i < px.length; i++) px[i] = (byte) i;
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      Image image = new DefaultImage(px, 512, 512, 1, 1, coords, metadata);
+      try {
+         File tempDir = Files.createTempDir();
+         String path = tempDir.getPath() + "/g8";
+         DefaultDatastore writeStore = new DefaultDatastore(null);
+         StorageMultipageTiff writeStorage = new StorageMultipageTiff(
+               null, writeStore, path, true, false, false);
+         writeStore.setStorage(writeStorage);
+         writeStore.setSummaryMetadata(new DefaultSummaryMetadata.Builder().build());
+         writeStore.putImage(image);
+         writeStore.freeze();
+         writeStorage.close();
+
+         DefaultDatastore readStore = new DefaultDatastore(null);
+         StorageMultipageTiff readStorage = new StorageMultipageTiff(
+               null, readStore, path, false, false, false);
+         Image loadedImg = readStorage.getImage(coords);
+         Assert.assertNotNull(loadedImg);
+         Assert.assertEquals(1, loadedImg.getBytesPerPixel());
+         Assert.assertArrayEquals(px, (byte[]) loadedImg.getRawPixels());
+         readStorage.close();
+      } catch (Exception e) {
+         Assert.fail("GRAY8 TIFF round-trip failed: " + e);
+      }
+   }
+
+   @Test
+   public void testGray16TiffRoundTrip() throws Exception {
+      short[] px = new short[512 * 512];
+      for (int i = 0; i < px.length; i++) px[i] = (short) (i * 100);
+      Coords coords = new DefaultCoords.Builder().build();
+      Metadata metadata = new DefaultMetadata.Builder().build();
+      Image image = new DefaultImage(px, 512, 512, 2, 1, coords, metadata);
+      try {
+         File tempDir = Files.createTempDir();
+         String path = tempDir.getPath() + "/g16";
+         DefaultDatastore writeStore = new DefaultDatastore(null);
+         StorageMultipageTiff writeStorage = new StorageMultipageTiff(
+               null, writeStore, path, true, false, false);
+         writeStore.setStorage(writeStorage);
+         writeStore.setSummaryMetadata(new DefaultSummaryMetadata.Builder().build());
+         writeStore.putImage(image);
+         writeStore.freeze();
+         writeStorage.close();
+
+         DefaultDatastore readStore = new DefaultDatastore(null);
+         StorageMultipageTiff readStorage = new StorageMultipageTiff(
+               null, readStore, path, false, false, false);
+         Image loadedImg = readStorage.getImage(coords);
+         Assert.assertNotNull(loadedImg);
+         Assert.assertEquals(2, loadedImg.getBytesPerPixel());
+         Assert.assertArrayEquals(px, (short[]) loadedImg.getRawPixels());
+         readStorage.close();
+      } catch (Exception e) {
+         Assert.fail("GRAY16 TIFF round-trip failed: " + e);
+      }
+   }
+}

--- a/mmstudio/src/test/java/org/micromanager/data/internal/HelperImageInfo.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/HelperImageInfo.java
@@ -84,7 +84,7 @@ public class HelperImageInfo {
          Assert.assertEquals(metadata_.getBinning(), metadata.getBinning());
          Assert.assertEquals(metadata_.getBitDepth(), metadata.getBitDepth());
          Assert.assertEquals(metadata_.getCamera(), metadata.getCamera());
-         Assert.assertEquals(metadata_.getElapsedTimeMs(0.0), metadata.getElapsedTimeMs(0.0));
+         Assert.assertEquals(metadata_.getElapsedTimeMs(0.0), metadata.getElapsedTimeMs(0.0), 0.1);
          Assert.assertEquals(metadata_.getExposureMs(), metadata.getExposureMs());
          // Assert.assertEquals(metadata_.getIjType(), metadata.getIjType());
          Assert.assertEquals(metadata_.getImageNumber(), metadata.getImageNumber());

--- a/mmstudio/src/test/java/org/micromanager/data/internal/HelperImageInfo.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/HelperImageInfo.java
@@ -69,6 +69,22 @@ public class HelperImageInfo {
          }
          return result;
       }
+      else if (pixelsArr instanceof float[]) {
+         int result = 0;
+         float[] pixels = (float[]) pixelsArr;
+         for (int i = 0; i < pixels.length; ++i) {
+            result = result * 23 + Float.floatToRawIntBits(pixels[i]);
+         }
+         return result;
+      }
+      else if (pixelsArr instanceof int[]) {
+         int result = 0;
+         int[] pixels = (int[]) pixelsArr;
+         for (int i = 0; i < pixels.length; ++i) {
+            result = result * 23 + pixels[i];
+         }
+         return result;
+      }
       else {
          Assert.fail("Unrecognized pixel type");
          return 0;

--- a/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
@@ -59,15 +59,15 @@ public class ManualTiffTest {
     * Path for one of the file sets we use. This is a manually-created (i.e.
     * not using MDA) singleplane TIFF acquisition.
     */
-   private static final String ALPHA2_PATH = System.getProperty("user.dir") + "/src/test/resources/org/micromanager/data/internal/alpha_2.0_singleplane_manual";
+   private static final String ALPHA2_PATH = System.getProperty("user.dir") + "\\src\\test\\resources\\org\\micromanager\\data\\internal\\alpha_2.0_singleplane_manual";
 
    private static final String COMMENT_KEY = "comment";
    private static final String IMAGE_COMMENT = "This is an image comment";
    private static final String SUMMARY_COMMENT = "This is a summary comment";
 
    static {
-      SUMMARIES = new HashMap<String, SummaryMetadata>();
-      IMAGES = new HashMap<String, ArrayList<HelperImageInfo>>();
+      SUMMARIES = new HashMap<>();
+      IMAGES = new HashMap<>();
 
       DefaultSummaryMetadata.Builder summary = new DefaultSummaryMetadata.Builder();
       summary.prefix("thisIsAPrefix")
@@ -80,8 +80,8 @@ public class ManualTiffTest {
          .channelNames(new String[] {"Alpha", "Beta", "Romeo"})
          .zStepUm(123456789.012345).waitInterval(-1234.5678)
          .customIntervalsMs(new Double[] {12.34, 56.78})
-         .axisOrder(new String[] {"axis 5", "axis 3", "axis 97"})
-         .intendedDimensions((new DefaultCoords.Builder()).index("axis 5", 2).index("axis 3", 9).index("axis 97", 8).build())
+         .axisOrder(new String[] {"axis5", "axis3", "axis97"})
+         .intendedDimensions((new DefaultCoords.Builder()).index("axis5", 2).index("axis3", 9).index("axis97", 8).build())
          .startDate("The age of Aquarius")
          .stagePositions(new MultiStagePosition[] {
             new MultiStagePosition("some xy stage", 24.3, 43.2, "some z stage", 1.01),
@@ -183,24 +183,18 @@ public class ManualTiffTest {
    // Tests proper loading of a stored singleplane TIFF file.
    @Test
    public void testSinglePlaneTIFFLoad() {
-      DefaultDataManager manager = new DefaultDataManager(MMStudio.getInstance());
-      for (String path : SUMMARIES.keySet()) {
-         try {
-            Datastore data = manager.loadData(path, true);
-            testSummary(path, data.getSummaryMetadata());
-            testImages(path, data);
-         }
-         catch (IOException e) {
-            Assert.fail("Unable to load required data file " + path);
-         }
-      }
+      testTIFFSaveLoad(Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES);
+   }
+
+   @Test
+   public void testMultipageTIFFSaveLoad() {
+      testTIFFSaveLoad(Datastore.SaveMode.MULTIPAGE_TIFF);
    }
 
    // Creates a new multipage TIFF, saves it, loads it, and verifies the
    // results are as expected. For convenience, re-uses the summary metadata
    // and image metadata used by the testSinglePlaneTIFFLoad() method.
-   @Test
-   public void testMultipageTIFFSaveLoad() {
+   public void testTIFFSaveLoad(Datastore.SaveMode saveMode) {
       DefaultDataManager manager = new DefaultDataManager(MMStudio.getInstance());
       Datastore store = manager.createRAMDatastore();
       // Manufacture an Image.
@@ -219,9 +213,10 @@ public class ManualTiffTest {
       HelperImageInfo info = new HelperImageInfo(builder.build(), metadata,
             HelperImageInfo.hashPixels(image));
       try {
-         store.putImage(image);
+         // need to set SummaryMetadata before inserting images
          SummaryMetadata summary = SUMMARIES.get(ALPHA2_PATH);
          store.setSummaryMetadata(summary);
+         store.putImage(image);
       }
       catch (DatastoreFrozenException e) {
          Assert.fail("Unable to add images or set summary metadata: " + e);
@@ -246,8 +241,8 @@ public class ManualTiffTest {
       File tempDir = Files.createTempDir();
       String path = tempDir.getPath() + "/test";
       try {
-      store.save(Datastore.SaveMode.MULTIPAGE_TIFF, path);
-      store.setSavePath(path);
+         store.save(saveMode, path);
+         store.setSavePath(path);
       } catch (IOException io) {
          Assert.fail("IOException while saving store " + io);
       }
@@ -257,10 +252,12 @@ public class ManualTiffTest {
          Datastore loadedStore = manager.loadData(path, true);
          testSummary(ALPHA2_PATH, loadedStore.getSummaryMetadata());
          info.test(loadedStore);
-         //testComments(loadedStore);
+         loadedStore.freeze();
+         loadedStore.close();
       }
       catch (IOException e) {
          Assert.fail("Unable to load newly-generated datastore: " + e);
       }
+      tempDir.deleteOnExit();
    }
 }

--- a/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
@@ -194,6 +194,150 @@ public class ManualTiffTest {
       testTIFFSaveLoad(Datastore.SaveMode.MULTIPAGE_TIFF);
    }
 
+   @Test
+   public void testSinglePlaneTIFFSaveLoadByte() {
+      testTIFFSaveLoadPixelType(Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES, PixelTypeCase.GRAY8);
+   }
+
+   @Test
+   public void testMultipageTIFFSaveLoadByte() {
+      testTIFFSaveLoadPixelType(Datastore.SaveMode.MULTIPAGE_TIFF, PixelTypeCase.GRAY8);
+   }
+
+   @Test
+   public void testSinglePlaneTIFFSaveLoadShort() {
+      testTIFFSaveLoadPixelType(Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES, PixelTypeCase.GRAY16);
+   }
+
+   @Test
+   public void testMultipageTIFFSaveLoadShort() {
+      testTIFFSaveLoadPixelType(Datastore.SaveMode.MULTIPAGE_TIFF, PixelTypeCase.GRAY16);
+   }
+
+   @Test
+   public void testSinglePlaneTIFFSaveLoadFloat() {
+      testTIFFSaveLoadPixelType(Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES, PixelTypeCase.GRAY32);
+   }
+
+   @Test
+   public void testMultipageTIFFSaveLoadFloat() {
+      testTIFFSaveLoadPixelType(Datastore.SaveMode.MULTIPAGE_TIFF, PixelTypeCase.GRAY32);
+   }
+
+   @Test
+   public void testSinglePlaneTIFFSaveLoadRGB() {
+      testTIFFSaveLoadPixelType(Datastore.SaveMode.SINGLEPLANE_TIFF_SERIES, PixelTypeCase.RGB32);
+   }
+
+   @Test
+   public void testMultipageTIFFSaveLoadRGB() {
+      testTIFFSaveLoadPixelType(Datastore.SaveMode.MULTIPAGE_TIFF, PixelTypeCase.RGB32);
+   }
+
+   private enum PixelTypeCase {
+      GRAY8, GRAY16, GRAY32, RGB32
+   }
+
+   private Image makeTestImage(PixelTypeCase type, Coords coords, Metadata metadata) {
+      final int width = 24;
+      final int height = 16;
+      switch (type) {
+         case GRAY8: {
+            byte[] pixels = new byte[width * height];
+            for (int i = 0; i < height; ++i) {
+               for (int j = 0; j < width; ++j) {
+                  pixels[i * width + j] = (byte) (i * 10 + j);
+               }
+            }
+            return new DefaultImage(pixels, width, height, 1, 1, coords, metadata);
+         }
+         case GRAY16: {
+            short[] pixels = new short[width * height];
+            for (int i = 0; i < height; ++i) {
+               for (int j = 0; j < width; ++j) {
+                  pixels[i * width + j] = (short) (i * 100 + j);
+               }
+            }
+            return new DefaultImage(pixels, width, height, 2, 1, coords, metadata);
+         }
+         case GRAY32: {
+            float[] pixels = new float[width * height];
+            for (int i = 0; i < height; ++i) {
+               for (int j = 0; j < width; ++j) {
+                  pixels[i * width + j] = (i - height / 2) * 10.5f + j * 0.1f;
+               }
+            }
+            return new DefaultImage(pixels, width, height, 4, 1, coords, metadata);
+         }
+         case RGB32: {
+            int[] pixels = new int[width * height];
+            for (int i = 0; i < height; ++i) {
+               for (int j = 0; j < width; ++j) {
+                  int r = (i * 5) & 0xFF;
+                  int g = (j * 7) & 0xFF;
+                  int b = ((i + j) * 3) & 0xFF;
+                  pixels[i * width + j] = (r << 16) | (g << 8) | b;
+               }
+            }
+            return new DefaultImage(pixels, width, height, 4, 3, coords, metadata);
+         }
+         default:
+            throw new IllegalArgumentException("Unknown pixel type: " + type);
+      }
+   }
+
+   private Metadata metadataForPixelType(PixelTypeCase type) {
+      Metadata.Builder base = IMAGES.get(ALPHA2_PATH).get(0).getMetadata().copyBuilderWithNewUUID();
+      switch (type) {
+         case GRAY8:  return base.bitDepth(8).build();
+         case GRAY16: return base.bitDepth(16).build();
+         case GRAY32: return base.bitDepth(32).build();
+         case RGB32:  return base.bitDepth(8).build();
+         default:     return base.build();
+      }
+   }
+
+   private void testTIFFSaveLoadPixelType(Datastore.SaveMode saveMode, PixelTypeCase type) {
+      DefaultDataManager manager = new DefaultDataManager(MMStudio.getInstance());
+      Coords coords = manager.getCoordsBuilder().z(0).time(0).channel(0).stagePosition(0).build();
+      Metadata metadata = metadataForPixelType(type);
+      Image image = makeTestImage(type, coords, metadata);
+      HelperImageInfo info = new HelperImageInfo(coords, metadata,
+            HelperImageInfo.hashPixels(image));
+
+      Datastore store = manager.createRAMDatastore();
+      try {
+         store.setSummaryMetadata(SUMMARIES.get(ALPHA2_PATH));
+         store.putImage(image);
+      } catch (DatastoreFrozenException e) {
+         Assert.fail("Unable to add images or set summary metadata: " + e);
+      } catch (DatastoreRewriteException e) {
+         Assert.fail("Unable to add images or set summary metadata: " + e);
+      } catch (IOException io) {
+         Assert.fail("IOException while adding image to store " + io);
+      }
+
+      File tempDir = Files.createTempDir();
+      String path = tempDir.getPath() + "/test";
+      try {
+         store.save(saveMode, path);
+         store.setSavePath(path);
+      } catch (Exception e) {
+         Assert.fail("IOException while saving store: " + e);
+      }
+
+      System.out.println("Loading " + type + " data from " + path);
+      try {
+         Datastore loadedStore = manager.loadData(path, true);
+         info.test(loadedStore);
+         loadedStore.freeze();
+         loadedStore.close();
+      } catch (IOException e) {
+         Assert.fail("Unable to load " + type + " datastore: " + e);
+      }
+      tempDir.deleteOnExit();
+   }
+
    // Creates a new multipage TIFF, saves it, loads it, and verifies the
    // results are as expected. For convenience, re-uses the summary metadata
    // and image metadata used by the testSinglePlaneTIFFLoad() method.

--- a/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
@@ -279,7 +279,7 @@ public class ManualTiffTest {
                   pixels[i * width + j] = (r << 16) | (g << 8) | b;
                }
             }
-            return new DefaultImage(pixels, width, height, 4, 3, coords, metadata);
+            return new DefaultImage(BufferTools.rgb32IntToBytes(pixels), width, height, 4, 3, coords, metadata);
          }
          default:
             throw new IllegalArgumentException("Unknown pixel type: " + type);
@@ -326,8 +326,12 @@ public class ManualTiffTest {
             Assert.fail("IOException while saving store: " + e);
          }
       } finally {
-         store.freeze();
-         store.close();
+         try {
+            store.freeze();
+            store.close();
+         } catch (IOException e) {
+            Assert.fail("IOException while closing store: " + e);
+         }
       }
 
       System.out.println("Loading " + type + " data from " + path);
@@ -389,8 +393,16 @@ public class ManualTiffTest {
       } catch (IOException io) {
          Assert.fail("IOException while saving store " + io);
       } finally {
-         store.freeze();
-         store.close();
+         try {
+            store.freeze();
+         } catch (IOException e) {
+            Assert.fail("IOException while freezing store: " + e);
+         }
+         try {
+            store.close();
+         } catch (IOException e) {
+            Assert.fail("IOException while closing store: " + e);
+         }
       }
 
       System.out.println("Loading data from " + path);

--- a/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
@@ -59,7 +59,10 @@ public class ManualTiffTest {
     * Path for one of the file sets we use. This is a manually-created (i.e.
     * not using MDA) singleplane TIFF acquisition.
     */
-   private static final String ALPHA2_PATH = System.getProperty("user.dir") + "\\src\\test\\resources\\org\\micromanager\\data\\internal\\alpha_2.0_singleplane_manual";
+   private static final String ALPHA2_PATH = java.nio.file.Paths.get(
+         System.getProperty("user.dir"),
+         "src", "test", "resources", "org", "micromanager", "data", "internal",
+         "alpha_2.0_singleplane_manual").toString();
 
    private static final String COMMENT_KEY = "comment";
    private static final String IMAGE_COMMENT = "This is an image comment";

--- a/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
+++ b/mmstudio/src/test/java/org/micromanager/data/internal/ManualTiffTest.java
@@ -305,33 +305,40 @@ public class ManualTiffTest {
       HelperImageInfo info = new HelperImageInfo(coords, metadata,
             HelperImageInfo.hashPixels(image));
 
-      Datastore store = manager.createRAMDatastore();
-      try {
-         store.setSummaryMetadata(SUMMARIES.get(ALPHA2_PATH));
-         store.putImage(image);
-      } catch (DatastoreFrozenException e) {
-         Assert.fail("Unable to add images or set summary metadata: " + e);
-      } catch (DatastoreRewriteException e) {
-         Assert.fail("Unable to add images or set summary metadata: " + e);
-      } catch (IOException io) {
-         Assert.fail("IOException while adding image to store " + io);
-      }
-
       File tempDir = Files.createTempDir();
       String path = tempDir.getPath() + "/test";
+      Datastore store = manager.createRAMDatastore();
       try {
-         store.save(saveMode, path);
-         store.setSavePath(path);
-      } catch (Exception e) {
-         Assert.fail("IOException while saving store: " + e);
+         try {
+            store.setSummaryMetadata(SUMMARIES.get(ALPHA2_PATH));
+            store.putImage(image);
+         } catch (DatastoreFrozenException e) {
+            Assert.fail("Unable to add images or set summary metadata: " + e);
+         } catch (DatastoreRewriteException e) {
+            Assert.fail("Unable to add images or set summary metadata: " + e);
+         } catch (IOException io) {
+            Assert.fail("IOException while adding image to store " + io);
+         }
+         try {
+            store.save(saveMode, path);
+            store.setSavePath(path);
+         } catch (Exception e) {
+            Assert.fail("IOException while saving store: " + e);
+         }
+      } finally {
+         store.freeze();
+         store.close();
       }
 
       System.out.println("Loading " + type + " data from " + path);
       try {
          Datastore loadedStore = manager.loadData(path, true);
-         info.test(loadedStore);
-         loadedStore.freeze();
-         loadedStore.close();
+         try {
+            info.test(loadedStore);
+         } finally {
+            loadedStore.freeze();
+            loadedStore.close();
+         }
       } catch (IOException e) {
          Assert.fail("Unable to load " + type + " datastore: " + e);
       }
@@ -374,17 +381,6 @@ public class ManualTiffTest {
       catch (IOException io) {
          Assert.fail("IOException while adding image to store " + io);
       }
-      //try {
-         //Annotation annotation = store.loadAnnotation("comments.txt");
-         PropertyMap.PropertyMapBuilder commentsBuilder = manager.getPropertyMapBuilder();
-         //annotation.setImageAnnotation(image.getCoords(),
-         //      commentsBuilder.putString(COMMENT_KEY, IMAGE_COMMENT).build());
-         //annotation.setGeneralAnnotation(commentsBuilder.putString(COMMENT_KEY,
-         //         SUMMARY_COMMENT).build());
-      //}
-      //catch (IOException e) {
-      //   Assert.fail("Couldn't create comments annotation: " + e);
-      //}
       File tempDir = Files.createTempDir();
       String path = tempDir.getPath() + "/test";
       try {
@@ -392,17 +388,22 @@ public class ManualTiffTest {
          store.setSavePath(path);
       } catch (IOException io) {
          Assert.fail("IOException while saving store " + io);
+      } finally {
+         store.freeze();
+         store.close();
       }
 
       System.out.println("Loading data from " + path);
       try {
          Datastore loadedStore = manager.loadData(path, true);
-         testSummary(ALPHA2_PATH, loadedStore.getSummaryMetadata());
-         info.test(loadedStore);
-         loadedStore.freeze();
-         loadedStore.close();
-      }
-      catch (IOException e) {
+         try {
+            testSummary(ALPHA2_PATH, loadedStore.getSummaryMetadata());
+            info.test(loadedStore);
+         } finally {
+            loadedStore.freeze();
+            loadedStore.close();
+         }
+      } catch (IOException e) {
          Assert.fail("Unable to load newly-generated datastore: " + e);
       }
       tempDir.deleteOnExit();


### PR DESCRIPTION
Adds support for 32 bit float images, in the Datastore and DataViewer.  Testing with the demo camera shows correct behavior, including histograms that look correct.  Testing code shows that data are saved and read correctly from the Multipage Tiff datastore, but not from Single plane tiff files (which should be fixable if desired).  

This PR adds end-to-end support for 32-bit float (GRAY32) images across Micro-Manager’s data model, TIFF persistence, and viewer pipeline so 32-bit images can be saved/loaded and inspected in the DataViewer.

Changes:

    Add GRAY32 to PixelType, extend DefaultImage/BufferTools to handle float[] pixels, and update pixel-intensity string handling.
    Update multipage TIFF writer/reader to write/read float pixels and emit TIFF SampleFormat=3 (IEEE float) when appropriate.
    Extend display stats/histogram and pixel-info event handling to support float images; add a new GRAY32 regression test suite.
