### PR TITLE
Full support for RGB images in the Display

### DIFF
--- a/libraries/ExportTiles/src/main/java/org/micromanager/exporttiles/ExportImageExporter.java
+++ b/libraries/ExportTiles/src/main/java/org/micromanager/exporttiles/ExportImageExporter.java
@@ -105,27 +105,6 @@ public class ExportImageExporter {
 
       for (int c = 0; c < numChannels; c++) {
          String chName = channelNames.get(c);
-         String displayKey = (chName != null) ? chName : "NO_CHANNEL_PRESENT";
-         int color = 0xFFFFFF;
-         int cMin  = 0;
-         int cMax  = 65535;
-         if (displaySettings_ != null) {
-            try {
-               JSONObject chSettings = displaySettings_.optJSONObject(displayKey);
-               if (chSettings != null) {
-                  color = chSettings.optInt("Color", 0xFFFFFF) & 0xFFFFFF;
-                  cMin  = chSettings.optInt("Min", 0);
-                  cMax  = chSettings.optInt("Max", 65535);
-               }
-            } catch (Exception e) {
-               // use defaults
-            }
-         }
-         float range = Math.max(1, cMax - cMin);
-
-         float chR = ((color >> 16) & 0xFF) / 255f;
-         float chG = ((color >>  8) & 0xFF) / 255f;
-         float chB = (color         & 0xFF) / 255f;
 
          HashMap<String, Object> axes = new HashMap<>(baseAxes);
          if (chName != null) {
@@ -136,13 +115,60 @@ public class ExportImageExporter {
             continue;
          }
 
-         short[] pixels = (short[]) img.pix;
-         for (int i = 0; i < pixels.length; i++) {
-            float norm = Math.min(1f, Math.max(0f,
-                    ((pixels[i] & 0xFFFF) - cMin) / range));
-            rAcc[i] += norm * chR;
-            gAcc[i] += norm * chG;
-            bAcc[i] += norm * chB;
+         if (img.pix instanceof byte[]) {
+            // RGB32: BGRA byte[] layout — apply per-channel contrast (cMin/cMax in [0,255]).
+            String displayKey = (chName != null) ? chName : "NO_CHANNEL_PRESENT";
+            int cMin = 0;
+            int cMax = 255;
+            if (displaySettings_ != null) {
+               try {
+                  JSONObject chSettings = displaySettings_.optJSONObject(displayKey);
+                  if (chSettings != null) {
+                     cMin = chSettings.optInt("Min", 0);
+                     cMax = chSettings.optInt("Max", 255);
+                  }
+               } catch (Exception e) {
+                  // use defaults
+               }
+            }
+            final float rgb32Min = Math.min(255f, Math.max(0f, cMin));
+            final float rgb32Range = Math.max(1f, Math.min(255f, cMax) - rgb32Min);
+            byte[] bytes = (byte[]) img.pix;
+            for (int i = 0; i < dsW * dsH; i++) {
+               rAcc[i] += Math.min(1f, Math.max(0f, ((bytes[4 * i + 2] & 0xFF) - rgb32Min) / rgb32Range));
+               gAcc[i] += Math.min(1f, Math.max(0f, ((bytes[4 * i + 1] & 0xFF) - rgb32Min) / rgb32Range));
+               bAcc[i] += Math.min(1f, Math.max(0f, ((bytes[4 * i    ] & 0xFF) - rgb32Min) / rgb32Range));
+            }
+         } else {
+            String displayKey = (chName != null) ? chName : "NO_CHANNEL_PRESENT";
+            int color = 0xFFFFFF;
+            int cMin  = 0;
+            int cMax  = 65535;
+            if (displaySettings_ != null) {
+               try {
+                  JSONObject chSettings = displaySettings_.optJSONObject(displayKey);
+                  if (chSettings != null) {
+                     color = chSettings.optInt("Color", 0xFFFFFF) & 0xFFFFFF;
+                     cMin  = chSettings.optInt("Min", 0);
+                     cMax  = chSettings.optInt("Max", 65535);
+                  }
+               } catch (Exception e) {
+                  // use defaults
+               }
+            }
+            float range = Math.max(1, cMax - cMin);
+            float chR = ((color >> 16) & 0xFF) / 255f;
+            float chG = ((color >>  8) & 0xFF) / 255f;
+            float chB = (color         & 0xFF) / 255f;
+
+            short[] pixels = (short[]) img.pix;
+            for (int i = 0; i < pixels.length; i++) {
+               float norm = Math.min(1f, Math.max(0f,
+                       ((pixels[i] & 0xFFFF) - cMin) / range));
+               rAcc[i] += norm * chR;
+               gAcc[i] += norm * chG;
+               bAcc[i] += norm * chB;
+            }
          }
       }
 

--- a/libraries/ExportTiles/src/main/java/org/micromanager/exporttiles/ExportImageExporter.java
+++ b/libraries/ExportTiles/src/main/java/org/micromanager/exporttiles/ExportImageExporter.java
@@ -135,9 +135,12 @@ public class ExportImageExporter {
             final float rgb32Range = Math.max(1f, Math.min(255f, cMax) - rgb32Min);
             byte[] bytes = (byte[]) img.pix;
             for (int i = 0; i < dsW * dsH; i++) {
-               rAcc[i] += Math.min(1f, Math.max(0f, ((bytes[4 * i + 2] & 0xFF) - rgb32Min) / rgb32Range));
-               gAcc[i] += Math.min(1f, Math.max(0f, ((bytes[4 * i + 1] & 0xFF) - rgb32Min) / rgb32Range));
-               bAcc[i] += Math.min(1f, Math.max(0f, ((bytes[4 * i    ] & 0xFF) - rgb32Min) / rgb32Range));
+               rAcc[i] += Math.min(1f,
+                        Math.max(0f, ((bytes[4 * i + 2] & 0xFF) - rgb32Min) / rgb32Range));
+               gAcc[i] += Math.min(1f,
+                        Math.max(0f, ((bytes[4 * i + 1] & 0xFF) - rgb32Min) / rgb32Range));
+               bAcc[i] += Math.min(1f,
+                        Math.max(0f, ((bytes[4 * i    ] & 0xFF) - rgb32Min) / rgb32Range));
             }
          } else {
             String displayKey = (chName != null) ? chName : "NO_CHANNEL_PRESENT";

--- a/libraries/ExportTiles/src/main/java/org/micromanager/exporttiles/TileBlender.java
+++ b/libraries/ExportTiles/src/main/java/org/micromanager/exporttiles/TileBlender.java
@@ -112,8 +112,13 @@ public class TileBlender {
          if (probe.pix instanceof short[]) {
             nPix = ((short[]) probe.pix).length;
          } else if (probe.pix instanceof byte[]) {
-            // RGB32: 4 bytes per pixel
             int bpp = (probe.tags != null) ? probe.tags.optInt("BytesPerPixel", 1) : 1;
+            String pt = (probe.tags != null) ? probe.tags.optString("PixelType", "") : "";
+            // Treat as RGB32 (4 bytes/pixel) when BytesPerPixel==4, PixelType=="RGB32",
+            // or when BytesPerPixel was not written but PixelType indicates RGB.
+            if (bpp == 1 && "RGB32".equals(pt)) {
+               bpp = 4;
+            }
             nPix = ((byte[]) probe.pix).length / bpp;
          } else {
             continue;
@@ -249,14 +254,24 @@ public class TileBlender {
                      ? taggedImage.tags.optInt("BytesPerPixel", 1) : 1;
                int nc  = (taggedImage.tags != null)
                      ? taggedImage.tags.optInt("NumComponents", 1) : 1;
+               String pixelType = (taggedImage.tags != null)
+                     ? taggedImage.tags.optString("PixelType", "") : "";
                int fullTileW = (taggedImage.tags != null)
                      ? taggedImage.tags.optInt("Width", 0) : 0;
-               if (bpp == 4 && nc == 3) {
-                  // RGB32 (BGRA byte[], 4 bytes per pixel): accumulate R/G/B directly,
-                  // bypassing min/max and channel-color mapping (tile is already colored).
+               int fullTileH = (taggedImage.tags != null)
+                     ? taggedImage.tags.optInt("Height", 0) : 0;
+               boolean isRGB32 = (bpp == 4 && nc == 3) || "RGB32".equals(pixelType)
+                     || (fullTileW > 0 && fullTileH > 0
+                        && tilePix.length == fullTileW * fullTileH * 4);
+               if (isRGB32) {
+                  // RGB32 (BGRA byte[], 4 bytes per pixel): extract R/G/B and apply
+                  // per-channel contrast (cMin/cMax are in [0,255] for 8-bit components).
                   if (fullTileW <= 0) {
                      fullTileW = dsTileW * scale;
                   }
+                  // cMin/cMax from display settings are 16-bit scale; clamp to 8-bit range.
+                  final float rgb32Min = Math.min(255f, Math.max(0f, cMin));
+                  final float rgb32Range = Math.max(1f, Math.min(255f, cMax) - rgb32Min);
                   for (int py = interY0; py < interY1; py++) {
                      for (int px = interX0; px < interX1; px++) {
                         int tx = px - tileOriginX;
@@ -269,9 +284,12 @@ public class TileBlender {
                            continue;
                         }
                         // BGRA layout: byte 0=B, 1=G, 2=R, 3=A
-                        float tB = (tilePix[byteOff]     & 0xFF) / 255f;
-                        float tG = (tilePix[byteOff + 1] & 0xFF) / 255f;
-                        float tR = (tilePix[byteOff + 2] & 0xFF) / 255f;
+                        float tB = Math.min(1f, Math.max(0f,
+                              ((tilePix[byteOff]     & 0xFF) - rgb32Min) / rgb32Range));
+                        float tG = Math.min(1f, Math.max(0f,
+                              ((tilePix[byteOff + 1] & 0xFF) - rgb32Min) / rgb32Range));
+                        float tR = Math.min(1f, Math.max(0f,
+                              ((tilePix[byteOff + 2] & 0xFF) - rgb32Min) / rgb32Range));
                         int outIdx = (py - dsRoiY) * dsRoiW + (px - dsRoiX);
                         rAcc[outIdx] += tR * w;
                         gAcc[outIdx] += tG * w;

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
@@ -4,7 +4,6 @@ import java.awt.Cursor;
 import java.awt.Point;
 import java.awt.Window;
 import java.awt.geom.Point2D;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import javax.swing.JButton;

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelPlugin.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelPlugin.java
@@ -9,8 +9,8 @@ import org.scijava.plugin.Plugin;
 
 @Plugin(type = InspectorPanelPlugin.class,
       priority = Priority.NORMAL - 50.0,
-      name = "NDViewer2 Controls",
-      description = "Zoom, view, and export controls for NDViewer2")
+      name = "Explorer Controls",
+      description = "Zoom, view, and export controls for Explorer/TiledDataViewer")
 public final class TiledDataViewerInspectorPanelPlugin implements InspectorPanelPlugin {
 
    @Override

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataViewer.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataViewer.java
@@ -42,10 +42,10 @@ import org.micromanager.display.internal.event.DefaultDisplayDidShowImageEvent;
 import org.micromanager.display.internal.event.DisplayWindowDidAddOverlayEvent;
 import org.micromanager.display.internal.event.DisplayWindowDidRemoveOverlayEvent;
 import org.micromanager.display.internal.imagestats.BoundsRectAndMask;
+import org.micromanager.display.internal.imagestats.ComponentStats;
 import org.micromanager.display.internal.imagestats.ImageStats;
 import org.micromanager.display.internal.imagestats.ImageStatsRequest;
 import org.micromanager.display.internal.imagestats.ImagesAndStats;
-import org.micromanager.display.internal.imagestats.IntegerComponentStats;
 import org.micromanager.display.internal.imagestats.StatsComputeQueue;
 import org.micromanager.display.overlay.Overlay;
 import org.micromanager.display.overlay.OverlayListener;
@@ -732,9 +732,9 @@ public final class TiledDataViewerDataViewer extends AbstractDataViewer
    private static ImageStats mergeImageStats(ImageStats a, ImageStats b) {
       int nComponents = Math.min(
             a.getNumberOfComponents(), b.getNumberOfComponents());
-      IntegerComponentStats[] merged = new IntegerComponentStats[nComponents];
+      ComponentStats[] merged = new ComponentStats[nComponents];
       for (int c = 0; c < nComponents; c++) {
-         merged[c] = IntegerComponentStats.merge(
+         merged[c] = ComponentStats.merge(
                a.getComponentStats(c), b.getComponentStats(c));
       }
       return ImageStats.create(a.getIndex(), merged);

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/ImageMaker.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/ImageMaker.java
@@ -218,6 +218,15 @@ public class ImageMaker {
 
                //recompute 8 bit image
                channelProcessors_.get(c).recompute();
+               {
+                  NDVImageProcessor proc = channelProcessors_.get(c);
+                  boolean noPixels = (proc instanceof NDVImageProcessorRGB)
+                        ? ((NDVImageProcessorRGB) proc).rProcessor_.reds == null
+                        : proc.reds == null;
+                  if (noPixels) {
+                     continue; // No pixels yet
+                  }
+               }
                if (firstActive) {
                   if (channelProcessors_.get(c) instanceof NDVImageProcessorRGB) {
                      byte[] bytesR = ((NDVImageProcessorRGB) channelProcessors_.get(c)).rProcessor_
@@ -364,18 +373,32 @@ public class ImageMaker {
       }
 
       public void changePixels(Object pix, int w, int h) {
-         byte[] rPix = new byte[w * h];
-         byte[] gPix = new byte[w * h];
-         byte[] bPix = new byte[w * h];
-         for (int i = 0; i < w * h; i++) {
-            bPix[i] = ((byte[]) pix)[4 * i ];
-            gPix[i] = ((byte[]) pix)[4 * i + 1];
-            rPix[i] = ((byte[]) pix)[4 * i + 2];
-         }
+         if (pix != null) {
+            byte[] rPix = new byte[w * h];
+            byte[] gPix = new byte[w * h];
+            byte[] bPix = new byte[w * h];
+            if (pix instanceof byte[]) {
+               // MM RGB32 byte[] format: B, G, R, _ per pixel
+               byte[] bytes = (byte[]) pix;
+               for (int i = 0; i < w * h; i++) {
+                  bPix[i] = bytes[4 * i];
+                  gPix[i] = bytes[4 * i + 1];
+                  rPix[i] = bytes[4 * i + 2];
+               }
+            } else if (pix instanceof int[]) {
+               // int[] RGB32 format: each int = 0x00RRGGBB
+               int[] ints = (int[]) pix;
+               for (int i = 0; i < w * h; i++) {
+                  bPix[i] = (byte) (ints[i] & 0xff);
+                  gPix[i] = (byte) ((ints[i] >> 8) & 0xff);
+                  rPix[i] = (byte) ((ints[i] >> 16) & 0xff);
+               }
+            }
 
-         rProcessor_.changePixels(rPix, w, h);
-         gProcessor_.changePixels(gPix, w, h);
-         bProcessor_.changePixels(bPix, w, h);
+            rProcessor_.changePixels(rPix, w, h);
+            gProcessor_.changePixels(gPix, w, h);
+            bProcessor_.changePixels(bPix, w, h);
+         }
       }
 
       public void recompute() {
@@ -392,6 +415,9 @@ public class ImageMaker {
          rProcessor_.create8BitImage();
          gProcessor_.create8BitImage();
          bProcessor_.create8BitImage();
+         if (rProcessor_.rawHistogram == null) {
+            return; // No pixels yet — nothing to recompute
+         }
          rawHistogram = new int[rProcessor_.rawHistogram.length];
          for (int i = 0; i < rawHistogram.length; i++) {
             rawHistogram[i] += rProcessor_.rawHistogram[i];

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/ImageMaker.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/ImageMaker.java
@@ -218,15 +218,15 @@ public class ImageMaker {
 
                //recompute 8 bit image
                channelProcessors_.get(c).recompute();
-               {
-                  NDVImageProcessor proc = channelProcessors_.get(c);
-                  boolean noPixels = (proc instanceof NDVImageProcessorRGB)
-                        ? ((NDVImageProcessorRGB) proc).rProcessor_.reds == null
-                        : proc.reds == null;
-                  if (noPixels) {
-                     continue; // No pixels yet
+                  {
+                     NDVImageProcessor proc = channelProcessors_.get(c);
+                     boolean noPixels = (proc instanceof NDVImageProcessorRGB)
+                           ? ((NDVImageProcessorRGB) proc).rProcessor_.reds == null
+                           : proc.reds == null;
+                     if (noPixels) {
+                        continue; // No pixels yet
+                     }
                   }
-               }
                if (firstActive) {
                   if (channelProcessors_.get(c) instanceof NDVImageProcessorRGB) {
                      byte[] bytesR = ((NDVImageProcessorRGB) channelProcessors_.get(c)).rProcessor_

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -605,8 +605,9 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
                posList,
                chSpecs,
                null);
-      } else if ((acquisitionSettings.useChannels() && !chSpecs.isEmpty())
-               || acquisitionSettings.useAutofocus()) {
+      } else if (((acquisitionSettings.useChannels() && !chSpecs.isEmpty())
+               || acquisitionSettings.useAutofocus())
+               && !studio_.core().getFocusDevice().isEmpty()) {
          // add a fake z stack so that the channel z-offsets and AF are handles correctly
          if (acquisitionSettings.usePositionList()
                   && AcqEngJUtils.posListHasZDrive(studio_, posList_)) {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -1245,6 +1245,10 @@ public enum PropertyKey {
 
    SCALING_MAX("ScalingMax", ComponentDisplaySettings.class),
 
+   WHITE_MAIN_MAX("WhiteMainMax", ChannelDisplaySettings.class),
+
+   WHITE_RATIOS("WhiteRatios", ChannelDisplaySettings.class),
+
    SCOPE_DATA("ScopeData", "scopeData", Metadata.class) {
       @Override
       public String getDescription() {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -1245,10 +1245,6 @@ public enum PropertyKey {
 
    SCALING_MAX("ScalingMax", ComponentDisplaySettings.class),
 
-   WHITE_MAIN_MAX("WhiteMainMax", ChannelDisplaySettings.class),
-
-   WHITE_RATIOS("WhiteRatios", ChannelDisplaySettings.class),
-
    SCOPE_DATA("ScopeData", "scopeData", Metadata.class) {
       @Override
       public String getDescription() {

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
@@ -2,6 +2,7 @@ package org.micromanager.display;
 
 import java.awt.Color;
 import java.util.List;
+import org.micromanager.display.internal.DefaultChannelDisplaySettings;
 
 /**
  * Stores the display settings for individual channels Coords of image to be displayed.
@@ -52,6 +53,8 @@ public interface ChannelDisplaySettings {
       Builder component(int component);
 
       Builder component(int component, ComponentDisplaySettings settings);
+
+      Builder intensityScaling(ChannelIntensityRanges ranges);
 
       int getNumberOfComponents();
 
@@ -117,4 +120,7 @@ public interface ChannelDisplaySettings {
 
    Builder copyBuilderWithComponentSettings(int component, ComponentDisplaySettings settings);
 
+   static Builder builder() {
+      return DefaultChannelDisplaySettings.builder();
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
@@ -54,6 +54,17 @@ public interface ChannelDisplaySettings {
 
       Builder component(int component, ComponentDisplaySettings settings);
 
+      /**
+       * Sets the intensity scaling (min/max) for all components of this channel in one call.
+       *
+       * <p>This is a convenience alternative to calling
+       * {@link #component(int, ComponentDisplaySettings)} once per component.
+       * Only min and max are transferred; any gamma values already set on existing
+       * component settings are preserved.
+       *
+       * @param ranges per-component intensity ranges for this channel
+       * @return this builder
+       */
       Builder intensityScaling(ChannelIntensityRanges ranges);
 
       int getNumberOfComponents();

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelIntensityRanges.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelIntensityRanges.java
@@ -1,0 +1,40 @@
+package org.micromanager.display;
+
+import java.util.List;
+import org.micromanager.display.internal.DefaultChannelIntensityRanges;
+
+public interface ChannelIntensityRanges {
+   interface Builder {
+      Builder componentRange(int component, long min, long max);
+
+      Builder componentRange(int component, ComponentIntensityRange range);
+
+      Builder componentMinimum(int component, long min);
+
+      Builder componentMaximum(int component, long max);
+
+      Builder componentRanges(List<ComponentIntensityRange> ranges);
+
+      ChannelIntensityRanges build();
+   }
+
+   static Builder builder() {
+      return new DefaultChannelIntensityRanges.Builder();
+   }
+
+   Builder copyBuilder();
+
+   int getNumberOfComponents();
+
+   long getComponentMinimum(int component);
+
+   long getComponentMaximum(int component);
+
+   ComponentIntensityRange getComponentRange(int component);
+
+   List<ComponentIntensityRange> getAllComponentRanges();
+
+   List<Long> getComponentMinima();
+
+   List<Long> getComponentMaxima();
+}

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelIntensityRanges.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelIntensityRanges.java
@@ -3,38 +3,165 @@ package org.micromanager.display;
 import java.util.List;
 import org.micromanager.display.internal.DefaultChannelIntensityRanges;
 
+/**
+ * The intensity (brightness/contrast) scaling ranges for all components of one channel.
+ *
+ * <p>A "component" is one scalar channel within a pixel: for a grayscale image there is
+ * one component; for an RGB image there are three (red=0, green=1, blue=2).
+ *
+ * <p>This interface groups per-component {@link ComponentIntensityRange} objects for a
+ * single image channel.  It is used as a convenience argument to
+ * {@link ChannelDisplaySettings.Builder#intensityScaling(ChannelIntensityRanges)}, which
+ * applies all component ranges in one call instead of building a separate
+ * {@link ComponentDisplaySettings} per component.
+ *
+ * <p><strong>Note:</strong> this interface is write-only in the sense that
+ * {@link ChannelDisplaySettings} does not expose a {@code getIntensityScaling()} getter;
+ * the ranges are stored inside the per-component {@link ComponentDisplaySettings} accessible
+ * via {@link ChannelDisplaySettings#getComponentSettings(int)}.
+ *
+ * <p><strong>Default values:</strong> components that have not been explicitly set return
+ * {@code minimum = 0} and {@code maximum = Long.MAX_VALUE} (full camera range).
+ * {@link #getNumberOfComponents()} returns 0 when no components have been explicitly set.
+ *
+ * <p>Instances are immutable.  Use {@link #builder()} or {@link #copyBuilder()} to
+ * construct one.
+ *
+ * @see ComponentIntensityRange
+ * @see ChannelDisplaySettings.Builder#intensityScaling(ChannelIntensityRanges)
+ */
 public interface ChannelIntensityRanges {
+
+   /**
+    * Builder for {@link ChannelIntensityRanges}.
+    *
+    * <p>Obtain an instance via {@link ChannelIntensityRanges#builder()} or
+    * {@link ChannelIntensityRanges#copyBuilder()}.
+    */
    interface Builder {
+
+      /**
+       * Sets the range for the given component by explicit min and max values.
+       *
+       * @param component zero-based component index (e.g. 0=red, 1=green, 2=blue for RGB)
+       * @param min       black point
+       * @param max       white point ({@code Long.MAX_VALUE} = full camera range)
+       * @return this builder
+       */
       Builder componentRange(int component, long min, long max);
 
+      /**
+       * Sets the range for the given component from a {@link ComponentIntensityRange}.
+       *
+       * @param component zero-based component index
+       * @param range     range to copy min/max from
+       * @return this builder
+       */
       Builder componentRange(int component, ComponentIntensityRange range);
 
+      /**
+       * Sets only the minimum (black point) for the given component.
+       *
+       * @param component zero-based component index
+       * @param min       black point
+       * @return this builder
+       */
       Builder componentMinimum(int component, long min);
 
+      /**
+       * Sets only the maximum (white point) for the given component.
+       *
+       * @param component zero-based component index
+       * @param max       white point ({@code Long.MAX_VALUE} = full camera range)
+       * @return this builder
+       */
       Builder componentMaximum(int component, long max);
 
+      /**
+       * Replaces all component ranges with the given list.
+       *
+       * @param ranges list of ranges, one per component; index 0 is the first component
+       * @return this builder
+       */
       Builder componentRanges(List<ComponentIntensityRange> ranges);
 
+      /**
+       * Builds and returns the {@link ChannelIntensityRanges}.
+       *
+       * @return immutable {@link ChannelIntensityRanges}
+       */
       ChannelIntensityRanges build();
    }
 
+   /**
+    * Returns a new builder with no components set (all defaults).
+    *
+    * @return new builder
+    */
    static Builder builder() {
       return new DefaultChannelIntensityRanges.Builder();
    }
 
+   /**
+    * Returns a builder pre-populated with this instance's component ranges.
+    *
+    * @return copy builder
+    */
    Builder copyBuilder();
 
+   /**
+    * Returns the number of components for which a range has been explicitly set.
+    *
+    * <p>Components beyond this index return default values (min=0, max=Long.MAX_VALUE).
+    * May return 0 if no ranges have been set.
+    *
+    * @return number of explicitly-set components
+    */
    int getNumberOfComponents();
 
+   /**
+    * Returns the minimum intensity (black point) for the given component.
+    *
+    * @param component zero-based component index
+    * @return minimum intensity; 0 if not explicitly set or index out of range
+    */
    long getComponentMinimum(int component);
 
+   /**
+    * Returns the maximum intensity (white point) for the given component.
+    *
+    * @param component zero-based component index
+    * @return maximum intensity; {@code Long.MAX_VALUE} if not explicitly set or
+    *     index out of range, meaning "use the full camera bit-depth range"
+    */
    long getComponentMaximum(int component);
 
+   /**
+    * Returns the range for the given component as a {@link ComponentIntensityRange}.
+    *
+    * @param component zero-based component index
+    * @return range for that component; returns a default range if index is out of bounds
+    */
    ComponentIntensityRange getComponentRange(int component);
 
+   /**
+    * Returns all explicitly-set component ranges as a list.
+    *
+    * @return list of size {@link #getNumberOfComponents()}
+    */
    List<ComponentIntensityRange> getAllComponentRanges();
 
+   /**
+    * Returns the minimum values for all explicitly-set components.
+    *
+    * @return list of minimum values, one per component
+    */
    List<Long> getComponentMinima();
 
+   /**
+    * Returns the maximum values for all explicitly-set components.
+    *
+    * @return list of maximum values, one per component
+    */
    List<Long> getComponentMaxima();
 }

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
@@ -1,5 +1,7 @@
 package org.micromanager.display;
 
+import org.micromanager.display.internal.DefaultComponentDisplaySettings;
+
 /**
  * Certain cameras (such as RGB cameras) can produce images where each pixel has multiple
  * components.  This interface determines how these components should be displayed.
@@ -17,6 +19,8 @@ public interface ComponentDisplaySettings {
 
       Builder scalingRange(long minIntensity, long maxIntensity);
 
+      Builder scalingRange(ComponentIntensityRange range);
+
       Builder scalingGamma(double gamma);
 
       ComponentDisplaySettings build();
@@ -30,5 +34,7 @@ public interface ComponentDisplaySettings {
 
    Builder copyBuilder();
 
-   // TODO Add static builder() in Java 8
+   static Builder builder() {
+      return DefaultComponentDisplaySettings.builder();
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
@@ -2,7 +2,7 @@ package org.micromanager.display;
 
 /**
  * Certain cameras (such as RGB cameras) can produce images where each pixel has multiple
- * components.  This inteface determines how these components should be displayed.
+ * components.  This interface determines how these components should be displayed.
  *
  * @author mark
  */

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
@@ -19,6 +19,15 @@ public interface ComponentDisplaySettings {
 
       Builder scalingRange(long minIntensity, long maxIntensity);
 
+      /**
+       * Sets both minimum and maximum scaling values from a {@link ComponentIntensityRange}.
+       *
+       * <p>Convenience overload for
+       * {@link #scalingRange(long, long) scalingRange(range.getMinimum(), range.getMaximum())}.
+       *
+       * @param range source of min/max values
+       * @return this builder
+       */
       Builder scalingRange(ComponentIntensityRange range);
 
       Builder scalingGamma(double gamma);

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentIntensityRange.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentIntensityRange.java
@@ -1,0 +1,25 @@
+package org.micromanager.display;
+
+import org.micromanager.display.internal.DefaultComponentIntensityRange;
+
+public interface ComponentIntensityRange {
+   interface Builder {
+      Builder minimum(long min);
+
+      Builder maximum(long max);
+
+      Builder range(long min, long max);
+
+      ComponentIntensityRange build();
+   }
+
+   static Builder builder() {
+      return new DefaultComponentIntensityRange.Builder();
+   }
+
+   Builder copyBuilder();
+
+   long getMinimum();
+
+   long getMaximum();
+}

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentIntensityRange.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentIntensityRange.java
@@ -2,24 +2,102 @@ package org.micromanager.display;
 
 import org.micromanager.display.internal.DefaultComponentIntensityRange;
 
+/**
+ * The intensity (brightness/contrast) scaling range for a single image component.
+ *
+ * <p>A "component" is one scalar channel within a pixel: for a grayscale image there is
+ * one component; for an RGB image there are three (red, green, blue).
+ *
+ * <p>This interface is a simple min/max pair.  It is used as a data-transfer object
+ * when building display settings via
+ * {@link ComponentDisplaySettings.Builder#scalingRange(ComponentIntensityRange)},
+ * {@link ChannelIntensityRanges.Builder#componentRange(int, ComponentIntensityRange)}, and
+ * related methods.  It does not carry gamma; for that, use {@link ComponentDisplaySettings}
+ * directly.
+ *
+ * <p>Instances are immutable.  Use {@link #builder()} or {@link #copyBuilder()} to
+ * construct one.
+ *
+ * <p><strong>Default values:</strong> a freshly built instance (no setters called) has
+ * {@code minimum = 0} and {@code maximum = Long.MAX_VALUE}.
+ * {@code Long.MAX_VALUE} is a sentinel meaning "use the full camera bit-depth range."
+ *
+ * @see ChannelIntensityRanges
+ * @see ComponentDisplaySettings
+ */
 public interface ComponentIntensityRange {
+
+   /**
+    * Builder for {@link ComponentIntensityRange}.
+    *
+    * <p>Obtain an instance via {@link ComponentIntensityRange#builder()} or
+    * {@link ComponentIntensityRange#copyBuilder()}.
+    */
    interface Builder {
+
+      /**
+       * Sets the minimum intensity (black point) for this component.
+       *
+       * @param min intensity value at or below which pixels display as black
+       * @return this builder
+       */
       Builder minimum(long min);
 
+      /**
+       * Sets the maximum intensity (white point) for this component.
+       *
+       * <p>Use {@code Long.MAX_VALUE} to indicate "use the full camera bit-depth range."
+       *
+       * @param max intensity value at or above which pixels display at full brightness
+       * @return this builder
+       */
       Builder maximum(long max);
 
+      /**
+       * Convenience method to set both minimum and maximum in one call.
+       *
+       * @param min intensity value at or below which pixels display as black
+       * @param max intensity value at or above which pixels display at full brightness
+       * @return this builder
+       */
       Builder range(long min, long max);
 
+      /**
+       * Builds and returns the {@link ComponentIntensityRange}.
+       *
+       * @return immutable {@link ComponentIntensityRange}
+       */
       ComponentIntensityRange build();
    }
 
+   /**
+    * Returns a new builder with default values ({@code min=0}, {@code max=Long.MAX_VALUE}).
+    *
+    * @return new builder
+    */
    static Builder builder() {
       return new DefaultComponentIntensityRange.Builder();
    }
 
+   /**
+    * Returns a builder pre-populated with this instance's values.
+    *
+    * @return copy builder
+    */
    Builder copyBuilder();
 
+   /**
+    * Returns the minimum intensity (black point).
+    *
+    * @return minimum intensity; 0 when not explicitly set
+    */
    long getMinimum();
 
+   /**
+    * Returns the maximum intensity (white point).
+    *
+    * @return maximum intensity; {@code Long.MAX_VALUE} when not explicitly set,
+    *     which means "use the full camera bit-depth range"
+    */
    long getMaximum();
 }

--- a/mmstudio/src/main/java/org/micromanager/display/DisplayIntensityRanges.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayIntensityRanges.java
@@ -1,0 +1,48 @@
+package org.micromanager.display;
+
+import java.util.List;
+import org.micromanager.display.internal.DefaultDisplayIntensityRanges;
+
+public interface DisplayIntensityRanges {
+   interface Builder {
+      Builder componentRange(int channel, int component, long min, long max);
+
+      Builder componentRange(int channel, int component, ComponentIntensityRange range);
+
+      Builder componentMinimum(int channel, int component, long min);
+
+      Builder componentMaximum(int channel, int component, long max);
+
+      Builder componentRanges(int channel, List<ComponentIntensityRange> ranges);
+
+      Builder channelRanges(List<ChannelIntensityRanges> channelRanges);
+
+      DisplayIntensityRanges build();
+   }
+
+   static Builder builder() {
+      return new DefaultDisplayIntensityRanges.Builder();
+   }
+
+   Builder copyBuilder();
+
+   int getNumberOfChannels();
+
+   int getChannelNumberOfComponents(int channel);
+
+   long getComponentMinimum(int channel, int component);
+
+   long getComponentMaximum(int channel, int component);
+
+   ComponentIntensityRange getComponentRange(int channel, int component);
+
+   ChannelIntensityRanges getChannelRanges(int channel);
+
+   List<ComponentIntensityRange> getAllComponentRanges(int channel);
+
+   List<Long> getComponentMinima(int channel);
+
+   List<Long> getComponentMaxima(int channel);
+
+   List<ChannelIntensityRanges> getAllChannelRanges();
+}

--- a/mmstudio/src/main/java/org/micromanager/display/DisplayIntensityRanges.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplayIntensityRanges.java
@@ -3,46 +3,207 @@ package org.micromanager.display;
 import java.util.List;
 import org.micromanager.display.internal.DefaultDisplayIntensityRanges;
 
+/**
+ * The intensity (brightness/contrast) scaling ranges for all channels and components
+ * of a display.
+ *
+ * <p>This interface aggregates {@link ChannelIntensityRanges} objects, one per channel,
+ * into a single value object.  It is used as a bulk convenience argument to
+ * {@link DisplaySettings.Builder#intensityScaling(DisplayIntensityRanges)}, which applies
+ * all channel ranges in one call instead of setting each channel individually.
+ *
+ * <p>Each channel in turn holds per-component ranges (see {@link ChannelIntensityRanges}).
+ * For a grayscale display with multiple channels each channel has one component;
+ * for an RGB image each channel has three components (red=0, green=1, blue=2).
+ *
+ * <p><strong>Note:</strong> this interface is write-only in the sense that
+ * {@link DisplaySettings} does not expose a corresponding {@code getIntensityScaling()}
+ * getter; ranges are stored inside the per-channel / per-component
+ * {@link ComponentDisplaySettings} accessible via
+ * {@link DisplaySettings#getChannelSettings(int)} →
+ * {@link ChannelDisplaySettings#getComponentSettings(int)}.
+ *
+ * <p>Instances are immutable.  Use {@link #builder()} or {@link #copyBuilder()} to
+ * construct one.
+ *
+ * @see ChannelIntensityRanges
+ * @see ComponentIntensityRange
+ * @see DisplaySettings.Builder#intensityScaling(DisplayIntensityRanges)
+ */
 public interface DisplayIntensityRanges {
+
+   /**
+    * Builder for {@link DisplayIntensityRanges}.
+    *
+    * <p>Obtain an instance via {@link DisplayIntensityRanges#builder()} or
+    * {@link DisplayIntensityRanges#copyBuilder()}.
+    */
    interface Builder {
+
+      /**
+       * Sets the range for a specific channel and component by explicit min/max values.
+       *
+       * @param channel   zero-based channel index
+       * @param component zero-based component index (e.g. 0=red, 1=green, 2=blue for RGB)
+       * @param min       black point
+       * @param max       white point ({@code Long.MAX_VALUE} = full camera range)
+       * @return this builder
+       */
       Builder componentRange(int channel, int component, long min, long max);
 
+      /**
+       * Sets the range for a specific channel and component from a
+       * {@link ComponentIntensityRange}.
+       *
+       * @param channel   zero-based channel index
+       * @param component zero-based component index
+       * @param range     range to copy min/max from
+       * @return this builder
+       */
       Builder componentRange(int channel, int component, ComponentIntensityRange range);
 
+      /**
+       * Sets only the minimum (black point) for a specific channel and component.
+       *
+       * @param channel   zero-based channel index
+       * @param component zero-based component index
+       * @param min       black point
+       * @return this builder
+       */
       Builder componentMinimum(int channel, int component, long min);
 
+      /**
+       * Sets only the maximum (white point) for a specific channel and component.
+       *
+       * @param channel   zero-based channel index
+       * @param component zero-based component index
+       * @param max       white point ({@code Long.MAX_VALUE} = full camera range)
+       * @return this builder
+       */
       Builder componentMaximum(int channel, int component, long max);
 
+      /**
+       * Replaces all component ranges for the given channel with the given list.
+       *
+       * @param channel zero-based channel index
+       * @param ranges  list of ranges, one per component; index 0 is the first component
+       * @return this builder
+       */
       Builder componentRanges(int channel, List<ComponentIntensityRange> ranges);
 
+      /**
+       * Replaces all channel ranges with the given list.
+       *
+       * @param channelRanges list of {@link ChannelIntensityRanges}, one per channel
+       * @return this builder
+       */
       Builder channelRanges(List<ChannelIntensityRanges> channelRanges);
 
+      /**
+       * Builds and returns the {@link DisplayIntensityRanges}.
+       *
+       * @return immutable {@link DisplayIntensityRanges}
+       */
       DisplayIntensityRanges build();
    }
 
+   /**
+    * Returns a new builder with no channels or components set (all defaults).
+    *
+    * @return new builder
+    */
    static Builder builder() {
       return new DefaultDisplayIntensityRanges.Builder();
    }
 
+   /**
+    * Returns a builder pre-populated with all channel ranges from this instance.
+    *
+    * @return copy builder
+    */
    Builder copyBuilder();
 
+   /**
+    * Returns the number of channels for which ranges have been set.
+    *
+    * @return number of channels
+    */
    int getNumberOfChannels();
 
+   /**
+    * Returns the number of components for which ranges have been explicitly set
+    * in the given channel.
+    *
+    * @param channel zero-based channel index
+    * @return number of explicitly-set components; may be 0
+    */
    int getChannelNumberOfComponents(int channel);
 
+   /**
+    * Returns the minimum intensity (black point) for the given channel and component.
+    *
+    * @param channel   zero-based channel index
+    * @param component zero-based component index
+    * @return minimum intensity; 0 if not explicitly set
+    */
    long getComponentMinimum(int channel, int component);
 
+   /**
+    * Returns the maximum intensity (white point) for the given channel and component.
+    *
+    * @param channel   zero-based channel index
+    * @param component zero-based component index
+    * @return maximum intensity; {@code Long.MAX_VALUE} if not explicitly set,
+    *     meaning "use the full camera bit-depth range"
+    */
    long getComponentMaximum(int channel, int component);
 
+   /**
+    * Returns the range for the given channel and component as a
+    * {@link ComponentIntensityRange}.
+    *
+    * @param channel   zero-based channel index
+    * @param component zero-based component index
+    * @return range for that channel/component; returns a default range if out of bounds
+    */
    ComponentIntensityRange getComponentRange(int channel, int component);
 
+   /**
+    * Returns the {@link ChannelIntensityRanges} for the given channel.
+    *
+    * @param channel zero-based channel index
+    * @return channel ranges; returns a default (empty) instance if out of bounds
+    */
    ChannelIntensityRanges getChannelRanges(int channel);
 
+   /**
+    * Returns all explicitly-set component ranges for the given channel as a list.
+    *
+    * @param channel zero-based channel index
+    * @return list of size {@link #getChannelNumberOfComponents(int)}
+    */
    List<ComponentIntensityRange> getAllComponentRanges(int channel);
 
+   /**
+    * Returns the minimum values for all explicitly-set components of the given channel.
+    *
+    * @param channel zero-based channel index
+    * @return list of minimum values, one per component
+    */
    List<Long> getComponentMinima(int channel);
 
+   /**
+    * Returns the maximum values for all explicitly-set components of the given channel.
+    *
+    * @param channel zero-based channel index
+    * @return list of maximum values, one per component
+    */
    List<Long> getComponentMaxima(int channel);
 
+   /**
+    * Returns all channel ranges as a list.
+    *
+    * @return list of {@link ChannelIntensityRanges}, one per channel
+    */
    List<ChannelIntensityRanges> getAllChannelRanges();
 }

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -22,6 +22,8 @@ package org.micromanager.display;
 
 import java.awt.Color;
 import java.util.List;
+import org.micromanager.display.internal.DefaultChannelDisplaySettings;
+import org.micromanager.display.internal.DefaultDisplaySettings;
 
 /**
  * This class defines the parameters that control how a given DisplayWindow
@@ -116,6 +118,8 @@ public interface DisplaySettings {
        * @return builder instance to enable chaining commands
        */
       Builder channels(Iterable<ChannelDisplaySettings> channelSettings);
+
+      Builder intensityScaling(DisplayIntensityRanges ranges);
 
       /**
        * Number of ChannelDisplaySettings in this builder.  Not sure why a builder needs this...
@@ -227,8 +231,9 @@ public interface DisplaySettings {
    Builder copyBuilderWithComponentSettings(
          int channel, int component, ComponentDisplaySettings settings);
 
-
-   // TODO Add static builder() in Java 8
+   static Builder builder() {
+      return DefaultDisplaySettings.builder();
+   }
 
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -130,6 +130,17 @@ public interface DisplaySettings {
        */
       Builder channels(Iterable<ChannelDisplaySettings> channelSettings);
 
+      /**
+       * Sets the intensity scaling (min/max) for all channels and components in one call.
+       *
+       * <p>This is a convenience alternative to calling
+       * {@link #channel(int, ChannelDisplaySettings)} once per channel.
+       * Only min and max are transferred per component; gamma values already set on
+       * existing component settings are preserved.
+       *
+       * @param ranges per-channel, per-component intensity ranges for the whole display
+       * @return this builder
+       */
       Builder intensityScaling(DisplayIntensityRanges ranges);
 
       /**

--- a/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/DisplaySettings.java
@@ -23,7 +23,6 @@ package org.micromanager.display;
 
 import java.awt.Color;
 import java.util.List;
-import org.micromanager.display.internal.DefaultDisplaySettings;
 
 
 /**

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -461,8 +461,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       long max;
       if (settings.isAutostretchEnabled()) {
          double q = settings.getAutoscaleIgnoredQuantile();
-         min = componentStats.getAutoscaleMinForQuantile(q);
-         max = componentStats.getAutoscaleMaxForQuantile(q);
+         long[] minMax = new long[2];
+         componentStats.getAutoscaleMinMaxForQuantile(q, minMax);
+         min = minMax[0];
+         max = minMax[1];
       } else {
          ComponentDisplaySettings componentSettings =
                settings.getChannelSettings(channelIndex_)
@@ -618,8 +620,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          int nComponents = stats_.getNumberOfComponents();
          for (int i = 0; i < nComponents; ++i) {
             IntegerComponentStats stats = stats_.getComponentStats(i);
-            long min = stats.getAutoscaleMinForQuantile(q);
-            long max = stats.getAutoscaleMaxForQuantile(q);
+            long[] minMax = new long[2];
+            stats.getAutoscaleMinMaxForQuantile(q, minMax);
+            long min = minMax[0];
+            long max = minMax[1];
             builder.component(i,
                   channelSettings.getComponentSettings(i).copyBuilder()
                         .scalingRange(min, max).build());

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -583,7 +583,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          ChannelDisplaySettings channelSettings =
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
-         int nComponents = 1; // TODO
+         int nComponents = stats_.getNumberOfComponents();
          for (int i = 0; i < nComponents; ++i) {
             try {
                int cameraBits = viewer_.getDataProvider().getAnyImage(). // can throw IOException
@@ -615,7 +615,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          ChannelDisplaySettings channelSettings =
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
-         int nComponents = 1; // TODO
+         int nComponents = stats_.getNumberOfComponents();
          for (int i = 0; i < nComponents; ++i) {
             IntegerComponentStats stats = stats_.getComponentStats(i);
             long min = stats.getAutoscaleMinForQuantile(q);

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -9,7 +9,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.io.IOException;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.Icon;
@@ -31,7 +30,6 @@ import org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEv
 import org.micromanager.display.internal.imagestats.ImageStats;
 import org.micromanager.display.internal.imagestats.IntegerComponentStats;
 import org.micromanager.internal.utils.MustCallOnEDT;
-import org.micromanager.internal.utils.ReportingUtils;
 
 /**
  * Controls brightness / contrast / gamma in the display of a single channel.
@@ -587,19 +585,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
          int nComponents = stats_.getNumberOfComponents();
          for (int i = 0; i < nComponents; ++i) {
-            try {
-               int cameraBits = viewer_.getDataProvider().getAnyImage(). // can throw IOException
-                     getMetadata().getBitDepth();
-               long max = 1 << cameraBits;
-               builder.component(i,
-                     channelSettings.getComponentSettings(i).copyBuilder()
-                           .scalingRange(0L,
-                                 max >= 0 ? max : Long.MAX_VALUE)
-                           .build());
-            } catch (IOException ioe) {
-               // if we could not find an image, we have bigger problems
-               ReportingUtils.logError(ioe);
-            }
+            long max = 1 << stats_.getComponentStats(0).getBitDepth();
+            builder.component(i,
+                  channelSettings.getComponentSettings(i).copyBuilder()
+                        .scalingRange(0L, max >= 0 ? max : Long.MAX_VALUE)
+                        .build());
          }
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -28,6 +28,7 @@ import org.micromanager.display.ComponentDisplaySettings;
 import org.micromanager.display.DataViewer;
 import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEvent;
+import org.micromanager.display.internal.event.DisplayMouseEvent;
 import org.micromanager.display.internal.imagestats.ImageStats;
 import org.micromanager.display.internal.imagestats.IntegerComponentStats;
 import org.micromanager.internal.utils.MustCallOnEDT;
@@ -59,8 +60,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    // engine from interfering; this flag tracks the user's actual intent.
    private boolean rgbAutostretchEnabled_ = false;
    private boolean suppressAutostretchDetection_ = false;
+   private boolean pickingWhiteBalancePoint_ = false;
+   private long[] lastPickedValues_ = null; // pixel values tracked while in pick mode
 
    private final JToggleButton[] componentButtons_ = new JToggleButton[4];
+   private final javax.swing.JButton whiteBalanceButton_ = new javax.swing.JButton("White Balance");
 
    private final HistogramView histogram_ = HistogramView.create();
    private final JButton histoRangeDownButton_ = new JButton();
@@ -354,6 +358,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       channelPanel_.add(fullscaleButton, new CC().pushX().wrap());
       JButton autostretchOnceButton = new JButton("Auto Once");
       channelPanel_.add(autostretchOnceButton, new CC().pushX().wrap("rel"));
+      whiteBalanceButton_.setVisible(false);
+      whiteBalanceButton_.addActionListener((ActionEvent e) -> showWhiteBalancePopup());
+      channelPanel_.add(whiteBalanceButton_, new CC().pushX().wrap());
 
       histoPanel_.setLayout(new MigLayout(
             new LC().fill().insets("0").gridGap("0", "0")));
@@ -637,6 +644,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       for (int i = 0; i < componentButtons_.length; i++) {
          componentButtons_[i].setVisible(isRGB);
       }
+      if (!isRGB) {
+         whiteBalanceButton_.setVisible(false);
+      }
 
       if (isRGB && !wasRGB) {
          // Auto-select White when entering RGB mode for the first time.
@@ -659,13 +669,17 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          histogram_.setComponentColor(0, Color.RED, Color.RED);
          histogram_.setComponentColor(COMPONENT_WHITE, Color.WHITE, Color.WHITE);
          histogram_.setSelectedComponent(COMPONENT_WHITE);
+         whiteBalanceButton_.setVisible(true);
       } else {
          whiteRatios_ = null;
          whiteMainMax_ = 0;
+         pickingWhiteBalancePoint_ = false;
+         lastPickedValues_ = null;
          // Deactivate the white slot so its dotted line disappears.
          histogram_.clearComponentGraph(COMPONENT_WHITE);
          histogram_.setComponentColor(0, Color.RED, Color.RED);
          histogram_.setSelectedComponent(component);
+         whiteBalanceButton_.setVisible(false);
       }
       // Refresh scaling indicators immediately so the handle position reflects the
       // new mode (white main max vs Red's individual max) without waiting for the
@@ -1099,31 +1113,337 @@ public final class ChannelIntensityController implements HistogramView.Listener 
     */
    @Subscribe
    public void onEvent(DataViewerMousePixelInfoChangedEvent e) {
+      if (pickingWhiteBalancePoint_) {
+         // In pick mode, track the current pixel values but wait for a click to apply.
+         if (e.isInfoAvailable()) {
+            long[] values = getPixelValuesForChannel(e);
+            if (values != null && values.length >= 3) {
+               lastPickedValues_ = values;
+            }
+         }
+         return;
+      }
+
       histogram_.clearComponentHighlights();
       if (!e.isInfoAvailable()) {
          return;
       }
 
+      long[] values = getPixelValuesForChannel(e);
+      if (values != null) {
+         for (int component = 0; component < values.length; ++component) {
+            histogram_.setComponentHighlight(component, values[component]);
+         }
+      }
+   }
+
+   private long[] getPixelValuesForChannel(DataViewerMousePixelInfoChangedEvent e) {
       // Channel-less case
       if (channelIndex_ == 0 && e.getNumberOfCoords() == 1) {
          Coords coords = e.getAllCoords().get(0);
          if (!coords.hasAxis(Coords.CHANNEL)) {
-            long[] values = e.getComponentValuesForCoords(coords);
-            for (int component = 0; component < values.length; ++component) {
-               histogram_.setComponentHighlight(component, values[component]);
-            }
-            return;
+            return e.getComponentValuesForCoords(coords);
          }
       }
-
       for (Coords coords : e.getAllCoords()) {
          if (coords.getChannel() == channelIndex_) {
-            long[] values = e.getComponentValuesForCoords(coords);
-            for (int component = 0; component < values.length; ++component) {
-               histogram_.setComponentHighlight(component, values[component]);
-            }
-            return;
+            return e.getComponentValuesForCoords(coords);
          }
       }
+      return null;
+   }
+
+   @MustCallOnEDT
+   private void showWhiteBalancePopup() {
+      javax.swing.JPopupMenu menu = new javax.swing.JPopupMenu();
+      menu.add(new javax.swing.AbstractAction("From picked point") {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            startPickedPointWhiteBalance();
+         }
+      });
+      menu.add(new javax.swing.AbstractAction("From average intensity") {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            applyAverageIntensityWhiteBalance();
+         }
+      });
+      menu.add(new javax.swing.AbstractAction("From color temperature...") {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            showColorTemperatureDialog();
+         }
+      });
+      menu.show(whiteBalanceButton_, 0, whiteBalanceButton_.getHeight());
+   }
+
+   @MustCallOnEDT
+   private void showColorTemperatureDialog() {
+      // Snapshot settings so we can restore on Cancel.
+      final DisplaySettings settingsOnOpen = viewer_.getDisplaySettings();
+      final double[] ratiosOnOpen = whiteRatios_ == null ? null : whiteRatios_.clone();
+      final long mainMaxOnOpen = whiteMainMax_;
+
+      java.awt.Window owner = javax.swing.SwingUtilities.getWindowAncestor(whiteBalanceButton_);
+      javax.swing.JDialog dialog = new javax.swing.JDialog(owner, "Color Temperature",
+            java.awt.Dialog.ModalityType.MODELESS);
+      dialog.setLayout(new MigLayout(new LC().insets("8").fillX()));
+
+      // Slider: 2000K–10000K
+      final int MIN_K = 2000;
+      final int MAX_K = 10000;
+      final int DEFAULT_K = whiteRatios_ != null
+            ? estimateColorTemperature(whiteRatios_, MIN_K, MAX_K) : 6500;
+      final javax.swing.JSlider slider = new javax.swing.JSlider(MIN_K, MAX_K, DEFAULT_K);
+      slider.setMajorTickSpacing(2000);
+      slider.setMinorTickSpacing(500);
+      slider.setPaintTicks(true);
+
+      // Text field showing K value
+      final javax.swing.JTextField kField = new javax.swing.JTextField(
+            Integer.toString(DEFAULT_K), 6);
+
+      // Color swatch showing the illuminant color
+      final javax.swing.JPanel colorSwatch = new javax.swing.JPanel() {
+         @Override
+         protected void paintComponent(java.awt.Graphics g) {
+            super.paintComponent(g);
+            g.setColor(getBackground());
+            g.fillRect(0, 0, getWidth(), getHeight());
+         }
+      };
+      colorSwatch.setPreferredSize(new java.awt.Dimension(48, 24));
+      colorSwatch.setBorder(BorderFactory.createLineBorder(java.awt.Color.GRAY));
+      colorSwatch.setOpaque(true);
+
+      // Lay out: label + field + swatch on first row, slider spanning full width
+      dialog.add(new javax.swing.JLabel("Temperature (K):"));
+      dialog.add(kField, new CC().width("60!").gapAfter("rel"));
+      dialog.add(colorSwatch, new CC().wrap());
+      dialog.add(slider, new CC().spanX().growX().wrap("rel"));
+
+      // OK / Cancel buttons
+      javax.swing.JButton okButton = new javax.swing.JButton("OK");
+      javax.swing.JButton cancelButton = new javax.swing.JButton("Cancel");
+      dialog.add(okButton, new CC().spanX().split(2).tag("ok"));
+      dialog.add(cancelButton, new CC().tag("cancel"));
+
+      // Shared update logic: apply balance and update swatch
+      final Runnable applyTemperature = new Runnable() {
+         @Override
+         public void run() {
+            int k = slider.getValue();
+            int[] rgb = colorTemperatureToRgb(k);
+            colorSwatch.setBackground(new java.awt.Color(rgb[0], rgb[1], rgb[2]));
+            colorSwatch.repaint();
+            applyColorTemperatureWhiteBalance(k);
+         }
+      };
+
+      slider.addChangeListener(e -> {
+         kField.setText(Integer.toString(slider.getValue()));
+         applyTemperature.run();
+      });
+
+      kField.addActionListener(e -> {
+         try {
+            int k = Integer.parseInt(kField.getText().trim());
+            k = Math.max(MIN_K, Math.min(MAX_K, k));
+            slider.setValue(k);  // triggers changeListener → applyTemperature
+         } catch (NumberFormatException ex) {
+            kField.setText(Integer.toString(slider.getValue()));
+         }
+      });
+
+      okButton.addActionListener(e -> dialog.dispose());
+
+      cancelButton.addActionListener(e -> {
+         // Restore settings from before the dialog opened
+         whiteRatios_ = ratiosOnOpen;
+         whiteMainMax_ = mainMaxOnOpen;
+         DisplaySettings current;
+         do {
+            current = viewer_.getDisplaySettings();
+         } while (!viewer_.compareAndSetDisplaySettings(current, settingsOnOpen));
+         statsOrRangeChanged();
+         dialog.dispose();
+      });
+
+      // Seed the swatch without applying a balance change
+      int[] initRgb = colorTemperatureToRgb(DEFAULT_K);
+      colorSwatch.setBackground(new java.awt.Color(initRgb[0], initRgb[1], initRgb[2]));
+
+      dialog.pack();
+      dialog.setLocationRelativeTo(whiteBalanceButton_);
+      dialog.setVisible(true);
+   }
+
+   /**
+    * Estimates the color temperature in Kelvin that best matches the given white ratios,
+    * by finding the K in [minK, maxK] whose correction ratios minimize squared error.
+    */
+   private static int estimateColorTemperature(double[] ratios, int minK, int maxK) {
+      int bestK = 6500;
+      double bestError = Double.MAX_VALUE;
+      for (int k = minK; k <= maxK; k++) {
+         int[] illuminant = colorTemperatureToRgb(k);
+         double minIlluminant = Math.min(illuminant[0], Math.min(illuminant[1], illuminant[2]));
+         if (minIlluminant <= 0) {
+            continue;
+         }
+         double[] correctionRatios = new double[] {
+               minIlluminant / illuminant[0],
+               minIlluminant / illuminant[1],
+               minIlluminant / illuminant[2]
+         };
+         double error = 0;
+         for (int c = 0; c < 3; c++) {
+            double diff = ratios[c] - correctionRatios[c];
+            error += diff * diff;
+         }
+         if (error < bestError) {
+            bestError = error;
+            bestK = k;
+         }
+      }
+      return bestK;
+   }
+
+   /**
+    * Converts a color temperature in Kelvin to an approximate RGB illuminant color.
+    * Based on Tanner Helland's algorithm (http://www.tannerhelland.com/4435/).
+    * Output values are in the range 0–255.
+    */
+   private static int[] colorTemperatureToRgb(int kelvin) {
+      double t = Math.max(1000, Math.min(40000, kelvin)) / 100.0;
+      int r, g, b;
+
+      if (t <= 66) {
+         r = 255;
+      } else {
+         r = (int) (329.698727446 * Math.pow(t - 60, -0.1332047592));
+         r = Math.max(0, Math.min(255, r));
+      }
+
+      if (t <= 66) {
+         g = (int) (99.4708025861 * Math.log(t) - 161.1195681661);
+      } else {
+         g = (int) (288.1221695283 * Math.pow(t - 60, -0.0755148492));
+      }
+      g = Math.max(0, Math.min(255, g));
+
+      if (t >= 66) {
+         b = 255;
+      } else if (t <= 19) {
+         b = 0;
+      } else {
+         b = (int) (138.5177312231 * Math.log(t - 10) - 305.0447927307);
+         b = Math.max(0, Math.min(255, b));
+      }
+
+      return new int[] {r, g, b};
+   }
+
+   @MustCallOnEDT
+   private void applyColorTemperatureWhiteBalance(int kelvin) {
+      int[] illuminant = colorTemperatureToRgb(kelvin);
+      // Correction is the inverse: channels with less illuminant light get boosted.
+      // Normalize so the smallest correction = 1.0 (i.e. the brightest illuminant
+      // channel drives the others relative to it).
+      double minIlluminant = Math.min(illuminant[0], Math.min(illuminant[1], illuminant[2]));
+      if (minIlluminant <= 0) {
+         return;
+      }
+      whiteRatios_ = new double[] {
+            minIlluminant / illuminant[0],
+            minIlluminant / illuminant[1],
+            minIlluminant / illuminant[2]
+      };
+      applyCurrentWhiteRatios();
+   }
+
+   @MustCallOnEDT
+   private void startPickedPointWhiteBalance() {
+      lastPickedValues_ = null;
+      pickingWhiteBalancePoint_ = true;
+   }
+
+   @MustCallOnEDT
+   private void applyPickedPointWhiteBalance(long[] pixelValues) {
+      long maxVal = 0;
+      for (long v : pixelValues) {
+         if (v > maxVal) { maxVal = v; }
+      }
+      if (maxVal == 0) {
+         return; // can't balance a black pixel
+      }
+      whiteRatios_ = new double[] {
+            (double) pixelValues[0] / maxVal,
+            (double) pixelValues[1] / maxVal,
+            (double) pixelValues[2] / maxVal
+      };
+      applyCurrentWhiteRatios();
+   }
+
+   @MustCallOnEDT
+   private void applyAverageIntensityWhiteBalance() {
+      if (stats_ == null || stats_.getNumberOfComponents() < 3) {
+         return;
+      }
+      long[] means = new long[3];
+      for (int c = 0; c < 3; c++) {
+         means[c] = stats_.getComponentStats(c).getMeanIntensityExcludingZeros();
+      }
+      long maxMean = Math.max(means[0], Math.max(means[1], means[2]));
+      if (maxMean == 0) {
+         return;
+      }
+      whiteRatios_ = new double[] {
+            (double) means[0] / maxMean,
+            (double) means[1] / maxMean,
+            (double) means[2] / maxMean
+      };
+      applyCurrentWhiteRatios();
+   }
+
+   @Subscribe
+   public void onEvent(DisplayMouseEvent e) {
+      if (!pickingWhiteBalancePoint_) {
+         return;
+      }
+      if (e.getEvent().getID() == java.awt.event.MouseEvent.MOUSE_PRESSED
+            && javax.swing.SwingUtilities.isLeftMouseButton(e.getEvent())) {
+         pickingWhiteBalancePoint_ = false;
+         final long[] values = lastPickedValues_;
+         lastPickedValues_ = null;
+         if (values != null) {
+            javax.swing.SwingUtilities.invokeLater(() -> applyPickedPointWhiteBalance(values));
+         }
+      }
+   }
+
+   @MustCallOnEDT
+   private void applyCurrentWhiteRatios() {
+      if (whiteMainMax_ <= 0) {
+         captureWhiteRatios();
+      }
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      do {
+         oldDisplaySettings = viewer_.getDisplaySettings();
+         ChannelDisplaySettings channelSettings =
+               oldDisplaySettings.getChannelSettings(channelIndex_);
+         ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
+         for (int c = 0; c < 3; c++) {
+            long scaledMax = Math.max(Math.round(whiteRatios_[c] * whiteMainMax_), 1L);
+            long currentMin = channelSettings.getComponentSettings(c).getScalingMinimum();
+            scaledMax = Math.max(scaledMax, currentMin + 1);
+            builder.component(c, channelSettings.getComponentSettings(c)
+                  .copyBuilder().scalingRange(currentMin, scaledMax).build());
+         }
+         newDisplaySettings = oldDisplaySettings.copyBuilder()
+               .channel(channelIndex_, builder.build()).build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+      statsOrRangeChanged();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -22,15 +22,14 @@ import net.miginfocom.layout.CC;
 import net.miginfocom.layout.LC;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.data.Coords;
-import org.micromanager.data.Image;
 import org.micromanager.display.ChannelDisplaySettings;
 import org.micromanager.display.ComponentDisplaySettings;
 import org.micromanager.display.DataViewer;
 import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEvent;
 import org.micromanager.display.internal.event.DisplayMouseEvent;
+import org.micromanager.display.internal.imagestats.ComponentStats;
 import org.micromanager.display.internal.imagestats.ImageStats;
-import org.micromanager.display.internal.imagestats.IntegerComponentStats;
 import org.micromanager.internal.utils.MustCallOnEDT;
 
 /**
@@ -61,6 +60,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    // engine from interfering; this flag tracks the user's actual intent.
    private boolean rgbAutostretchEnabled_ = false;
    private boolean suppressAutostretchDetection_ = false;
+   // Non-null for float images: one mapper per component, rebuilt on each statsOrRangeChanged().
+   private FloatCoordinateMapper[] floatMappers_ = null;
    private boolean pickingWhiteBalancePoint_ = false;
    private long[] lastPickedValues_ = null; // pixel values tracked while in pick mode
 
@@ -482,7 +483,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       int selectedComponent = getSelectedComponent();
       // In white mode, show stats for component 0 (Red) as representative
       int statsComponent = (selectedComponent == COMPONENT_WHITE) ? 0 : selectedComponent;
-      IntegerComponentStats selectedStats = stats_.getComponentStats(statsComponent);
+      ComponentStats selectedStats = stats_.getComponentStats(statsComponent);
 
       final DisplaySettings displaySettings = viewer_.getDisplaySettings();
       boolean ignoreZeros = displaySettings.isAutoscaleIgnoringZeros();
@@ -517,7 +518,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
       boolean whiteMode = getSelectedComponent() == COMPONENT_WHITE;
       for (int c = 0; c < numComponents; c++) {
-         IntegerComponentStats cStats = stats_.getComponentStats(c);
+         ComponentStats cStats = stats_.getComponentStats(c);
          long[] data = cStats.getInRangeHistogram();
          if (data != null) {
             // For float images: the histogram is built in actual pixel-value coordinates
@@ -525,13 +526,24 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             // real pixel values. For integer images: use the bit-depth combo box selection,
             // capping at 30 bits to avoid Java int-shift overflow (1<<32 == 1).
             if (cStats.isFloat()) {
-               long rangeMin = cStats.getHistogramRangeMin();
-               long rangeMax = cStats.getHistogramRangeMax();
-               if (rangeMax <= rangeMin) {
-                  rangeMax = rangeMin + 1;
+               // Use bin-index coordinate space: rangeMin=0, rangeMax=binCount (~256).
+               // The X axis shows bin indices; labels are formatted as pixel values via
+               // the FloatCoordinateMapper wired into HistogramView.
+               FloatCoordinateMapper mapper = new FloatCoordinateMapper(cStats);
+               if (floatMappers_ == null || floatMappers_.length != numComponents) {
+                  floatMappers_ = new FloatCoordinateMapper[numComponents];
                }
-               histogram_.setComponentGraph(c, data, data.length, rangeMin, rangeMax);
+               floatMappers_[c] = mapper;
+               long binCount = Math.max(1L, mapper.getBinCount());
+               histogram_.setComponentGraph(c, data, data.length, 0L, binCount);
+               histogram_.setComponentFloatMapper(c, mapper);
+               histogram_.setComponentRangeMaxLabel(c, mapper.formatBinIndex(binCount));
             } else {
+               if (c == 0) {
+                  floatMappers_ = null; // integer image: clear all mappers
+               }
+               histogram_.setComponentFloatMapper(c, null);
+               histogram_.setComponentRangeMaxLabel(c, null);
                int clampedRangeBits = Math.min(rangeBits, 30);
                int lengthToUse = Math.min(data.length, (1 << clampedRangeBits) - 1);
                if (lengthToUse <= 0) {
@@ -553,7 +565,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    // R/G/B component (indices 0–2). Always reflects the component's own
    // ComponentDisplaySettings — independent of white mode.
    private void updateScalingIndicators(DisplaySettings settings,
-                                        IntegerComponentStats componentStats, int component) {
+                                        ComponentStats componentStats, int component) {
       long min;
       long max;
       if (settings.isAutostretchEnabled()) {
@@ -567,10 +579,25 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             min = minMax[0];
             max = minMax[1];
          }
+         // For float images the histogram X-axis is in bin-index space; convert.
+         min = toStoredScalingValue(component, min);
+         max = toStoredScalingValue(component, max);
       } else {
          ComponentDisplaySettings componentSettings =
                settings.getChannelSettings(channelIndex_)
                      .getComponentSettings(component);
+         if (componentStats.isFloat() && floatMappers_ != null
+               && component < floatMappers_.length && floatMappers_[component] != null) {
+            FloatCoordinateMapper mapper = floatMappers_[component];
+            int binCount = mapper.getBinCount();
+            long storedMax = componentSettings.getScalingMaximum();
+            long storedMin = componentSettings.getScalingMinimum();
+            long clampedMax = (storedMax == Long.MAX_VALUE) ? binCount
+                              : Math.min(binCount, storedMax);
+            long clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
+            histogram_.setComponentScaling(component, clampedMin, clampedMax);
+            return;
+         }
          max = Math.min(componentStats.getHistogramRangeMax(),
                componentSettings.getScalingMaximum());
          long rangeMin = componentStats.getHistogramRangeMin();
@@ -583,7 +610,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    // Updates the white handle (HistogramView slot COMPONENT_WHITE) to show
    // whiteMainMax_ as the max handle and whiteMainMin_ as the min handle.
    private void updateWhiteScalingIndicator(DisplaySettings settings,
-                                            IntegerComponentStats comp0Stats) {
+                                            ComponentStats comp0Stats) {
       long rangeMax = comp0Stats.getHistogramRangeMax();
       long max = whiteMainMax_ > 0
             ? Math.min(whiteMainMax_, rangeMax)
@@ -799,6 +826,14 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       rgbAutostretchEnabled_ = enabled;
    }
 
+   private long toStoredScalingValue(int component, long pixelValue) {
+      if (floatMappers_ != null && component < floatMappers_.length
+            && floatMappers_[component] != null) {
+         return floatMappers_[component].pixelValueToBinIndex((double) pixelValue);
+      }
+      return pixelValue;
+   }
+
    @MustCallOnEDT
    private void turnOffAutostretchInSettings() {
       DisplaySettings oldSettings;
@@ -889,8 +924,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
       } else {
          // Single component: only autoscale the selected component, leave others unchanged.
-         final long newMin;
-         final long newMax;
+         long newMin;
+         long newMax;
          if (ignoreZeros) {
             newMin = 0L;
             newMax = stats_.getComponentStats(selectedComponent)
@@ -901,6 +936,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             newMin = minMax[0];
             newMax = minMax[1];
          }
+         newMin = toStoredScalingValue(selectedComponent, newMin);
+         newMax = toStoredScalingValue(selectedComponent, newMax);
          do {
             oldDisplaySettings = viewer_.getDisplaySettings();
             ChannelDisplaySettings channelSettings =
@@ -918,14 +955,18 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    private void handleFullscale() {
       final int nComponents = stats_.getNumberOfComponents();
+      int sel = getSelectedComponent();
       Integer bitDepth = stats_.getComponentStats(0).getBitDepth();
       long fullMax;
-      if (bitDepth == null) {
+      int floatSel = (sel == COMPONENT_WHITE) ? 0 : sel;
+      if (floatMappers_ != null && floatSel < floatMappers_.length
+            && floatMappers_[floatSel] != null) {
+         fullMax = floatMappers_[floatSel].getBinCount();
+      } else if (bitDepth == null) {
          fullMax = stats_.getComponentStats(0).getHistogramRangeMax();
       } else {
          fullMax = bitDepth >= 63 ? Long.MAX_VALUE : (1L << bitDepth) - 1L;
       }
-      int sel = getSelectedComponent();
       if (sel == COMPONENT_WHITE && whiteRatios_ == null) {
          captureWhiteRatios();
       }
@@ -992,7 +1033,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             }
 
          } else {
-            IntegerComponentStats stats = stats_.getComponentStats(sel);
+            ComponentStats stats = stats_.getComponentStats(sel);
             long min;
             long max;
             if (ignoreZeros) {
@@ -1004,6 +1045,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                min = minMax[0];
                max = minMax[1];
             }
+            min = toStoredScalingValue(sel, min);
+            max = toStoredScalingValue(sel, max);
             builder.component(sel,
                   channelSettings.getComponentSettings(sel).copyBuilder()
                         .scalingRange(min, max).build());
@@ -1215,7 +1258,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          histogram_.setComponentColor(c, color, highlight);
 
          if (stats_ != null) {
-            IntegerComponentStats componentStats = stats_.getComponentStats(c);
+            ComponentStats componentStats = stats_.getComponentStats(c);
             updateScalingIndicators(settings, componentStats, c);
          }
       }
@@ -1251,7 +1294,13 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       long[] values = getPixelValuesForChannel(e);
       if (values != null) {
          for (int component = 0; component < values.length; ++component) {
-            histogram_.setComponentHighlight(component, values[component]);
+            long highlightValue = values[component];
+            if (floatMappers_ != null && component < floatMappers_.length
+                  && floatMappers_[component] != null) {
+               highlightValue = floatMappers_[component].pixelValueToBinIndex(
+                     (double) highlightValue);
+            }
+            histogram_.setComponentHighlight(component, highlightValue);
          }
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -1428,8 +1428,13 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    /**
     * Converts a color temperature in Kelvin to an approximate RGB illuminant color.
-    * Based on Tanner Helland's algorithm (http://www.tannerhelland.com/4435/).
-    * Output values are in the range 0–255.
+    * Output values are in the range 0-255.
+    *
+    * <p>Algorithm by Tanner Helland, based on blackbody data by Mitchell Charity.
+    * Licensed under CC BY-SA 4.0.
+    * Source: https://tannerhelland.com/2012/09/18/convert-temperature-rgb-algorithm-code.html
+    *
+    * <p>Suitable for display purposes; not intended for scientific use.
     */
    private static int[] colorTemperatureToRgb(int kelvin) {
       double t = Math.max(1000, Math.min(40000, kelvin)) / 100.0;

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -52,15 +52,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private final JToggleButton channelVisibleButton_ = new JToggleButton();
    private static final int COMPONENT_WHITE = 3;
    private double[] whiteRatios_ = null; // non-null when white mode is active
-   private long whiteMasterMax_ = 0; // master max shown by white handle; = max(R,G,B)
-   // When white mode is active, we manage autostretch ourselves to preserve
-   // ratios. DisplaySettings.isAutostretchEnabled() is kept false so the
-   // display engine's independent-per-component autostretch doesn't fire.
-   // This flag remembers that the user actually wants autostretch on.
-   // For RGB images, autostretch is managed here rather than in DisplayUIController
-   // so that we can honour the selected component and white-mode ratios.
-   // DisplaySettings.isAutostretchEnabled() is kept false; this flag tracks the
-   // user's actual intent.
+   private long whiteMainMax_ = 0; // main max shown by white handle; = max(R,G,B)
+   // For RGB images we manage autostretch here (not in DisplayUIController) so we
+   // can honour the selected component and white-mode ratios.
+   // DisplaySettings.isAutostretchEnabled() is kept false to prevent the display
+   // engine from interfering; this flag tracks the user's actual intent.
    private boolean rgbAutostretchEnabled_ = false;
    private boolean suppressAutostretchDetection_ = false;
 
@@ -496,6 +492,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       int numComponents = stats_.getNumberOfComponents();
       setRGBMode(numComponents > 1);
 
+      boolean whiteMode = getSelectedComponent() == COMPONENT_WHITE;
       for (int c = 0; c < numComponents; c++) {
          IntegerComponentStats cStats = stats_.getComponentStats(c);
          long[] data = cStats.getInRangeHistogram();
@@ -507,29 +504,25 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          }
          updateScalingIndicators(displaySettings, cStats, c);
       }
+      if (whiteMode) {
+         updateWhiteScalingIndicator(displaySettings, stats_.getComponentStats(0));
+      }
    }
 
    @MustCallOnEDT
+   // Updates the histogram's scaling indicator (dotted lines + handle) for a single
+   // R/G/B component (indices 0–2). Always reflects the component's own
+   // ComponentDisplaySettings — independent of white mode.
    private void updateScalingIndicators(DisplaySettings settings,
                                         IntegerComponentStats componentStats, int component) {
       long min;
       long max;
-      boolean whiteMode = getSelectedComponent() == COMPONENT_WHITE;
       if (settings.isAutostretchEnabled()) {
          double q = settings.getAutoscaleIgnoredQuantile();
          long[] minMax = new long[2];
          componentStats.getAutoscaleMinMaxForQuantile(q, minMax);
          min = minMax[0];
          max = minMax[1];
-      } else if (whiteMode && component == 0) {
-         // White mode: show the virtual master max at the handle (not Red's raw max),
-         // so the white handle position is independent of Red's ComponentDisplaySettings.
-         ComponentDisplaySettings componentSettings =
-               settings.getChannelSettings(channelIndex_).getComponentSettings(0);
-         min = Math.max(0, componentSettings.getScalingMinimum());
-         max = whiteMasterMax_ > 0 ? whiteMasterMax_
-               : Math.min(componentStats.getHistogramRangeMax(),
-                          componentSettings.getScalingMaximum());
       } else {
          ComponentDisplaySettings componentSettings =
                settings.getChannelSettings(channelIndex_)
@@ -540,6 +533,28 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                componentSettings.getScalingMinimum()));
       }
       histogram_.setComponentScaling(component, min, max);
+   }
+
+   // Updates the white handle (HistogramView slot COMPONENT_WHITE) to show
+   // whiteMainMax_ as the draggable position. Uses component 0's rangeMax and
+   // min for positioning since white mode operates in the same intensity space.
+   private void updateWhiteScalingIndicator(DisplaySettings settings,
+                                            IntegerComponentStats comp0Stats) {
+      long rangeMax = comp0Stats.getHistogramRangeMax();
+      long max = whiteMainMax_ > 0
+            ? Math.min(whiteMainMax_, rangeMax)
+            : Math.min(settings.getChannelSettings(channelIndex_)
+                  .getComponentSettings(0).getScalingMaximum(), rangeMax);
+      ComponentDisplaySettings comp0Settings =
+            settings.getChannelSettings(channelIndex_).getComponentSettings(0);
+      long min = Math.max(0, comp0Settings.getScalingMinimum());
+      // Feed component 3 the same graph data as component 0 so that rangeMax_ is
+      // set in HistogramView (required for handle position calculation).
+      long[] graph = comp0Stats.getInRangeHistogram();
+      if (graph != null && rangeMax > 0) {
+         histogram_.setComponentGraph(COMPONENT_WHITE, graph, graph.length, rangeMax);
+         histogram_.setComponentScaling(COMPONENT_WHITE, min, max);
+      }
    }
 
    @MustCallOnEDT
@@ -623,8 +638,13 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          componentButtons_[i].setVisible(isRGB);
       }
 
-      // Reapply display settings with correct component handling
-      newDisplaySettings(viewer_.getDisplaySettings());
+      if (isRGB && !wasRGB) {
+         // Auto-select White when entering RGB mode for the first time.
+         handleComponentSelection(COMPONENT_WHITE);
+      } else {
+         // Reapply display settings with correct component handling
+         newDisplaySettings(viewer_.getDisplaySettings());
+      }
    }
 
    @MustCallOnEDT
@@ -634,16 +654,21 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       }
       if (component == COMPONENT_WHITE) {
          captureWhiteRatios();
-         histogram_.setComponentColor(0, Color.WHITE, Color.WHITE);
-         histogram_.setSelectedComponent(0);
+         // Use HistogramView slot 3 for the white handle so that Red (slot 0)
+         // keeps its own independent dotted line and handle.
+         histogram_.setComponentColor(0, Color.RED, Color.RED);
+         histogram_.setComponentColor(COMPONENT_WHITE, Color.WHITE, Color.WHITE);
+         histogram_.setSelectedComponent(COMPONENT_WHITE);
       } else {
          whiteRatios_ = null;
-         whiteMasterMax_ = 0;
+         whiteMainMax_ = 0;
+         // Deactivate the white slot so its dotted line disappears.
+         histogram_.clearComponentGraph(COMPONENT_WHITE);
          histogram_.setComponentColor(0, Color.RED, Color.RED);
          histogram_.setSelectedComponent(component);
       }
       // Refresh scaling indicators immediately so the handle position reflects the
-      // new mode (white master max vs Red's individual max) without waiting for the
+      // new mode (white main max vs Red's individual max) without waiting for the
       // next stats update.
       statsOrRangeChanged();
       // If autostretch is active (managed by us), re-apply for the new selection
@@ -659,7 +684,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             return i;
          }
       }
-      return 0; // Shouldn't reach
+      return 0; // component 0 selected by default
    }
 
    @MustCallOnEDT
@@ -679,13 +704,13 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             effectiveMax[c] = settingsMax == Long.MAX_VALUE ? 255 : settingsMax;
          }
       }
-      long masterMax = Math.max(effectiveMax[0], Math.max(effectiveMax[1], effectiveMax[2]));
-      whiteMasterMax_ = masterMax;
-      if (masterMax > 0) {
+      long mainMax = Math.max(effectiveMax[0], Math.max(effectiveMax[1], effectiveMax[2]));
+      whiteMainMax_ = mainMax;
+      if (mainMax > 0) {
          whiteRatios_ = new double[] {
-               (double) effectiveMax[0] / masterMax,
-               (double) effectiveMax[1] / masterMax,
-               (double) effectiveMax[2] / masterMax
+               (double) effectiveMax[0] / mainMax,
+               (double) effectiveMax[1] / mainMax,
+               (double) effectiveMax[2] / mainMax
          };
       } else {
          whiteRatios_ = new double[] {1.0, 1.0, 1.0};
@@ -713,17 +738,20 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       } while (!viewer_.compareAndSetDisplaySettings(oldSettings, newSettings));
    }
 
-   @MustCallOnEDT
-   private void restoreAutostretchInSettings() {
-      DisplaySettings oldSettings;
-      DisplaySettings newSettings;
-      do {
-         oldSettings = viewer_.getDisplaySettings();
-         if (oldSettings.isAutostretchEnabled()) {
-            return;
-         }
-         newSettings = oldSettings.copyBuilder().autostretch(true).build();
-      } while (!viewer_.compareAndSetDisplaySettings(oldSettings, newSettings));
+   // Returns {mainMax, commonMin} across all components at the given quantile.
+   // mainMax = brightest autoscale max, so the white handle lands at the image's
+   // true peak value rather than an inflated implied value.
+   private long[] computeWhiteAutoscaleRange(double q) {
+      long mainMax = 0;
+      long commonMin = Long.MAX_VALUE;
+      int nComponents = stats_.getNumberOfComponents();
+      for (int c = 0; c < nComponents; c++) {
+         long[] minMax = new long[2];
+         stats_.getComponentStats(c).getAutoscaleMinMaxForQuantile(q, minMax);
+         if (minMax[1] > mainMax) { mainMax = minMax[1]; }
+         if (minMax[0] < commonMin) { commonMin = minMax[0]; }
+      }
+      return new long[] { mainMax, commonMin == Long.MAX_VALUE ? 0 : commonMin };
    }
 
    @MustCallOnEDT
@@ -734,40 +762,23 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       DisplaySettings oldDisplaySettings;
       DisplaySettings newDisplaySettings;
       double q = viewer_.getDisplaySettings().getAutoscaleIgnoredQuantile();
-      int nComponents = stats_.getNumberOfComponents();
       int selectedComponent = getSelectedComponent();
 
       if (selectedComponent == COMPONENT_WHITE) {
-         // White mode: scale all components proportionally
          if (whiteRatios_ == null) {
             captureWhiteRatios();
          }
-         // masterMax = brightest autoscale max across all components.
-         // This is the actual peak pixel value in the image, so the white handle
-         // lands at the image's true maximum rather than an inflated implied value.
-         long masterAutoscaleMax = 0;
-         long commonMin = Long.MAX_VALUE;
-         for (int c = 0; c < nComponents; c++) {
-            long[] minMax = new long[2];
-            stats_.getComponentStats(c).getAutoscaleMinMaxForQuantile(q, minMax);
-            if (minMax[1] > masterAutoscaleMax) {
-               masterAutoscaleMax = minMax[1];
-            }
-            if (minMax[0] < commonMin) {
-               commonMin = minMax[0];
-            }
-         }
-         final long masterMax = masterAutoscaleMax;
-         whiteMasterMax_ = masterMax;
-         final long sharedMin = commonMin == Long.MAX_VALUE ? 0 : commonMin;
+         long[] range = computeWhiteAutoscaleRange(q);
+         whiteMainMax_ = range[0];
+         final long sharedMin = range[1];
+         int nComponents = stats_.getNumberOfComponents();
          do {
             oldDisplaySettings = viewer_.getDisplaySettings();
             ChannelDisplaySettings channelSettings =
                   oldDisplaySettings.getChannelSettings(channelIndex_);
             ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
             for (int c = 0; c < nComponents; c++) {
-               long scaledMax = Math.round(whiteRatios_[c] * masterMax);
-               scaledMax = Math.max(scaledMax, sharedMin + 1);
+               long scaledMax = Math.max(Math.round(whiteRatios_[c] * whiteMainMax_), sharedMin + 1);
                builder.component(c,
                      channelSettings.getComponentSettings(c).copyBuilder()
                            .scalingRange(sharedMin, scaledMax).build());
@@ -778,7 +789,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                   .build();
          } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
       } else {
-         // Single component selected: only autoscale that component, leave others unchanged
+         // Single component: only autoscale the selected component, leave others unchanged.
          long[] minMax = new long[2];
          stats_.getComponentStats(selectedComponent).getAutoscaleMinMaxForQuantile(q, minMax);
          final long newMin = minMax[0];
@@ -799,6 +810,19 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
 
    private void handleFullscale() {
+      int nComponents = stats_.getNumberOfComponents();
+      long fullMax = 1 << stats_.getComponentStats(0).getBitDepth();
+      if (fullMax < 0) {
+         fullMax = Long.MAX_VALUE;
+      }
+      int sel = getSelectedComponent();
+      if (sel == COMPONENT_WHITE && whiteRatios_ == null) {
+         captureWhiteRatios();
+      }
+      if (sel == COMPONENT_WHITE) {
+         whiteMainMax_ = fullMax;
+      }
+      final long finalFullMax = fullMax;
       DisplaySettings oldDisplaySettings;
       DisplaySettings newDisplaySettings;
       do {
@@ -806,30 +830,17 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          ChannelDisplaySettings channelSettings =
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
-         int nComponents = stats_.getNumberOfComponents();
-         long fullMax = 1 << stats_.getComponentStats(0).getBitDepth();
-         if (fullMax < 0) {
-            fullMax = Long.MAX_VALUE;
-         }
-         if (getSelectedComponent() == COMPONENT_WHITE) {
-            if (whiteRatios_ == null) {
-               captureWhiteRatios();
-            }
-            whiteMasterMax_ = fullMax;
+         if (sel == COMPONENT_WHITE) {
             for (int i = 0; i < nComponents; ++i) {
-               long scaledMax = Math.round(whiteRatios_[i] * fullMax);
-               scaledMax = Math.max(scaledMax, 1);
+               long scaledMax = Math.max(Math.round(whiteRatios_[i] * finalFullMax), 1L);
                builder.component(i,
                      channelSettings.getComponentSettings(i).copyBuilder()
-                           .scalingRange(0L, scaledMax)
-                           .build());
+                           .scalingRange(0L, scaledMax).build());
             }
          } else {
-            int sel = getSelectedComponent();
             builder.component(sel,
                   channelSettings.getComponentSettings(sel).copyBuilder()
-                        .scalingRange(0L, fullMax)
-                        .build());
+                        .scalingRange(0L, finalFullMax).build());
          }
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
@@ -852,24 +863,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             if (whiteRatios_ == null) {
                captureWhiteRatios();
             }
-            // masterMax = brightest autoscale max across all components.
-            long masterAutoscaleMax = 0;
-            long commonMin = Long.MAX_VALUE;
+            long[] range = computeWhiteAutoscaleRange(q);
+            whiteMainMax_ = range[0];
+            long commonMin = range[1];
             for (int i = 0; i < nComponents; ++i) {
-               IntegerComponentStats stats = stats_.getComponentStats(i);
-               long[] minMax = new long[2];
-               stats.getAutoscaleMinMaxForQuantile(q, minMax);
-               if (minMax[1] > masterAutoscaleMax) {
-                  masterAutoscaleMax = minMax[1];
-               }
-               if (minMax[0] < commonMin) {
-                  commonMin = minMax[0];
-               }
-            }
-            whiteMasterMax_ = masterAutoscaleMax;
-            for (int i = 0; i < nComponents; ++i) {
-               long scaledMax = Math.round(whiteRatios_[i] * masterAutoscaleMax);
-               scaledMax = Math.max(scaledMax, commonMin + 1);
+               long scaledMax = Math.max(Math.round(whiteRatios_[i] * whiteMainMax_), commonMin + 1);
                builder.component(i,
                      channelSettings.getComponentSettings(i).copyBuilder()
                            .scalingRange(commonMin, scaledMax).build());
@@ -891,7 +889,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    @Override
    public void histogramScalingMinChanged(int component, long newMin) {
-      if (getSelectedComponent() == COMPONENT_WHITE) {
+      rgbAutostretchEnabled_ = false;
+      if (component == COMPONENT_WHITE) {
          applyAbsoluteMinToAllComponents(newMin);
          return;
       }
@@ -919,7 +918,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    @Override
    public void histogramScalingMaxChanged(int component, long newMax) {
-      if (getSelectedComponent() == COMPONENT_WHITE) {
+      rgbAutostretchEnabled_ = false;
+      if (component == COMPONENT_WHITE) {
          applyProportionalMaxScaling(newMax);
          return;
       }
@@ -950,9 +950,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          captureWhiteRatios();
       }
       // newMasterMax is the value the white handle was dragged to — this IS the
-      // master max directly (updateScalingIndicators now shows whiteMasterMax_ at
+      // main max directly (updateScalingIndicators now shows whiteMainMax_ at
       // the handle, not Red's raw max, so no division is needed).
-      whiteMasterMax_ = newMasterMax;
+      whiteMainMax_ = newMasterMax;
       DisplaySettings oldDisplaySettings;
       DisplaySettings newDisplaySettings;
       do {
@@ -1077,14 +1077,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
       boolean whiteMode = getSelectedComponent() == COMPONENT_WHITE;
       for (int c = 0; c < numComponents; c++) {
-         Color color;
-         if (numComponents <= 1) {
-            color = channelSettings.getColor();
-         } else if (whiteMode && c == 0) {
-            color = Color.WHITE;
-         } else {
-            color = RGB_COLORS[c];
-         }
+         Color color = numComponents <= 1 ? channelSettings.getColor() : RGB_COLORS[c];
          Color highlight = numComponents <= 1 ? Color.YELLOW : color;
          histogram_.setComponentColor(c, color, highlight);
 
@@ -1092,6 +1085,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             IntegerComponentStats componentStats = stats_.getComponentStats(c);
             updateScalingIndicators(settings, componentStats, c);
          }
+      }
+      if (whiteMode && stats_ != null) {
+         updateWhiteScalingIndicator(settings, stats_.getComponentStats(0));
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -50,7 +50,21 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private final ColorSwatch channelColorSwatch_ = new ColorSwatch();
    private final JLabel channelNameLabel_ = new JLabel();
    private final JToggleButton channelVisibleButton_ = new JToggleButton();
-   private final JToggleButton[] componentButtons_ = new JToggleButton[3];
+   private static final int COMPONENT_WHITE = 3;
+   private double[] whiteRatios_ = null; // non-null when white mode is active
+   private long whiteMasterMax_ = 0; // master max shown by white handle; = max(R,G,B)
+   // When white mode is active, we manage autostretch ourselves to preserve
+   // ratios. DisplaySettings.isAutostretchEnabled() is kept false so the
+   // display engine's independent-per-component autostretch doesn't fire.
+   // This flag remembers that the user actually wants autostretch on.
+   // For RGB images, autostretch is managed here rather than in DisplayUIController
+   // so that we can honour the selected component and white-mode ratios.
+   // DisplaySettings.isAutostretchEnabled() is kept false; this flag tracks the
+   // user's actual intent.
+   private boolean rgbAutostretchEnabled_ = false;
+   private boolean suppressAutostretchDetection_ = false;
+
+   private final JToggleButton[] componentButtons_ = new JToggleButton[4];
 
    private final HistogramView histogram_ = HistogramView.create();
    private final JButton histoRangeDownButton_ = new JButton();
@@ -259,6 +273,32 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          IconLoader.getIcon("/org/micromanager/icons/rgb_blue_blank.png")
    };
 
+   private static Icon makeFilledSquareIcon(final Color fill, final Color border,
+                                            final boolean withTriangle) {
+      return new Icon() {
+         @Override
+         public void paintIcon(java.awt.Component c, Graphics g, int x, int y) {
+            g.setColor(fill);
+            g.fillRect(x, y, 14, 14);
+            g.setColor(border);
+            g.drawRect(x, y, 13, 13);
+            if (withTriangle) {
+               // Triangle in top-right corner, matching the R/G/B active icons.
+               // Use dark gray to contrast against the white background.
+               g.setColor(Color.DARK_GRAY);
+               int[] tx = {x + 7, x + 13, x + 13};
+               int[] ty = {y + 1, y + 1, y + 7};
+               g.fillPolygon(tx, ty, 3);
+            }
+         }
+         @Override public int getIconWidth()  { return 14; }
+         @Override public int getIconHeight() { return 14; }
+      };
+   }
+
+   private static final Icon WHITE_ICON_ACTIVE   = makeFilledSquareIcon(Color.WHITE, Color.DARK_GRAY, true);
+   private static final Icon WHITE_ICON_INACTIVE = makeFilledSquareIcon(new Color(180, 180, 180), Color.GRAY, false);
+
 
    /**
     * Create an instance of the ChannelIntensityController.
@@ -290,6 +330,19 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          final int ii = i;
          componentButtons_[i].addActionListener((ActionEvent e) -> handleComponentSelection(ii));
       }
+      componentButtons_[COMPONENT_WHITE] = new JToggleButton(WHITE_ICON_INACTIVE);
+      componentButtons_[COMPONENT_WHITE].setSelectedIcon(WHITE_ICON_ACTIVE);
+      componentButtons_[COMPONENT_WHITE].setBorder(BorderFactory.createEmptyBorder());
+      componentButtons_[COMPONENT_WHITE].setBorderPainted(false);
+      componentButtons_[COMPONENT_WHITE].setOpaque(true);
+      componentButtons_[COMPONENT_WHITE].setVisible(false);
+      componentButtons_[COMPONENT_WHITE].setSelected(false);
+      componentButtons_[COMPONENT_WHITE].addActionListener(
+            (ActionEvent e) -> handleComponentSelection(COMPONENT_WHITE));
+      javax.swing.ButtonGroup rgbGroup = new javax.swing.ButtonGroup();
+      for (JToggleButton btn : componentButtons_) {
+         rgbGroup.add(btn);
+      }
 
       channelPanel_.setLayout(new MigLayout(
             new LC().fill().insets("0").gridGap("0", "0")));
@@ -297,9 +350,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       channelPanel_.add(channelVisibleButton_, new CC().gapBefore("rel").split(2));
       channelPanel_.add(channelColorSwatch_, new CC().gapBefore("rel").width("32").wrap());
       channelPanel_.add(channelNameLabel_, new CC().gapBefore("rel").pushX().wrap("rel:rel:push"));
-      channelPanel_.add(componentButtons_[0], new CC().gapBefore("push").gapAfter("0").split(3));
+      channelPanel_.add(componentButtons_[0], new CC().gapBefore("push").gapAfter("0").split(4));
       channelPanel_.add(componentButtons_[1], new CC().gapAfter("0"));
-      channelPanel_.add(componentButtons_[2], new CC().gapAfter("push").wrap("rel"));
+      channelPanel_.add(componentButtons_[2], new CC().gapAfter("0"));
+      channelPanel_.add(componentButtons_[COMPONENT_WHITE], new CC().gapAfter("push").wrap("rel"));
       JButton fullscaleButton = new JButton("Fullscale");
       channelPanel_.add(fullscaleButton, new CC().pushX().wrap());
       JButton autostretchOnceButton = new JButton("Auto Once");
@@ -413,7 +467,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       histogram_.setOverlayText(null);
 
       int selectedComponent = getSelectedComponent();
-      IntegerComponentStats selectedStats = stats_.getComponentStats(selectedComponent);
+      // In white mode, show stats for component 0 (Red) as representative
+      int statsComponent = (selectedComponent == COMPONENT_WHITE) ? 0 : selectedComponent;
+      IntegerComponentStats selectedStats = stats_.getComponentStats(statsComponent);
       long min = selectedStats.getMinIntensity();
       intensityStatsPanel_.setMin(min >= 0 ? Long.toString(min) : null);
       long max = selectedStats.getMaxIntensity();
@@ -458,12 +514,22 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                                         IntegerComponentStats componentStats, int component) {
       long min;
       long max;
+      boolean whiteMode = getSelectedComponent() == COMPONENT_WHITE;
       if (settings.isAutostretchEnabled()) {
          double q = settings.getAutoscaleIgnoredQuantile();
          long[] minMax = new long[2];
          componentStats.getAutoscaleMinMaxForQuantile(q, minMax);
          min = minMax[0];
          max = minMax[1];
+      } else if (whiteMode && component == 0) {
+         // White mode: show the virtual master max at the handle (not Red's raw max),
+         // so the white handle position is independent of Red's ComponentDisplaySettings.
+         ComponentDisplaySettings componentSettings =
+               settings.getChannelSettings(channelIndex_).getComponentSettings(0);
+         min = Math.max(0, componentSettings.getScalingMinimum());
+         max = whiteMasterMax_ > 0 ? whiteMasterMax_
+               : Math.min(componentStats.getHistogramRangeMax(),
+                          componentSettings.getScalingMaximum());
       } else {
          ComponentDisplaySettings componentSettings =
                settings.getChannelSettings(channelIndex_)
@@ -497,6 +563,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    @MustCallOnEDT
    void setStats(ImageStats stats) {
       stats_ = stats;
+      if (rgbAutostretchEnabled_) {
+         applyRGBAutostretch();
+      }
       statsOrRangeChanged();
    }
 
@@ -560,21 +629,174 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    @MustCallOnEDT
    private void handleComponentSelection(int component) {
-      for (int i = 0; i < 3; i++) {
+      for (int i = 0; i < componentButtons_.length; i++) {
          componentButtons_[i].setSelected(i == component);
       }
-      histogram_.setSelectedComponent(component);
+      if (component == COMPONENT_WHITE) {
+         captureWhiteRatios();
+         histogram_.setComponentColor(0, Color.WHITE, Color.WHITE);
+         histogram_.setSelectedComponent(0);
+      } else {
+         whiteRatios_ = null;
+         whiteMasterMax_ = 0;
+         histogram_.setComponentColor(0, Color.RED, Color.RED);
+         histogram_.setSelectedComponent(component);
+      }
+      // Refresh scaling indicators immediately so the handle position reflects the
+      // new mode (white master max vs Red's individual max) without waiting for the
+      // next stats update.
+      statsOrRangeChanged();
+      // If autostretch is active (managed by us), re-apply for the new selection
+      if (rgbAutostretchEnabled_) {
+         applyRGBAutostretch();
+      }
    }
 
    @MustCallOnEDT
    private int getSelectedComponent() {
-      for (int i = 0; i < 3; i++) {
+      for (int i = 0; i < componentButtons_.length; i++) {
          if (componentButtons_[i].isSelected()) {
             return i;
          }
       }
       return 0; // Shouldn't reach
    }
+
+   @MustCallOnEDT
+   private void captureWhiteRatios() {
+      // Use the effective (displayed) max for each component: clamped to histogram range.
+      // This matches what updateScalingIndicators uses and avoids Long.MAX_VALUE defaults
+      // polluting the ratio when a channel hasn't been manually adjusted yet.
+      DisplaySettings settings = viewer_.getDisplaySettings();
+      ChannelDisplaySettings ch = settings.getChannelSettings(channelIndex_);
+      long[] effectiveMax = new long[3];
+      for (int c = 0; c < 3; c++) {
+         long settingsMax = ch.getComponentSettings(c).getScalingMaximum();
+         if (stats_ != null) {
+            long rangeMax = stats_.getComponentStats(c).getHistogramRangeMax();
+            effectiveMax[c] = Math.min(settingsMax, rangeMax);
+         } else {
+            effectiveMax[c] = settingsMax == Long.MAX_VALUE ? 255 : settingsMax;
+         }
+      }
+      long masterMax = Math.max(effectiveMax[0], Math.max(effectiveMax[1], effectiveMax[2]));
+      whiteMasterMax_ = masterMax;
+      if (masterMax > 0) {
+         whiteRatios_ = new double[] {
+               (double) effectiveMax[0] / masterMax,
+               (double) effectiveMax[1] / masterMax,
+               (double) effectiveMax[2] / masterMax
+         };
+      } else {
+         whiteRatios_ = new double[] {1.0, 1.0, 1.0};
+      }
+   }
+
+   boolean isRgbAutostretchEnabled() {
+      return rgbAutostretchEnabled_;
+   }
+
+   void setRgbAutostretchEnabled(boolean enabled) {
+      rgbAutostretchEnabled_ = enabled;
+   }
+
+   @MustCallOnEDT
+   private void turnOffAutostretchInSettings() {
+      DisplaySettings oldSettings;
+      DisplaySettings newSettings;
+      do {
+         oldSettings = viewer_.getDisplaySettings();
+         if (!oldSettings.isAutostretchEnabled()) {
+            return;
+         }
+         newSettings = oldSettings.copyBuilder().autostretch(false).build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldSettings, newSettings));
+   }
+
+   @MustCallOnEDT
+   private void restoreAutostretchInSettings() {
+      DisplaySettings oldSettings;
+      DisplaySettings newSettings;
+      do {
+         oldSettings = viewer_.getDisplaySettings();
+         if (oldSettings.isAutostretchEnabled()) {
+            return;
+         }
+         newSettings = oldSettings.copyBuilder().autostretch(true).build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldSettings, newSettings));
+   }
+
+   @MustCallOnEDT
+   private void applyRGBAutostretch() {
+      if (stats_ == null) {
+         return;
+      }
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      double q = viewer_.getDisplaySettings().getAutoscaleIgnoredQuantile();
+      int nComponents = stats_.getNumberOfComponents();
+      int selectedComponent = getSelectedComponent();
+
+      if (selectedComponent == COMPONENT_WHITE) {
+         // White mode: scale all components proportionally
+         if (whiteRatios_ == null) {
+            captureWhiteRatios();
+         }
+         // masterMax = brightest autoscale max across all components.
+         // This is the actual peak pixel value in the image, so the white handle
+         // lands at the image's true maximum rather than an inflated implied value.
+         long masterAutoscaleMax = 0;
+         long commonMin = Long.MAX_VALUE;
+         for (int c = 0; c < nComponents; c++) {
+            long[] minMax = new long[2];
+            stats_.getComponentStats(c).getAutoscaleMinMaxForQuantile(q, minMax);
+            if (minMax[1] > masterAutoscaleMax) {
+               masterAutoscaleMax = minMax[1];
+            }
+            if (minMax[0] < commonMin) {
+               commonMin = minMax[0];
+            }
+         }
+         final long masterMax = masterAutoscaleMax;
+         whiteMasterMax_ = masterMax;
+         final long sharedMin = commonMin == Long.MAX_VALUE ? 0 : commonMin;
+         do {
+            oldDisplaySettings = viewer_.getDisplaySettings();
+            ChannelDisplaySettings channelSettings =
+                  oldDisplaySettings.getChannelSettings(channelIndex_);
+            ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
+            for (int c = 0; c < nComponents; c++) {
+               long scaledMax = Math.round(whiteRatios_[c] * masterMax);
+               scaledMax = Math.max(scaledMax, sharedMin + 1);
+               builder.component(c,
+                     channelSettings.getComponentSettings(c).copyBuilder()
+                           .scalingRange(sharedMin, scaledMax).build());
+            }
+            newDisplaySettings = oldDisplaySettings
+                  .copyBuilderWithChannelSettings(channelIndex_, builder.build())
+                  .autostretch(false)
+                  .build();
+         } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+      } else {
+         // Single component selected: only autoscale that component, leave others unchanged
+         long[] minMax = new long[2];
+         stats_.getComponentStats(selectedComponent).getAutoscaleMinMaxForQuantile(q, minMax);
+         final long newMin = minMax[0];
+         final long newMax = minMax[1];
+         do {
+            oldDisplaySettings = viewer_.getDisplaySettings();
+            ChannelDisplaySettings channelSettings =
+                  oldDisplaySettings.getChannelSettings(channelIndex_);
+            newDisplaySettings = oldDisplaySettings
+                  .copyBuilderWithComponentSettings(channelIndex_, selectedComponent,
+                        channelSettings.getComponentSettings(selectedComponent).copyBuilder()
+                              .scalingRange(newMin, newMax).build())
+                  .autostretch(false)
+                  .build();
+         } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+      }
+   }
+
 
    private void handleFullscale() {
       DisplaySettings oldDisplaySettings;
@@ -585,11 +807,28 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
          int nComponents = stats_.getNumberOfComponents();
-         for (int i = 0; i < nComponents; ++i) {
-            long max = 1 << stats_.getComponentStats(0).getBitDepth();
-            builder.component(i,
-                  channelSettings.getComponentSettings(i).copyBuilder()
-                        .scalingRange(0L, max >= 0 ? max : Long.MAX_VALUE)
+         long fullMax = 1 << stats_.getComponentStats(0).getBitDepth();
+         if (fullMax < 0) {
+            fullMax = Long.MAX_VALUE;
+         }
+         if (getSelectedComponent() == COMPONENT_WHITE) {
+            if (whiteRatios_ == null) {
+               captureWhiteRatios();
+            }
+            whiteMasterMax_ = fullMax;
+            for (int i = 0; i < nComponents; ++i) {
+               long scaledMax = Math.round(whiteRatios_[i] * fullMax);
+               scaledMax = Math.max(scaledMax, 1);
+               builder.component(i,
+                     channelSettings.getComponentSettings(i).copyBuilder()
+                           .scalingRange(0L, scaledMax)
+                           .build());
+            }
+         } else {
+            int sel = getSelectedComponent();
+            builder.component(sel,
+                  channelSettings.getComponentSettings(sel).copyBuilder()
+                        .scalingRange(0L, fullMax)
                         .build());
          }
          newDisplaySettings = oldDisplaySettings
@@ -609,15 +848,40 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
          int nComponents = stats_.getNumberOfComponents();
-         for (int i = 0; i < nComponents; ++i) {
-            IntegerComponentStats stats = stats_.getComponentStats(i);
+         if (getSelectedComponent() == COMPONENT_WHITE) {
+            if (whiteRatios_ == null) {
+               captureWhiteRatios();
+            }
+            // masterMax = brightest autoscale max across all components.
+            long masterAutoscaleMax = 0;
+            long commonMin = Long.MAX_VALUE;
+            for (int i = 0; i < nComponents; ++i) {
+               IntegerComponentStats stats = stats_.getComponentStats(i);
+               long[] minMax = new long[2];
+               stats.getAutoscaleMinMaxForQuantile(q, minMax);
+               if (minMax[1] > masterAutoscaleMax) {
+                  masterAutoscaleMax = minMax[1];
+               }
+               if (minMax[0] < commonMin) {
+                  commonMin = minMax[0];
+               }
+            }
+            whiteMasterMax_ = masterAutoscaleMax;
+            for (int i = 0; i < nComponents; ++i) {
+               long scaledMax = Math.round(whiteRatios_[i] * masterAutoscaleMax);
+               scaledMax = Math.max(scaledMax, commonMin + 1);
+               builder.component(i,
+                     channelSettings.getComponentSettings(i).copyBuilder()
+                           .scalingRange(commonMin, scaledMax).build());
+            }
+         } else {
+            int sel = getSelectedComponent();
+            IntegerComponentStats stats = stats_.getComponentStats(sel);
             long[] minMax = new long[2];
             stats.getAutoscaleMinMaxForQuantile(q, minMax);
-            long min = minMax[0];
-            long max = minMax[1];
-            builder.component(i,
-                  channelSettings.getComponentSettings(i).copyBuilder()
-                        .scalingRange(min, max).build());
+            builder.component(sel,
+                  channelSettings.getComponentSettings(sel).copyBuilder()
+                        .scalingRange(minMax[0], minMax[1]).build());
          }
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
@@ -627,6 +891,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    @Override
    public void histogramScalingMinChanged(int component, long newMin) {
+      if (getSelectedComponent() == COMPONENT_WHITE) {
+         applyAbsoluteMinToAllComponents(newMin);
+         return;
+      }
       DisplaySettings oldDisplaySettings;
       DisplaySettings newDisplaySettings;
       do {
@@ -651,6 +919,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    @Override
    public void histogramScalingMaxChanged(int component, long newMax) {
+      if (getSelectedComponent() == COMPONENT_WHITE) {
+         applyProportionalMaxScaling(newMax);
+         return;
+      }
       DisplaySettings oldDisplaySettings;
       DisplaySettings newDisplaySettings;
       do {
@@ -667,6 +939,62 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                .build();
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithComponentSettings(channelIndex_, component, componentSettings)
+               .autostretch(false)
+               .build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+   }
+
+   @MustCallOnEDT
+   private void applyProportionalMaxScaling(long newMasterMax) {
+      if (whiteRatios_ == null) {
+         captureWhiteRatios();
+      }
+      // newMasterMax is the value the white handle was dragged to — this IS the
+      // master max directly (updateScalingIndicators now shows whiteMasterMax_ at
+      // the handle, not Red's raw max, so no division is needed).
+      whiteMasterMax_ = newMasterMax;
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      do {
+         oldDisplaySettings = viewer_.getDisplaySettings();
+         ChannelDisplaySettings channelSettings =
+               oldDisplaySettings.getChannelSettings(channelIndex_);
+         ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
+         for (int c = 0; c < 3; c++) {
+            long scaledMax = Math.round(whiteRatios_[c] * newMasterMax);
+            long currentMin = channelSettings.getComponentSettings(c).getScalingMinimum();
+            scaledMax = Math.max(scaledMax, currentMin + 1);
+            builder.component(c,
+                  channelSettings.getComponentSettings(c).copyBuilder()
+                        .scalingMaximum(scaledMax)
+                        .build());
+         }
+         newDisplaySettings = oldDisplaySettings
+               .copyBuilderWithChannelSettings(channelIndex_, builder.build())
+               .autostretch(false)
+               .build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+   }
+
+   @MustCallOnEDT
+   private void applyAbsoluteMinToAllComponents(long newMin) {
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      do {
+         oldDisplaySettings = viewer_.getDisplaySettings();
+         ChannelDisplaySettings channelSettings =
+               oldDisplaySettings.getChannelSettings(channelIndex_);
+         ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
+         for (int c = 0; c < 3; c++) {
+            long currentMax = channelSettings.getComponentSettings(c).getScalingMaximum();
+            long clampedMin = Math.max(0, Math.min(newMin, currentMax - 1));
+            builder.component(c,
+                  channelSettings.getComponentSettings(c).copyBuilder()
+                        .scalingMinimum(clampedMin)
+                        .build());
+         }
+         newDisplaySettings = oldDisplaySettings
+               .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                .autostretch(false)
                .build();
       } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
@@ -707,6 +1035,32 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    }
 
    void newDisplaySettings(DisplaySettings settings) {
+      // For RGB images, intercept autostretch so we can honour the selected
+      // component and white-mode ratios. Keep DisplaySettings.isAutostretchEnabled()
+      // false and drive updates ourselves from setStats().
+      int numComponents = stats_ == null ? 1 : stats_.getNumberOfComponents();
+      if (numComponents > 1 && !suppressAutostretchDetection_) {
+         if (settings.isAutostretchEnabled() && !rgbAutostretchEnabled_) {
+            // User just checked Autostretch — take ownership.
+            rgbAutostretchEnabled_ = true;
+            suppressAutostretchDetection_ = true;
+            try {
+               turnOffAutostretchInSettings();
+            } finally {
+               suppressAutostretchDetection_ = false;
+            }
+            applyRGBAutostretch();
+            return;
+         }
+         // Note: disabling rgbAutostretchEnabled_ when the user unchecks the box
+         // is handled externally via setRgbAutostretchEnabled(false), called from
+         // IntensityInspectorPanelController.handleAutostretch(). We must NOT do it
+         // here based on isAutostretchEnabled()==false, because we always keep that
+         // flag false in DisplaySettings (to prevent the display engine from
+         // interfering), so this condition would fire on every settings update and
+         // immediately reset rgbAutostretchEnabled_.
+      }
+
       ChannelDisplaySettings channelSettings =
             settings.getChannelSettings(channelIndex_);
       channelVisibleButton_.setSelected(channelSettings.isVisible());
@@ -715,15 +1069,22 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
       histoRangeComboBoxModel_.setBits(channelSettings);
 
-      int numComponents = stats_ == null ? 1 : stats_.getNumberOfComponents();
       if (numComponents <= 1) {
          histogram_.setGamma(channelSettings
                .getComponentSettings(0)
                .getScalingGamma());
       }
 
+      boolean whiteMode = getSelectedComponent() == COMPONENT_WHITE;
       for (int c = 0; c < numComponents; c++) {
-         Color color = numComponents <= 1 ? channelSettings.getColor() : RGB_COLORS[c];
+         Color color;
+         if (numComponents <= 1) {
+            color = channelSettings.getColor();
+         } else if (whiteMode && c == 0) {
+            color = Color.WHITE;
+         } else {
+            color = RGB_COLORS[c];
+         }
          Color highlight = numComponents <= 1 ? Color.YELLOW : color;
          histogram_.setComponentColor(c, color, highlight);
 

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -65,7 +65,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private long[] lastPickedValues_ = null; // pixel values tracked while in pick mode
 
    private final JToggleButton[] componentButtons_ = new JToggleButton[4];
-   private final javax.swing.JButton whiteBalanceButton_ = new javax.swing.JButton("White Balance");
+   private final JButton whiteBalanceButton_ = new JButton("White Balance");
 
    private final HistogramView histogram_ = HistogramView.create();
    private final JButton histoRangeDownButton_ = new JButton();
@@ -474,19 +474,24 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       // In white mode, show stats for component 0 (Red) as representative
       int statsComponent = (selectedComponent == COMPONENT_WHITE) ? 0 : selectedComponent;
       IntegerComponentStats selectedStats = stats_.getComponentStats(statsComponent);
-      long min = selectedStats.getMinIntensity();
+
+      final DisplaySettings displaySettings = viewer_.getDisplaySettings();
+      boolean ignoreZeros = displaySettings.isAutoscaleIgnoringZeros();
+
+      long min = ignoreZeros ? selectedStats.getMinIntensityExcludingZeros()
+                             : selectedStats.getMinIntensity();
       intensityStatsPanel_.setMin(min >= 0 ? Long.toString(min) : null);
       long max = selectedStats.getMaxIntensity();
       intensityStatsPanel_.setMax(max >= 0 ? Long.toString(max) : null);
-      long mean = selectedStats.getMeanIntensity();
+      long mean = ignoreZeros ? selectedStats.getMeanIntensityExcludingZeros()
+                              : selectedStats.getMeanIntensity();
       intensityStatsPanel_.setMean(mean >= 0 ? Long.toString(mean) : null);
-      double stdev = selectedStats.getStandardDeviation();
+      double stdev = ignoreZeros ? selectedStats.getStandardDeviationExcludingZeros()
+                                 : selectedStats.getStandardDeviation();
       intensityStatsPanel_.setStdev(Double.isNaN(stdev) ? null :
             String.format("%1.2e", stdev));
 
       cameraBits_ = stats_.getComponentStats(0).getBitDepth();
-
-      final DisplaySettings displaySettings = viewer_.getDisplaySettings();
       ChannelDisplaySettings chanDispSettings = histoRangeComboBoxModel_.getBits(
               displaySettings.getChannelSettings(channelIndex_), cameraBits_);
 
@@ -668,9 +673,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          componentButtons_[i].setSelected(i == component);
       }
       if (component == COMPONENT_WHITE) {
-         captureWhiteRatios();
-         // Immediately persist the ratios (and recompute per-component maxima) so
-         // that a first-seen channel does not store raw Long.MAX_VALUE defaults.
+         // applyCurrentWhiteRatios() calls captureWhiteRatios() internally when needed.
+         // Calling it here ensures first-seen channels immediately persist sensible
+         // values rather than raw Long.MAX_VALUE defaults.
          applyCurrentWhiteRatios();
          // Use HistogramView slot 3 for the white handle so that Red (slot 0)
          // keeps its own independent dotted line and handle.
@@ -720,10 +725,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private void restoreWhiteBalanceFromSettings() {
       ChannelDisplaySettings ch =
             viewer_.getDisplaySettings().getChannelSettings(channelIndex_);
-      double[] wb = DefaultChannelDisplaySettings.extractWhiteBalance(ch);
-      if (wb != null) {
-         whiteMainMax_ = (long) wb[0];
-         whiteRatios_ = new double[] {wb[1], wb[2], wb[3]};
+      long storedMax = DefaultChannelDisplaySettings.getStoredWhiteMainMax(ch);
+      double[] storedRatios = DefaultChannelDisplaySettings.getStoredWhiteRatios(ch);
+      if (storedMax > 0 && storedRatios != null) {
+         whiteMainMax_ = storedMax;
+         whiteRatios_ = storedRatios;
          // Recompute per-component scaling from the restored ratios so the
          // display is consistent rather than showing the raw stored component values.
          applyCurrentWhiteRatios();
@@ -761,14 +767,6 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       } else {
          whiteRatios_ = new double[] {1.0, 1.0, 1.0};
       }
-   }
-
-   /**
-    * Embeds the current white balance state (whiteMainMax_ and whiteRatios_) into a
-    * ChannelDisplaySettings builder so it gets persisted to the user profile.
-    */
-   private void applyWhiteBalanceToBuilder(ChannelDisplaySettings.Builder builder) {
-      DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
    }
 
    boolean isRgbAutostretchEnabled() {
@@ -837,7 +835,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                      channelSettings.getComponentSettings(c).copyBuilder()
                            .scalingRange(sharedMin, scaledMax).build());
             }
-            applyWhiteBalanceToBuilder(builder);
+            DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
             newDisplaySettings = oldDisplaySettings
                   .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                   .autostretch(false)
@@ -866,9 +864,12 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    private void handleFullscale() {
       int nComponents = stats_.getNumberOfComponents();
-      long fullMax = 1 << stats_.getComponentStats(0).getBitDepth();
-      if (fullMax < 0) {
-         fullMax = Long.MAX_VALUE;
+      Integer bitDepth = stats_.getComponentStats(0).getBitDepth();
+      long fullMax;
+      if (bitDepth == null) {
+         fullMax = stats_.getComponentStats(0).getHistogramRangeMax();
+      } else {
+         fullMax = bitDepth >= 63 ? Long.MAX_VALUE : (1L << bitDepth) - 1L;
       }
       int sel = getSelectedComponent();
       if (sel == COMPONENT_WHITE && whiteRatios_ == null) {
@@ -892,7 +893,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                      channelSettings.getComponentSettings(i).copyBuilder()
                            .scalingRange(0L, scaledMax).build());
             }
-            applyWhiteBalanceToBuilder(builder);
+            DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
          } else {
             builder.component(sel,
                   channelSettings.getComponentSettings(sel).copyBuilder()
@@ -915,7 +916,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
          int nComponents = stats_.getNumberOfComponents();
-         if (getSelectedComponent() == COMPONENT_WHITE) {
+         int sel = getSelectedComponent();
+         if (sel == COMPONENT_WHITE) {
             if (whiteRatios_ == null) {
                captureWhiteRatios();
             }
@@ -928,9 +930,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                      channelSettings.getComponentSettings(i).copyBuilder()
                            .scalingRange(commonMin, scaledMax).build());
             }
-            applyWhiteBalanceToBuilder(builder);
+            DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
          } else {
-            int sel = getSelectedComponent();
             IntegerComponentStats stats = stats_.getComponentStats(sel);
             long[] minMax = new long[2];
             stats.getAutoscaleMinMaxForQuantile(q, minMax);
@@ -1026,7 +1027,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                         .scalingMaximum(scaledMax)
                         .build());
          }
-         applyWhiteBalanceToBuilder(builder);
+         DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                .autostretch(false)
@@ -1051,7 +1052,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                         .scalingMinimum(clampedMin)
                         .build());
          }
-         applyWhiteBalanceToBuilder(builder);
+         DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                .autostretch(false)
@@ -1486,7 +1487,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             builder.component(c, channelSettings.getComponentSettings(c)
                   .copyBuilder().scalingRange(currentMin, scaledMax).build());
          }
-         applyWhiteBalanceToBuilder(builder);
+         DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
          newDisplaySettings = oldDisplaySettings.copyBuilder()
                .channel(channelIndex_, builder.build()).build();
       } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -541,10 +541,15 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       long max;
       if (settings.isAutostretchEnabled()) {
          double q = settings.getAutoscaleIgnoredQuantile();
-         long[] minMax = new long[2];
-         componentStats.getAutoscaleMinMaxForQuantile(q, minMax);
-         min = minMax[0];
-         max = minMax[1];
+         if (settings.isAutoscaleIgnoringZeros()) {
+            min = 0L;
+            max = componentStats.getAutoscaleMaxForQuantileIgnoringZeros(q);
+         } else {
+            long[] minMax = new long[2];
+            componentStats.getAutoscaleMinMaxForQuantile(q, minMax);
+            min = minMax[0];
+            max = minMax[1];
+         }
       } else {
          ComponentDisplaySettings componentSettings =
                settings.getChannelSettings(channelIndex_)
@@ -802,18 +807,27 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    // Returns {mainMax, commonMin} across all components at the given quantile.
    // mainMax = brightest autoscale max, so the white handle lands at the image's
    // true peak value rather than an inflated implied value.
-   private long[] computeWhiteAutoscaleRange(double q) {
+   private long[] computeWhiteAutoscaleRange(double q, boolean ignoreZeros) {
       long mainMax = 0;
       long commonMin = Long.MAX_VALUE;
       int nComponents = stats_.getNumberOfComponents();
       for (int c = 0; c < nComponents; c++) {
-         long[] minMax = new long[2];
-         stats_.getComponentStats(c).getAutoscaleMinMaxForQuantile(q, minMax);
-         if (minMax[1] > mainMax) {
-            mainMax = minMax[1];
+         long cMax;
+         long cMin;
+         if (ignoreZeros) {
+            cMax = stats_.getComponentStats(c).getAutoscaleMaxForQuantileIgnoringZeros(q);
+            cMin = 0L;
+         } else {
+            long[] minMax = new long[2];
+            stats_.getComponentStats(c).getAutoscaleMinMaxForQuantile(q, minMax);
+            cMax = minMax[1];
+            cMin = minMax[0];
          }
-         if (minMax[0] < commonMin) {
-            commonMin = minMax[0];
+         if (cMax > mainMax) {
+            mainMax = cMax;
+         }
+         if (cMin < commonMin) {
+            commonMin = cMin;
          }
       }
       return new long[] { mainMax, commonMin == Long.MAX_VALUE ? 0 : commonMin };
@@ -827,13 +841,14 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       DisplaySettings oldDisplaySettings;
       DisplaySettings newDisplaySettings;
       double q = viewer_.getDisplaySettings().getAutoscaleIgnoredQuantile();
+      boolean ignoreZeros = viewer_.getDisplaySettings().isAutoscaleIgnoringZeros();
       int selectedComponent = getSelectedComponent();
 
       if (selectedComponent == COMPONENT_WHITE) {
          if (whiteRatios_ == null) {
             captureWhiteRatios();
          }
-         long[] range = computeWhiteAutoscaleRange(q);
+         long[] range = computeWhiteAutoscaleRange(q, ignoreZeros);
          whiteMainMax_ = range[0];
          final long sharedMin = range[1];
          int nComponents = stats_.getNumberOfComponents();
@@ -858,10 +873,18 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
       } else {
          // Single component: only autoscale the selected component, leave others unchanged.
-         long[] minMax = new long[2];
-         stats_.getComponentStats(selectedComponent).getAutoscaleMinMaxForQuantile(q, minMax);
-         final long newMin = minMax[0];
-         final long newMax = minMax[1];
+         final long newMin;
+         final long newMax;
+         if (ignoreZeros) {
+            newMin = 0L;
+            newMax = stats_.getComponentStats(selectedComponent)
+                  .getAutoscaleMaxForQuantileIgnoringZeros(q);
+         } else {
+            long[] minMax = new long[2];
+            stats_.getComponentStats(selectedComponent).getAutoscaleMinMaxForQuantile(q, minMax);
+            newMin = minMax[0];
+            newMax = minMax[1];
+         }
          do {
             oldDisplaySettings = viewer_.getDisplaySettings();
             ChannelDisplaySettings channelSettings =
@@ -927,6 +950,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       do {
          oldDisplaySettings = viewer_.getDisplaySettings();
          double q = oldDisplaySettings.getAutoscaleIgnoredQuantile();
+         boolean ignoreZeros = oldDisplaySettings.isAutoscaleIgnoringZeros();
          ChannelDisplaySettings channelSettings =
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
@@ -936,7 +960,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             if (whiteRatios_ == null) {
                captureWhiteRatios();
             }
-            long[] range = computeWhiteAutoscaleRange(q);
+            long[] range = computeWhiteAutoscaleRange(q, ignoreZeros);
             whiteMainMax_ = range[0];
             long commonMin = range[1];
             for (int i = 0; i < nComponents; ++i) {
@@ -949,11 +973,20 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
          } else {
             IntegerComponentStats stats = stats_.getComponentStats(sel);
-            long[] minMax = new long[2];
-            stats.getAutoscaleMinMaxForQuantile(q, minMax);
+            long min;
+            long max;
+            if (ignoreZeros) {
+               min = 0L;
+               max = stats.getAutoscaleMaxForQuantileIgnoringZeros(q);
+            } else {
+               long[] minMax = new long[2];
+               stats.getAutoscaleMinMaxForQuantile(q, minMax);
+               min = minMax[0];
+               max = minMax[1];
+            }
             builder.component(sel,
                   channelSettings.getComponentSettings(sel).copyBuilder()
-                        .scalingRange(minMax[0], minMax[1]).build());
+                        .scalingRange(min, max).build());
          }
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
@@ -1257,8 +1290,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    @MustCallOnEDT
    private void showColorTemperatureDialog() {
-      // Snapshot settings so we can restore on Cancel.
-      final DisplaySettings settingsOnOpen = viewer_.getDisplaySettings();
+      // Snapshot only the channel settings we will modify, so Cancel can revert
+      // just this channel without clobbering unrelated concurrent changes.
+      final ChannelDisplaySettings channelOnOpen =
+            viewer_.getDisplaySettings().getChannelSettings(channelIndex_);
       final double[] ratiosOnOpen = whiteRatios_ == null ? null : whiteRatios_.clone();
       final long mainMaxOnOpen = whiteMainMax_;
 
@@ -1336,13 +1371,17 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       okButton.addActionListener(e -> dialog.dispose());
 
       cancelButton.addActionListener(e -> {
-         // Restore settings from before the dialog opened
+         // Revert only this channel's scaling — leave all other display changes intact.
          whiteRatios_ = ratiosOnOpen;
          whiteMainMax_ = mainMaxOnOpen;
          DisplaySettings current;
+         DisplaySettings reverted;
          do {
             current = viewer_.getDisplaySettings();
-         } while (!viewer_.compareAndSetDisplaySettings(current, settingsOnOpen));
+            reverted = current
+                  .copyBuilderWithChannelSettings(channelIndex_, channelOnOpen)
+                  .build();
+         } while (!viewer_.compareAndSetDisplaySettings(current, reverted));
          statsOrRangeChanged();
          dialog.dispose();
       });

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -292,13 +292,22 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                g.fillPolygon(tx, ty, 3);
             }
          }
-         @Override public int getIconWidth()  { return 14; }
-         @Override public int getIconHeight() { return 14; }
+
+         @Override public int getIconWidth()  {
+            return 14;
+         }
+
+         @Override public int getIconHeight() {
+            return 14;
+         }
+
       };
    }
 
-   private static final Icon WHITE_ICON_ACTIVE   = makeFilledSquareIcon(Color.WHITE, Color.DARK_GRAY, true);
-   private static final Icon WHITE_ICON_INACTIVE = makeFilledSquareIcon(new Color(180, 180, 180), Color.GRAY, false);
+   private static final Icon WHITE_ICON_ACTIVE   = makeFilledSquareIcon(Color.WHITE,
+            Color.DARK_GRAY, true);
+   private static final Icon WHITE_ICON_INACTIVE = makeFilledSquareIcon(new Color(
+            180, 180, 180), Color.GRAY, false);
 
 
    /**
@@ -800,8 +809,12 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       for (int c = 0; c < nComponents; c++) {
          long[] minMax = new long[2];
          stats_.getComponentStats(c).getAutoscaleMinMaxForQuantile(q, minMax);
-         if (minMax[1] > mainMax) { mainMax = minMax[1]; }
-         if (minMax[0] < commonMin) { commonMin = minMax[0]; }
+         if (minMax[1] > mainMax) {
+            mainMax = minMax[1];
+         }
+         if (minMax[0] < commonMin) {
+            commonMin = minMax[0];
+         }
       }
       return new long[] { mainMax, commonMin == Long.MAX_VALUE ? 0 : commonMin };
    }
@@ -830,12 +843,14 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                   oldDisplaySettings.getChannelSettings(channelIndex_);
             ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
             for (int c = 0; c < nComponents; c++) {
-               long scaledMax = Math.max(Math.round(whiteRatios_[c] * whiteMainMax_), sharedMin + 1);
+               long scaledMax = Math.max(Math.round(whiteRatios_[c] * whiteMainMax_),
+                        sharedMin + 1);
                builder.component(c,
                      channelSettings.getComponentSettings(c).copyBuilder()
                            .scalingRange(sharedMin, scaledMax).build());
             }
-            DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
+            DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_,
+                     whiteRatios_);
             newDisplaySettings = oldDisplaySettings
                   .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                   .autostretch(false)
@@ -863,7 +878,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
 
    private void handleFullscale() {
-      int nComponents = stats_.getNumberOfComponents();
+      final int nComponents = stats_.getNumberOfComponents();
       Integer bitDepth = stats_.getComponentStats(0).getBitDepth();
       long fullMax;
       if (bitDepth == null) {
@@ -925,7 +940,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             whiteMainMax_ = range[0];
             long commonMin = range[1];
             for (int i = 0; i < nComponents; ++i) {
-               long scaledMax = Math.max(Math.round(whiteRatios_[i] * whiteMainMax_), commonMin + 1);
+               long scaledMax = Math.max(Math.round(whiteRatios_[i] * whiteMainMax_),
+                        commonMin + 1);
                builder.component(i,
                      channelSettings.getComponentSettings(i).copyBuilder()
                            .scalingRange(commonMin, scaledMax).build());
@@ -1183,6 +1199,22 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       }
    }
 
+   @Subscribe
+   public void onEvent(DisplayMouseEvent e) {
+      if (!pickingWhiteBalancePoint_) {
+         return;
+      }
+      if (e.getEvent().getID() == java.awt.event.MouseEvent.MOUSE_PRESSED
+               && javax.swing.SwingUtilities.isLeftMouseButton(e.getEvent())) {
+         pickingWhiteBalancePoint_ = false;
+         final long[] values = lastPickedValues_;
+         lastPickedValues_ = null;
+         if (values != null) {
+            javax.swing.SwingUtilities.invokeLater(() -> applyPickedPointWhiteBalance(values));
+         }
+      }
+   }
+
    private long[] getPixelValuesForChannel(DataViewerMousePixelInfoChangedEvent e) {
       // Channel-less case
       if (channelIndex_ == 0 && e.getNumberOfCoords() == 1) {
@@ -1362,8 +1394,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
     */
    private static int[] colorTemperatureToRgb(int kelvin) {
       double t = Math.max(1000, Math.min(40000, kelvin)) / 100.0;
-      int r, g, b;
 
+      int r;
       if (t <= 66) {
          r = 255;
       } else {
@@ -1371,6 +1403,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          r = Math.max(0, Math.min(255, r));
       }
 
+      int g;
       if (t <= 66) {
          g = (int) (99.4708025861 * Math.log(t) - 161.1195681661);
       } else {
@@ -1378,6 +1411,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       }
       g = Math.max(0, Math.min(255, g));
 
+      int b;
       if (t >= 66) {
          b = 255;
       } else if (t <= 19) {
@@ -1418,7 +1452,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private void applyPickedPointWhiteBalance(long[] pixelValues) {
       long maxVal = 0;
       for (long v : pixelValues) {
-         if (v > maxVal) { maxVal = v; }
+         if (v > maxVal) {
+            maxVal = v;
+         }
       }
       if (maxVal == 0) {
          return; // can't balance a black pixel
@@ -1450,22 +1486,6 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             (double) means[2] / maxMean
       };
       applyCurrentWhiteRatios();
-   }
-
-   @Subscribe
-   public void onEvent(DisplayMouseEvent e) {
-      if (!pickingWhiteBalancePoint_) {
-         return;
-      }
-      if (e.getEvent().getID() == java.awt.event.MouseEvent.MOUSE_PRESSED
-            && javax.swing.SwingUtilities.isLeftMouseButton(e.getEvent())) {
-         pickingWhiteBalancePoint_ = false;
-         final long[] values = lastPickedValues_;
-         lastPickedValues_ = null;
-         if (values != null) {
-            javax.swing.SwingUtilities.invokeLater(() -> applyPickedPointWhiteBalance(values));
-         }
-      }
    }
 
    @MustCallOnEDT

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -717,7 +717,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          applyCurrentWhiteRatios();
          // Use HistogramView slot 3 for the white handle so that Red (slot 0)
          // keeps its own independent dotted line and handle.
-         histogram_.setComponentColor(0, Color.RED, Color.RED);
+         for (int c = 0; c < RGB_COLORS.length; c++) {
+            histogram_.setComponentColor(c, RGB_COLORS[c], RGB_COLORS[c]);
+         }
          histogram_.setComponentColor(COMPONENT_WHITE, Color.WHITE, Color.WHITE);
          histogram_.setSelectedComponent(COMPONENT_WHITE);
          whiteBalanceButton_.setVisible(true);
@@ -810,13 +812,15 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       } while (!viewer_.compareAndSetDisplaySettings(oldSettings, newSettings));
    }
 
-   // Returns {mainMax, commonMin} across all components at the given quantile.
-   // mainMax = brightest autoscale max, so the white handle lands at the image's
-   // true peak value rather than an inflated implied value.
+   // Returns {mainMax, commonMin, cMax[0], cMax[1], cMax[2]} across all components
+   // at the given quantile. mainMax = brightest autoscale max so the white handle
+   // lands at the image's true peak value. Per-component maxes are used to recompute
+   // white ratios from actual image content rather than stale captured values.
    private long[] computeWhiteAutoscaleRange(double q, boolean ignoreZeros) {
       long mainMax = 0;
       long commonMin = Long.MAX_VALUE;
       int nComponents = stats_.getNumberOfComponents();
+      long[] cMaxes = new long[nComponents];
       for (int c = 0; c < nComponents; c++) {
          long cMax;
          long cMin;
@@ -829,6 +833,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             cMax = minMax[1];
             cMin = minMax[0];
          }
+         cMaxes[c] = cMax;
          if (cMax > mainMax) {
             mainMax = cMax;
          }
@@ -836,7 +841,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             commonMin = cMin;
          }
       }
-      return new long[] { mainMax, commonMin == Long.MAX_VALUE ? 0 : commonMin };
+      long[] result = new long[2 + nComponents];
+      result[0] = mainMax;
+      result[1] = commonMin == Long.MAX_VALUE ? 0 : commonMin;
+      System.arraycopy(cMaxes, 0, result, 2, nComponents);
+      return result;
    }
 
    @MustCallOnEDT
@@ -851,22 +860,24 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       int selectedComponent = getSelectedComponent();
 
       if (selectedComponent == COMPONENT_WHITE) {
-         if (whiteRatios_ == null) {
-            captureWhiteRatios();
-         }
          long[] range = computeWhiteAutoscaleRange(q, ignoreZeros);
          whiteMainMax_ = range[0];
          final long sharedMin = range[1];
          whiteMainMin_ = sharedMin;
          int nComponents = stats_.getNumberOfComponents();
+         // Recompute ratios from actual per-component image maxima so that white
+         // mode reflects true color balance rather than stale default values.
+         whiteRatios_ = new double[nComponents];
+         for (int c = 0; c < nComponents; c++) {
+            whiteRatios_[c] = whiteMainMax_ > 0 ? (double) range[2 + c] / whiteMainMax_ : 1.0;
+         }
          do {
             oldDisplaySettings = viewer_.getDisplaySettings();
             ChannelDisplaySettings channelSettings =
                   oldDisplaySettings.getChannelSettings(channelIndex_);
             ChannelDisplaySettings.Builder builder = channelSettings.copyBuilder();
             for (int c = 0; c < nComponents; c++) {
-               long scaledMax = Math.max(Math.round(whiteRatios_[c] * whiteMainMax_),
-                        sharedMin + 1);
+               long scaledMax = Math.max(range[2 + c], sharedMin + 1);
                builder.component(c,
                      channelSettings.getComponentSettings(c).copyBuilder()
                            .scalingRange(sharedMin, scaledMax).build());
@@ -963,16 +974,18 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          int nComponents = stats_.getNumberOfComponents();
          int sel = getSelectedComponent();
          if (sel == COMPONENT_WHITE) {
-            if (whiteRatios_ == null) {
-               captureWhiteRatios();
-            }
             long[] range = computeWhiteAutoscaleRange(q, ignoreZeros);
             whiteMainMax_ = range[0];
             long commonMin = range[1];
             whiteMainMin_ = commonMin;
+            // Recompute ratios from actual per-component image maxima so that white
+            // mode reflects true color balance rather than stale default values.
+            whiteRatios_ = new double[nComponents];
             for (int i = 0; i < nComponents; ++i) {
-               long scaledMax = Math.max(Math.round(whiteRatios_[i] * whiteMainMax_),
-                        commonMin + 1);
+               whiteRatios_[i] = whiteMainMax_ > 0 ? (double) range[2 + i] / whiteMainMax_ : 1.0;
+            }
+            for (int i = 0; i < nComponents; ++i) {
+               long scaledMax = Math.max(range[2 + i], commonMin + 1);
                builder.component(i,
                      channelSettings.getComponentSettings(i).copyBuilder()
                            .scalingRange(commonMin, scaledMax).build());

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -27,6 +27,7 @@ import org.micromanager.display.ChannelDisplaySettings;
 import org.micromanager.display.ComponentDisplaySettings;
 import org.micromanager.display.DataViewer;
 import org.micromanager.display.DisplaySettings;
+import org.micromanager.display.internal.DefaultChannelDisplaySettings;
 import org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEvent;
 import org.micromanager.display.internal.event.DisplayMouseEvent;
 import org.micromanager.display.internal.imagestats.ImageStats;
@@ -649,6 +650,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       }
 
       if (isRGB && !wasRGB) {
+         // Restore persisted white balance data if available, so that
+         // captureWhiteRatios() (called inside handleComponentSelection) is skipped
+         // and the stored ratios are used instead of re-deriving from raw component values.
+         restoreWhiteBalanceFromSettings();
          // Auto-select White when entering RGB mode for the first time.
          handleComponentSelection(COMPONENT_WHITE);
       } else {
@@ -664,6 +669,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       }
       if (component == COMPONENT_WHITE) {
          captureWhiteRatios();
+         // Immediately persist the ratios (and recompute per-component maxima) so
+         // that a first-seen channel does not store raw Long.MAX_VALUE defaults.
+         applyCurrentWhiteRatios();
          // Use HistogramView slot 3 for the white handle so that Red (slot 0)
          // keeps its own independent dotted line and handle.
          histogram_.setComponentColor(0, Color.RED, Color.RED);
@@ -701,8 +709,32 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       return 0; // component 0 selected by default
    }
 
+   /**
+    * Loads whiteRatios_ and whiteMainMax_ from persisted ChannelDisplaySettings if
+    * available. When present, the stored values are used directly; captureWhiteRatios()
+    * will then be a no-op (it only runs when whiteRatios_ is null).
+    * Also applies the ratios to recompute per-component settings from the stored values
+    * so that the display does not show stale per-component maxima from the profile.
+    */
+   @MustCallOnEDT
+   private void restoreWhiteBalanceFromSettings() {
+      ChannelDisplaySettings ch =
+            viewer_.getDisplaySettings().getChannelSettings(channelIndex_);
+      double[] wb = DefaultChannelDisplaySettings.extractWhiteBalance(ch);
+      if (wb != null) {
+         whiteMainMax_ = (long) wb[0];
+         whiteRatios_ = new double[] {wb[1], wb[2], wb[3]};
+         // Recompute per-component scaling from the restored ratios so the
+         // display is consistent rather than showing the raw stored component values.
+         applyCurrentWhiteRatios();
+      }
+   }
+
    @MustCallOnEDT
    private void captureWhiteRatios() {
+      if (whiteRatios_ != null) {
+         return; // already set (e.g. restored from profile or set by white balance)
+      }
       // Use the effective (displayed) max for each component: clamped to histogram range.
       // This matches what updateScalingIndicators uses and avoids Long.MAX_VALUE defaults
       // polluting the ratio when a channel hasn't been manually adjusted yet.
@@ -729,6 +761,14 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       } else {
          whiteRatios_ = new double[] {1.0, 1.0, 1.0};
       }
+   }
+
+   /**
+    * Embeds the current white balance state (whiteMainMax_ and whiteRatios_) into a
+    * ChannelDisplaySettings builder so it gets persisted to the user profile.
+    */
+   private void applyWhiteBalanceToBuilder(ChannelDisplaySettings.Builder builder) {
+      DefaultChannelDisplaySettings.applyWhiteBalance(builder, whiteMainMax_, whiteRatios_);
    }
 
    boolean isRgbAutostretchEnabled() {
@@ -797,6 +837,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                      channelSettings.getComponentSettings(c).copyBuilder()
                            .scalingRange(sharedMin, scaledMax).build());
             }
+            applyWhiteBalanceToBuilder(builder);
             newDisplaySettings = oldDisplaySettings
                   .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                   .autostretch(false)
@@ -851,6 +892,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                      channelSettings.getComponentSettings(i).copyBuilder()
                            .scalingRange(0L, scaledMax).build());
             }
+            applyWhiteBalanceToBuilder(builder);
          } else {
             builder.component(sel,
                   channelSettings.getComponentSettings(sel).copyBuilder()
@@ -886,6 +928,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                      channelSettings.getComponentSettings(i).copyBuilder()
                            .scalingRange(commonMin, scaledMax).build());
             }
+            applyWhiteBalanceToBuilder(builder);
          } else {
             int sel = getSelectedComponent();
             IntegerComponentStats stats = stats_.getComponentStats(sel);
@@ -983,6 +1026,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                         .scalingMaximum(scaledMax)
                         .build());
          }
+         applyWhiteBalanceToBuilder(builder);
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                .autostretch(false)
@@ -1007,6 +1051,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                         .scalingMinimum(clampedMin)
                         .build());
          }
+         applyWhiteBalanceToBuilder(builder);
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                .autostretch(false)
@@ -1441,6 +1486,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             builder.component(c, channelSettings.getComponentSettings(c)
                   .copyBuilder().scalingRange(currentMin, scaledMax).build());
          }
+         applyWhiteBalanceToBuilder(builder);
          newDisplaySettings = oldDisplaySettings.copyBuilder()
                .channel(channelIndex_, builder.build()).build();
       } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/FloatCoordinateMapper.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/FloatCoordinateMapper.java
@@ -1,0 +1,58 @@
+package org.micromanager.display.inspector.internal.panels.intensity;
+
+import org.micromanager.display.internal.imagestats.ComponentStats;
+
+/**
+ * Converts between histogram bin indices (the long values stored in
+ * ComponentDisplaySettings for float images) and actual pixel values.
+ *
+ * <p>For float images the long stored in ComponentDisplaySettings represents
+ * a bin index (0..binCount). This gives ~256 discrete slider positions
+ * regardless of the pixel-value dynamic range.
+ */
+final class FloatCoordinateMapper {
+   private final double rangeMin_;
+   private final double binWidth_;
+   private final int binCount_;
+
+   FloatCoordinateMapper(ComponentStats stats) {
+      rangeMin_ = stats.getHistogramRangeMinDouble();
+      binWidth_ = stats.getBinWidthDouble();
+      binCount_ = stats.getHistogramBinCount();
+   }
+
+   long pixelValueToBinIndex(double pixelValue) {
+      if (binWidth_ == 0.0) {
+         return 0;
+      }
+      long idx = Math.round((pixelValue - rangeMin_) / binWidth_);
+      return Math.max(0, Math.min(binCount_, idx));
+   }
+
+   double binIndexToPixelValue(long binIndex) {
+      return rangeMin_ + binIndex * binWidth_;
+   }
+
+   String formatBinIndex(long binIndex) {
+      double v = binIndexToPixelValue(binIndex);
+      if (Math.abs(binWidth_) < 0.01) {
+         return String.format("%.4g", v);
+      }
+      if (Math.abs(binWidth_) < 0.1) {
+         return String.format("%.3g", v);
+      }
+      return String.format("%.2g", v);
+   }
+
+   int getBinCount() {
+      return binCount_;
+   }
+
+   double getRangeMin() {
+      return rangeMin_;
+   }
+
+   double getBinWidth() {
+      return binWidth_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -178,15 +178,11 @@ public final class HistogramView extends JPanel {
       listeners_.removeListener(listener);
    }
 
-   /**
-    * Sets which component is selected (presumable used in RGB images).
-    *
-    * @param component index of selected component.
-    */
    public void setSelectedComponent(int component) {
       Preconditions.checkElementIndex(component, componentStates_.size());
       selectedComponent_ = component;
       cachedGammaMappingPath_ = null;
+      repaint();
    }
 
    public void setComponentGraph(int component, long[] graph, long rangeMax) {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -728,7 +728,7 @@ public final class HistogramView extends JPanel {
       Graphics2D g2d = (Graphics2D) g.create();
       g2d.setColor(OVERLAY_COLOR);
       g2d.setFont(g.getFont().deriveFont(OVERLAY_FONT_SIZE).deriveFont(OVERLAY_FONT_STYLE));
-      FontMetrics metrics = g.getFontMetrics();
+      FontMetrics metrics = g2d.getFontMetrics();
       g2d.drawString(text, graphTopRight.x - metrics.stringWidth(text) - 3,
             graphTopRight.y + metrics.getAscent());
    }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -811,16 +811,28 @@ public final class HistogramView extends JPanel {
             return null;
          }
 
+         // Find the first and last bins with non-zero count to avoid drawing
+         // a flat zero-count line at the edges of the histogram.
+         int firstNonZero = 0;
+         while (firstNonZero < data.length && data[firstNonZero] == 0.0f) {
+            firstNonZero++;
+         }
+         int lastNonZero = data.length - 1;
+         while (lastNonZero > firstNonZero && data[lastNonZero] == 0.0f) {
+            lastNonZero--;
+         }
+
          state.cachedPath_ =
                new Path2D.Float(Path2D.WIND_EVEN_ODD, 2 * data.length + 2);
-         state.cachedPath_.moveTo(0.0f, (float) rect.height);
-         for (int i = 0; i < data.length; ++i) {
+         float startX = firstNonZero * pixelsPerBin;
+         state.cachedPath_.moveTo(startX, (float) rect.height);
+         for (int i = firstNonZero; i <= lastNonZero; ++i) {
             float x = i * pixelsPerBin;
             float y = rect.height - dataScaling * data[i];
             state.cachedPath_.lineTo(x, y);                // Vertical
             state.cachedPath_.lineTo(x + pixelsPerBin, y); // Horizontal
          }
-         state.cachedPath_.lineTo((float) rect.width, (float) rect.height);
+         state.cachedPath_.lineTo((lastNonZero + 1) * pixelsPerBin, (float) rect.height);
          if (fillHistograms_) {
             state.cachedPath_.closePath();
          }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -211,14 +211,29 @@ public final class HistogramView extends JPanel {
    public void clearGraphs() {
       nullRectsAndMappingPath();
       for (ComponentState state : componentStates_) {
-         state.graph_ = null;
-         state.rangeMax_ = 0;
-         state.scalingMin_ = 0;
-         state.scalingMax_ = 0;
-         state.cachedInterpolatedLogScaledGraph_ = null;
-         state.cachedPath_ = null;
+         clearComponentState(state);
       }
       repaint();
+   }
+
+   public void clearComponentGraph(int component) {
+      if (component >= componentStates_.size()) {
+         return;
+      }
+      if (component == selectedComponent_) {
+         nullRectsAndMappingPath();
+      }
+      clearComponentState(componentStates_.get(component));
+      repaint();
+   }
+
+   private void clearComponentState(ComponentState state) {
+      state.graph_ = null;
+      state.rangeMax_ = 0;
+      state.scalingMin_ = 0;
+      state.scalingMax_ = 0;
+      state.cachedInterpolatedLogScaledGraph_ = null;
+      state.cachedPath_ = null;
    }
 
    public void setComponentColor(int component, Color color, Color highlightColor) {
@@ -592,6 +607,9 @@ public final class HistogramView extends JPanel {
    private void drawComponentScalingLimits(int component, Graphics2D g) {
       Rectangle rect = getGraphRect();
       ComponentState state = componentStates_.get(component);
+      if (state.rangeMax_ <= 0) {
+         return;
+      }
       float binCount = state.rangeMax_ + 1;
       float loXPos = getScalingHandlePos(component, false);
       if (loXPos < rect.x) { // Prevent from being clipped

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -236,6 +236,7 @@ public final class HistogramView extends JPanel {
 
    private void clearComponentState(ComponentState state) {
       state.graph_ = null;
+      state.rangeMin_ = 0;
       state.rangeMax_ = 0;
       state.scalingMin_ = 0;
       state.scalingMax_ = 0;
@@ -1104,7 +1105,6 @@ public final class HistogramView extends JPanel {
             + state.rangeMin_);
       intensity = Math.max(state.rangeMin_, Math.min(state.rangeMax_, intensity));
       if (top) {
-         intensity--;
          intensity = Math.max(state.scalingMin_ + 1, intensity);
          setComponentScaling(selectedComponent_, state.scalingMin_, intensity);
          listeners_.fire().histogramScalingMaxChanged(selectedComponent_, intensity);
@@ -1154,7 +1154,6 @@ public final class HistogramView extends JPanel {
       }
       intensity = Math.max(state.rangeMin_, Math.min(state.rangeMax_, intensity));
       if (top) {
-         intensity--;
          intensity = Math.max(state.scalingMin_ + 1, intensity);
          setComponentScaling(selectedComponent_, state.scalingMin_, intensity);
          listeners_.fire().histogramScalingMaxChanged(selectedComponent_, intensity);

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -75,6 +75,10 @@ public final class HistogramView extends JPanel {
       long highlightIntensity_ = -1; // Negative = off
       long scalingMin_ = 0;
       long scalingMax_ = rangeMax_;
+      // Non-null for float images: converts bin-index longs to pixel-value strings.
+      FloatCoordinateMapper floatMapper_ = null;
+      // Optional label override for the range-max tick (e.g. "1.000" for bin-index 256).
+      String rangeMaxLabel_ = null;
 
       float[] cachedInterpolatedLogScaledGraph_;
       Path2D.Float cachedPath_;
@@ -240,6 +244,8 @@ public final class HistogramView extends JPanel {
       state.rangeMax_ = 0;
       state.scalingMin_ = 0;
       state.scalingMax_ = 0;
+      state.floatMapper_ = null;
+      state.rangeMaxLabel_ = null;
       state.cachedInterpolatedLogScaledGraph_ = null;
       state.cachedPath_ = null;
    }
@@ -297,6 +303,23 @@ public final class HistogramView extends JPanel {
    public long getComponentScalingMax(int component) {
       Preconditions.checkElementIndex(component, componentStates_.size());
       return componentStates_.get(component).scalingMax_;
+   }
+
+   public void setComponentFloatMapper(int component, FloatCoordinateMapper mapper) {
+      Preconditions.checkArgument(component >= 0);
+      addComponentIfNecessary(component);
+      componentStates_.get(component).floatMapper_ = mapper;
+      if (component == selectedComponent_) {
+         nullRectsAndMappingPath();
+      }
+      repaint();
+   }
+
+   public void setComponentRangeMaxLabel(int component, String label) {
+      Preconditions.checkArgument(component >= 0);
+      addComponentIfNecessary(component);
+      componentStates_.get(component).rangeMaxLabel_ = label;
+      repaint();
    }
 
    /**
@@ -412,7 +435,9 @@ public final class HistogramView extends JPanel {
          Rectangle rect = getGraphRect();
          ComponentState state = componentStates_.get(component);
          long intensity = top ? state.scalingMax_ : state.scalingMin_;
-         String text = Long.toString(intensity);
+         String text = (state.floatMapper_ != null)
+               ? state.floatMapper_.formatBinIndex(intensity)
+               : Long.toString(intensity);
 
          int x = (int) getScalingHandlePos(component, top);
 
@@ -587,7 +612,10 @@ public final class HistogramView extends JPanel {
             return; // Only draw if all components have the same max
          }
       }
-      String text = Long.toString(rangeMax);
+      ComponentState first = componentStates_.get(0);
+      String text = (first.rangeMaxLabel_ != null)
+            ? first.rangeMaxLabel_
+            : Long.toString(rangeMax);
       Rectangle rect = getGraphRect();
       Point graphBottomRight = new Point(rect.x + rect.width, rect.y + rect.height);
 
@@ -716,7 +744,9 @@ public final class HistogramView extends JPanel {
          return;
       }
       long intensity = top ? state.scalingMax_ : state.scalingMin_;
-      final String text = Long.toString(intensity);
+      final String text = (state.floatMapper_ != null)
+            ? state.floatMapper_.formatBinIndex(intensity)
+            : Long.toString(intensity);
 
       float x = getScalingHandlePos(component, top);
       if (x < rect.x - 1 || x > rect.x + rect.width) {
@@ -1071,6 +1101,14 @@ public final class HistogramView extends JPanel {
 
    private void startScalingEdit(final boolean top) {
       final ComponentState state = componentStates_.get(selectedComponent_);
+      if (state.floatMapper_ != null) {
+         startFloatScalingEdit(top, state);
+      } else {
+         startIntegerScalingEdit(top, state);
+      }
+   }
+
+   private void startIntegerScalingEdit(final boolean top, final ComponentState state) {
       long intensity = top ? state.scalingMax_ : state.scalingMin_;
       long min = top ? state.scalingMin_ + 1 : state.rangeMin_;
       long max = top ? state.rangeMax_ : state.scalingMax_ - 1;
@@ -1091,6 +1129,39 @@ public final class HistogramView extends JPanel {
       });
       JPopupMenu popup = new JPopupMenu();
       popup.add(scalingSpinner);
+      popup.validate();
+      int x = (int) getScalingHandlePos(selectedComponent_, top)
+            - popup.getPreferredSize().width / 2;
+      int y = top ? -popup.getPreferredSize().height : getBounds().height;
+      popup.show(this, x, y);
+   }
+
+   private void startFloatScalingEdit(final boolean top, final ComponentState state) {
+      final FloatCoordinateMapper mapper = state.floatMapper_;
+      long curBin = top ? state.scalingMax_ : state.scalingMin_;
+      long minBin = top ? state.scalingMin_ + 1 : 0;
+      long maxBin = top ? (long) mapper.getBinCount() : state.scalingMax_ - 1;
+      double curVal = mapper.binIndexToPixelValue(curBin);
+      double minVal = mapper.binIndexToPixelValue(minBin);
+      double maxVal = mapper.binIndexToPixelValue(maxBin);
+      double step = mapper.getBinWidth();
+      final JSpinner spinner = new JSpinner(
+            new SpinnerNumberModel(curVal, minVal, maxVal, step));
+      spinner.addChangeListener((ChangeEvent e) -> {
+         double val = ((Number) spinner.getValue()).doubleValue();
+         long binIdx = mapper.pixelValueToBinIndex(val);
+         if (top) {
+            binIdx = Math.max(state.scalingMin_ + 1, binIdx);
+            setComponentScaling(selectedComponent_, state.scalingMin_, binIdx);
+            listeners_.fire().histogramScalingMaxChanged(selectedComponent_, binIdx);
+         } else {
+            binIdx = Math.min(state.scalingMax_ - 1, binIdx);
+            setComponentScaling(selectedComponent_, binIdx, state.scalingMax_);
+            listeners_.fire().histogramScalingMinChanged(selectedComponent_, binIdx);
+         }
+      });
+      JPopupMenu popup = new JPopupMenu();
+      popup.add(spinner);
       popup.validate();
       int x = (int) getScalingHandlePos(selectedComponent_, top)
             - popup.getPreferredSize().width / 2;

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
@@ -281,6 +281,7 @@ public class IntensityInspectorPanelController
          if (viewer_ != null) {
             ChannelIntensityController chanController
                   = ChannelIntensityController.create(viewer_, i);
+            chanController.setHistogramLogYAxis(gearMenuLogYAxisItem_.isSelected());
             channelControllers_.add(chanController);
             channelHistogramsPanel_.add(chanController.getChannelPanel(),
                   new CC().growY());

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
@@ -422,21 +422,16 @@ public class IntensityInspectorPanelController
       boolean enabled = autostretchCheckBox_.isSelected();
       double percentile = (Double) percentileSpinner_.getValue();
       if (!enabled) {
-         // When turning autostretch off, freeze the current autoscaled values
-         // into DisplaySettings so the image doesn't snap back to the previous
-         // manual range. Do this before disabling autostretch so that
-         // handleAutoscale() can still read the current stats.
+         // Freeze the current autoscaled values into DisplaySettings before disabling,
+         // so the image doesn't snap back to the prior manual range.
+         // Also clear rgbAutostretchEnabled here — we can't detect the transition via
+         // DisplaySettings.isAutostretchEnabled() because we keep that false for RGB.
          displaySettingsUpdateSuspended_ = true;
          for (ChannelIntensityController ch : channelControllers_) {
             ch.handleAutoscale();
-         }
-         displaySettingsUpdateSuspended_ = false;
-         // Disable RGB autostretch tracking. Must be done here (not in
-         // newDisplaySettings) because we always keep DisplaySettings.isAutostretchEnabled()
-         // false for RGB images, so that field can't be used to detect the transition.
-         for (ChannelIntensityController ch : channelControllers_) {
             ch.setRgbAutostretchEnabled(false);
          }
+         displaySettingsUpdateSuspended_ = false;
       }
       DisplaySettings oldSettings;
       DisplaySettings newSettings;

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
@@ -421,30 +421,32 @@ public class IntensityInspectorPanelController
    private void handleAutostretch() {
       boolean enabled = autostretchCheckBox_.isSelected();
       double percentile = (Double) percentileSpinner_.getValue();
+      if (!enabled) {
+         // When turning autostretch off, freeze the current autoscaled values
+         // into DisplaySettings so the image doesn't snap back to the previous
+         // manual range. Do this before disabling autostretch so that
+         // handleAutoscale() can still read the current stats.
+         displaySettingsUpdateSuspended_ = true;
+         for (ChannelIntensityController ch : channelControllers_) {
+            ch.handleAutoscale();
+         }
+         displaySettingsUpdateSuspended_ = false;
+         // Disable RGB autostretch tracking. Must be done here (not in
+         // newDisplaySettings) because we always keep DisplaySettings.isAutostretchEnabled()
+         // false for RGB images, so that field can't be used to detect the transition.
+         for (ChannelIntensityController ch : channelControllers_) {
+            ch.setRgbAutostretchEnabled(false);
+         }
+      }
       DisplaySettings oldSettings;
       DisplaySettings newSettings;
-      // boolean needToSetFixedMinMaxToAutoscaled = false;
       do {
          oldSettings = viewer_.getDisplaySettings();
-         //needToSetFixedMinMaxToAutoscaled = !enabled && oldSettings.isAutostretchEnabled();
          newSettings = oldSettings.copyBuilder()
                .autostretch(enabled)
                .autoscaleIgnoredPercentile(percentile)
                .build();
       } while (!viewer_.compareAndSetDisplaySettings(oldSettings, newSettings));
-      /*
-      if (needToSetFixedMinMaxToAutoscaled) {
-         // When autostretch is turned off, rather than snapping back to
-         // whatever the range was before autostretch was enabled, we want to
-         // keep the current actual range. That can be accomplished by the
-         // equivalent of clicking on Auto Once for each channel.
-         displaySettingsUpdateSuspended_ = true;
-         for (ChannelIntensityController ch : channelControllers_) {
-              ch.handleAutoscale();
-         }
-         displaySettingsUpdateSuspended_ = false;
-      }
-      */
    }
 
    @MustCallOnEDT
@@ -567,7 +569,13 @@ public class IntensityInspectorPanelController
       // or something external. So sync to the panel UI first, but do so
       // without generating UI actions.
       gearMenuUseROIItem_.setSelected(settings.isROIAutoscaleEnabled());
-      autostretchCheckBox_.setSelected(settings.isAutostretchEnabled());
+      // For RGB images, autostretch is managed by ChannelIntensityController (kept off
+      // in DisplaySettings to prevent the display engine from interfering). Use
+      // rgbAutostretchEnabled_ from the first channel controller as the authoritative state.
+      boolean autostretchOn = settings.isAutostretchEnabled()
+            || (!channelControllers_.isEmpty()
+                  && channelControllers_.get(0).isRgbAutostretchEnabled());
+      autostretchCheckBox_.setSelected(autostretchOn);
 
       // A spinner's change listener, unlike an action listener, gets notified
       // upon programmatic changes. Use a flag to suppress re-entrant handling.
@@ -584,13 +592,7 @@ public class IntensityInspectorPanelController
          ignoreLabel_.setText(")");
       }
 
-      if (autostretchCheckBox_.isSelected() && !settings.isAutostretchEnabled()) {
-         displaySettingsUpdateSuspended_ = true;
-         for (ChannelIntensityController ch : channelControllers_) {
-            ch.handleAutoscale();
-         }
-         displaySettingsUpdateSuspended_ = false;
-      }
+
 
       gearMenuLogYAxisItem_.setSelected(settings.isHistogramLogarithmic());
       gearMenuUseROIItem_.setSelected(settings.isROIAutoscaleEnabled());

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/IntensityInspectorPanelController.java
@@ -560,7 +560,7 @@ public class IntensityInspectorPanelController
          return;
       }
 
-      // We may arrive here as a result of UI actions in this insector panel,
+      // We may arrive here as a result of UI actions in this inspector panel,
       // or something external. So sync to the panel UI first, but do so
       // without generating UI actions.
       gearMenuUseROIItem_.setSelected(settings.isROIAutoscaleEnabled());

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
@@ -8,6 +8,7 @@ import org.micromanager.PropertyMap;
 import org.micromanager.PropertyMaps;
 import org.micromanager.data.internal.PropertyKey;
 import org.micromanager.display.ChannelDisplaySettings;
+import org.micromanager.display.ChannelIntensityRanges;
 import org.micromanager.display.ComponentDisplaySettings;
 import org.micromanager.internal.utils.ColorPalettes;
 
@@ -150,6 +151,20 @@ public final class DefaultChannelDisplaySettings
          component(component);
          componentSettings_.set(component, settings);
          return this;
+      }
+
+      @Override
+      public Builder intensityScaling(ChannelIntensityRanges ranges) {
+         int nComponents = ranges.getNumberOfComponents();
+         Builder ret = this;
+         ret = ret.component(nComponents - 1);
+         for (int c = 0; c < nComponents; ++c) {
+            ret = ret.component(c,
+                  componentSettings_.get(c).copyBuilder()
+                        .scalingRange(ranges.getComponentRange(c))
+                        .build());
+         }
+         return ret;
       }
 
       @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
@@ -160,6 +160,9 @@ public final class DefaultChannelDisplaySettings
       @Override
       public Builder intensityScaling(ChannelIntensityRanges ranges) {
          int nComponents = ranges.getNumberOfComponents();
+         if (nComponents == 0) {
+            return this;
+         }
          Builder ret = this;
          ret = ret.component(nComponents - 1);
          for (int c = 0; c < nComponents; ++c) {
@@ -201,37 +204,33 @@ public final class DefaultChannelDisplaySettings
    }
 
    /**
-    * Embeds white balance data into a ChannelDisplaySettings.Builder so it is
-    * persisted to the user profile. No-op if the builder is not a
-    * DefaultChannelDisplaySettings.Builder or if the data is not set.
-    *
-    * @param builder     The builder to update in place.
-    * @param whiteMainMax The master max for white mode (0 = not set).
-    * @param whiteRatios  The RGB ratios for white mode (null = not set).
+    * Returns the stored white-mode main max from a ChannelDisplaySettings, or 0
+    * if none is stored.
     */
+   public static long getStoredWhiteMainMax(ChannelDisplaySettings settings) {
+      if (settings instanceof DefaultChannelDisplaySettings) {
+         return ((DefaultChannelDisplaySettings) settings).whiteMainMax_;
+      }
+      return 0;
+   }
+
    /**
-    * Extracts white balance data from a ChannelDisplaySettings if it was
-    * previously stored there, returning {whiteMainMax, r, g, b} or null if
-    * no white balance data is present.
-    *
-    * @param settings The channel settings to read from.
-    * @return double[] {whiteMainMax, ratioR, ratioG, ratioB}, or null if not set.
+    * Returns the stored white-mode RGB ratios from a ChannelDisplaySettings, or
+    * null if none are stored.
     */
-   public static double[] extractWhiteBalance(ChannelDisplaySettings settings) {
+   public static double[] getStoredWhiteRatios(ChannelDisplaySettings settings) {
       if (settings instanceof DefaultChannelDisplaySettings) {
          DefaultChannelDisplaySettings dcds = (DefaultChannelDisplaySettings) settings;
-         if (dcds.whiteRatios_ != null && dcds.whiteMainMax_ > 0) {
-            return new double[] {
-                  dcds.whiteMainMax_,
-                  dcds.whiteRatios_[0],
-                  dcds.whiteRatios_[1],
-                  dcds.whiteRatios_[2]
-            };
-         }
+         return dcds.whiteRatios_ != null ? dcds.whiteRatios_.clone() : null;
       }
       return null;
    }
 
+   /**
+    * Embeds white balance data into a ChannelDisplaySettings.Builder so it is
+    * persisted to the user profile. No-op if the builder is not a
+    * DefaultChannelDisplaySettings.Builder or if the data is not set.
+    */
    public static void applyWhiteBalance(ChannelDisplaySettings.Builder builder,
                                         long whiteMainMax, double[] whiteRatios) {
       if (whiteRatios != null && whiteMainMax > 0 && builder instanceof Builder) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
@@ -25,6 +25,8 @@ public final class DefaultChannelDisplaySettings
    private final int histoRangeBits_;
    private final boolean useCameraRange_;
    private final List<ComponentDisplaySettings> componentSettings_;
+   private final long whiteMainMax_;    // 0 = not set; master max for white mode
+   private final double[] whiteRatios_; // null = not set; RGB ratios for white mode
 
 
    private static final class Builder
@@ -38,6 +40,8 @@ public final class DefaultChannelDisplaySettings
       private boolean useCameraRange_ = true;
       private final List<ComponentDisplaySettings> componentSettings_ =
             new ArrayList<>();
+      private long whiteMainMax_ = 0;
+      private double[] whiteRatios_ = null;
 
       private Builder() {
          componentSettings_.add(DefaultComponentDisplaySettings.builder().build());
@@ -179,11 +183,60 @@ public final class DefaultChannelDisplaySettings
          return componentSettings_.get(component);
       }
 
+      public Builder whiteMainMax(long max) {
+         whiteMainMax_ = max;
+         return this;
+      }
+
+      public Builder whiteRatios(double[] ratios) {
+         whiteRatios_ = ratios != null ? ratios.clone() : null;
+         return this;
+      }
+
       @Override
       public ChannelDisplaySettings build() {
          return new DefaultChannelDisplaySettings(this);
       }
 
+   }
+
+   /**
+    * Embeds white balance data into a ChannelDisplaySettings.Builder so it is
+    * persisted to the user profile. No-op if the builder is not a
+    * DefaultChannelDisplaySettings.Builder or if the data is not set.
+    *
+    * @param builder     The builder to update in place.
+    * @param whiteMainMax The master max for white mode (0 = not set).
+    * @param whiteRatios  The RGB ratios for white mode (null = not set).
+    */
+   /**
+    * Extracts white balance data from a ChannelDisplaySettings if it was
+    * previously stored there, returning {whiteMainMax, r, g, b} or null if
+    * no white balance data is present.
+    *
+    * @param settings The channel settings to read from.
+    * @return double[] {whiteMainMax, ratioR, ratioG, ratioB}, or null if not set.
+    */
+   public static double[] extractWhiteBalance(ChannelDisplaySettings settings) {
+      if (settings instanceof DefaultChannelDisplaySettings) {
+         DefaultChannelDisplaySettings dcds = (DefaultChannelDisplaySettings) settings;
+         if (dcds.whiteRatios_ != null && dcds.whiteMainMax_ > 0) {
+            return new double[] {
+                  dcds.whiteMainMax_,
+                  dcds.whiteRatios_[0],
+                  dcds.whiteRatios_[1],
+                  dcds.whiteRatios_[2]
+            };
+         }
+      }
+      return null;
+   }
+
+   public static void applyWhiteBalance(ChannelDisplaySettings.Builder builder,
+                                        long whiteMainMax, double[] whiteRatios) {
+      if (whiteRatios != null && whiteMainMax > 0 && builder instanceof Builder) {
+         ((Builder) builder).whiteMainMax(whiteMainMax).whiteRatios(whiteRatios);
+      }
    }
 
    public static ChannelDisplaySettings.Builder builder() {
@@ -199,6 +252,8 @@ public final class DefaultChannelDisplaySettings
       histoRangeBits_ = builder.histoRangeBits_;
       useCameraRange_ = builder.useCameraRange_;
       componentSettings_ = new ArrayList<>(builder.componentSettings_);
+      whiteMainMax_ = builder.whiteMainMax_;
+      whiteRatios_ = builder.whiteRatios_ != null ? builder.whiteRatios_.clone() : null;
    }
 
    @Override
@@ -254,6 +309,14 @@ public final class DefaultChannelDisplaySettings
       return new ArrayList<>(componentSettings_);
    }
 
+   public long getWhiteMainMax() {
+      return whiteMainMax_;
+   }
+
+   public double[] getWhiteRatios() {
+      return whiteRatios_ != null ? whiteRatios_.clone() : null;
+   }
+
    @Override
    public ChannelDisplaySettings.Builder copyBuilder() {
       Builder builder = new Builder();
@@ -266,6 +329,8 @@ public final class DefaultChannelDisplaySettings
       builder.useCameraRange_ = useCameraRange_;
       builder.componentSettings_.clear();
       builder.componentSettings_.addAll(componentSettings_);
+      builder.whiteMainMax_ = whiteMainMax_;
+      builder.whiteRatios_ = whiteRatios_ != null ? whiteRatios_.clone() : null;
       return builder;
    }
 
@@ -315,7 +380,7 @@ public final class DefaultChannelDisplaySettings
          componentSettings.add(((DefaultComponentDisplaySettings) cs).toPropertyMap());
       }
 
-      return PropertyMaps.builder()
+      PropertyMap.Builder pmBuilder = PropertyMaps.builder()
             .putColor(PropertyKey.COLOR.key(), color_)
             .putString(PropertyKey.CHANNEL_NAME.key(), name_)
             .putString(PropertyKey.CHANNEL_GROUP.key(), groupName_)
@@ -323,8 +388,14 @@ public final class DefaultChannelDisplaySettings
             .putBoolean(PropertyKey.VISIBLE.key(), visible_)
             .putInteger(PropertyKey.HISTOGRAM_BIT_DEPTH.key(), histoRangeBits_)
             .putBoolean(PropertyKey.USE_CAMERA_BIT_DEPTH.key(), useCameraRange_)
-            .putPropertyMapList(PropertyKey.COMPONENT_SETTINGS.key(), componentSettings)
-            .build();
+            .putPropertyMapList(PropertyKey.COMPONENT_SETTINGS.key(), componentSettings);
+      if (whiteMainMax_ > 0) {
+         pmBuilder.putLong(PropertyKey.WHITE_MAIN_MAX.key(), whiteMainMax_);
+      }
+      if (whiteRatios_ != null) {
+         pmBuilder.putDoubleList(PropertyKey.WHITE_RATIOS.key(), whiteRatios_);
+      }
+      return pmBuilder.build();
    }
 
    /**
@@ -366,6 +437,15 @@ public final class DefaultChannelDisplaySettings
       if (pMap.containsBoolean(PropertyKey.USE_CAMERA_BIT_DEPTH.key())) {
          b.useCameraHistoRange(pMap.getBoolean(PropertyKey.USE_CAMERA_BIT_DEPTH.key(),
                b.useCameraRange_));
+      }
+      if (pMap.containsLong(PropertyKey.WHITE_MAIN_MAX.key())) {
+         b.whiteMainMax(pMap.getLong(PropertyKey.WHITE_MAIN_MAX.key(), 0L));
+      }
+      if (pMap.containsDoubleList(PropertyKey.WHITE_RATIOS.key())) {
+         double[] ratios = pMap.getDoubleList(PropertyKey.WHITE_RATIOS.key());
+         if (ratios.length == 3) {
+            b.whiteRatios(ratios);
+         }
       }
 
       return b;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
@@ -233,9 +233,18 @@ public final class DefaultChannelDisplaySettings
     */
    public static void applyWhiteBalance(ChannelDisplaySettings.Builder builder,
                                         long whiteMainMax, double[] whiteRatios) {
-      if (whiteRatios != null && whiteMainMax > 0 && builder instanceof Builder) {
-         ((Builder) builder).whiteMainMax(whiteMainMax).whiteRatios(whiteRatios);
+      if (whiteRatios == null || whiteMainMax <= 0 || !(builder instanceof Builder)) {
+         return;
       }
+      if (whiteRatios.length != 3) {
+         return;
+      }
+      for (double r : whiteRatios) {
+         if (!Double.isFinite(r) || r <= 0.0) {
+            return;
+         }
+      }
+      ((Builder) builder).whiteMainMax(whiteMainMax).whiteRatios(whiteRatios);
    }
 
    public static ChannelDisplaySettings.Builder builder() {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelIntensityRanges.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelIntensityRanges.java
@@ -1,0 +1,170 @@
+package org.micromanager.display.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.micromanager.display.ChannelIntensityRanges;
+import org.micromanager.display.ComponentIntensityRange;
+
+public class DefaultChannelIntensityRanges implements ChannelIntensityRanges {
+   // Store as single array of alternating min/max values. Length is always even.
+   private final long[] ranges_; // Never null
+
+   public static class Builder implements ChannelIntensityRanges.Builder {
+      private long[] ranges_; // May be null
+
+      private void ensureNumComponents(int nComponents) {
+         int addedComponents = 0;
+         if (ranges_ == null) {
+            addedComponents = nComponents;
+            ranges_ = new long[2 * nComponents];
+         } else if (ranges_.length < 2 * nComponents) {
+            addedComponents = nComponents - ranges_.length / 2;
+            ranges_ = Arrays.copyOf(ranges_, 2 * nComponents);
+         }
+         for (int i = 0; i < addedComponents; ++i) {
+            ranges_[2 * i + 1] = Long.MAX_VALUE;
+         }
+      }
+
+      private void trimComponents(int nComponents) {
+         if (ranges_.length > 2 * nComponents) {
+            ranges_ = Arrays.copyOfRange(ranges_, 0, 2 * nComponents);
+         }
+      }
+
+      private void normalize() {
+         for (int c = ranges_.length / 2; c >= 0; c -= 2) {
+            if (ranges_[2 * c] != 0 || ranges_[2 * c + 1] != Long.MAX_VALUE) {
+               ranges_ = Arrays.copyOfRange(ranges_, 0, 2 * c);
+               return;
+            }
+         }
+         ranges_ = null; // All components had defaults
+      }
+
+      @Override
+      public ChannelIntensityRanges.Builder componentRange(int component, long min, long max) {
+         ensureNumComponents(component + 1);
+         ranges_[2 * component] = min;
+         ranges_[2 * component + 1] = max;
+         return this;
+      }
+
+      @Override
+      public ChannelIntensityRanges.Builder componentRange(int component,
+            ComponentIntensityRange range) {
+         ensureNumComponents(component + 1);
+         ranges_[2 * component] = range.getMinimum();
+         ranges_[2 * component + 1] = range.getMaximum();
+         return this;
+      }
+
+      @Override
+      public ChannelIntensityRanges.Builder componentMinimum(int component, long min) {
+         ensureNumComponents(component + 1);
+         ranges_[2 * component] = min;
+         return this;
+      }
+
+      @Override
+      public ChannelIntensityRanges.Builder componentMaximum(int component, long max) {
+         ensureNumComponents(component + 1);
+         ranges_[2 * component + 1] = max;
+         return this;
+      }
+
+      @Override
+      public ChannelIntensityRanges.Builder componentRanges(List<ComponentIntensityRange> ranges) {
+         ensureNumComponents(ranges.size());
+         trimComponents(ranges.size());
+         for (int c = 0; c < ranges.size(); ++c) {
+            ranges_[2 * c] = ranges.get(c).getMinimum();
+            ranges_[2 * c + 1] = ranges.get(c).getMaximum();
+         }
+         return this;
+      }
+
+      @Override
+      public DefaultChannelIntensityRanges build() {
+         return new DefaultChannelIntensityRanges(this);
+      }
+   }
+
+   private DefaultChannelIntensityRanges(Builder builder) {
+      builder.normalize();
+      if (builder.ranges_ == null) {
+         ranges_ = new long[0];
+      } else {
+         ranges_ = builder.ranges_.clone();
+      }
+   }
+
+   @Override
+   public Builder copyBuilder() {
+      Builder ret = new Builder();
+      ret.ranges_ = ranges_.clone();
+      return ret;
+   }
+
+   @Override
+   public int getNumberOfComponents() {
+      return ranges_.length / 2;
+   }
+
+   @Override
+   public long getComponentMinimum(int component) {
+      if (component > getNumberOfComponents()) {
+         return 0;
+      }
+      return ranges_[2 * component];
+   }
+
+   @Override
+   public long getComponentMaximum(int component) {
+      if (component > getNumberOfComponents()) {
+         return Long.MAX_VALUE;
+      }
+      return ranges_[2 * component + 1];
+   }
+
+   @Override
+   public ComponentIntensityRange getComponentRange(int component) {
+      if (component > getNumberOfComponents()) {
+         return ComponentIntensityRange.builder().build();
+      }
+      return ComponentIntensityRange.builder()
+            .range(ranges_[2 * component], ranges_[2 * component + 1])
+            .build();
+   }
+
+   @Override
+   public List<ComponentIntensityRange> getAllComponentRanges() {
+      int nComponents = getNumberOfComponents();
+      List<ComponentIntensityRange> ret = new ArrayList<>(nComponents);
+      for (int c = 0; c < nComponents; ++c) {
+         ret.add(getComponentRange(c));
+      }
+      return ret;
+   }
+
+   @Override
+   public List<Long> getComponentMinima() {
+      int nComponents = getNumberOfComponents();
+      List<Long> ret = new ArrayList<>(nComponents);
+      for (int c = 0; c < nComponents; ++c) {
+         ret.add(getComponentMinimum(c));
+      }
+      return ret;
+   }
+
+   @Override
+   public List<Long> getComponentMaxima() {
+      int nComponents = getNumberOfComponents();
+      List<Long> ret = new ArrayList<>(nComponents);
+      for (int c = 0; c < nComponents; ++c) {
+         ret.add(getComponentMaximum(c));
+      }
+      return ret;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelIntensityRanges.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelIntensityRanges.java
@@ -14,29 +14,34 @@ public class DefaultChannelIntensityRanges implements ChannelIntensityRanges {
       private long[] ranges_; // May be null
 
       private void ensureNumComponents(int nComponents) {
-         int addedComponents = 0;
          if (ranges_ == null) {
-            addedComponents = nComponents;
             ranges_ = new long[2 * nComponents];
+            for (int i = 0; i < nComponents; ++i) {
+               ranges_[2 * i + 1] = Long.MAX_VALUE;
+            }
          } else if (ranges_.length < 2 * nComponents) {
-            addedComponents = nComponents - ranges_.length / 2;
+            int existingComponents = ranges_.length / 2;
             ranges_ = Arrays.copyOf(ranges_, 2 * nComponents);
-         }
-         for (int i = 0; i < addedComponents; ++i) {
-            ranges_[2 * i + 1] = Long.MAX_VALUE;
+            for (int i = existingComponents; i < nComponents; ++i) {
+               ranges_[2 * i + 1] = Long.MAX_VALUE;
+            }
          }
       }
 
       private void trimComponents(int nComponents) {
-         if (ranges_.length > 2 * nComponents) {
+         if (ranges_ != null && ranges_.length > 2 * nComponents) {
             ranges_ = Arrays.copyOfRange(ranges_, 0, 2 * nComponents);
          }
       }
 
       private void normalize() {
-         for (int c = ranges_.length / 2; c >= 0; c -= 2) {
+         if (ranges_ == null) {
+            return; // already null (no components set)
+         }
+         for (int c = ranges_.length / 2 - 1; c >= 0; --c) {
             if (ranges_[2 * c] != 0 || ranges_[2 * c + 1] != Long.MAX_VALUE) {
-               ranges_ = Arrays.copyOfRange(ranges_, 0, 2 * c);
+               // c is the last non-default component; keep components 0..c inclusive
+               ranges_ = Arrays.copyOfRange(ranges_, 0, 2 * (c + 1));
                return;
             }
          }
@@ -114,7 +119,7 @@ public class DefaultChannelIntensityRanges implements ChannelIntensityRanges {
 
    @Override
    public long getComponentMinimum(int component) {
-      if (component > getNumberOfComponents()) {
+      if (component < 0 || component >= getNumberOfComponents()) {
          return 0;
       }
       return ranges_[2 * component];
@@ -122,7 +127,7 @@ public class DefaultChannelIntensityRanges implements ChannelIntensityRanges {
 
    @Override
    public long getComponentMaximum(int component) {
-      if (component > getNumberOfComponents()) {
+      if (component < 0 || component >= getNumberOfComponents()) {
          return Long.MAX_VALUE;
       }
       return ranges_[2 * component + 1];
@@ -130,7 +135,7 @@ public class DefaultChannelIntensityRanges implements ChannelIntensityRanges {
 
    @Override
    public ComponentIntensityRange getComponentRange(int component) {
-      if (component > getNumberOfComponents()) {
+      if (component < 0 || component >= getNumberOfComponents()) {
          return ComponentIntensityRange.builder().build();
       }
       return ComponentIntensityRange.builder()

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
@@ -5,6 +5,7 @@ import org.micromanager.PropertyMap;
 import org.micromanager.PropertyMaps;
 import org.micromanager.data.internal.PropertyKey;
 import org.micromanager.display.ComponentDisplaySettings;
+import org.micromanager.display.ComponentIntensityRange;
 
 /**
  * @author mark
@@ -38,6 +39,11 @@ public final class DefaultComponentDisplaySettings
          scalingMin_ = minIntensity;
          scalingMax_ = maxIntensity;
          return this;
+      }
+
+      @Override
+      public Builder scalingRange(ComponentIntensityRange range) {
+         return scalingRange(range.getMinimum(), range.getMaximum());
       }
 
       @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
@@ -73,11 +73,11 @@ public final class DefaultComponentDisplaySettings
       return scalingMax_;
    }
 
-   public void setScalingMinimum(long min) {
+   public void hackScalingMinimum(long min) {
       scalingMin_ = min;
    }
-
-   public void setScalingMaximum(long max) {
+   
+   public void hackScalingMaximum(long max) {
       scalingMax_ = max;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentIntensityRange.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentIntensityRange.java
@@ -1,0 +1,57 @@
+package org.micromanager.display.internal;
+
+import org.micromanager.display.ComponentIntensityRange;
+
+public class DefaultComponentIntensityRange implements ComponentIntensityRange {
+   private final long min_;
+   private final long max_;
+
+   public static class Builder implements ComponentIntensityRange.Builder {
+      private long min_ = 0;
+      private long max_ = Long.MAX_VALUE;
+
+      @Override
+      public Builder minimum(long min) {
+         min_ = min;
+         return this;
+      }
+
+      @Override
+      public Builder maximum(long max) {
+         max_ = max;
+         return this;
+      }
+
+      @Override
+      public Builder range(long min, long max) {
+         min_ = min;
+         max_ = max;
+         return this;
+      }
+
+      @Override
+      public DefaultComponentIntensityRange build() {
+         return new DefaultComponentIntensityRange(this);
+      }
+   }
+
+   private DefaultComponentIntensityRange(Builder builder) {
+      min_ = builder.min_;
+      max_ = builder.max_;
+   }
+
+   @Override
+   public Builder copyBuilder() {
+      return new Builder().range(min_, max_);
+   }
+
+   @Override
+   public long getMinimum() {
+      return min_;
+   }
+
+   @Override
+   public long getMaximum() {
+      return max_;
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayIntensityRanges.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayIntensityRanges.java
@@ -1,0 +1,164 @@
+package org.micromanager.display.internal;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import org.micromanager.display.ChannelIntensityRanges;
+import org.micromanager.display.ComponentIntensityRange;
+import org.micromanager.display.DisplayIntensityRanges;
+
+public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
+   private final ArrayList<ChannelIntensityRanges> channelRanges_;
+
+   public static class Builder implements DisplayIntensityRanges.Builder {
+      private final ArrayList<ChannelIntensityRanges.Builder> channelBuilders_
+              = new ArrayList<>();
+
+      private void ensureNumChannels(int nChannels) {
+         channelBuilders_.ensureCapacity(nChannels);
+         while (channelBuilders_.size() < nChannels) {
+            channelBuilders_.add(ChannelIntensityRanges.builder());
+         }
+      }
+
+      @Override
+      public Builder componentRange(int channel, int component, long min, long max) {
+         ensureNumChannels(channel + 1);
+         channelBuilders_.get(channel).componentRange(component, min, max);
+         return this;
+      }
+
+      @Override
+      public Builder componentRange(int channel, int component, ComponentIntensityRange range) {
+         ensureNumChannels(channel + 1);
+         channelBuilders_.get(channel).componentRange(component, range);
+         return this;
+      }
+
+      @Override
+      public Builder componentMinimum(int channel, int component, long min) {
+         ensureNumChannels(channel + 1);
+         channelBuilders_.get(channel).componentMinimum(component, min);
+         return this;
+      }
+
+      @Override
+      public Builder componentMaximum(int channel, int component, long max) {
+         ensureNumChannels(channel + 1);
+         channelBuilders_.get(channel).componentMaximum(component, max);
+         return this;
+      }
+
+      @Override
+      public Builder componentRanges(int channel, List<ComponentIntensityRange> ranges) {
+         ensureNumChannels(channel);
+         channelBuilders_.get(channel).componentRanges(ranges);
+         return this;
+      }
+
+      @Override
+      public Builder channelRanges(List<ChannelIntensityRanges> channelRanges) {
+         channelBuilders_.clear();
+         channelBuilders_.ensureCapacity(channelRanges.size());
+         for (ChannelIntensityRanges chanRange : channelRanges) {
+            channelBuilders_.add(chanRange.copyBuilder());
+         }
+         return this;
+      }
+
+      @Override
+      public DefaultDisplayIntensityRanges build() {
+         return new DefaultDisplayIntensityRanges(this);
+      }
+   }
+
+   private DefaultDisplayIntensityRanges(Builder builder) {
+      channelRanges_ = new ArrayList<>(builder.channelBuilders_.size());
+      for (ChannelIntensityRanges.Builder chanBuilder : builder.channelBuilders_) {
+         channelRanges_.add(chanBuilder.build());
+      }
+      // Normalize by removing any channels with zero components at the end
+      while (channelRanges_.get(channelRanges_.size() - 1).getNumberOfComponents() == 0) {
+         channelRanges_.remove(channelRanges_.size() - 1);
+      }
+   }
+
+   @Override
+   public Builder copyBuilder() {
+      return new Builder().channelRanges(channelRanges_);
+   }
+
+   @Override
+   public int getNumberOfChannels() {
+      return channelRanges_.size();
+   }
+
+   @Override
+   public int getChannelNumberOfComponents(int channel) {
+      if (channel > channelRanges_.size()) {
+         return 0;
+      }
+      return channelRanges_.get(channel).getNumberOfComponents();
+   }
+
+   @Override
+   public long getComponentMinimum(int channel, int component) {
+      if (channel > channelRanges_.size()) {
+         return 0;
+      }
+      return channelRanges_.get(channel).getComponentMinimum(component);
+   }
+
+   @Override
+   public long getComponentMaximum(int channel, int component) {
+      if (channel > channelRanges_.size()) {
+         return Long.MAX_VALUE;
+      }
+      return channelRanges_.get(channel).getComponentMaximum(component);
+   }
+
+   @Override
+   public ComponentIntensityRange getComponentRange(int channel, int component) {
+      if (channel > channelRanges_.size()) {
+         return ComponentIntensityRange.builder().build();
+      }
+      return channelRanges_.get(channel).getComponentRange(component);
+   }
+
+   @Override
+   public ChannelIntensityRanges getChannelRanges(int channel) {
+      if (channel > channelRanges_.size()) {
+         return ChannelIntensityRanges.builder().build();
+      }
+      return channelRanges_.get(channel);
+   }
+
+   @Override
+   public List<ComponentIntensityRange> getAllComponentRanges(int channel) {
+      if (channel > channelRanges_.size()) {
+         return Lists.newArrayList();
+      }
+      return channelRanges_.get(channel).getAllComponentRanges();
+   }
+
+   @Override
+   public List<Long> getComponentMinima(int channel) {
+      if (channel > channelRanges_.size()) {
+         return Lists.newArrayList();
+      }
+      return channelRanges_.get(channel).getComponentMinima();
+   }
+
+   @Override
+   public List<Long> getComponentMaxima(int channel) {
+      if (channel > channelRanges_.size()) {
+         return Lists.newArrayList();
+      }
+      return channelRanges_.get(channel).getComponentMaxima();
+   }
+
+   @Override
+   public List<ChannelIntensityRanges> getAllChannelRanges() {
+      return Lists.newArrayList(channelRanges_);
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayIntensityRanges.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplayIntensityRanges.java
@@ -51,7 +51,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
       @Override
       public Builder componentRanges(int channel, List<ComponentIntensityRange> ranges) {
-         ensureNumChannels(channel);
+         ensureNumChannels(channel + 1);
          channelBuilders_.get(channel).componentRanges(ranges);
          return this;
       }
@@ -78,7 +78,8 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
          channelRanges_.add(chanBuilder.build());
       }
       // Normalize by removing any channels with zero components at the end
-      while (channelRanges_.get(channelRanges_.size() - 1).getNumberOfComponents() == 0) {
+      while (!channelRanges_.isEmpty()
+            && channelRanges_.get(channelRanges_.size() - 1).getNumberOfComponents() == 0) {
          channelRanges_.remove(channelRanges_.size() - 1);
       }
    }
@@ -95,7 +96,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
    @Override
    public int getChannelNumberOfComponents(int channel) {
-      if (channel > channelRanges_.size()) {
+      if (channel < 0 || channel >= channelRanges_.size()) {
          return 0;
       }
       return channelRanges_.get(channel).getNumberOfComponents();
@@ -103,7 +104,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
    @Override
    public long getComponentMinimum(int channel, int component) {
-      if (channel > channelRanges_.size()) {
+      if (channel < 0 || channel >= channelRanges_.size()) {
          return 0;
       }
       return channelRanges_.get(channel).getComponentMinimum(component);
@@ -111,7 +112,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
    @Override
    public long getComponentMaximum(int channel, int component) {
-      if (channel > channelRanges_.size()) {
+      if (channel < 0 || channel >= channelRanges_.size()) {
          return Long.MAX_VALUE;
       }
       return channelRanges_.get(channel).getComponentMaximum(component);
@@ -119,7 +120,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
    @Override
    public ComponentIntensityRange getComponentRange(int channel, int component) {
-      if (channel > channelRanges_.size()) {
+      if (channel < 0 || channel >= channelRanges_.size()) {
          return ComponentIntensityRange.builder().build();
       }
       return channelRanges_.get(channel).getComponentRange(component);
@@ -127,7 +128,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
    @Override
    public ChannelIntensityRanges getChannelRanges(int channel) {
-      if (channel > channelRanges_.size()) {
+      if (channel < 0 || channel >= channelRanges_.size()) {
          return ChannelIntensityRanges.builder().build();
       }
       return channelRanges_.get(channel);
@@ -135,7 +136,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
    @Override
    public List<ComponentIntensityRange> getAllComponentRanges(int channel) {
-      if (channel > channelRanges_.size()) {
+      if (channel < 0 || channel >= channelRanges_.size()) {
          return Lists.newArrayList();
       }
       return channelRanges_.get(channel).getAllComponentRanges();
@@ -143,7 +144,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
    @Override
    public List<Long> getComponentMinima(int channel) {
-      if (channel > channelRanges_.size()) {
+      if (channel < 0 || channel >= channelRanges_.size()) {
          return Lists.newArrayList();
       }
       return channelRanges_.get(channel).getComponentMinima();
@@ -151,7 +152,7 @@ public class DefaultDisplayIntensityRanges implements DisplayIntensityRanges {
 
    @Override
    public List<Long> getComponentMaxima(int channel) {
-      if (channel > channelRanges_.size()) {
+      if (channel < 0 || channel >= channelRanges_.size()) {
          return Lists.newArrayList();
       }
       return channelRanges_.get(channel).getComponentMaxima();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -37,6 +37,7 @@ import org.micromanager.UserProfile;
 import org.micromanager.data.internal.PropertyKey;
 import org.micromanager.display.ChannelDisplaySettings;
 import org.micromanager.display.ComponentDisplaySettings;
+import org.micromanager.display.DisplayIntensityRanges;
 import org.micromanager.display.DisplaySettings;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.MDUtils;
@@ -164,6 +165,20 @@ public final class DefaultDisplaySettings implements DisplaySettings {
             channelSettings_.add(channelSetting);
          }
          return this;
+      }
+
+      @Override
+      public Builder intensityScaling(DisplayIntensityRanges ranges) {
+         int nChannels = ranges.getNumberOfChannels();
+         Builder ret = this;
+         ret = ret.channel(nChannels - 1);
+         for (int ch = 0; ch < nChannels; ++ch) {
+            ret = ret.channel(ch,
+                  channelSettings_.get(ch).copyBuilder()
+                        .intensityScaling(ranges.getChannelRanges(ch))
+                        .build());
+         }
+         return ret;
       }
 
       @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultDisplaySettings.java
@@ -200,6 +200,9 @@ public final class DefaultDisplaySettings implements DisplaySettings {
       @Override
       public Builder intensityScaling(DisplayIntensityRanges ranges) {
          int nChannels = ranges.getNumberOfChannels();
+         if (nChannels == 0) {
+            return this;
+         }
          Builder ret = this;
          ret = ret.channel(nChannels - 1);
          for (int ch = 0; ch < nChannels; ++ch) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1109,13 +1109,29 @@ public final class DisplayUIController implements Closeable, WindowListener,
             // object with completely new ComnponentDisplaySettings, but it seems
             // more than a little bit excessive to do that on every autostrech update
             // so we take the shortcut here
+            //
+            // Mark T. 2022-05-19: It is not stated above _why_ it is
+            // that the autostretched min/max in the DisplaySettings need to
+            // be always up to date. The intended semantics were that the
+            // scaling min/max should be considered invalid when autostretch
+            // is enabled, so any code that relies on those values is
+            // incorrect. However, one could say that thanks to those
+            // semantics, "correct" components should not have a problem even
+            // if the scaling min/max is mutated, as long as this is only done
+            // when autostretch is enabled. So I'm leaving this as is for now.
+            // Fortunately, we don't have to worry about autostretch having
+            // been switched off before we reach here, since we are only
+            // modifying the DisplaySettings instance passed to us, which had
+            // autostretch enabled (see, immutability is really nice!).
+            // It will still be nice to remove this if we ever can.
             DefaultComponentDisplaySettings dcds = (DefaultComponentDisplaySettings)
                   settings.getChannelSettings(i).getComponentSettings(0);
-            dcds.setScalingMinimum(min);
-            dcds.setScalingMaximum(max);
+            dcds.hackScalingMinimum(min);
+            dcds.hackScalingMaximum(max);
+
             ijBridge_.mm2ijSetIntensityScaling(i, (int) min, (int) max);
          } else {
-            ReportingUtils.logMessage("DisplayUICOntroller: Received request to "
+            ReportingUtils.logMessage("DisplayUIController: Received request to "
                   + "autostretch image for which no statistics are available");
          }
       }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1094,20 +1094,11 @@ public final class DisplayUIController implements Closeable, WindowListener,
 
          if (images.getResult().size() > statsIndex) {
             ImageStats stats = images.getResult().get(statsIndex);
-            long min = stats.getComponentStats(0).getAutoscaleMinForQuantile(q);
-            long max = Math.min(Integer.MAX_VALUE,
-                  stats.getComponentStats(0).getAutoscaleMaxForQuantile(q));
-            // NS 2019-05-29: This should not be done here, but in IntegerComponentsStats
-            // however, I do not understand that code enough to touch it....
-            // This at least fixes the display somewhat (showing black for
-            // a saturated image is really, really bad!)
-            if (min == max) {
-               if (max == 0) {
-                  max++;
-               } else {
-                  min--;
-               }
-            }
+            long[] minMax = new long[2];
+            stats.getComponentStats(0).getAutoscaleMinMaxForQuantile(q, minMax);
+            long min = minMax[0];
+            long max = minMax[1];
+
             // NS 2019-08-15: We really do need to write the min and max to
             // the DisplaySettings (there already is a work-around in the
             // IntensityInspectorPanelController handleAutostretch function, but

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1199,11 +1199,19 @@ public final class DisplayUIController implements Closeable, WindowListener,
          }
 
          int nComponents = stats.getNumberOfComponents();
+         boolean ignoreZeros = settings.isAutoscaleIgnoringZeros();
          for (int compo = 0; compo < nComponents; compo++) {
-            long[] minMax = new long[2];
-            stats.getComponentStats(compo).getAutoscaleMinMaxForQuantile(q, minMax);
-            long min = minMax[0];
-            long max = minMax[1];
+            long min;
+            long max;
+            if (ignoreZeros) {
+               min = 0L;
+               max = stats.getComponentStats(compo).getAutoscaleMaxForQuantileIgnoringZeros(q);
+            } else {
+               long[] minMax = new long[2];
+               stats.getComponentStats(compo).getAutoscaleMinMaxForQuantile(q, minMax);
+               min = minMax[0];
+               max = minMax[1];
+            }
 
 
             // NS 2019-08-15: We really do need to write the min and max to

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -98,6 +98,7 @@ import org.micromanager.display.internal.event.DisplayMouseEvent;
 import org.micromanager.display.internal.event.DisplayMouseWheelEvent;
 import org.micromanager.display.internal.gearmenu.GearButton;
 import org.micromanager.display.internal.imagestats.BoundsRectAndMask;
+import org.micromanager.display.internal.imagestats.ComponentStats;
 import org.micromanager.display.internal.imagestats.ImageStats;
 import org.micromanager.display.internal.imagestats.ImagesAndStats;
 import org.micromanager.display.overlay.Overlay;
@@ -1132,14 +1133,30 @@ public final class DisplayUIController implements Closeable, WindowListener,
             // TODO: Remember changes in component display settings?
             ijBridge_.mm2ijSetChannelColor(i, channelSettings.getColor());
             if (!autostretch) {
-               int max = (int) Math.min(Integer.MAX_VALUE,
-                     componentSettings.getScalingMaximum());
-               if (max < 1) {
-                  max = 1;
+               ComponentStats cStats = getDisplayedComponentStats(i, 0);
+               if (cStats != null && cStats.isFloat()) {
+                  long storedMin = componentSettings.getScalingMinimum();
+                  long storedMax = componentSettings.getScalingMaximum();
+                  int binCount = cStats.getHistogramBinCount();
+                  double binWidth = cStats.getBinWidthDouble();
+                  double rangeMin = cStats.getHistogramRangeMinDouble();
+                  long clampedMax = (storedMax == Long.MAX_VALUE) ? binCount
+                        : Math.min(binCount, storedMax);
+                  long clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
+                  double fMin = rangeMin + clampedMin * binWidth;
+                  double fMax = rangeMin + clampedMax * binWidth;
+                  fMax = Math.max(fMin + binWidth, fMax);
+                  ijBridge_.mm2ijSetFloatIntensityScaling(i, fMin, fMax, false);
+               } else {
+                  int max = (int) Math.min(Integer.MAX_VALUE,
+                        componentSettings.getScalingMaximum());
+                  if (max < 1) {
+                     max = 1;
+                  }
+                  int min = (int) componentSettings.getScalingMinimum();
+                  min = Math.min(max - 1, min);
+                  ijBridge_.mm2ijSetIntensityScaling(i, min, max, false);
                }
-               int min = (int) componentSettings.getScalingMinimum();
-               min = Math.min(max - 1, min);
-               ijBridge_.mm2ijSetIntensityScaling(i, min, max, false);
             }
             double gamma = componentSettings.getScalingGamma();
             ijBridge_.mm2ijSetIntensityGamma(i, gamma);
@@ -1156,12 +1173,29 @@ public final class DisplayUIController implements Closeable, WindowListener,
             for (int i = 0; i < nComponents; ++i) {
                ComponentDisplaySettings componentSettings
                      = settings.getChannelSettings(0).getComponentSettings(i);
-               int max = Math.min(Integer.MAX_VALUE,
-                     (int) componentSettings.getScalingMaximum());
-               int min = Math.max(1, (Math.min(max - 1,
-                     (int) componentSettings.getScalingMinimum())));
-               max = Math.max(min + 1, max);
-               ijBridge_.mm2ijSetIntensityScaling(i, min, max, i < nComponents - 1);
+               boolean defer = i < nComponents - 1;
+               ComponentStats cStats = getDisplayedComponentStats(chNr, i);
+               if (cStats != null && cStats.isFloat()) {
+                  long storedMin = componentSettings.getScalingMinimum();
+                  long storedMax = componentSettings.getScalingMaximum();
+                  int binCount = cStats.getHistogramBinCount();
+                  double binWidth = cStats.getBinWidthDouble();
+                  double rangeMin = cStats.getHistogramRangeMinDouble();
+                  long clampedMax = (storedMax == Long.MAX_VALUE) ? binCount
+                        : Math.min(binCount, storedMax);
+                  long clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
+                  double fMin = rangeMin + clampedMin * binWidth;
+                  double fMax = rangeMin + clampedMax * binWidth;
+                  fMax = Math.max(fMin + binWidth, fMax);
+                  ijBridge_.mm2ijSetFloatIntensityScaling(i, fMin, fMax, defer);
+               } else {
+                  int max = Math.min(Integer.MAX_VALUE,
+                        (int) componentSettings.getScalingMaximum());
+                  int min = Math.max(1, (Math.min(max - 1,
+                        (int) componentSettings.getScalingMinimum())));
+                  max = Math.max(min + 1, max);
+                  ijBridge_.mm2ijSetIntensityScaling(i, min, max, defer);
+               }
             }
          }
       }
@@ -1242,15 +1276,49 @@ public final class DisplayUIController implements Closeable, WindowListener,
             // modifying the DisplaySettings instance passed to us, which had
             // autostretch enabled (see, immutability is really nice!).
             // It will still be nice to remove this if we ever can.
-            DefaultComponentDisplaySettings dcds = (DefaultComponentDisplaySettings)
-                  settings.getChannelSettings(ch).getComponentSettings(compo);
-            dcds.hackScalingMinimum(min);
-            dcds.hackScalingMaximum(max);
-
             int ijIndex = nComponents > 1 ? compo : ch;
             boolean defer = nComponents > 1 && compo < nComponents - 1;
-            ijBridge_.mm2ijSetIntensityScaling(ijIndex, (int) min, (int) max, defer);
+
+            ComponentStats cStats = stats.getComponentStats(compo);
+            DefaultComponentDisplaySettings dcds = (DefaultComponentDisplaySettings)
+                  settings.getChannelSettings(ch).getComponentSettings(compo);
+            if (cStats.isFloat()) {
+               // min/max are actual pixel values from quantile computation.
+               // Pass pixel values directly to ImageJ; store bin indices in dcds for the inspector.
+               double binWidth = cStats.getBinWidthDouble();
+               double rangeMin = cStats.getHistogramRangeMinDouble();
+               long storedMin = binWidth != 0.0
+                     ? Math.max(0L, Math.round((min - rangeMin) / binWidth)) : 0L;
+               long storedMax = binWidth != 0.0
+                     ? Math.max(0L, Math.round((max - rangeMin) / binWidth)) : 0L;
+               dcds.hackScalingMinimum(storedMin);
+               dcds.hackScalingMaximum(storedMax);
+               ijBridge_.mm2ijSetFloatIntensityScaling(ijIndex, (double) min, (double) max, defer);
+            } else {
+               dcds.hackScalingMinimum(min);
+               dcds.hackScalingMaximum(max);
+               ijBridge_.mm2ijSetIntensityScaling(ijIndex, (int) min, (int) max, defer);
+            }
          }
+      }
+   }
+
+   private ComponentStats getDisplayedComponentStats(int channel, int component) {
+      if (displayedImages_ == null) {
+         return null;
+      }
+      try {
+         int statsIndex = 0;
+         for (int i = 0; i < displayedImages_.getRequest().getNumberOfImages(); ++i) {
+            Coords c = displayedImages_.getRequest().getImage(i).getCoords();
+            if (c.hasAxis(Coords.CHANNEL) && c.getChannel() == channel) {
+               statsIndex = i;
+               break;
+            }
+         }
+         return displayedImages_.getResult().get(statsIndex).getComponentStats(component);
+      } catch (IndexOutOfBoundsException e) {
+         return null;
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
@@ -180,7 +180,7 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
    }
 
    @Override
-   public void applyScaling(int index, int min, int max) {
+   public void applyScaling(int index, int min, int max, boolean defer) {
       Preconditions.checkArgument(min >= 0);
       Preconditions.checkArgument(max >= min);
       if (minima_.size() <= index) {
@@ -192,7 +192,9 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
       }
       minima_.set(index, min);
       maxima_.set(index, max);
-      apply();
+      if (!defer) {
+         apply();
+      }
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
@@ -31,20 +31,29 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
    private final List<Integer> maxima_ = new ArrayList<Integer>();
    private final List<Double> gammas_ = new ArrayList<Double>();
    private boolean highlightHiLo_ = false;
+   // Float-precision overrides for min/max (non-null entry wins over integer list).
+   private final List<Double> floatMinima_ = new ArrayList<Double>();
+   private final List<Double> floatMaxima_ = new ArrayList<Double>();
 
    private List<LUT> cachedLUTs_;
 
    protected AbstractColorModeStrategy(int nColors) {
    }
 
-   private int getMinimum(int index) {
+   private double getMinDouble(int index) {
+      if (index < floatMinima_.size() && floatMinima_.get(index) != null) {
+         return floatMinima_.get(index);
+      }
       if (index >= minima_.size()) {
          return 0;
       }
       return minima_.get(index);
    }
 
-   private int getMaximum(int index) {
+   private double getMaxDouble(int index) {
+      if (index < floatMaxima_.size() && floatMaxima_.get(index) != null) {
+         return floatMaxima_.get(index);
+      }
       if (index >= maxima_.size()) {
          return getSampleMax();
       }
@@ -124,8 +133,8 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
 
    private void applyToMonochromeImagePlus() {
       LUT lut = getCachedLUT(0);
-      lut.min = getMinimum(0);
-      lut.max = getMaximum(0);
+      lut.min = getMinDouble(0);
+      lut.max = getMaxDouble(0);
       imagePlus_.getProcessor().setLut(lut);
    }
 
@@ -135,13 +144,13 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
       int nChannels = ((IMMImagePlus) compositeImage).getNChannelsWithoutSideEffect();
       for (int i = 0; i < nChannels; ++i) {
          LUT lut = getCachedLUT(i);
-         lut.min = getMinimum(i);
-         lut.max = getMaximum(i);
+         lut.min = getMinDouble(i);
+         lut.max = getMaxDouble(i);
          compositeImage.setChannelLut(lut, i + 1);
          if (compositeImage.getMode() == CompositeImage.COMPOSITE) {
             ImageProcessor proc = compositeImage.getProcessor(i + 1);
             if (proc != null) { // ImageJ may not have allocated it yet
-               proc.setMinAndMax(getMinimum(i), getMaximum(i));
+               proc.setMinAndMax(getMinDouble(i), getMaxDouble(i));
             }
          }
       }
@@ -156,8 +165,8 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
       // (This may not be strictly necessary but is harmless.)
       int channel = compositeImage.getChannel() - 1;
       LUT lut = getCachedLUT(channel);
-      lut.min = getMinimum(channel);
-      lut.max = getMaximum(channel);
+      lut.min = getMinDouble(channel);
+      lut.max = getMaxDouble(channel);
       compositeImage.getProcessor().setLut(lut);
    }
 
@@ -198,6 +207,28 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
       }
       minima_.set(index, min);
       maxima_.set(index, max);
+      // Clear any float override so integer path takes effect.
+      if (index < floatMinima_.size()) {
+         floatMinima_.set(index, null);
+      }
+      if (index < floatMaxima_.size()) {
+         floatMaxima_.set(index, null);
+      }
+      if (!defer) {
+         apply();
+      }
+   }
+
+   @Override
+   public void applyFloatScaling(int index, double min, double max, boolean defer) {
+      while (floatMinima_.size() <= index) {
+         floatMinima_.add(null);
+      }
+      while (floatMaxima_.size() <= index) {
+         floatMaxima_.add(null);
+      }
+      floatMinima_.set(index, min);
+      floatMaxima_.set(index, max);
       if (!defer) {
          apply();
       }
@@ -229,6 +260,8 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
    @Override
    public void releaseImagePlus() {
       imagePlus_ = null;
+      floatMinima_.clear();
+      floatMaxima_.clear();
       flushCachedLUTs();
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ColorModeStrategy.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ColorModeStrategy.java
@@ -21,7 +21,7 @@ interface ColorModeStrategy {
 
    void applyColor(int index, Color color);
 
-   void applyScaling(int index, int min, int max);
+   void applyScaling(int index, int min, int max, boolean defer);
 
    void applyGamma(int index, double gamma);
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ColorModeStrategy.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ColorModeStrategy.java
@@ -23,6 +23,8 @@ interface ColorModeStrategy {
 
    void applyScaling(int index, int min, int max, boolean defer);
 
+   void applyFloatScaling(int index, double min, double max, boolean defer);
+
    void applyGamma(int index, double gamma);
 
    void applyVisibleInComposite(int index, boolean visible);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
@@ -447,9 +447,11 @@ public final class ImageJBridge {
    }
 
    @MustCallOnEDT
-   public void mm2ijSetIntensityScaling(int channelOrComponent, int min, int max) {
-      colorModeStrategy_.applyScaling(channelOrComponent, min, max);
-      mm2ijRepaint();
+   public void mm2ijSetIntensityScaling(int channelOrComponent, int min, int max, boolean defer) {
+      colorModeStrategy_.applyScaling(channelOrComponent, min, max, defer);
+      if (!defer) {
+         mm2ijRepaint();
+      }
    }
 
    @MustCallOnEDT

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/ImageJBridge.java
@@ -458,6 +458,15 @@ public final class ImageJBridge {
    }
 
    @MustCallOnEDT
+   public void mm2ijSetFloatIntensityScaling(int channelOrComponent,
+                                              double min, double max, boolean defer) {
+      colorModeStrategy_.applyFloatScaling(channelOrComponent, min, max, defer);
+      if (!defer) {
+         mm2ijRepaint();
+      }
+   }
+
+   @MustCallOnEDT
    public void mm2ijSetIntensityGamma(int channelOrComponent, double gamma) {
       colorModeStrategy_.applyGamma(channelOrComponent, gamma);
       mm2ijRepaint();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/RGBColorModeStrategy.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/RGBColorModeStrategy.java
@@ -114,6 +114,12 @@ class RGBColorModeStrategy implements ColorModeStrategy {
    }
 
    @Override
+   public void applyFloatScaling(int component, double min, double max, boolean defer) {
+      // RGBColorModeStrategy operates on byte (0-255) pixel values — clamp to that range.
+      applyScaling(component, (int) Math.max(0, min), (int) Math.min(255, max), defer);
+   }
+
+   @Override
    public void applyScaling(int component, int min, int max, boolean defer) {
       Preconditions.checkArgument(min >= 0);
       Preconditions.checkArgument(max >= min);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ComponentStats.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
  *
  * @author Mark A. Tsuchida
  */
-public final class IntegerComponentStats {
+public final class ComponentStats {
    private final Integer bitDepth_;
    private final long[] histogram_;
    private final int binWidthPowerOf2_;
@@ -132,8 +132,8 @@ public final class IntegerComponentStats {
          return this;
       }
 
-      public IntegerComponentStats build() {
-         return new IntegerComponentStats(this);
+      public ComponentStats build() {
+         return new ComponentStats(this);
       }
    }
 
@@ -149,8 +149,8 @@ public final class IntegerComponentStats {
     * @param b second stats
     * @return merged stats representing the union of both pixel populations
     */
-   public static IntegerComponentStats merge(
-         IntegerComponentStats a, IntegerComponentStats b) {
+   public static ComponentStats merge(
+            ComponentStats a, ComponentStats b) {
       long[] histA = getFullHistogram(a);
       long[] histB = getFullHistogram(b);
       long[] merged = new long[histA.length];
@@ -176,7 +176,7 @@ public final class IntegerComponentStats {
             .build();
    }
 
-   private static long[] getFullHistogram(IntegerComponentStats s) {
+   private static long[] getFullHistogram(ComponentStats s) {
       long[] inRange = s.getInRangeHistogram();
       long[] full = new long[inRange.length + 2];
       full[0] = s.getPixelCountBelowRange();
@@ -185,7 +185,7 @@ public final class IntegerComponentStats {
       return full;
    }
 
-   private IntegerComponentStats(Builder b) {
+   private ComponentStats(Builder b) {
       bitDepth_ = b.bitDepth_;
       histogram_ = b.histogram_ != null
             ? Arrays.copyOf(b.histogram_, b.histogram_.length) :
@@ -246,6 +246,10 @@ public final class IntegerComponentStats {
          return 0;
       }
       return 1 << binWidthPowerOf2_;
+   }
+
+   public double getBinWidthDouble() {
+      return binWidthFloat_;
    }
 
    public double getHistogramRangeMinDouble() {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStats.java
@@ -15,13 +15,13 @@ import java.util.List;
  */
 public class ImageStats {
    private final int index_;
-   private final List<IntegerComponentStats> componentStats_;
+   private final List<ComponentStats> componentStats_;
 
-   public static ImageStats create(int index, IntegerComponentStats... componentStats) {
+   public static ImageStats create(int index, ComponentStats... componentStats) {
       return new ImageStats(index, componentStats);
    }
 
-   private ImageStats(int index, IntegerComponentStats... componentStats) {
+   private ImageStats(int index, ComponentStats... componentStats) {
       index_ = index;
       componentStats_ = new ArrayList<>(Arrays.asList(componentStats));
    }
@@ -30,7 +30,7 @@ public class ImageStats {
       return componentStats_.size();
    }
 
-   public IntegerComponentStats getComponentStats(int component) {
+   public ComponentStats getComponentStats(int component) {
       return componentStats_.get(component);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -309,7 +309,7 @@ public final class ImageStatsProcessor {
       // Round to the nearest integer so that getMeanIntensity() and
       // getStandardDeviation() return values that are correct to integer precision,
       // matching the display which shows mean and stdev rounded to integers.
-      IntegerComponentStats stats = IntegerComponentStats.builder()
+      ComponentStats stats = ComponentStats.builder()
             .histogram(hist, 0)
             .isFloat(true)
             .rangeMin((double) fMin)
@@ -401,10 +401,10 @@ public final class ImageStatsProcessor {
          sumsOfSquares[component] += dataValue * dataValue;
       }
 
-      IntegerComponentStats[] componentStats =
-            new IntegerComponentStats[nComponents];
+      ComponentStats[] componentStats =
+            new ComponentStats[nComponents];
       for (int component = 0; component < nComponents; ++component) {
-         componentStats[component] = IntegerComponentStats.builder()
+         componentStats[component] = ComponentStats.builder()
                .bitDepth(metadataBitDepth)
                .histogram(histograms.get(component).toLongArray(),
                      Math.max(0, sampleBitDepth - binCountPowerOf2))

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -264,10 +264,8 @@ public final class ImageStatsProcessor {
             continue;
          }
 
-         int[] cxy = new int[3];
-         dataCursor.localize(cxy);
          // Flip component index to view BGR as RGB
-         int component = nComponents - 1 - cxy[0];
+         int component = nComponents - 1 - dataCursor.getIntPosition(0);
 
          long dataValue = dataSample.getIntegerLong();
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsRequest.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsRequest.java
@@ -18,6 +18,7 @@ import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.micromanager.data.Coords;
 import org.micromanager.data.Image;
 
@@ -64,7 +65,21 @@ public final class ImageStatsRequest {
    }
 
    public int getMaxBinCountPowerOf2() {
-      return 16; // TODO Should be configurable
+      try {
+         return images_.stream()
+                 .map((Image im) -> {
+                    Integer bits = im.getMetadata().getBitDepth();
+                    if (bits != null) {
+                       return bits;
+                    } else {
+                       return im.getBytesPerComponent() * 8;
+                    }
+                 })
+                 .max(Integer::compareTo)
+                 .get();
+      } catch (NoSuchElementException noImages) {
+         return 0;
+      }
    }
 
    public Rectangle getROIBounds() {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/IntegerComponentStats.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
  * @author Mark A. Tsuchida
  */
 public final class IntegerComponentStats {
+   private final Integer bitDepth_;
    private final long[] histogram_;
    private final int binWidthPowerOf2_;
    private final long pixelCount_;
@@ -33,6 +34,7 @@ public final class IntegerComponentStats {
    private final transient long[] cumulativeDistrib_;
 
    public static class Builder {
+      private Integer bitDepth_;
       private long[] histogram_;
       private int binWidthPowerOf2_;
       private long pixelCount_;
@@ -43,6 +45,15 @@ public final class IntegerComponentStats {
       private long sumOfSquares_;
 
       private Builder() {
+      }
+
+      public Builder bitDepth(Integer depth) {
+         Preconditions.checkArgument(depth == null || depth >= 0);
+         if (depth == 0) {
+            depth = null;
+         }
+         bitDepth_ = depth;
+         return this;
       }
 
       public Builder histogram(long[] binsIncludingOutOfRange, int binWidthPowerOf2) {
@@ -92,6 +103,7 @@ public final class IntegerComponentStats {
    }
 
    private IntegerComponentStats(Builder b) {
+      bitDepth_ = b.bitDepth_;
       histogram_ = b.histogram_ != null
             ? Arrays.copyOf(b.histogram_, b.histogram_.length) :
             null;
@@ -103,6 +115,14 @@ public final class IntegerComponentStats {
       sum_ = b.sum_;
       sumOfSquares_ = b.sumOfSquares_;
       cumulativeDistrib_ = computeCumulativeDistribution();
+   }
+
+   public Integer getBitDepth() {
+      // This is usually equal to the bit depth corresponding to the bin count
+      // and bin width, but may be null if the camera bit depth was unknown.
+      // I.e., this is based on knowledge of the data, not the integer type
+      // used to contain it.
+      return bitDepth_;
    }
 
    public long[] getInRangeHistogram() {

--- a/mmstudio/src/test/java/org/micromanager/display/internal/DefaultChannelIntensityRangesTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/DefaultChannelIntensityRangesTest.java
@@ -1,0 +1,189 @@
+package org.micromanager.display.internal;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.micromanager.display.ChannelIntensityRanges;
+import org.micromanager.display.ComponentIntensityRange;
+
+import static org.junit.Assert.*;
+
+public class DefaultChannelIntensityRangesTest {
+
+   // --- Default construction ---
+
+   @Test
+   public void testDefaultBuildHasZeroComponents() {
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder().build();
+      assertEquals(0, r.getNumberOfComponents());
+   }
+
+   @Test
+   public void testDefaultBuildOutOfRangeAccessReturnsDefaults() {
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder().build();
+      assertEquals(0L, r.getComponentMinimum(0));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(0));
+      assertNotNull(r.getComponentRange(0));
+   }
+
+   // --- Setting component ranges ---
+
+   @Test
+   public void testSetSingleComponent() {
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(0, 10L, 200L)
+            .build();
+      assertEquals(1, r.getNumberOfComponents());
+      assertEquals(10L, r.getComponentMinimum(0));
+      assertEquals(200L, r.getComponentMaximum(0));
+   }
+
+   @Test
+   public void testSetNonContiguousComponentExpandsDefaults() {
+      // Setting component 2 should expand to 3 components,
+      // with components 0 and 1 at their defaults.
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(2, 5L, 100L)
+            .build();
+      assertEquals(3, r.getNumberOfComponents());
+      assertEquals(0L, r.getComponentMinimum(0));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(0));
+      assertEquals(0L, r.getComponentMinimum(1));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(1));
+      assertEquals(5L, r.getComponentMinimum(2));
+      assertEquals(100L, r.getComponentMaximum(2));
+   }
+
+   @Test
+   public void testGrowingArrayPreservesExistingComponents() {
+      // Set component 0, then extend to component 2.
+      // Component 0's values must not be overwritten by the expansion.
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(0, 42L, 84L)
+            .componentRange(2, 1L, 99L)
+            .build();
+      assertEquals(42L, r.getComponentMinimum(0));
+      assertEquals(84L, r.getComponentMaximum(0));
+   }
+
+   // --- Normalization (trailing default components are stripped) ---
+
+   @Test
+   public void testNormalizationStripsTrailingDefaults() {
+      // Component 0 non-default, component 1 default → should be stored as 1 component.
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(0, 0L, 255L)
+            .componentMaximum(1, Long.MAX_VALUE) // explicitly default value
+            .build();
+      assertEquals(1, r.getNumberOfComponents());
+   }
+
+   @Test
+   public void testNormalizationAllDefaultsYieldsZeroComponents() {
+      // Explicitly writing the default values should normalize to 0 components.
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(0, 0L, Long.MAX_VALUE)
+            .componentRange(1, 0L, Long.MAX_VALUE)
+            .build();
+      assertEquals(0, r.getNumberOfComponents());
+   }
+
+   @Test
+   public void testNormalizationKeepsLeadingDefaultBeforeNonDefault() {
+      // Component 0 is default, component 1 is non-default → both must be kept.
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(1, 10L, 200L)
+            .build();
+      assertEquals(2, r.getNumberOfComponents());
+      assertEquals(0L, r.getComponentMinimum(0));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(0));
+      assertEquals(10L, r.getComponentMinimum(1));
+      assertEquals(200L, r.getComponentMaximum(1));
+   }
+
+   // --- componentRanges(List) resizes and trims ---
+
+   @Test
+   public void testComponentRangesListSetsAll() {
+      List<ComponentIntensityRange> list = Arrays.asList(
+            ComponentIntensityRange.builder().range(1L, 10L).build(),
+            ComponentIntensityRange.builder().range(2L, 20L).build()
+      );
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRanges(list)
+            .build();
+      assertEquals(2, r.getNumberOfComponents());
+      assertEquals(1L, r.getComponentMinimum(0));
+      assertEquals(10L, r.getComponentMaximum(0));
+      assertEquals(2L, r.getComponentMinimum(1));
+      assertEquals(20L, r.getComponentMaximum(1));
+   }
+
+   @Test
+   public void testComponentRangesListTrimsExcess() {
+      // First set 3 components, then replace with a 1-element list.
+      List<ComponentIntensityRange> list = Arrays.asList(
+            ComponentIntensityRange.builder().range(5L, 50L).build()
+      );
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(2, 99L, 999L)
+            .componentRanges(list)
+            .build();
+      assertEquals(1, r.getNumberOfComponents());
+      assertEquals(5L, r.getComponentMinimum(0));
+      assertEquals(50L, r.getComponentMaximum(0));
+   }
+
+   // --- Out-of-range access returns defaults ---
+
+   @Test
+   public void testOutOfRangeAccessNegativeIndex() {
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(0, 10L, 200L)
+            .build();
+      assertEquals(0L, r.getComponentMinimum(-1));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(-1));
+   }
+
+   @Test
+   public void testOutOfRangeAccessBeyondSize() {
+      ChannelIntensityRanges r = ChannelIntensityRanges.builder()
+            .componentRange(0, 10L, 200L)
+            .build();
+      assertEquals(1, r.getNumberOfComponents());
+      // component 1 is out of range
+      assertEquals(0L, r.getComponentMinimum(1));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(1));
+   }
+
+   // --- copyBuilder round-trips ---
+
+   @Test
+   public void testCopyBuilderPreservesValues() {
+      ChannelIntensityRanges original = ChannelIntensityRanges.builder()
+            .componentRange(0, 3L, 97L)
+            .componentRange(1, 7L, 200L)
+            .build();
+      ChannelIntensityRanges copy = original.copyBuilder().build();
+      assertEquals(original.getNumberOfComponents(), copy.getNumberOfComponents());
+      assertEquals(original.getComponentMinimum(0), copy.getComponentMinimum(0));
+      assertEquals(original.getComponentMaximum(0), copy.getComponentMaximum(0));
+      assertEquals(original.getComponentMinimum(1), copy.getComponentMinimum(1));
+      assertEquals(original.getComponentMaximum(1), copy.getComponentMaximum(1));
+   }
+
+   @Test
+   public void testCopyBuilderIsIndependent() {
+      ChannelIntensityRanges original = ChannelIntensityRanges.builder()
+            .componentRange(0, 3L, 97L)
+            .build();
+      ChannelIntensityRanges modified = original.copyBuilder()
+            .componentRange(0, 0L, 255L)
+            .build();
+      // Original must be unchanged
+      assertEquals(3L, original.getComponentMinimum(0));
+      assertEquals(97L, original.getComponentMaximum(0));
+      assertEquals(0L, modified.getComponentMinimum(0));
+      assertEquals(255L, modified.getComponentMaximum(0));
+   }
+}

--- a/mmstudio/src/test/java/org/micromanager/display/internal/DefaultDisplayIntensityRangesTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/DefaultDisplayIntensityRangesTest.java
@@ -1,0 +1,181 @@
+package org.micromanager.display.internal;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.micromanager.display.ChannelIntensityRanges;
+import org.micromanager.display.ComponentIntensityRange;
+import org.micromanager.display.DisplayIntensityRanges;
+
+import static org.junit.Assert.*;
+
+public class DefaultDisplayIntensityRangesTest {
+
+   // --- Default construction ---
+
+   @Test
+   public void testDefaultBuildHasZeroChannels() {
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder().build();
+      assertEquals(0, r.getNumberOfChannels());
+   }
+
+   @Test
+   public void testDefaultBuildOutOfRangeAccessReturnsDefaults() {
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder().build();
+      assertEquals(0, r.getChannelNumberOfComponents(0));
+      assertEquals(0L, r.getComponentMinimum(0, 0));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(0, 0));
+      assertNotNull(r.getComponentRange(0, 0));
+      assertNotNull(r.getChannelRanges(0));
+   }
+
+   // --- Setting component ranges ---
+
+   @Test
+   public void testSetSingleChannelSingleComponent() {
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .componentRange(0, 0, 10L, 200L)
+            .build();
+      assertEquals(1, r.getNumberOfChannels());
+      assertEquals(1, r.getChannelNumberOfComponents(0));
+      assertEquals(10L, r.getComponentMinimum(0, 0));
+      assertEquals(200L, r.getComponentMaximum(0, 0));
+   }
+
+   @Test
+   public void testSetMultipleChannels() {
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .componentRange(0, 0, 1L, 10L)
+            .componentRange(1, 0, 2L, 20L)
+            .build();
+      assertEquals(2, r.getNumberOfChannels());
+      assertEquals(1L, r.getComponentMinimum(0, 0));
+      assertEquals(10L, r.getComponentMaximum(0, 0));
+      assertEquals(2L, r.getComponentMinimum(1, 0));
+      assertEquals(20L, r.getComponentMaximum(1, 0));
+   }
+
+   @Test
+   public void testSetNonContiguousChannelExpandsWithDefaults() {
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .componentRange(2, 0, 5L, 100L)
+            .build();
+      // channels 0 and 1 should exist but have zero components (default/normalized away)
+      assertEquals(3, r.getNumberOfChannels());
+      assertEquals(5L, r.getComponentMinimum(2, 0));
+      assertEquals(100L, r.getComponentMaximum(2, 0));
+   }
+
+   // --- Normalization (trailing all-default channels are stripped) ---
+
+   @Test
+   public void testNormalizationStripsTrailingDefaultChannels() {
+      // Channel 0 non-default, channel 1 all-default → stored as 1 channel.
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .componentRange(0, 0, 0L, 255L)
+            .componentRange(1, 0, 0L, Long.MAX_VALUE) // default
+            .build();
+      assertEquals(1, r.getNumberOfChannels());
+   }
+
+   @Test
+   public void testNormalizationAllDefaultChannelsYieldsZero() {
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .componentRange(0, 0, 0L, Long.MAX_VALUE)
+            .componentRange(1, 0, 0L, Long.MAX_VALUE)
+            .build();
+      assertEquals(0, r.getNumberOfChannels());
+   }
+
+   // --- componentRanges(int, List) ---
+
+   @Test
+   public void testComponentRangesListSetsChannel() {
+      List<ComponentIntensityRange> list = Arrays.asList(
+            ComponentIntensityRange.builder().range(1L, 10L).build(),
+            ComponentIntensityRange.builder().range(2L, 20L).build()
+      );
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .componentRanges(0, list)
+            .build();
+      assertEquals(2, r.getChannelNumberOfComponents(0));
+      assertEquals(1L, r.getComponentMinimum(0, 0));
+      assertEquals(10L, r.getComponentMaximum(0, 0));
+      assertEquals(2L, r.getComponentMinimum(0, 1));
+      assertEquals(20L, r.getComponentMaximum(0, 1));
+   }
+
+   // --- channelRanges(List) replaces all channels ---
+
+   @Test
+   public void testChannelRangesListReplacesAll() {
+      ChannelIntensityRanges ch0 = ChannelIntensityRanges.builder()
+            .componentRange(0, 3L, 30L).build();
+      ChannelIntensityRanges ch1 = ChannelIntensityRanges.builder()
+            .componentRange(0, 7L, 70L).build();
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .channelRanges(Arrays.asList(ch0, ch1))
+            .build();
+      assertEquals(2, r.getNumberOfChannels());
+      assertEquals(3L, r.getComponentMinimum(0, 0));
+      assertEquals(30L, r.getComponentMaximum(0, 0));
+      assertEquals(7L, r.getComponentMinimum(1, 0));
+      assertEquals(70L, r.getComponentMaximum(1, 0));
+   }
+
+   // --- Out-of-range access returns defaults ---
+
+   @Test
+   public void testOutOfRangeNegativeChannelReturnsDefaults() {
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .componentRange(0, 0, 10L, 200L)
+            .build();
+      assertEquals(0, r.getChannelNumberOfComponents(-1));
+      assertEquals(0L, r.getComponentMinimum(-1, 0));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(-1, 0));
+      assertTrue(r.getAllComponentRanges(-1).isEmpty());
+      assertTrue(r.getComponentMinima(-1).isEmpty());
+      assertTrue(r.getComponentMaxima(-1).isEmpty());
+   }
+
+   @Test
+   public void testOutOfRangeBeyondSizeReturnsDefaults() {
+      DisplayIntensityRanges r = DisplayIntensityRanges.builder()
+            .componentRange(0, 0, 10L, 200L)
+            .build();
+      assertEquals(1, r.getNumberOfChannels());
+      assertEquals(0, r.getChannelNumberOfComponents(1));
+      assertEquals(0L, r.getComponentMinimum(1, 0));
+      assertEquals(Long.MAX_VALUE, r.getComponentMaximum(1, 0));
+   }
+
+   // --- copyBuilder round-trips ---
+
+   @Test
+   public void testCopyBuilderPreservesValues() {
+      DisplayIntensityRanges original = DisplayIntensityRanges.builder()
+            .componentRange(0, 0, 3L, 97L)
+            .componentRange(1, 0, 7L, 200L)
+            .build();
+      DisplayIntensityRanges copy = original.copyBuilder().build();
+      assertEquals(original.getNumberOfChannels(), copy.getNumberOfChannels());
+      assertEquals(original.getComponentMinimum(0, 0), copy.getComponentMinimum(0, 0));
+      assertEquals(original.getComponentMaximum(0, 0), copy.getComponentMaximum(0, 0));
+      assertEquals(original.getComponentMinimum(1, 0), copy.getComponentMinimum(1, 0));
+      assertEquals(original.getComponentMaximum(1, 0), copy.getComponentMaximum(1, 0));
+   }
+
+   @Test
+   public void testCopyBuilderIsIndependent() {
+      DisplayIntensityRanges original = DisplayIntensityRanges.builder()
+            .componentRange(0, 0, 3L, 97L)
+            .build();
+      DisplayIntensityRanges modified = original.copyBuilder()
+            .componentRange(0, 0, 0L, 255L)
+            .build();
+      assertEquals(3L, original.getComponentMinimum(0, 0));
+      assertEquals(97L, original.getComponentMaximum(0, 0));
+      assertEquals(0L, modified.getComponentMinimum(0, 0));
+      assertEquals(255L, modified.getComponentMaximum(0, 0));
+   }
+}

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsTest.java
@@ -47,13 +47,13 @@ public class ComponentStatsTest {
 
    @Test
    public void testEmpty() {
-      IntegerComponentStats cs = IntegerComponentStats.builder().build();
+      ComponentStats cs = ComponentStats.builder().build();
       assertNull(cs.getInRangeHistogram());
    }
 
    @Test
    public void testSize1() {
-      IntegerComponentStats cs = IntegerComponentStats.builder()
+      ComponentStats cs = ComponentStats.builder()
                   .histogram(new long[] {1, 2, 3}, 0)
                   .pixelCount(6)
                   .minimum(-1)
@@ -80,7 +80,7 @@ public class ComponentStatsTest {
 
    @Test
    public void testSize2() {
-      IntegerComponentStats cs = IntegerComponentStats.builder()
+      ComponentStats cs = ComponentStats.builder()
             .histogram(new long[] { 0, 1, 2, 0 }, 1)
             .pixelCount(3)
             .minimum(0)
@@ -116,7 +116,7 @@ public class ComponentStatsTest {
       hist[128] = 94;
       hist[255] = 2;
       hist[256] = 1;
-      IntegerComponentStats cs = IntegerComponentStats.builder()
+      ComponentStats cs = ComponentStats.builder()
             .histogram(hist, 0)
             .pixelCount(100)
             .minimum(0)
@@ -148,7 +148,7 @@ public class ComponentStatsTest {
       for (int i = 1; i < 257; ++i) {
          hist[i] = 5;
       }
-      IntegerComponentStats cs = IntegerComponentStats.builder()
+      ComponentStats cs = ComponentStats.builder()
             .histogram(hist, 8)
             .pixelCount(5 * 256)
             .minimum(0)

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsTest.java
@@ -72,7 +72,7 @@ public class ComponentStatsTest {
       assertEquals(6, cs.getPixelCount());
       assertEquals(0, cs.getMeanIntensity());
       assertEquals(1.0, cs.getQuantile(0.5), 0.001);
-      assertEquals(0.0, cs.getQuantileIgnoringZeros(0.5), 0.001);
+      assertEquals(1.0, cs.getQuantileIgnoringZeros(0.5), 0.001);
       assertEquals(1.0, cs.getQuantileIgnoringZeros(0.75), 0.001);
       assertEquals(4, cs.getSumOfSquares());
       assertTrue(cs.getStandardDeviation() > 0.0);
@@ -100,6 +100,8 @@ public class ComponentStatsTest {
       assertEquals(3, cs.getPixelCount());
       assertEquals(2, cs.getMeanIntensity());
       assertEquals(2.5, cs.getQuantile(0.5), 0.001);
+      //  The test expectation of 2.5 is semantically
+      //  right; the implementation is wrong.
       assertEquals(2.5, cs.getQuantileIgnoringZeros(0.5), 0.001);
       assertEquals(14, cs.getSumOfSquares());
       assertEquals(0.8165, cs.getStandardDeviation(), 0.001);

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/IntegerComponentStatsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/IntegerComponentStatsTest.java
@@ -21,13 +21,13 @@ public class IntegerComponentStatsTest {
    @Test
    public void testGetQuantile() {
       // histogram_[1]=1 means 1 pixel at intensity 0; quantile is bin-edge based.
-      IntegerComponentStats s = IntegerComponentStats.builder().
+      ComponentStats s = ComponentStats.builder().
             histogram(new long[] { 0, 1, 0 }, 0).pixelCount(1).build();
       assertEquals(0.0, s.getQuantile(0.0), e);
       assertEquals(1.0, s.getQuantile(1.0), e);
       assertEquals(0.5, s.getQuantile(0.5), e);
 
-      s = IntegerComponentStats.builder().
+      s = ComponentStats.builder().
             histogram(new long[] { 0, 1, 2, 0 }, 0).pixelCount(3).maximum(1).build();
       assertEquals(0.0, s.getQuantile(0.0), e);
       assertEquals(1.25, s.getQuantile(0.5), e);
@@ -36,7 +36,7 @@ public class IntegerComponentStatsTest {
 
    @Test
    public void testGetQuantileOutOfRange() {
-      IntegerComponentStats s = IntegerComponentStats.builder().
+      ComponentStats s = ComponentStats.builder().
             histogram(new long[] { 1, 1, 1, 1 }, 0).pixelCount(4).build();
       assertEquals(0.0, s.getQuantile(0.0), e);
       assertEquals(0.0, s.getQuantile(0.25), e);
@@ -48,7 +48,7 @@ public class IntegerComponentStatsTest {
    // Helper: build stats from a histogram (no out-of-range bins) with bin width 1.
    // histogram[i] = count of pixels with intensity i. Range is [0, histogram.length-1].
    // Sets minimum to the first non-zero bin and maximum to the last non-zero bin.
-   private static IntegerComponentStats buildStats(long[] histogram) {
+   private static ComponentStats buildStats(long[] histogram) {
       long[] full = new long[histogram.length + 2];
       System.arraycopy(histogram, 0, full, 1, histogram.length);
       long count = 0;
@@ -65,7 +65,7 @@ public class IntegerComponentStatsTest {
             maximum = i;
          }
       }
-      return IntegerComponentStats.builder()
+      return ComponentStats.builder()
             .histogram(full, 0)
             .pixelCount(count)
             .minimum(minimum)
@@ -82,7 +82,7 @@ public class IntegerComponentStatsTest {
       for (int i = 0; i < 256; i++) {
          hist[i] = 1;
       }
-      IntegerComponentStats s = buildStats(hist);
+      ComponentStats s = buildStats(hist);
       long[] minMax = new long[2];
       s.getAutoscaleMinMaxForQuantile(0.0, minMax);
       assertEquals(0L, minMax[0]);
@@ -95,7 +95,7 @@ public class IntegerComponentStatsTest {
       // All pixels have intensity 100; range should be widened to [99, 101].
       long[] hist = new long[256];
       hist[100] = 1000;
-      IntegerComponentStats s = buildStats(hist);
+      ComponentStats s = buildStats(hist);
       long[] minMax = new long[2];
       s.getAutoscaleMinMaxForQuantile(0.0, minMax);
       assertEquals(99L, minMax[0]);
@@ -109,7 +109,7 @@ public class IntegerComponentStatsTest {
       // mid == 0 == getHistogramRangeMin(), so min=0, max=2.
       long[] hist = new long[256];
       hist[0] = 500;
-      IntegerComponentStats s = buildStats(hist);
+      ComponentStats s = buildStats(hist);
       long[] minMax = new long[2];
       s.getAutoscaleMinMaxForQuantile(0.0, minMax);
       assertEquals(0L, minMax[0]);
@@ -123,7 +123,7 @@ public class IntegerComponentStatsTest {
       // mid == 255 == getHistogramRangeMax(), so max=255, min=253.
       long[] hist = new long[256];
       hist[255] = 500;
-      IntegerComponentStats s = buildStats(hist);
+      ComponentStats s = buildStats(hist);
       long[] minMax = new long[2];
       s.getAutoscaleMinMaxForQuantile(0.0, minMax);
       assertEquals(255L, minMax[1]);
@@ -137,7 +137,7 @@ public class IntegerComponentStatsTest {
       long[] hist = new long[256];
       hist[50] = 100;
       hist[51] = 100;
-      IntegerComponentStats s = buildStats(hist);
+      ComponentStats s = buildStats(hist);
       long[] minMax = new long[2];
       s.getAutoscaleMinMaxForQuantile(0.0, minMax);
       assertTrue(minMax[1] - minMax[0] >= 2);
@@ -152,7 +152,7 @@ public class IntegerComponentStatsTest {
       for (int i = 0; i < 256; i++) {
          java.util.Arrays.fill(hist, 0);
          hist[i] = 1;
-         IntegerComponentStats s = buildStats(hist);
+         ComponentStats s = buildStats(hist);
          s.getAutoscaleMinMaxForQuantile(0.0, minMax);
          assertTrue("width < 2 at intensity " + i, minMax[1] - minMax[0] >= 2);
       }

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/IntegerComponentStatsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/IntegerComponentStatsTest.java
@@ -43,4 +43,103 @@ public class IntegerComponentStatsTest {
       assertEquals(2.0, s.getQuantile(0.75), e);
       assertEquals(2.0, s.getQuantile(1.0), e);
    }
+
+   // Helper: build stats from a histogram (no out-of-range bins) with bin width 1.
+   // histogram[i] = count of pixels with intensity i. Range is [0, histogram.length-1].
+   private static IntegerComponentStats buildStats(long[] histogram) {
+      long[] full = new long[histogram.length + 2];
+      System.arraycopy(histogram, 0, full, 1, histogram.length);
+      long count = 0;
+      for (long c : histogram) {
+         count += c;
+      }
+      return IntegerComponentStats.builder()
+            .histogram(full, 0)
+            .pixelCount(count)
+            .build();
+   }
+
+   @Test
+   public void testAutoscaleNormalRange() {
+      // 256 bins, pixel counts spread across the range — quantile 0 should give
+      // min=0, max=254 (last bin edge - 1).
+      long[] hist = new long[256];
+      for (int i = 0; i < 256; i++) {
+         hist[i] = 1;
+      }
+      IntegerComponentStats s = buildStats(hist);
+      long[] minMax = new long[2];
+      s.getAutoscaleMinMaxForQuantile(0.0, minMax);
+      assertEquals(0L, minMax[0]);
+      assertEquals(254L, minMax[1]);
+      assertTrue(minMax[1] - minMax[0] >= 2);
+   }
+
+   @Test
+   public void testAutoscaleConstantImage() {
+      // All pixels have intensity 100; range should be widened to [99, 101].
+      long[] hist = new long[256];
+      hist[100] = 1000;
+      IntegerComponentStats s = buildStats(hist);
+      long[] minMax = new long[2];
+      s.getAutoscaleMinMaxForQuantile(0.0, minMax);
+      assertEquals(99L, minMax[0]);
+      assertEquals(101L, minMax[1]);
+      assertTrue(minMax[1] - minMax[0] >= 2);
+   }
+
+   @Test
+   public void testAutoscaleConstantImageAtZero() {
+      // All pixels have intensity 0 (at the histogram range minimum).
+      // mid == 0 == getHistogramRangeMin(), so min=0, max=2.
+      long[] hist = new long[256];
+      hist[0] = 500;
+      IntegerComponentStats s = buildStats(hist);
+      long[] minMax = new long[2];
+      s.getAutoscaleMinMaxForQuantile(0.0, minMax);
+      assertEquals(0L, minMax[0]);
+      assertEquals(2L, minMax[1]);
+      assertTrue(minMax[1] - minMax[0] >= 2);
+   }
+
+   @Test
+   public void testAutoscaleConstantImageAtMax() {
+      // All pixels saturated (intensity 255 = range max).
+      // mid == 255 == getHistogramRangeMax(), so max=255, min=253.
+      long[] hist = new long[256];
+      hist[255] = 500;
+      IntegerComponentStats s = buildStats(hist);
+      long[] minMax = new long[2];
+      s.getAutoscaleMinMaxForQuantile(0.0, minMax);
+      assertEquals(255L, minMax[1]);
+      assertEquals(253L, minMax[0]);
+      assertTrue(minMax[1] - minMax[0] >= 2);
+   }
+
+   @Test
+   public void testAutoscaleSmallRangeWidth() {
+      // Two adjacent intensities only — range width is 1, must be widened.
+      long[] hist = new long[256];
+      hist[50] = 100;
+      hist[51] = 100;
+      IntegerComponentStats s = buildStats(hist);
+      long[] minMax = new long[2];
+      s.getAutoscaleMinMaxForQuantile(0.0, minMax);
+      assertTrue(minMax[1] - minMax[0] >= 2);
+   }
+
+   @Test
+   public void testAutoscaleResultAlwaysMinWidthTwo() {
+      // Property test: for any single-valued image at any position in range,
+      // the result width must be >= 2.
+      long[] hist = new long[256];
+      long[] minMax = new long[2];
+      for (int i = 0; i < 256; i++) {
+         java.util.Arrays.fill(hist, 0);
+         hist[i] = 1;
+         IntegerComponentStats s = buildStats(hist);
+         s.getAutoscaleMinMaxForQuantile(0.0, minMax);
+         assertTrue("width < 2 at intensity " + i, minMax[1] - minMax[0] >= 2);
+      }
+   }
 }

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/IntegerComponentStatsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/IntegerComponentStatsTest.java
@@ -20,6 +20,7 @@ public class IntegerComponentStatsTest {
 
    @Test
    public void testGetQuantile() {
+      // histogram_[1]=1 means 1 pixel at intensity 0; quantile is bin-edge based.
       IntegerComponentStats s = IntegerComponentStats.builder().
             histogram(new long[] { 0, 1, 0 }, 0).pixelCount(1).build();
       assertEquals(0.0, s.getQuantile(0.0), e);
@@ -27,7 +28,7 @@ public class IntegerComponentStatsTest {
       assertEquals(0.5, s.getQuantile(0.5), e);
 
       s = IntegerComponentStats.builder().
-            histogram(new long[] { 0, 1, 2, 0 }, 0).pixelCount(3).build();
+            histogram(new long[] { 0, 1, 2, 0 }, 0).pixelCount(3).maximum(1).build();
       assertEquals(0.0, s.getQuantile(0.0), e);
       assertEquals(1.25, s.getQuantile(0.5), e);
       assertEquals(2.0, s.getQuantile(1.0), e);
@@ -46,23 +47,37 @@ public class IntegerComponentStatsTest {
 
    // Helper: build stats from a histogram (no out-of-range bins) with bin width 1.
    // histogram[i] = count of pixels with intensity i. Range is [0, histogram.length-1].
+   // Sets minimum to the first non-zero bin and maximum to the last non-zero bin.
    private static IntegerComponentStats buildStats(long[] histogram) {
       long[] full = new long[histogram.length + 2];
       System.arraycopy(histogram, 0, full, 1, histogram.length);
       long count = 0;
-      for (long c : histogram) {
-         count += c;
+      long minimum = 0;
+      long maximum = histogram.length - 1;
+      boolean foundMin = false;
+      for (int i = 0; i < histogram.length; i++) {
+         count += histogram[i];
+         if (histogram[i] > 0) {
+            if (!foundMin) {
+               minimum = i;
+               foundMin = true;
+            }
+            maximum = i;
+         }
       }
       return IntegerComponentStats.builder()
             .histogram(full, 0)
             .pixelCount(count)
+            .minimum(minimum)
+            .maximum(maximum)
             .build();
    }
 
    @Test
    public void testAutoscaleNormalRange() {
-      // 256 bins, pixel counts spread across the range — quantile 0 should give
-      // min=0, max=254 (last bin edge - 1).
+      // 256 bins, uniform distribution. With q=0.0 and min=0, max=255:
+      // getQuantile(0.0) returns minimum_=0, getQuantile(1.0) returns maximum_+1=256,
+      // so max = round(256)-1 = 255. Range = [0, 255], width=255 >= 2.
       long[] hist = new long[256];
       for (int i = 0; i < 256; i++) {
          hist[i] = 1;
@@ -71,7 +86,7 @@ public class IntegerComponentStatsTest {
       long[] minMax = new long[2];
       s.getAutoscaleMinMaxForQuantile(0.0, minMax);
       assertEquals(0L, minMax[0]);
-      assertEquals(254L, minMax[1]);
+      assertEquals(255L, minMax[1]);
       assertTrue(minMax[1] - minMax[0] >= 2);
    }
 

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/NumberComponentStatsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/NumberComponentStatsTest.java
@@ -12,8 +12,8 @@ import static org.junit.Assert.*;
  *
  * @author mark
  */
-public class IntegerComponentStatsTest {
-   public IntegerComponentStatsTest() {
+public class NumberComponentStatsTest {
+   public NumberComponentStatsTest() {
    }
 
    private static final double e = 0.001;

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -1291,7 +1291,8 @@ public class ExplorerManager {
          // PixelType has no builder method — inject directly into the PropertyMap
          return DefaultSummaryMetadata.fromPropertyMap(
                sm.toPropertyMap().copyBuilder()
-                     .putString("PixelType", isRGB_ ? "RGB32" : (bitDepth_ <= 8 ? "GRAY8" : "GRAY16"))
+                     .putString("PixelType",
+                              isRGB_ ? "RGB32" : (bitDepth_ <= 8 ? "GRAY8" : "GRAY16"))
                      .build());
       } catch (Exception e) {
          studio_.logs().logError(e, "Explorer: failed to build summary metadata");

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -1057,6 +1057,8 @@ public class ExplorerManager {
          tags.put("Height", image.getHeight());
          tags.put("BitDepth", bitDepth_);
          tags.put("PixelType", isRGB_ ? "RGB32" : (bitDepth_ <= 8 ? "GRAY8" : "GRAY16"));
+         tags.put("BytesPerPixel", isRGB_ ? 4 : (bitDepth_ <= 8 ? 1 : 2));
+         tags.put("NumComponents", isRGB_ ? 3 : 1);
          tags.put("PixelSizeUm", pixelSizeUm_);
 
          // Per-image metadata for MM Inspector "Plane Metadata" panel

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -123,6 +123,7 @@ public class ExplorerManager {
    private double overlapPercentage_ = 10.0;
    private volatile boolean acquisitionInterrupted_ = false;
    private final AtomicInteger pendingBatches_ = new AtomicInteger(0);
+   private boolean isRGB_ = false;
 
    public ExplorerManager(Studio studio, ExplorerFrame frame) {
       studio_ = studio;
@@ -168,6 +169,12 @@ public class ExplorerManager {
          cameraWidth_ = (int) studio_.core().getImageWidth();
          cameraHeight_ = (int) studio_.core().getImageHeight();
          bitDepth_ = (int) studio_.core().getImageBitDepth();
+         try {
+            isRGB_ = studio_.core().getNumberOfComponents() > 1;
+         } catch (Exception e) {
+            studio_.logs().logError(e, "Explorer: could not determine camera component count");
+            isRGB_ = false;
+         }
          pixelSizeUm_ = studio_.core().getPixelSizeUm();
          if (pixelSizeUm_ <= 0) {
             pixelSizeUm_ = 1.0;
@@ -203,7 +210,7 @@ public class ExplorerManager {
          TiledDataViewerAcqInterface acqInterface = createAcqInterface();
          mm2Viewer_ = TiledDataViewerFactory.createDataViewer(
                studio_, dataSource_, acqInterface, mm2DataProvider_,
-               summaryMetadataJson, pixelSizeUm_, false);
+               summaryMetadataJson, pixelSizeUm_, isRGB_);
          mm2Viewer_.setAccumulateStats(true);
 
          initDisplaySettings(summaryMetadataJson);
@@ -271,6 +278,7 @@ public class ExplorerManager {
          final int imageWidth = summaryMetadata.optInt("Width", 512);
          final int imageHeight = summaryMetadata.optInt("Height", 512);
          bitDepth_ = summaryMetadata.optInt("BitDepth", 16);
+         isRGB_ = "RGB32".equals(summaryMetadata.optString("PixelType", ""));
          pixelSizeUm_ = summaryMetadata.optDouble("PixelSize_um", 1.0);
          if (pixelSizeUm_ <= 0) {
             pixelSizeUm_ = 1.0;
@@ -327,7 +335,7 @@ public class ExplorerManager {
          TiledDataViewerAcqInterface acqInterface = createAcqInterface();
          mm2Viewer_ = TiledDataViewerFactory.createDataViewer(
                studio_, dataSource_, acqInterface, mm2DataProvider_,
-               summaryMetadata, pixelSizeUm_, false);
+               summaryMetadata, pixelSizeUm_, isRGB_);
          mm2Viewer_.setAccumulateStats(true);
 
          // Load saved MM display settings or derive from heuristics
@@ -1048,7 +1056,7 @@ public class ExplorerManager {
          tags.put("Width", image.getWidth());
          tags.put("Height", image.getHeight());
          tags.put("BitDepth", bitDepth_);
-         tags.put("PixelType", bitDepth_ <= 8 ? "GRAY8" : "GRAY16");
+         tags.put("PixelType", isRGB_ ? "RGB32" : (bitDepth_ <= 8 ? "GRAY8" : "GRAY16"));
          tags.put("PixelSizeUm", pixelSizeUm_);
 
          // Per-image metadata for MM Inspector "Plane Metadata" panel
@@ -1101,7 +1109,7 @@ public class ExplorerManager {
                  image.getRawPixels(),
                  tags,
                  axes,
-                 false,
+                 isRGB_,
                  bitDepth_,
                  image.getHeight(),
                  image.getWidth());
@@ -1281,7 +1289,7 @@ public class ExplorerManager {
          // PixelType has no builder method — inject directly into the PropertyMap
          return DefaultSummaryMetadata.fromPropertyMap(
                sm.toPropertyMap().copyBuilder()
-                     .putString("PixelType", bitDepth_ <= 8 ? "GRAY8" : "GRAY16")
+                     .putString("PixelType", isRGB_ ? "RGB32" : (bitDepth_ <= 8 ? "GRAY8" : "GRAY16"))
                      .build());
       } catch (Exception e) {
          studio_.logs().logError(e, "Explorer: failed to build summary metadata");

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
@@ -763,8 +763,9 @@ public class CVViewer implements DataViewer, ImageStatsPublisher {
                        lastCalculatedImagesAndStats_.getResult().get(ch).getComponentStats(0);
                ComponentDisplaySettings.Builder ccB =
                      csCopyBuilder.getComponentSettings(j).copyBuilder();
-               ccB.scalingRange(componentStats.getAutoscaleMinForQuantile(extremaPercentage),
-                       componentStats.getAutoscaleMaxForQuantile(extremaPercentage));
+               long[] minMax = new long[2];
+               componentStats.getAutoscaleMinMaxForQuantile(extremaPercentage, minMax);
+               ccB.scalingRange(minMax[0], minMax[1]);
                ccB.scalingGamma(displaySettings.getChannelSettings(ch)
                      .getComponentSettings(j).getScalingGamma());
                csCopyBuilder.component(j, ccB.build());

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
@@ -44,7 +44,6 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowFocusListener;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,10 +78,10 @@ import org.micromanager.display.internal.event.DataViewerDidBecomeVisibleEvent;
 import org.micromanager.display.internal.event.DataViewerWillCloseEvent;
 import org.micromanager.display.internal.event.DefaultDisplaySettingsChangedEvent;
 import org.micromanager.display.internal.imagestats.BoundsRectAndMask;
+import org.micromanager.display.internal.imagestats.ComponentStats;
 import org.micromanager.display.internal.imagestats.ImageStatsProcessor;
 import org.micromanager.display.internal.imagestats.ImageStatsRequest;
 import org.micromanager.display.internal.imagestats.ImagesAndStats;
-import org.micromanager.display.internal.imagestats.IntegerComponentStats;
 import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.internal.utils.WindowPositioning;
 
@@ -1128,7 +1127,7 @@ public class CVViewer implements DataViewer, ImageStatsPublisher {
             ChannelDisplaySettings.Builder csCopyBuilder = 
                     displaySettings.getChannelSettings(ch).copyBuilder();
             for (int j = 0; j < image.getNumComponents(); ++j) {
-               IntegerComponentStats componentStats = 
+               ComponentStats componentStats =
                        lastCalculatedImagesAndStats_.getResult().get(ch).getComponentStats(0);
                ComponentDisplaySettings.Builder ccB =
                      csCopyBuilder.getComponentSettings(j).copyBuilder();

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/CVViewer.java
@@ -1117,9 +1117,9 @@ public class CVViewer implements DataViewer, ImageStatsPublisher {
           
       DisplaySettings.Builder newSettingsBuilder = displaySettings.copyBuilder();
       Coords baseCoords = getDisplayedImages().get(0).getCoords();
-      double extremaPercentage = displaySettings.getAutoscaleIgnoredPercentile();
-      if (extremaPercentage < 0.0) {
-         extremaPercentage = 0.0;
+      double extremaQuantile = displaySettings.getAutoscaleIgnoredQuantile();
+      if (extremaQuantile < 0.0) {
+         extremaQuantile = 0.0;
       }
       for (int ch = 0; ch < dataProvider_.getNextIndex(Coords.CHANNEL); ++ch) {
          Image image = dataProvider_.getImage(baseCoords.copyBuilder().channel(ch).build());
@@ -1128,11 +1128,11 @@ public class CVViewer implements DataViewer, ImageStatsPublisher {
                     displaySettings.getChannelSettings(ch).copyBuilder();
             for (int j = 0; j < image.getNumComponents(); ++j) {
                ComponentStats componentStats =
-                       lastCalculatedImagesAndStats_.getResult().get(ch).getComponentStats(0);
+                       lastCalculatedImagesAndStats_.getResult().get(ch).getComponentStats(j);
                ComponentDisplaySettings.Builder ccB =
                      csCopyBuilder.getComponentSettings(j).copyBuilder();
                long[] minMax = new long[2];
-               componentStats.getAutoscaleMinMaxForQuantile(extremaPercentage, minMax);
+               componentStats.getAutoscaleMinMaxForQuantile(extremaQuantile, minMax);
                ccB.scalingRange(minMax[0], minMax[1]);
                ccB.scalingGamma(displaySettings.getChannelSettings(ch)
                      .getComponentSettings(j).getScalingGamma());


### PR DESCRIPTION
Building on a branch by @marktsuchida, I addede a "White" icon that let's the user change the brightness/contrast of all 3 primary colors simultanuously.  In addition, when the "White" mode is selected, a "Color Balance" button shows up that let's the user manipulate the color balance (which is the ratio of the max of R, G, and B) using 3 methods: 

1. Picking a point in the image, 
2. using the average intensity of the 3 colors, 
3. using (inverted) color temperature.  
 
White main maximum and White ratios (color balance) persist in the display settings. 

Changes to non-internal classes:

 PropertyKey (data/internal — but the enum is the registry for all PropertyMap keys):
Two new keys added: WHITE_MAIN_MAX and WHITE_RATIOS, both attributed to ChannelDisplaySettings.

  DefaultChannelDisplaySettings (display/internal):
Gained two optional fields — whiteMainMax_ (long) and whiteRatios_ (double[3])  — that are serialized to/from the user profile via toPropertyMap/fromPropertyMap. Three new public static helpers provide the only external access point: getStoredWhiteMainMax(), getStoredWhiteRatios(), and applyWhiteBalance(). The copyBuilder() preserves both fields. No changes
to the public ChannelDisplaySettings interface.

 Everything else (ChannelIntensityController, HistogramView, IntensityInspectorPanelController) is internal to the inspector package and not part of the public API.


