### PR TITLE
Projector: Fix bug in SLM expose ROIs function.

### DIFF
--- a/libraries/Projector/src/main/java/org/micromanager/projector/ProjectionDevice.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/ProjectionDevice.java
@@ -67,19 +67,32 @@ public interface ProjectionDevice {
    // ## Alert when something has changed.
    void addOnStateListener(OnStateListener listener);
 
-   // ## Get/set internal exposure setting
+   /**
+    * Returns the exposure time of the projection device in microseconds.
+    *
+    * @return exposure time in microseconds
+    */
    long getExposure();
 
    /**
-    * Sets exposure of the projection device in Micro-Seconds.
+    * Sets the exposure time of the projection device.
     *
-    * @param intervalUs Exposure in Micro-Seconds
+    * @param intervalUs exposure time in microseconds
     */
    void setExposure(long intervalUs);
 
-   // ## Get/set internal ROI interval setting
+   /**
+    * Sets the interval between successive ROI exposures.
+    *
+    * @param roiIntervalUs interval in microseconds
+    */
    void setRoiInterval(long roiIntervalUs);
 
+   /**
+    * Returns the interval between successive ROI exposures in microseconds.
+    *
+    * @return interval in microseconds
+    */
    long getRoiInterval();
 
    // ## Control illumination

--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
@@ -398,7 +398,6 @@ public class ProjectorControlForm extends JFrame {
       calibrator_ = new Calibrator(studio_, dev_, settings_);
       final String originalChannel = projectorControlExecution_.prepareChannel(
               settings_.getString(Terms.PTCHANNEL, ""));
-      final boolean shutterWasOpen = projectorControlExecution_.prepareShutter(desiredShutter);
       Future<Boolean> runCalibration = calibrator_.runCalibration();
       Thread t = new Thread() {
          @Override
@@ -412,7 +411,6 @@ public class ProjectorControlForm extends JFrame {
             if (success) {
                mapping_ = MappingStorage.loadMapping(core_, dev_, settings_.toPropertyMap());
             }
-            projectorControlExecution_.returnShutter(desiredShutter, shutterWasOpen);
             if (originalChannel != null && !originalChannel.isEmpty()) {
                projectorControlExecution_.returnChannel(originalChannel);
             }

--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/ProjectorControlForm.java
@@ -398,15 +398,7 @@ public class ProjectorControlForm extends JFrame {
       calibrator_ = new Calibrator(studio_, dev_, settings_);
       final String originalChannel = projectorControlExecution_.prepareChannel(
               settings_.getString(Terms.PTCHANNEL, ""));
-      String originalShutterT = studio_.core().getShutterDevice();
-      if (!desiredShutter.isEmpty()) {
-         try {
-            studio_.core().setShutterDevice(desiredShutter);
-         } catch (Exception ex) {
-            originalShutterT = "";
-         }
-      }
-      final String originalShutter = originalShutterT;
+      final boolean shutterWasOpen = projectorControlExecution_.prepareShutter(desiredShutter);
       Future<Boolean> runCalibration = calibrator_.runCalibration();
       Thread t = new Thread() {
          @Override
@@ -420,13 +412,7 @@ public class ProjectorControlForm extends JFrame {
             if (success) {
                mapping_ = MappingStorage.loadMapping(core_, dev_, settings_.toPropertyMap());
             }
-            if (!originalShutter.isEmpty()) {
-               try {
-                  studio_.core().setShutterDevice(originalShutter);
-               } catch (Exception ex) {
-                  studio_.logs().logError("Failed to reset shutter in Projector calibration");
-               }
-            }
+            projectorControlExecution_.returnShutter(desiredShutter, shutterWasOpen);
             if (originalChannel != null && !originalChannel.isEmpty()) {
                projectorControlExecution_.returnChannel(originalChannel);
             }

--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/devices/Galvo.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/devices/Galvo.java
@@ -298,6 +298,11 @@ public class Galvo implements ProjectionDevice {
       }
    }
 
+   /**
+    * Sets the galvo spot dwell time. The Core galvo API also expects microseconds.
+    *
+    * @param intervalUs exposure time in microseconds
+    */
    @Override
    public void setExposure(long intervalUs) {
       try {
@@ -308,7 +313,11 @@ public class Galvo implements ProjectionDevice {
       }
    }
 
-   // Reads the exposure time in us
+   /**
+    * Returns the galvo spot dwell time in microseconds.
+    *
+    * @return exposure time in microseconds
+    */
    @Override
    public long getExposure() {
       return intervalUs_;

--- a/libraries/Projector/src/main/java/org/micromanager/projector/internal/devices/SLM.java
+++ b/libraries/Projector/src/main/java/org/micromanager/projector/internal/devices/SLM.java
@@ -113,8 +113,12 @@ public class SLM implements ProjectionDevice {
       }
    }
 
-   // Sets how long the SLM will be illuminated when we display an
-   // image.
+   /**
+    * Sets the SLM illumination duration. Converts from microseconds to the milliseconds expected
+    * by the Core SLM API.
+    *
+    * @param intervalUs exposure time in microseconds
+    */
    @Override
    public void setExposure(long intervalUs) {
       try {
@@ -124,19 +128,27 @@ public class SLM implements ProjectionDevice {
       }
    }
 
-   // Reads the exposure time in microseconds.
+   /**
+    * Returns the SLM illumination duration in microseconds. Converts from the milliseconds
+    * returned by the Core SLM API.
+    *
+    * @return exposure time in microseconds
+    */
    @Override
    public long getExposure() {
       try {
-         return (long) (mmc_.getSLMExposure(slm_));
+         return (long) (mmc_.getSLMExposure(slm_) * 1000);
       } catch (Exception ex) {
          app_.logs().showError(ex);
       }
       return 0;
    }
 
-   // Sets how long the SLM will be off between image
-   // NB: not currently implemented
+   /**
+    * Not currently implemented for SLM devices.
+    *
+    * @param intervalUs interval in microseconds (ignored)
+    */
    @Override
    public void setRoiInterval(long intervalUs) {
       return;


### PR DESCRIPTION
Also added Javadoc to clarify that in the Projector API functions we are using microseconds rather than milliseconds.