### PR TITLE
Improves some of the UI around the Z Drive selection

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
@@ -27,6 +27,7 @@ import mmcorej.CMMCore;
 import org.micromanager.Studio;
 import org.micromanager.events.PixelSizeAffineChangedEvent;
 import org.micromanager.events.PixelSizeChangedEvent;
+import org.micromanager.events.PropertyChangedEvent;
 import org.micromanager.events.StagePositionChangedEvent;
 import org.micromanager.events.XYStagePositionChangedEvent;
 import org.micromanager.internal.utils.AffineUtils;
@@ -140,6 +141,28 @@ public class MMCache {
    public void onStagePositionChanged(StagePositionChangedEvent event) {
       if (event.getDeviceName().equals(zStageLabel_)) {
          updateZPos(event.getPos());
+      }
+   }
+
+   /**
+    * Handles Core property changes; updates zStageLabel_ when Core.Focus is reassigned.
+    *
+    * @param event Holds device, property, and new value.
+    */
+   @Subscribe
+   public void onPropertyChanged(PropertyChangedEvent event) {
+      if ("Core".equals(event.getDevice()) && "Focus".equals(event.getProperty())) {
+         zStageLabel_ = event.getValue() == null ? "" : event.getValue();
+         double zPos = 0.0;
+         try {
+            if (zStageLabel_.length() > 0) {
+               zPos = core_.getPosition(zStageLabel_);
+            }
+         } catch (Exception e) {
+            ReportingUtils.showError(e, "Failed to get Z stage position");
+         }
+         zPos_ = zPos;
+         updateInfoDisplay();
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1626,14 +1626,15 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
             zDriveCombo_.addItem(zDrives.get(i));
          }
          String focusDevice = mmStudio_.core().getFocusDevice();
-         zDriveCombo_.setSelectedItem(focusDevice.isEmpty() ? "" : focusDevice);
+         boolean hasFocus = focusDevice != null && !focusDevice.isEmpty();
+         zDriveCombo_.setSelectedItem(hasFocus ? focusDevice : "");
          try {
             zDriveCombo_.setVisible(true);
             double pixelSize = mmStudio_.core().getPixelSizeUm();
             if (pixelSize != 0.0) {
                proposedZStepLabel_.setText(getOptimalZStep(true));
             }
-            if (!mmStudio_.core().getFocusDevice().isEmpty()) {
+            if (hasFocus) {
                zDrivePositionLabel_.setText(NumberUtils.doubleToDisplayString(
                         mmStudio_.core().getPosition()));
             }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1693,7 +1693,8 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
          for (ActionListener al : actionListeners) {
             zDriveCombo_.removeActionListener(al);
          }
-         zDriveCombo_.setSelectedItem(focusDevice == null || focusDevice.isEmpty() ? "" : focusDevice);
+         zDriveCombo_.setSelectedItem(focusDevice == null
+                  || focusDevice.isEmpty() ? "" : focusDevice);
          for (ActionListener al : actionListeners) {
             zDriveCombo_.addActionListener(al);
          }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1621,10 +1621,12 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
             zDriveCombo_.removeActionListener(al);
          }
          zDriveCombo_.removeAllItems();
+         zDriveCombo_.addItem("");
          for (int i = 0; i < zDrives.size(); i++) {
             zDriveCombo_.addItem(zDrives.get(i));
          }
-         zDriveCombo_.setSelectedItem(mmStudio_.core().getFocusDevice());
+         String focusDevice = mmStudio_.core().getFocusDevice();
+         zDriveCombo_.setSelectedItem(focusDevice.isEmpty() ? "" : focusDevice);
          try {
             zDriveCombo_.setVisible(true);
             double pixelSize = mmStudio_.core().getPixelSizeUm();
@@ -1685,9 +1687,22 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
    @Subscribe
    public void onPropertyChangedEvent(PropertyChangedEvent pce) {
       if ("Core".equals(pce.getDevice()) && ("Focus".equals(pce.getProperty()))) {
+         String focusDevice = pce.getValue();
+         ActionListener[] actionListeners = zDriveCombo_.getActionListeners();
+         for (ActionListener al : actionListeners) {
+            zDriveCombo_.removeActionListener(al);
+         }
+         zDriveCombo_.setSelectedItem(focusDevice == null || focusDevice.isEmpty() ? "" : focusDevice);
+         for (ActionListener al : actionListeners) {
+            zDriveCombo_.addActionListener(al);
+         }
          try {
-            zDrivePositionLabel_.setText(NumberUtils.doubleToDisplayString(
-                     mmStudio_.core().getPosition()));
+            if (focusDevice != null && !focusDevice.isEmpty()) {
+               zDrivePositionLabel_.setText(NumberUtils.doubleToDisplayString(
+                        mmStudio_.core().getPosition()));
+            } else {
+               zDrivePositionLabel_.setText("");
+            }
          } catch (Exception e) {
             mmStudio_.logs().logError(e, "Failed to get Z drive position from core.");
          }
@@ -1785,13 +1800,17 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
       if (newZDrive != null && !newZDrive.equals(mmStudio_.core().getFocusDevice())) {
          try {
             mmStudio_.core().setFocusDevice(newZDrive);
-            double position = mmStudio_.core().getPosition();
-            zDrivePositionLabel_.setText(NumberUtils.doubleToDisplayString(position));
-            if (ABSOLUTE_Z.equals(zValCombo_.getSelectedItem())) {
-               // New Z drive: to avoid danger, set start and end to the current position
-               zStart_.setValue(position);
-               zEnd_.setValue(position);
-            } // if relative Z, it should be safe and logical to keep it where it is.
+            if (newZDrive.isEmpty()) {
+               zDrivePositionLabel_.setText("");
+            } else {
+               double position = mmStudio_.core().getPosition();
+               zDrivePositionLabel_.setText(NumberUtils.doubleToDisplayString(position));
+               if (ABSOLUTE_Z.equals(zValCombo_.getSelectedItem())) {
+                  // New Z drive: to avoid danger, set start and end to the current position
+                  zStart_.setValue(position);
+                  zEnd_.setValue(position);
+               } // if relative Z, it should be safe and logical to keep it where it is.
+            }
          } catch (Exception e) {
             mmStudio_.logs().logError(e, "Failed to set focus device");
          }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -362,13 +362,16 @@ public final class StageControlFrame extends JFrame {
             // user edits any value in this dialog.
             String selectedDrive = (String) zDriveSelect_[idx].getSelectedItem();
             if (selectedDrive != null && !selectedDrive.isEmpty()) {
-               try {
+               Object smallVal = zStepTextsSmall_[idx].getValue();
+               Object medVal = zStepTextsMedium_[idx].getValue();
+               if (smallVal instanceof Number && medVal instanceof Number) {
                   settings_.putDouble(SMALL_MOVEMENT_Z + selectedDrive,
-                        NumberUtils.displayStringToDouble(zStepTextsSmall_[idx].getText()));
+                        ((Number) smallVal).doubleValue());
                   settings_.putDouble(MEDIUM_MOVEMENT_Z + selectedDrive,
-                        NumberUtils.displayStringToDouble(zStepTextsMedium_[idx].getText()));
-               } catch (ParseException pex) {
-                  studio_.logs().logError("Error parsing Z step size in Stage Control Frame");
+                        ((Number) medVal).doubleValue());
+               } else {
+                  studio_.logs().logError("Z step size field has unexpected value type for drive \""
+                        + selectedDrive + "\": small=" + smallVal + ", medium=" + medVal);
                }
             }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -32,11 +32,9 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.text.NumberFormat;
 import java.text.ParseException;
-import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -46,7 +44,6 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import mmcorej.CMMCore;
@@ -106,9 +103,6 @@ public final class StageControlFrame extends JFrame {
 
    private static long extraWait_ = 100;
 
-   // used to keep track of the "active" Z Drive
-   public static final String SELECTED_Z_DRIVE = "SELECTED_Z_DRIVE";
-
    // used by Drive selection combo boxes
    private static final String CURRENT_Z_DRIVE = "CURRENTZDRIVE";
 
@@ -124,8 +118,6 @@ public final class StageControlFrame extends JFrame {
    private final JPanel[] zPanel_ = new JPanel[MAX_NUM_Z_PANELS];
    @SuppressWarnings({"unchecked", "rawtypes"})
    private final JComboBox<String>[] zDriveSelect_ = new JComboBox[MAX_NUM_Z_PANELS];
-   private final JRadioButton[] zDriveActiveButtons_ = new JRadioButton[MAX_NUM_Z_PANELS];
-   private final ButtonGroup zDriveActiveGroup_ = new ButtonGroup();
 
    private final JLabel[] zPositionLabel_ = new JLabel[MAX_NUM_Z_PANELS];
    private JPanel settingsPanel_;
@@ -324,8 +316,6 @@ public final class StageControlFrame extends JFrame {
          for (int idx = MAX_NUM_Z_PANELS - 1; idx > -1; idx--) {
             zDriveSelect_[idx].setVisible(true);
             zDriveSelect_[idx].setEnabled(nrZDrives > 1);
-            zDriveActiveButtons_[idx].setVisible(true);
-            zDriveActiveButtons_[idx].setEnabled(nrZDrives > 1);
 
             // remove item listeners temporarily
             ItemListener[] zDriveItemListeners =
@@ -366,9 +356,20 @@ public final class StageControlFrame extends JFrame {
             zDriveSelect_[idx].setSelectedIndex(-1);
 
             zDriveSelect_[idx].setSelectedIndex(cbIndex);
-            if (Objects.equals(zDriveSelect_[idx].getSelectedItem(),
-                  settings_.getString(SELECTED_Z_DRIVE, " "))) {
-               zDriveActiveButtons_[idx].setSelected(true);
+
+            // Ensure per-drive step sizes are written to the profile so that
+            // XYZKeyListener and ZWheelListener can read them even before the
+            // user edits any value in this dialog.
+            String selectedDrive = (String) zDriveSelect_[idx].getSelectedItem();
+            if (selectedDrive != null && !selectedDrive.isEmpty()) {
+               try {
+                  settings_.putDouble(SMALL_MOVEMENT_Z + selectedDrive,
+                        NumberUtils.displayStringToDouble(zStepTextsSmall_[idx].getText()));
+                  settings_.putDouble(MEDIUM_MOVEMENT_Z + selectedDrive,
+                        NumberUtils.displayStringToDouble(zStepTextsMedium_[idx].getText()));
+               } catch (ParseException pex) {
+                  studio_.logs().logError("Error parsing Z step size in Stage Control Frame");
+               }
             }
 
             plusButtons_[idx].setVisible(false);
@@ -582,19 +583,6 @@ public final class StageControlFrame extends JFrame {
       final JPanel result = new JPanel(new MigLayout("insets 0, gap 0, flowy"));
       // result.add(new JLabel("Z Stage", JLabel.CENTER), "growx, alignx center");
       zDriveSelect_[idx] = new JComboBox<>();
-      zDriveActiveButtons_[idx] = new JRadioButton();
-      zDriveActiveButtons_[idx].addItemListener(e -> {
-         if (e.getStateChange() == ItemEvent.SELECTED) {
-            String activeZDrive = (String) zDriveSelect_[idx].getSelectedItem();
-            // push to profile
-            settings_.putString(SELECTED_Z_DRIVE, activeZDrive);
-            settings_.putDouble(SMALL_MOVEMENT_Z, settings_.getDouble(
-                  SMALL_MOVEMENT_Z + idx, 1.1));
-            settings_.putDouble(MEDIUM_MOVEMENT_Z, settings_.getDouble(
-                  MEDIUM_MOVEMENT_Z + idx, 11.1));
-         }
-      });
-      zDriveActiveGroup_.add(zDriveActiveButtons_[idx]);
 
       // use ItemListener here instead of ActionListener so initialize() only has to worry about
       //   one type of listener on the combo-box (there are also ItemListeners for step size fields)
@@ -615,8 +603,6 @@ public final class StageControlFrame extends JFrame {
       // and Z panels.
       result.add(zDriveSelect_[idx],
             "height 22!, gaptop 4, gapbottom 4, hidemode 0, growx");
-      result.add(zDriveActiveButtons_[idx],
-            "height 22!, gaptop 4, gapbottom 4, hidemode 0, alignx center");
 
       // Create buttons for stepping up/down.
       // Icon name prefix: double, single, single, double
@@ -645,7 +631,6 @@ public final class StageControlFrame extends JFrame {
                return;
             }
             setRelativeStagePosition(dz * stepSize, idx);
-            zDriveActiveButtons_[idx].setSelected(true);
          });
          result.add(button, "alignx center, growx");
          if (i == 1) {

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYZKeyListener.java
@@ -19,7 +19,6 @@
 package org.micromanager.internal.navigation;
 
 import static org.micromanager.internal.dialogs.StageControlFrame.MEDIUM_MOVEMENT_Z;
-import static org.micromanager.internal.dialogs.StageControlFrame.SELECTED_Z_DRIVE;
 import static org.micromanager.internal.dialogs.StageControlFrame.SMALL_MOVEMENT_Z;
 import static org.micromanager.internal.dialogs.StageControlFrame.X_MOVEMENTS;
 import static org.micromanager.internal.dialogs.StageControlFrame.Y_MOVEMENTS;
@@ -93,8 +92,11 @@ public final class XYZKeyListener {
       for (int i = 0; i < yMovesMicron_.length; ++i) {
          yMovesMicron_[i] = settings_.getDouble(Y_MOVEMENTS[i], yMovesMicron_[i]);
       }
-      zMovesMicron_[0] = settings_.getDouble(SMALL_MOVEMENT_Z, 1.1);
-      zMovesMicron_[1] = settings_.getDouble(MEDIUM_MOVEMENT_Z, 11.1);
+      String focusDevice = core_.getFocusDevice();
+      if (focusDevice != null && !focusDevice.isEmpty()) {
+         zMovesMicron_[0] = settings_.getDouble(SMALL_MOVEMENT_Z + focusDevice, 1.1);
+         zMovesMicron_[1] = settings_.getDouble(MEDIUM_MOVEMENT_Z + focusDevice, 11.1);
+      }
       boolean consumed = false;
 
       switch (e.getKeyCode()) {
@@ -183,7 +185,7 @@ public final class XYZKeyListener {
     */
    public void incrementZ(double micron) {
       // Get needed info from core
-      String zStage = settings_.getString(SELECTED_Z_DRIVE, core_.getFocusDevice());
+      String zStage = core_.getFocusDevice();
       if (zStage == null || zStage.isEmpty()) {
          return;
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/ZWheelListener.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/ZWheelListener.java
@@ -21,8 +21,11 @@
 package org.micromanager.internal.navigation;
 
 import com.google.common.eventbus.Subscribe;
+import java.awt.event.MouseWheelEvent;
 import org.micromanager.Studio;
 import org.micromanager.display.internal.event.DisplayMouseWheelEvent;
+import org.micromanager.internal.dialogs.StageControlFrame;
+import org.micromanager.propertymap.MutablePropertyMapView;
 
 /**
  * Classs that translates changes in the mouse wheel into Z stage movements.
@@ -31,10 +34,12 @@ public final class ZWheelListener {
    private static final double MOVE_INCREMENT = 0.20;
    private final Studio studio_;
    private final ZNavigator zNavigator_;
+   private final MutablePropertyMapView settings_;
 
    public ZWheelListener(final Studio studio, final ZNavigator zNavigator) {
       studio_ = studio;
       zNavigator_ = zNavigator;
+      settings_ = studio_.profile().getSettings(StageControlFrame.class);
    }
 
 
@@ -44,27 +49,54 @@ public final class ZWheelListener {
     * executors for each zStage, and combines movement requests if they come in
     * too fast.
     *
+    * <p>The step size depends on modifier keys held during the scroll:
+    * <ul>
+    *   <li>No modifier: optimal Z step from the core ({@code getPixelSizeOptimalZUm}),
+    *       falling back to 2 &times; pixel size, or {@value MOVE_INCREMENT} &micro;m if
+    *       no pixel size is configured. This matches the "Use:" value shown in the
+    *       MDA dialog Z-stack section.</li>
+    *   <li>Ctrl: fine step size configured in the Stage Control dialog for the
+    *       current focus device.</li>
+    *   <li>Shift: medium step size configured in the Stage Control dialog for the
+    *       current focus device.</li>
+    * </ul>
+    *
     * @param e DisplayMouseWheelEvent containing a MouseWheel event
     */
    @Subscribe
    public void mouseWheelMoved(DisplayMouseWheelEvent e) {
       synchronized (this) {
-         // Get needed info from core
          String zStage = studio_.core().getFocusDevice();
          if (zStage == null || zStage.equals("")) {
             return;
          }
 
-         double moveIncrement = MOVE_INCREMENT;
-         double pixSizeUm = studio_.core().getPixelSizeUm(true);
-         if (pixSizeUm > 0.0) {
-            moveIncrement = 2 * pixSizeUm;
-         }
-         // Get coordinates of event
-         int move = e.getEvent().getWheelRotation();
-         double moveUm = move * moveIncrement;
+         MouseWheelEvent mwe = e.getEvent();
+         double moveIncrement;
 
-         zNavigator_.setPosition(zStage, moveUm);
+         if (mwe.isControlDown()) {
+            moveIncrement = settings_.getDouble(
+                  StageControlFrame.SMALL_MOVEMENT_Z + zStage, 1.1);
+         } else if (mwe.isShiftDown()) {
+            moveIncrement = settings_.getDouble(
+                  StageControlFrame.MEDIUM_MOVEMENT_Z + zStage, 11.1);
+         } else {
+            double optimalZ = 0.0;
+            try {
+               optimalZ = studio_.core().getPixelSizeOptimalZUm(true);
+            } catch (Exception ex) {
+               studio_.logs().logError(ex, "Failed to get optimal Z step");
+            }
+            if (optimalZ > 0.0) {
+               moveIncrement = optimalZ;
+            } else {
+               double pixSizeUm = studio_.core().getPixelSizeUm(true);
+               moveIncrement = pixSizeUm > 0.0 ? 2.0 * pixSizeUm : MOVE_INCREMENT;
+            }
+         }
+
+         int move = mwe.getWheelRotation();
+         zNavigator_.setPosition(zStage, move * moveIncrement);
       }
    }
 


### PR DESCRIPTION
- MDA Z-drive drop down now has an empty line to correspond with Core Focus drive being empty
- Removed Radio buttons from Stage Control Frame
- Movement keys now move Core Focus Drive
- ZWheel Listener now looks at optimal Z Step size, and modifier keys make it use the values in Stage Control Frame