### PR TITLE
Stitcher plugin improvements

### DIFF
--- a/libraries/ImageProcessing/src/main/java/org/micromanager/imageprocessing/ImageTransformUtils.java
+++ b/libraries/ImageProcessing/src/main/java/org/micromanager/imageprocessing/ImageTransformUtils.java
@@ -5,9 +5,10 @@ import java.awt.geom.AffineTransform;
 /**
  * Utility methods for correcting camera orientation in tiled datasets.
  *
- * <p>The affine transform stored in per-image metadata encodes the relationship
- * between stage movement (µm) and camera pixels. This class provides methods to
- * derive the correction needed and apply it to pixel arrays.</p>
+ * <p>The {@code pixelSizeAffine} stored in per-image metadata maps
+ * <em>camera-pixel displacement → stage displacement (µm)</em>, consistent with
+ * how the rest of the codebase uses it (e.g. {@code XYNavigator} and
+ * {@code TileCreator} both call {@code affine.transform(pixelDelta, stageDelta)}).</p>
  */
 public class ImageTransformUtils {
 
@@ -17,11 +18,15 @@ public class ImageTransformUtils {
     * Derive the correction (mirror + rotation) needed to map camera-space pixels
     * back to stage-space orientation, from the pixelSizeAffine stored in image metadata.
     *
-    * <p>The affine maps stage displacement (µm) to camera-pixel displacement.
-    * A rotation of {@code rot} degrees in the affine means the camera's pixel axes are
-    * rotated {@code rot} degrees relative to stage space. To convert camera pixels back
-    * to stage orientation, apply the <em>same</em> rotation: correctionRotation = rot,
-    * correctionMirror = mirror.</p>
+    * <p><b>Affine convention:</b> {@code pixelSizeAffine} maps camera-pixel displacement
+    * → stage displacement (µm).  A rotation angle {@code rot} extracted from the affine
+    * means the camera's pixel axes are rotated {@code rot} degrees relative to stage
+    * space.  Applying that same rotation to the pixel data restores stage orientation:
+    * correctionRotation = rot, correctionMirror = mirror.</p>
+    *
+    * <p><b>Rotation direction:</b> {@link #transformPixels} applies rotations
+    * <em>clockwise</em> — a 90° argument rotates the image 90° CW in screen
+    * coordinates (origin top-left).</p>
     *
     * @param affine the AffineTransform from {@code Metadata.getPixelSizeAffine()},
     *               or null

--- a/libraries/ImageProcessing/src/main/java/org/micromanager/imageprocessing/ImageTransformUtils.java
+++ b/libraries/ImageProcessing/src/main/java/org/micromanager/imageprocessing/ImageTransformUtils.java
@@ -18,8 +18,10 @@ public class ImageTransformUtils {
     * back to stage-space orientation, from the pixelSizeAffine stored in image metadata.
     *
     * <p>The affine maps stage displacement (µm) to camera-pixel displacement.
-    * To convert camera pixels back to stage orientation we apply the inverse linear
-    * transform: correctionRotation = (360 - rot) % 360, correctionMirror = mirror.</p>
+    * A rotation of {@code rot} degrees in the affine means the camera's pixel axes are
+    * rotated {@code rot} degrees relative to stage space. To convert camera pixels back
+    * to stage orientation, apply the <em>same</em> rotation: correctionRotation = rot,
+    * correctionMirror = mirror.</p>
     *
     * @param affine the AffineTransform from {@code Metadata.getPixelSizeAffine()},
     *               or null
@@ -55,8 +57,8 @@ public class ImageTransformUtils {
       // Round to nearest 90°
       int rot = (int) (Math.round(rotDeg / 90.0) * 90) % 360;
 
-      // Correction is the inverse: rotation = (360 - rot) % 360
-      int correctionRot = (360 - rot) % 360;
+      // Correction applies the same rotation to map camera pixels back to stage orientation
+      int correctionRot = rot;
       int correctionMirror = mirror ? 1 : 0;
 
       return new int[]{correctionRot, correctionMirror};

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchDataProviderAdapter.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchDataProviderAdapter.java
@@ -112,6 +112,28 @@ public class StitchDataProviderAdapter extends MMDataProviderAdapter {
       return stepY * maxRow + imageHeight_;
    }
 
+   /** Return the maximum column index in the tile grid (0-based). */
+   public int getMaxCol() {
+      int max = 0;
+      for (GridCell cell : positionGrid_.values()) {
+         if (cell.col > max) {
+            max = cell.col;
+         }
+      }
+      return max;
+   }
+
+   /** Return the maximum row index in the tile grid (0-based). */
+   public int getMaxRow() {
+      int max = 0;
+      for (GridCell cell : positionGrid_.values()) {
+         if (cell.row > max) {
+            max = cell.row;
+         }
+      }
+      return max;
+   }
+
    // -------------------------------------------------------------------------
    // Overrides: inject row/col into every axes map
    // -------------------------------------------------------------------------
@@ -292,7 +314,73 @@ public class StitchDataProviderAdapter extends MMDataProviderAdapter {
       }
       // Accept if any position has explicit non-zero grid coords, OR if there is only
       // one position (single-tile dataset: (0,0) is correct, not the unset default).
-      return (anyNonZero || positions.size() == 1) ? shiftToZero(grid) : null;
+      if (!anyNonZero && positions.size() != 1) {
+         return null;
+      }
+      Map<Integer, GridCell> shifted = shiftToZero(grid);
+      // Validate that gridCol correlates with X and gridRow correlates with Y.
+      // If they are spatially transposed (e.g. gridCol tracks Y and gridRow tracks X,
+      // as happens when the acquisition snake axis labelling differs from spatial axes),
+      // fall back to XY-based grid building instead.
+      return gridConsistentWithXY(shifted, positions) ? shifted : null;
+   }
+
+   /**
+    * Returns true if the grid assignment is spatially consistent with the XY positions:
+    * gridCol should be more strongly correlated with X than with Y, and gridRow with Y
+    * than with X.  Uses the absolute Pearson correlation coefficient as the metric.
+    * Returns true when there are fewer than 2 positions (nothing to validate).
+    */
+   private static boolean gridConsistentWithXY(Map<Integer, GridCell> grid,
+                                                List<MultiStagePosition> positions) {
+      int n = positions.size();
+      if (n < 2) {
+         return true;
+      }
+      double[] rows = new double[n];
+      double[] cols = new double[n];
+      double[] xs   = new double[n];
+      double[] ys   = new double[n];
+      for (int i = 0; i < n; i++) {
+         GridCell cell = grid.get(i);
+         rows[i] = cell.row;
+         cols[i] = cell.col;
+         xs[i]   = positions.get(i).getX();
+         ys[i]   = positions.get(i).getY();
+      }
+      double corrColX = Math.abs(pearson(cols, xs));
+      double corrColY = Math.abs(pearson(cols, ys));
+      double corrRowX = Math.abs(pearson(rows, xs));
+      double corrRowY = Math.abs(pearson(rows, ys));
+      // Col should track X more than Y; row should track Y more than X.
+      return corrColX >= corrColY && corrRowY >= corrRowX;
+   }
+
+   /** Pearson correlation coefficient between two equal-length arrays. */
+   private static double pearson(double[] a, double[] b) {
+      int n = a.length;
+      double meanA = 0;
+      double meanB = 0;
+      for (int i = 0; i < n; i++) {
+         meanA += a[i];
+         meanB += b[i];
+      }
+      meanA /= n;
+      meanB /= n;
+      double num = 0;
+      double varA = 0;
+      double varB = 0;
+      for (int i = 0; i < n; i++) {
+         double da = a[i] - meanA;
+         double db = b[i] - meanB;
+         num  += da * db;
+         varA += da * da;
+         varB += db * db;
+      }
+      if (varA == 0 || varB == 0) {
+         return 0;
+      }
+      return num / Math.sqrt(varA * varB);
    }
 
    /**

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
@@ -869,9 +869,7 @@ public class StitchFrame extends JDialog {
     * Stitch tiles for a single channel into a canvas without blending.
     *
     * <p>Iterates all axes sets from the adapter and copies each tile's pixels
-    * into the correct position on the canvas based on its row/column. If a
-    * correction is provided, each tile is transformed before placement and the
-    * canvas dimensions are adjusted accordingly.</p>
+    * into the correct position on the canvas based on its row/column.</p>
     *
     * @param channelName the channel to stitch, or null for RGB (no channel axis)
     * @param canvasW     output canvas width in pixels (caller must supply the corrected size)

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
@@ -511,9 +511,29 @@ public class StitchFrame extends JDialog {
       // Derive correction components (null correction = no-op)
       boolean doMirror = correction != null && correction[1] != 0;
       int rotationDeg = correction != null ? correction[0] : 0;
-      // Canvas dims may change if rotation is 90/270
-      int outCanvasW = (rotationDeg == 90 || rotationDeg == 270) ? canvasH : canvasW;
-      int outCanvasH = (rotationDeg == 90 || rotationDeg == 270) ? canvasW : canvasH;
+      // Compute output canvas from corrected tile geometry rather than naively swapping
+      // the raw adapter canvas dims.  The adapter canvas is in stage-coordinate space
+      // (X→width, Y→height); swapping it for 90/270° rotations is wrong when the grid
+      // is not square.  Instead derive the output size from corrected tile step * grid extent.
+      boolean swapCanvasDims = rotationDeg == 90 || rotationDeg == 270;
+      mmcorej.org.json.JSONObject rawMD = adapter.getSummaryMetadata();
+      int rawTileW = rawMD != null ? rawMD.optInt("Width", 0) : 0;
+      int rawTileH = rawMD != null ? rawMD.optInt("Height", 0) : 0;
+      int rawOverlapX = rawMD != null ? rawMD.optInt("GridPixelOverlapX", 0) : 0;
+      int rawOverlapY = rawMD != null ? rawMD.optInt("GridPixelOverlapY", 0) : 0;
+      int corrTileWDim = swapCanvasDims ? rawTileH : rawTileW;
+      int corrTileHDim = swapCanvasDims ? rawTileW : rawTileH;
+      int corrOverlapXDim = swapCanvasDims ? rawOverlapY : rawOverlapX;
+      int corrOverlapYDim = swapCanvasDims ? rawOverlapX : rawOverlapY;
+      int outCanvasW;
+      int outCanvasH;
+      if (corrTileWDim > 0 && corrTileHDim > 0 && (swapCanvasDims || doMirror)) {
+         outCanvasW = (corrTileWDim - corrOverlapXDim) * adapter.getMaxCol() + corrTileWDim;
+         outCanvasH = (corrTileHDim - corrOverlapYDim) * adapter.getMaxRow() + corrTileHDim;
+      } else {
+         outCanvasW = canvasW;
+         outCanvasH = canvasH;
+      }
 
       try {
          // Step 2: set SummaryMetadata — copy from source, then fix up stitched-specific fields
@@ -790,8 +810,8 @@ public class StitchFrame extends JDialog {
                               adapter,
                               tzAxes,
                               chName,
-                              canvasW,
-                              canvasH,
+                              outCanvasW,
+                              outCanvasH,
                            correction, tOrigins, is16bit, isRgb,
                            pct -> {
                               int base = doAlign ? 50 : 0;
@@ -854,6 +874,8 @@ public class StitchFrame extends JDialog {
     * canvas dimensions are adjusted accordingly.</p>
     *
     * @param channelName the channel to stitch, or null for RGB (no channel axis)
+    * @param canvasW     output canvas width in pixels (caller must supply the corrected size)
+    * @param canvasH     output canvas height in pixels (caller must supply the corrected size)
     * @param correction  int[]{rotation, mirror} from
     *                    {@link ImageTransformUtils#correctionFromAffine}, or null
     * @return Object[]{pixels, bytesPerPixel, numComponents, canvasWidth, canvasHeight}
@@ -877,11 +899,11 @@ public class StitchFrame extends JDialog {
       boolean doMirror = correction != null && correction[1] != 0;
       int rotationDeg = correction != null ? correction[0] : 0;
       boolean needsTransform = correction != null && (doMirror || rotationDeg != 0);
-      // Corrected tile dims: swap w/h for 90/270 rotations
+      // swapTileDims governs stepX/stepY axis swap for 90/270° rotations
       boolean swapTileDims = rotationDeg == 90 || rotationDeg == 270;
-      // Corrected canvas dims (determined once tile dims are known)
-      int corrCanvasW = swapTileDims ? canvasH : canvasW;
-      int corrCanvasH = swapTileDims ? canvasW : canvasH;
+      // Canvas dims are already corrected by the caller
+      int corrCanvasW = canvasW;
+      int corrCanvasH = canvasH;
 
       Object targetZ = baseAxes.get("z");
       Object targetT = baseAxes.get(Coords.TIME_POINT);

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
@@ -640,6 +640,16 @@ public class StitchFrame extends JDialog {
          }
          studio_.logs().logMessage("Stitch: is16bit=" + is16bit + " isRgb=" + isRgb);
 
+         // For RGB the whole assembled canvas is rotated (no per-tile transform), so the
+         // output dims are the naive swap of raw canvas dims — exactly what transformPixels
+         // returns — not the corrected-geometry formula used for grayscale.
+         if (isRgb && swapCanvasDims) {
+            outCanvasW = canvasH;
+            outCanvasH = canvasW;
+            ds.setSummaryMetadata(ds.getSummaryMetadata().copyBuilder()
+                  .imageWidth(outCanvasW).imageHeight(outCanvasH).build());
+         }
+
          // RGB images have no channel axis — override chNames to a single null entry
          // so the channel loop runs once and no channel filtering is applied.
          final List<String> effectiveChNames;
@@ -729,9 +739,13 @@ public class StitchFrame extends JDialog {
                }
 
                if (doBlend) {
+                  // RGB composite() has no per-tile transform — the whole assembled canvas is
+                  // rotated afterward, so the blender must use the raw (uncorrected) tile geometry.
+                  // Grayscale paths apply per-tile transforms and need the corrected geometry.
                   TileBlender blender = new TileBlender(adapter,
                         new mmcorej.org.json.JSONObject(),
-                        tzAxes, effectiveChNames, correctedBlendSummaryMD);
+                        tzAxes, effectiveChNames,
+                        isRgb ? blendSummaryMD : correctedBlendSummaryMD);
 
                   for (int c = 0; c < effectiveNumCh; c++) {
                      final int tIdx = t;


### PR DESCRIPTION
Fixing the Stitch plugin's "correct camera orientation" option, which applied the wrong rotation and produced a too-small canvas with missing tiles.  Also fixes incorrect reading of Tile Row and Column metadata provided by the Create Grid option.