### PR TITLE
Fix bug introduced in February that caused the Z stage to first move to the start, then the desired position for all Z slices.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/MDAAcqEventModules.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/MDAAcqEventModules.java
@@ -94,9 +94,6 @@ public class MDAAcqEventModules {
                      throw new RuntimeException(e);
                   }
                }
-               if (positionList == null) {
-                  event.setStageCoordinate(Engine.getCore().getFocusDevice(), zOrigin);
-               }
                double zPos = 0.0;
 
                if (acquisitionSettings.acqOrderMode() == AcqOrderMode.POS_TIME_CHANNEL_SLICE


### PR DESCRIPTION
Closes #2352.

Bug was introduced in #2301.  If there are side effect to this change, please open a new Issue.