### PR TITLE
Make use of affine transform in Explorer plugin and TileCreator

### DIFF
--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerAcqInterface.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerAcqInterface.java
@@ -12,6 +12,19 @@ public interface TiledDataViewerAcqInterface {
 
    boolean isFinished();
 
+   /**
+    * Called on the EDT when the user requests to close the viewer window,
+    * before any close action is taken.  Return {@code false} to veto the close
+    * (e.g. to show a save-data dialog and leave the window open if the user
+    * clicks Cancel).  The default implementation returns {@code true} so that
+    * existing callers are unaffected.
+    *
+    * @return true to allow the close to proceed, false to cancel it.
+    */
+   default boolean requestToClose() {
+      return true;
+   }
+
    void abort();
 
    void setPaused(boolean paused);

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewer.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewer.java
@@ -574,6 +574,11 @@ public class TiledDataViewer implements TiledDataViewerAPI {
             }
          });
       } else {
+         // Give the acquisition a chance to veto the close (e.g. to show a
+         // save-data dialog).  If it returns false, leave the window open.
+         if (acq_ != null && !acq_.requestToClose()) {
+            return;
+         }
          //check to stop acquisiton?, return here if the attempt to close window unsuccesslful
          if (acq_ != null && !acq_.isFinished()) {
             int result = JOptionPane.showConfirmDialog(null, "Finish acquisition?",

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/testacquisition/TestAcqAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/testacquisition/TestAcqAdapter.java
@@ -301,7 +301,13 @@ public class TestAcqAdapter extends DataViewerListener implements
          }
 
          // These hooks make sure that continuousfocus is off when running a Z stack.
-         if (studio_.core().isContinuousFocusEnabled()) {
+         // Only add them when there will actually be Z motion (a Z stack or channels with
+         // Z offsets), otherwise continuous focus is unnecessarily disabled for every
+         // single-frame acquisition such as those used by the Explorer plugin.
+         boolean hasZOffsets = sequenceSettings.useChannels()
+                 && sequenceSettings.channels().stream().anyMatch(c -> c.zOffset() != 0);
+         if (studio_.core().isContinuousFocusEnabled()
+                 && (sequenceSettings.useSlices() || hasZOffsets)) {
             currentAcquisition_.addHook(continuousFocusHookBefore(acquisitionSettings),
                     AcquisitionAPI.BEFORE_HARDWARE_HOOK);
             currentAcquisition_.addHook(continuousFocusHookAfter(acquisitionSettings),

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
@@ -80,9 +80,11 @@ public class XYNavigator {
          if (userData == null) {
             return null;
          }
-         // Both keys must be present for the flipper to have touched this image.
-         if (!userData.containsKey("ImageFlipper-Rotation")
-               || !userData.containsKey("ImageFlipper-Mirror")) {
+         // Both keys must be present with the correct types for the flipper to have
+         // touched this image.  Type-specific checks avoid ClassCastException if
+         // unrelated metadata happens to use the same key names with different types.
+         if (!userData.containsInteger("ImageFlipper-Rotation")
+               || !userData.containsString("ImageFlipper-Mirror")) {
             return null;
          }
          int rotation = userData.getInteger("ImageFlipper-Rotation", 0);
@@ -106,9 +108,10 @@ public class XYNavigator {
          } else if (rotation == 270) {
             correction.quadrantRotate(3); // CCW 270° = inverse of CW 270°
          }
-         // Step 2: undo the mirror (mirror-X is self-inverse)
+         // Step 2: undo the mirror — pre-multiply so mirror is applied AFTER rotate(-N),
+         // giving correction = M * R(-N) rather than R(-N) * M.
          if (mirrored) {
-            correction.scale(-1.0, 1.0);
+            correction.preConcatenate(AffineTransform.getScaleInstance(-1.0, 1.0));
          }
          return correction;
       } catch (Exception e) {

--- a/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/navigation/XYNavigator.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.AtomicDouble;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -13,7 +14,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.swing.JOptionPane;
 import mmcorej.MMCoreJ;
+import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
+import org.micromanager.data.Image;
+import org.micromanager.display.DisplayWindow;
 import org.micromanager.events.internal.DefaultXYStagePositionChangedEvent;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.ReportingUtils;
@@ -50,6 +54,68 @@ public class XYNavigator {
       xyStageMoverMap_ = new HashMap<>();
    }
 
+
+   /**
+    * Returns an AffineTransform representing the inverse of the ImageFlipper
+    * transformation currently applied to the live display image, or null if no
+    * ImageFlipper transform is active.  Because we work with pixel *deltas* the
+    * transform is purely linear (no translation term matters).
+    *
+    * <p>The ImageFlipper applies: mirror-X first, then rotation.  To convert
+    * post-flipper mouse-pixel deltas back to raw camera-pixel deltas we must
+    * apply the inverse: rotate by -rotation, then mirror-X again (mirror is its
+    * own inverse).
+    */
+   private AffineTransform getImageFlipperCorrection() {
+      try {
+         DisplayWindow display = studio_.live().getDisplay();
+         if (display == null || display.isClosed()) {
+            return null;
+         }
+         List<Image> images = display.getDisplayedImages();
+         if (images == null || images.isEmpty()) {
+            return null;
+         }
+         PropertyMap userData = images.get(0).getMetadata().getUserData();
+         if (userData == null) {
+            return null;
+         }
+         // Both keys must be present for the flipper to have touched this image.
+         if (!userData.containsKey("ImageFlipper-Rotation")
+               || !userData.containsKey("ImageFlipper-Mirror")) {
+            return null;
+         }
+         int rotation = userData.getInteger("ImageFlipper-Rotation", 0);
+         boolean mirrored = "On".equals(userData.getString("ImageFlipper-Mirror", "Off"));
+
+         if (rotation == 0 && !mirrored) {
+            return null; // identity — no correction needed
+         }
+
+         // Build the inverse of "mirror then rotate(rotation)":
+         //   inverse = rotate(-rotation) then mirror
+         // AffineTransform.quadrantRotate(n) rotates CCW by n*90 degrees.
+         // ImageFlipper R90 = ImageJ rotateRight = CW 90, so its inverse is
+         // CCW 90 = quadrantRotate(1).
+         AffineTransform correction = new AffineTransform();
+         // Step 1: undo the rotation
+         if (rotation == 90) {
+            correction.quadrantRotate(1); // CCW 90° = inverse of CW 90°
+         } else if (rotation == 180) {
+            correction.quadrantRotate(2); // 180° is self-inverse
+         } else if (rotation == 270) {
+            correction.quadrantRotate(3); // CCW 270° = inverse of CW 270°
+         }
+         // Step 2: undo the mirror (mirror-X is self-inverse)
+         if (mirrored) {
+            correction.scale(-1.0, 1.0);
+         }
+         return correction;
+      } catch (Exception e) {
+         ReportingUtils.logError(e, "Failed to read ImageFlipper metadata");
+         return null;
+      }
+   }
 
    /*
     * Ensures that the stage moves in the expected direction
@@ -94,6 +160,17 @@ public class XYNavigator {
             transposeXY_ = !(tmp.equals("0"));
          } catch (Exception exc) {
             ReportingUtils.showError(exc);
+         }
+      } else {
+         // Pre-multiply the affine transform by the inverse of any ImageFlipper
+         // transform so that mouse-pixel deltas (which are in post-flipper image
+         // space) are correctly mapped back to raw camera-pixel space before the
+         // camera→stage affine is applied.
+         AffineTransform flipperCorrection = getImageFlipperCorrection();
+         if (flipperCorrection != null) {
+            // concatenate() applies flipperCorrection first, then affineTransform_,
+            // so the combined transform maps post-flipper pixel deltas → stage microns.
+            affineTransform_.concatenate(flipperCorrection);
          }
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/utils/TileCreator.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/utils/TileCreator.java
@@ -23,6 +23,8 @@
 package org.micromanager.internal.positionlist.utils;
 
 import java.awt.Component;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.text.DecimalFormat;
 import javax.swing.JOptionPane;
 import mmcorej.CMMCore;
@@ -31,6 +33,7 @@ import mmcorej.StrVector;
 import org.micromanager.MultiStagePosition;
 import org.micromanager.PositionList;
 import org.micromanager.StagePosition;
+import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 
@@ -157,8 +160,39 @@ public final class TileCreator {
       double offsetXUm = (totalSizeXUm - boundingXUm) / 2;
       double offsetYUm = (totalSizeYUm - boundingYUm) / 2;
 
+      // Compute per-tile step vectors in stage space.
+      // With an affine transform, moving one tile to the right in camera-pixel space
+      // corresponds to affine * (tileWidthPx, 0) in stage microns — not simply
+      // (tileSizeXUm, 0).  Similarly for the Y direction.
+      // Without a valid affine we fall back to the existing axis-aligned behaviour.
+      final AffineTransform affine = getPixelSizeAffine(pixelSizeUm);
+      final double stepXdx; // stage-X component of "one step right"
+      final double stepXdy; // stage-Y component of "one step right"
+      final double stepYdx; // stage-X component of "one step down"
+      final double stepYdy; // stage-Y component of "one step down"
+      if (affine != null) {
+         double tileWidthPx  = tileSizeXUm / pixelSizeUm;
+         double tileHeightPx = tileSizeYUm / pixelSizeUm;
+         Point2D.Double stepX = new Point2D.Double();
+         Point2D.Double stepY = new Point2D.Double();
+         affine.transform(new Point2D.Double(tileWidthPx, 0), stepX);
+         affine.transform(new Point2D.Double(0, tileHeightPx), stepY);
+         stepXdx = stepX.x;
+         stepXdy = stepX.y;
+         stepYdx = stepY.x;
+         stepYdy = stepY.y;
+      } else {
+         stepXdx = tileSizeXUm;
+         stepXdy = 0;
+         stepYdx = 0;
+         stepYdy = tileSizeYUm;
+      }
+
+      // Origin of the grid in stage space: top-left corner adjusted for centering offset.
+      final double originX = minX - offsetXUm;
+      final double originY = minY - offsetYUm;
+
       PositionList posList = new PositionList();
-      // todo handle mirrorX mirrorY
       for (int y = 0; y < nrImagesY; y++) {
          for (int x = 0; x < nrImagesX; x++) {
             // on even rows go left to right, on odd rows right to left
@@ -171,8 +205,8 @@ public final class TileCreator {
             // Add XY position
             // xyStage is not null; we've checked above.
             msp.setDefaultXYStage(xyStage);
-            double dx = minX - offsetXUm + (tmpX * tileSizeXUm);
-            double dy = minY - offsetYUm + (y * tileSizeYUm);
+            double dx = originX + tmpX * stepXdx + y * stepYdx;
+            double dy = originY + tmpX * stepXdy + y * stepYdy;
             StagePosition spXY = StagePosition.create2D(xyStage, dx, dy);
             msp.add(spXY);
 
@@ -359,6 +393,25 @@ public final class TileCreator {
          posList.addPosition(msp);
       }
       return posList;
+   }
+
+   /**
+    * Returns the validated pixel-size affine transform (camera pixels → stage microns),
+    * or null if none is available or it fails the 10 % consistency check against pixelSizeUm.
+    * The MM core affine always has zero translation terms, so it can be used directly
+    * to transform pixel-delta vectors to stage-micron-delta vectors.
+    */
+   private AffineTransform getPixelSizeAffine(double pixelSizeUm) {
+      try {
+         AffineTransform at = AffineUtils.doubleToAffine(core_.getPixelSizeAffine(true));
+         double affinePixelSize = AffineUtils.deducePixelSize(at);
+         if (Math.abs(pixelSizeUm - affinePixelSize) > 0.1 * pixelSizeUm) {
+            return null;
+         }
+         return at;
+      } catch (Exception e) {
+         return null;
+      }
    }
 
    private boolean isSwappedXY() {

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -3,6 +3,8 @@ package org.micromanager.explorer;
 import com.google.common.eventbus.Subscribe;
 import java.awt.Color;
 import java.awt.Point;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Point2D;
 import java.io.File;
 import java.io.IOException;
@@ -43,6 +45,7 @@ import org.micromanager.display.internal.DefaultDisplaySettings;
 import org.micromanager.display.internal.RememberedDisplaySettings;
 import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.internal.propertymap.NonPropertyMapJSONFormats;
+import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.ColorPalettes;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.ndtiffstorage.EssentialImageMetadata;
@@ -120,6 +123,10 @@ public class ExplorerManager {
    private double initialStageX_ = 0;
    private double initialStageY_ = 0;
    private double pixelSizeUm_ = 1.0;
+   // Affine: camera-pixel delta → stage-micron delta. Null = use scalar fallback.
+   private AffineTransform pixelSizeAffine_ = null;
+   // Pre-computed inverse: stage-micron delta → camera-pixel delta.
+   private AffineTransform pixelSizeAffineInverse_ = null;
    private double overlapPercentage_ = 10.0;
    private volatile boolean acquisitionInterrupted_ = false;
    private final AtomicInteger pendingBatches_ = new AtomicInteger(0);
@@ -188,6 +195,7 @@ public class ExplorerManager {
          // Stage step in microns = camera FOV × pixel size
          stageTileWidthUm_ = cameraWidth_ * pixelSizeUm_;
          stageTileHeightUm_ = cameraHeight_ * pixelSizeUm_;
+         loadPixelSizeAffine();
 
          // Initial tile-grid estimate uses camera dimensions (corrected after first acq)
          dataSource_.setTileDimensions(cameraWidth_, cameraHeight_);
@@ -627,14 +635,8 @@ public class ExplorerManager {
          }
       }
 
-      if (mm2Viewer_ != null) {
-         mm2Viewer_.closeWithoutNDViewer();
-      }
-      mm2Viewer_ = null;
-      mm2DataProvider_ = null;
-      viewer_ = null;
-
       if (loadedData_) {
+         closeViewerReferences();
          stopExplore(false);
          return true;
       }
@@ -659,11 +661,9 @@ public class ExplorerManager {
                     "Save");
 
             if (choice == 2 || choice == JOptionPane.CLOSED_OPTION) {
+               // User cancelled — leave the viewer open.
                studio_.logs().logMessage("Explorer: close cancelled, data remains in: "
                         + storageDir_);
-               if (!calledFromShutdown) {
-                  stopExplore(false);
-               }
                viewerClosing_ = false;
                return false;
             } else if (choice == 0) {
@@ -693,8 +693,18 @@ public class ExplorerManager {
          }
       }
 
+      closeViewerReferences();
       stopExplore(true);
       return true;
+   }
+
+   private void closeViewerReferences() {
+      if (mm2Viewer_ != null) {
+         mm2Viewer_.closeWithoutNDViewer();
+      }
+      mm2Viewer_ = null;
+      mm2DataProvider_ = null;
+      viewer_ = null;
    }
 
    private boolean saveDataTo(File destDir) {
@@ -827,6 +837,43 @@ public class ExplorerManager {
    }
 
    /**
+    * Loads and validates the pixel-size affine transform from the core.
+    * Sets pixelSizeAffine_ / pixelSizeAffineInverse_ on success, leaves both null
+    * (scalar fallback) on any failure or if the affine does not match pixelSizeUm_.
+    * The MM core affine has zero translation terms, so AffineTransform.transform()
+    * on a pixel-delta Point2D gives the correct stage-micron delta.
+    */
+   private void loadPixelSizeAffine() {
+      pixelSizeAffine_ = null;
+      pixelSizeAffineInverse_ = null;
+      if (pixelSizeUm_ <= 0) {
+         return;
+      }
+      try {
+         AffineTransform at = AffineUtils.doubleToAffine(
+               studio_.core().getPixelSizeAffine(true));
+         double affinePixelSize = AffineUtils.deducePixelSize(at);
+         if (Math.abs(pixelSizeUm_ - affinePixelSize) > 0.1 * pixelSizeUm_) {
+            studio_.logs().logMessage("Explorer: affine pixel size " + affinePixelSize
+                  + " differs from declared " + pixelSizeUm_
+                  + " by >10%; using scalar coordinate conversion");
+            return;
+         }
+         pixelSizeAffine_ = at;
+         try {
+            pixelSizeAffineInverse_ = at.createInverse();
+         } catch (NoninvertibleTransformException e) {
+            studio_.logs().logMessage(
+                  "Explorer: pixel-size affine is singular; using scalar coordinate conversion");
+            pixelSizeAffine_ = null;
+         }
+      } catch (Exception e) {
+         studio_.logs().logMessage("Explorer: could not load pixel-size affine ("
+               + e.getMessage() + "); using scalar coordinate conversion");
+      }
+   }
+
+   /**
     * Acquires multiple tiles sequentially, moving the stage between positions.
     * Stage step is based on the camera FOV × pixel size (stageTileWidthUm_/stageTileHeightUm_).
     */
@@ -853,8 +900,9 @@ public class ExplorerManager {
             // Stage step in microns: derived from camera FOV (not pipeline-output tile size).
             // The pipeline may resize images, but the stage still moves by the camera FOV.
             double overlapFraction = overlapPercentage_ / 100.0;
-            double effectiveStepWidthUm = stageTileWidthUm_ * (1.0 - overlapFraction);
-            double effectiveStepHeightUm = stageTileHeightUm_ * (1.0 - overlapFraction);
+            // Effective tile step in camera-pixel space (affine operates on camera pixels).
+            double effectivePixelStepX = cameraWidth_  * (1.0 - overlapFraction);
+            double effectivePixelStepY = cameraHeight_ * (1.0 - overlapFraction);
 
             for (Point tile : tiles) {
                if (acquisitionInterrupted_) {
@@ -863,8 +911,21 @@ public class ExplorerManager {
                int row = tile.x;
                int col = tile.y;
 
-               double targetX = initialStageX_ + col * effectiveStepWidthUm;
-               double targetY = initialStageY_ + row * effectiveStepHeightUm;
+               double targetX;
+               double targetY;
+               if (pixelSizeAffine_ != null) {
+                  Point2D.Double pixelOffset = new Point2D.Double(
+                        col * effectivePixelStepX, row * effectivePixelStepY);
+                  Point2D.Double stageOffset = new Point2D.Double();
+                  pixelSizeAffine_.transform(pixelOffset, stageOffset);
+                  targetX = initialStageX_ + stageOffset.x;
+                  targetY = initialStageY_ + stageOffset.y;
+               } else {
+                  double effectiveStepWidthUm  = stageTileWidthUm_  * (1.0 - overlapFraction);
+                  double effectiveStepHeightUm = stageTileHeightUm_ * (1.0 - overlapFraction);
+                  targetX = initialStageX_ + col * effectiveStepWidthUm;
+                  targetY = initialStageY_ + row * effectiveStepHeightUm;
+               }
 
                studio_.core().setXYPosition(targetX, targetY);
                studio_.core().waitForDevice(studio_.core().getXYStageDevice());
@@ -967,9 +1028,7 @@ public class ExplorerManager {
                continue;
             }
             int channelIndex = c.getChannel();
-            String[] chNames = summaryMeta.getChannelNames();
-            String channelName = (chNames != null && channelIndex < chNames.length)
-                  ? chNames[channelIndex] : "Default";
+            String channelName = summaryMeta.getSafeChannelName(channelIndex);
             HashMap<String, Object> axes = storeImage(img, row, col, channelName);
             if (axes != null) {
                storedAxes.add(axes);
@@ -1157,20 +1216,27 @@ public class ExplorerManager {
       int overlapPixels = (int) Math.round(tw * overlapPercentage_ / 100.0);
       double effectiveTileWidth = tw - overlapPixels;
       double effectiveTileHeight = th - overlapPixels;
-      // NDTiff canvas coords: tile (row,col) occupies [col*effectiveTileWidth,
-      // (col+1)*effectiveTileWidth).
-      // Stage step per tile = stageTileWidthUm_ * (1 - overlap) / pixelSizeUm_ pixels.
-      // Scale maps stage-offset pixels to NDTiff canvas pixels.
-      double stageStepX = stageTileWidthUm_ > 0
-               ? stageTileWidthUm_ * (1.0 - overlapPercentage_ / 100.0) / pixelSizeUm_
-               : effectiveTileWidth;
-      double stageStepY = stageTileHeightUm_ > 0
-               ? stageTileHeightUm_ * (1.0 - overlapPercentage_ / 100.0) / pixelSizeUm_
-               : effectiveTileHeight;
-      double scaleX = effectiveTileWidth / stageStepX;
-      double scaleY = effectiveTileHeight / stageStepY;
-      double pixelX = (stageX - initialStageX_) / pixelSizeUm_ * scaleX + effectiveTileWidth / 2.0;
-      double pixelY = (stageY - initialStageY_) / pixelSizeUm_ * scaleY + effectiveTileHeight / 2.0;
+      double stageOffsetX = stageX - initialStageX_;
+      double stageOffsetY = stageY - initialStageY_;
+
+      double camPixelDeltaX;
+      double camPixelDeltaY;
+      if (pixelSizeAffineInverse_ != null) {
+         // Apply inverse affine: stage-micron delta → camera-pixel delta.
+         Point2D.Double stageOffset = new Point2D.Double(stageOffsetX, stageOffsetY);
+         Point2D.Double camDelta = new Point2D.Double();
+         pixelSizeAffineInverse_.transform(stageOffset, camDelta);
+         camPixelDeltaX = camDelta.x;
+         camPixelDeltaY = camDelta.y;
+      } else {
+         camPixelDeltaX = stageOffsetX / pixelSizeUm_;
+         camPixelDeltaY = stageOffsetY / pixelSizeUm_;
+      }
+      // Scale from camera-pixel space to canvas (pipeline-output) pixel space.
+      double pipelineScaleX = (tw > 0 && cameraWidth_  > 0) ? (double) tw / cameraWidth_  : 1.0;
+      double pipelineScaleY = (th > 0 && cameraHeight_ > 0) ? (double) th / cameraHeight_ : 1.0;
+      double pixelX = camPixelDeltaX * pipelineScaleX + effectiveTileWidth  / 2.0;
+      double pixelY = camPixelDeltaY * pipelineScaleY + effectiveTileHeight / 2.0;
       return new Point2D.Double(pixelX, pixelY);
    }
 
@@ -1231,20 +1297,35 @@ public class ExplorerManager {
             double effectiveTileWidth = tw - overlapPixels;
             double effectiveTileHeight = th - overlapPixels;
 
-            double stageStepX = stageTileWidthUm_ > 0
-                  ? stageTileWidthUm_ * (1.0 - overlapPercentage_ / 100.0) / pixelSizeUm_
-                     : effectiveTileWidth;
-            double stageStepY = stageTileHeightUm_ > 0
-                  ? stageTileHeightUm_ * (1.0 - overlapPercentage_ / 100.0) / pixelSizeUm_
-                     : effectiveTileHeight;
-            double scaleX = stageStepX / effectiveTileWidth;
-            double scaleY = stageStepY / effectiveTileHeight;
-
             double offsetPixelX = pixelX - effectiveTileWidth / 2.0;
             double offsetPixelY = pixelY - effectiveTileHeight / 2.0;
 
-            double targetX = initialStageX_ + offsetPixelX * pixelSizeUm_ * scaleX;
-            double targetY = initialStageY_ + offsetPixelY * pixelSizeUm_ * scaleY;
+            double targetX;
+            double targetY;
+            if (pixelSizeAffine_ != null) {
+               // Convert canvas-pixel delta to camera-pixel delta, then apply affine.
+               double pipelineScaleX = (tw > 0 && cameraWidth_  > 0)
+                     ? (double) cameraWidth_  / tw : 1.0;
+               double pipelineScaleY = (th > 0 && cameraHeight_ > 0)
+                     ? (double) cameraHeight_ / th : 1.0;
+               Point2D.Double camPixelDelta = new Point2D.Double(
+                     offsetPixelX * pipelineScaleX, offsetPixelY * pipelineScaleY);
+               Point2D.Double stageOffset = new Point2D.Double();
+               pixelSizeAffine_.transform(camPixelDelta, stageOffset);
+               targetX = initialStageX_ + stageOffset.x;
+               targetY = initialStageY_ + stageOffset.y;
+            } else {
+               double stageStepX = stageTileWidthUm_ > 0
+                     ? stageTileWidthUm_ * (1.0 - overlapPercentage_ / 100.0) / pixelSizeUm_
+                        : effectiveTileWidth;
+               double stageStepY = stageTileHeightUm_ > 0
+                     ? stageTileHeightUm_ * (1.0 - overlapPercentage_ / 100.0) / pixelSizeUm_
+                        : effectiveTileHeight;
+               double scaleX = stageStepX / effectiveTileWidth;
+               double scaleY = stageStepY / effectiveTileHeight;
+               targetX = initialStageX_ + offsetPixelX * pixelSizeUm_ * scaleX;
+               targetY = initialStageY_ + offsetPixelY * pixelSizeUm_ * scaleY;
+            }
 
             studio_.core().setXYPosition(targetX, targetY);
             studio_.core().waitForDevice(studio_.core().getXYStageDevice());

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -1224,9 +1224,10 @@ public class ExplorerManager {
       if (tw <= 0 || th <= 0 || pixelSizeUm_ <= 0) {
          return null;
       }
-      int overlapPixels = (int) Math.round(tw * overlapPercentage_ / 100.0);
-      double effectiveTileWidth = tw - overlapPixels;
-      double effectiveTileHeight = th - overlapPixels;
+      int overlapPixelsX = (int) Math.round(tw * overlapPercentage_ / 100.0);
+      int overlapPixelsY = (int) Math.round(th * overlapPercentage_ / 100.0);
+      double effectiveTileWidth = tw - overlapPixelsX;
+      double effectiveTileHeight = th - overlapPixelsY;
       double stageOffsetX = stageX - initialStageX_;
       double stageOffsetY = stageY - initialStageY_;
 
@@ -1304,9 +1305,10 @@ public class ExplorerManager {
          try {
             int tw = dataSource_ != null ? dataSource_.getTileWidth() : cameraWidth_;
             int th = dataSource_ != null ? dataSource_.getTileHeight() : cameraHeight_;
-            int overlapPixels = (int) Math.round(tw * overlapPercentage_ / 100.0);
-            double effectiveTileWidth = tw - overlapPixels;
-            double effectiveTileHeight = th - overlapPixels;
+            int overlapPixelsX = (int) Math.round(tw * overlapPercentage_ / 100.0);
+            int overlapPixelsY = (int) Math.round(th * overlapPercentage_ / 100.0);
+            double effectiveTileWidth = tw - overlapPixelsX;
+            double effectiveTileHeight = th - overlapPixelsY;
 
             double offsetPixelX = pixelX - effectiveTileWidth / 2.0;
             double offsetPixelY = pixelY - effectiveTileHeight / 2.0;

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -452,6 +452,16 @@ public class ExplorerManager {
             return true; // Prevents "Finish Acquisition?" dialog on close
          }
 
+         /**
+          * Called on the EDT when the user clicks the viewer's X button.
+          * Shows the save/discard/cancel dialog when there is unsaved data.
+          * Returns false (vetoing the close) if the user clicks Cancel.
+          */
+         @Override
+         public boolean requestToClose() {
+            return promptForUnsavedData();
+         }
+
          @Override
          public void abort() {
          }
@@ -603,20 +613,17 @@ public class ExplorerManager {
       if (event.isCanceled() || !exploring_) {
          return;
       }
-      shutdownInProgress_ = true;
-      boolean proceeded = onViewerClosed(true);
-      if (!proceeded) {
+      if (!promptForUnsavedData()) {
          event.cancelShutdown();
+         return;
       }
+      shutdownInProgress_ = true;
+      onViewerClosed();
    }
 
    public void onViewerClosed() {
-      onViewerClosed(false);
-   }
-
-   private boolean onViewerClosed(boolean calledFromShutdown) {
       if (!exploring_ || viewerClosing_) {
-         return true;
+         return;
       }
       viewerClosing_ = true;
 
@@ -635,67 +642,71 @@ public class ExplorerManager {
          }
       }
 
+      closeViewerReferences();
+      stopExplore(!loadedData_);
+   }
+
+   /**
+    * Shows the save/discard/cancel dialog when there is unsaved Explorer data.
+    * Returns true if the caller should proceed (data was saved or discarded),
+    * false if the user cancelled.  Returns true immediately when there is no
+    * unsaved data (loaded-data sessions, empty storage, etc.).
+    * Must be called on the EDT.
+    */
+   private boolean promptForUnsavedData() {
       if (loadedData_) {
-         closeViewerReferences();
-         stopExplore(false);
          return true;
       }
-
       boolean hasData = false;
       try {
-         hasData = storage_ != null && !storage_.isFinished() && !storage_.getAxesSet().isEmpty();
+         hasData = storage_ != null && !storage_.isFinished()
+               && !storage_.getAxesSet().isEmpty();
       } catch (Exception e) {
-         studio_.logs().logMessage("Explorer: could not check storage state: " + e.getMessage());
+         studio_.logs().logMessage(
+               "Explorer: could not check storage state: " + e.getMessage());
       }
-
-      if (hasData) {
-         while (true) {
-            int choice = JOptionPane.showOptionDialog(
-                    null,
-                    "Save the acquired Explorer data?",
-                    "Save Explorer Data",
-                    JOptionPane.YES_NO_CANCEL_OPTION,
-                    JOptionPane.QUESTION_MESSAGE,
-                    null,
-                    new String[]{"Save", "Discard", "Cancel"},
-                    "Save");
-
-            if (choice == 2 || choice == JOptionPane.CLOSED_OPTION) {
-               // User cancelled — leave the viewer open.
-               studio_.logs().logMessage("Explorer: close cancelled, data remains in: "
-                        + storageDir_);
-               viewerClosing_ = false;
-               return false;
-            } else if (choice == 0) {
-               JFileChooser chooser = new JFileChooser();
-               chooser.setDialogTitle("Save Explorer Data");
-               chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-               String suggestedPath = FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET);
-               if (suggestedPath != null) {
-                  File suggested = new File(suggestedPath);
-                  File dir = suggested.isDirectory() ? suggested : suggested.getParentFile();
-                  if (dir != null) {
-                     chooser.setCurrentDirectory(dir);
-                  }
+      if (!hasData) {
+         return true;
+      }
+      while (true) {
+         int choice = JOptionPane.showOptionDialog(
+                 null,
+                 "Save the acquired Explorer data?",
+                 "Save Explorer Data",
+                 JOptionPane.YES_NO_CANCEL_OPTION,
+                 JOptionPane.QUESTION_MESSAGE,
+                 null,
+                 new String[]{"Save", "Discard", "Cancel"},
+                 "Save");
+         if (choice == 2 || choice == JOptionPane.CLOSED_OPTION) {
+            studio_.logs().logMessage(
+                  "Explorer: close cancelled, data remains in: " + storageDir_);
+            return false;
+         } else if (choice == 0) {
+            JFileChooser chooser = new JFileChooser();
+            chooser.setDialogTitle("Save Explorer Data");
+            chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+            String suggestedPath = FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET);
+            if (suggestedPath != null) {
+               File suggested = new File(suggestedPath);
+               File dir = suggested.isDirectory() ? suggested : suggested.getParentFile();
+               if (dir != null) {
+                  chooser.setCurrentDirectory(dir);
                }
-               chooser.setSelectedFile(new File(acqName_));
-               if (chooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
-                  File destDir = chooser.getSelectedFile();
-                  FileDialogs.storePath(FileDialogs.MM_DATA_SET, destDir);
-                  writeSettingsToTempDir();
-                  if (saveDataTo(destDir)) {
-                     break;
-                  }
-               }
-            } else {
-               break; // Discard
             }
+            chooser.setSelectedFile(new File(acqName_));
+            if (chooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
+               File destDir = chooser.getSelectedFile();
+               FileDialogs.storePath(FileDialogs.MM_DATA_SET, destDir);
+               writeSettingsToTempDir();
+               if (saveDataTo(destDir)) {
+                  return true;
+               }
+            }
+         } else {
+            return true; // Discard
          }
       }
-
-      closeViewerReferences();
-      stopExplore(true);
-      return true;
    }
 
    private void closeViewerReferences() {


### PR DESCRIPTION
This should result in images that are easier to stitch.  Also fixes bugs in the Explorer plugin: - Cancel button did not work as expected, - Continuous focus used to be toggled when acquiring a tile.