### PR TITLE
Studio: Fix JComboBox cell editor regression introduced in PR #2377.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/ConfigGroupPad.java
@@ -128,8 +128,12 @@ public final class ConfigGroupPad extends JScrollPane {
    public void refreshGroup(String groupName, String configName) {
       if (data_ != null) {
          data_.refreshGroup(groupName, configName);
-         // Use fireTableDataChanged() to preserve selection during updates
-         data_.fireTableDataChanged();
+         // Skip fireTableDataChanged while a cell is being edited — it would
+         // tear down the editor via removeEditor(), discarding in-progress edits.
+         // A plain repaint keeps non-editing rows up to date.
+         if (!table_.isEditing()) {
+            data_.fireTableDataChanged();
+         }
          table_.repaint();
       }
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -25,6 +25,7 @@ import com.google.common.eventbus.Subscribe;
 import java.awt.Component;
 import java.awt.Font;
 import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -33,6 +34,7 @@ import java.awt.event.WindowEvent;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Objects;
 import javax.swing.AbstractCellEditor;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -493,6 +495,10 @@ public final class AutofocusPropertyEditor extends JDialog {
       SliderPanel slider_ = new SliderPanel();
       int editingCol_;
       PropertyItem item_;
+      // True only after the user picks an item from the open dropdown.
+      // getCellEditorValue() returns the original value when false, making any
+      // external stopCellEditing() call (e.g. Tab) a no-op commit.
+      private boolean selectionMade_ = false;
 
       /**
        * Component that edits the cell's value.
@@ -501,34 +507,37 @@ public final class AutofocusPropertyEditor extends JDialog {
          super();
          check_.addActionListener(e -> fireEditingStopped());
 
-         // Commit only when the user picks a *different* value from the dropdown.
-         // ActionListener fires spuriously on focus loss, so we use PopupMenuListener
-         // instead: snapshot the selection when the popup opens, then compare on close.
+         // Commit when the user picks a value from the dropdown while it is open.
+         // A bare ActionListener fires spuriously on focus loss; gating it on the
+         // popup-open flag suppresses those false fires while still catching every
+         // genuine selection (including selecting the first item when an empty
+         // entry was previously chosen — a case where PopupMenuListener comparison
+         // logic breaks on the Windows L&F).
          combo_.addPopupMenuListener(new PopupMenuListener() {
-            private Object itemOnOpen_ = null;
-
             @Override
             public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
-               itemOnOpen_ = combo_.getSelectedItem();
+               combo_.putClientProperty("popupOpen", Boolean.TRUE);
             }
 
             @Override
             public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
-               // popupMenuCanceled fires first on Escape (on most L&Fs), so by the
-               // time we arrive here itemOnOpen_ has been nulled and we do nothing.
-               if (itemOnOpen_ != null && !itemOnOpen_.equals(combo_.getSelectedItem())) {
-                  itemOnOpen_ = null;
-                  fireEditingStopped();
-               } else {
-                  itemOnOpen_ = null;
-                  fireEditingCanceled();
-               }
+               combo_.putClientProperty("popupOpen", null);
             }
 
             @Override
             public void popupMenuCanceled(PopupMenuEvent e) {
-               itemOnOpen_ = null;
+               combo_.putClientProperty("popupOpen", null);
                fireEditingCanceled();
+            }
+         });
+
+         combo_.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+               if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+                  selectionMade_ = true;
+                  fireEditingStopped();
+               }
             }
          });
 
@@ -577,11 +586,16 @@ public final class AutofocusPropertyEditor extends JDialog {
                }
             }
 
+            selectionMade_ = false;
+            combo_.putClientProperty("popupOpen", null);
             combo_.removeAllItems();
             for (String allowed : item_.allowed) {
                combo_.addItem(allowed);
             }
             combo_.setSelectedItem(item_.value);
+            if (!Objects.equals(item_.value, combo_.getSelectedItem())) {
+               combo_.setSelectedIndex(-1);
+            }
             return combo_;
          } else if (colIndex == 2) {
             return check_;
@@ -601,7 +615,7 @@ public final class AutofocusPropertyEditor extends JDialog {
                   return text_.getText();
                }
             } else {
-               return combo_.getSelectedItem();
+               return selectionMade_ ? combo_.getSelectedItem() : item_.value;
             }
          } else {
             if (editingCol_ == 2) {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
@@ -1,6 +1,8 @@
 package org.micromanager.internal.utils;
 
 import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.KeyAdapter;
@@ -8,6 +10,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.ParseException;
+import java.util.Objects;
 import javax.swing.AbstractCellEditor;
 import javax.swing.JComboBox;
 import javax.swing.JTable;
@@ -32,6 +35,11 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
 
    public boolean disableExcluded_;
 
+   // True only after the user picks an item from the open dropdown.
+   // getCellEditorValue() returns the original value when false, making any
+   // external stopCellEditing() call (e.g. Tab) a no-op commit.
+   private boolean selectionMade_ = false;
+
 
    public PropertyValueCellEditor() {
       this(false);
@@ -42,34 +50,31 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
 
       disableExcluded_ = disableExcluded;
 
-      // Commit only when the user picks a *different* value from the dropdown.
-      // ActionListener fires spuriously on focus loss, so we use PopupMenuListener
-      // instead: snapshot the selection when the popup opens, then compare on close.
       combo_.addPopupMenuListener(new PopupMenuListener() {
-         private Object itemOnOpen_ = null;
-
          @Override
          public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
-            itemOnOpen_ = combo_.getSelectedItem();
+            combo_.putClientProperty("popupOpen", Boolean.TRUE);
          }
 
          @Override
          public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
-            // popupMenuCanceled fires first on Escape (on most L&Fs), so by the
-            // time we arrive here itemOnOpen_ has been nulled and we do nothing.
-            if (itemOnOpen_ != null && !itemOnOpen_.equals(combo_.getSelectedItem())) {
-               itemOnOpen_ = null;
-               fireEditingStopped();
-            } else {
-               itemOnOpen_ = null;
-               fireEditingCanceled();
-            }
+            combo_.putClientProperty("popupOpen", null);
          }
 
          @Override
          public void popupMenuCanceled(PopupMenuEvent e) {
-            itemOnOpen_ = null;
+            combo_.putClientProperty("popupOpen", null);
             fireEditingCanceled();
+         }
+      });
+
+      combo_.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+               selectionMade_ = true;
+               fireEditingStopped();
+            }
          }
       });
 
@@ -128,11 +133,16 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
                return text_;
             }
          } else {
+            selectionMade_ = false;
+            combo_.putClientProperty("popupOpen", null);
             combo_.removeAllItems();
             for (int i = 0; i < item_.allowed.length; i++) {
                combo_.addItem(item_.allowed[i]);
             }
             combo_.setSelectedItem(item_.value);
+            if (!Objects.equals(item_.value, combo_.getSelectedItem())) {
+               combo_.setSelectedIndex(-1);
+            }
             return combo_;
          }
       } else {
@@ -152,7 +162,7 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
             return text_.getText();
          }
       } else {
-         return combo_.getSelectedItem();
+         return selectionMade_ ? combo_.getSelectedItem() : item_.value;
       }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
@@ -7,6 +7,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.ParseException;
 import java.util.Arrays;
+import java.util.Objects;
 import javax.swing.AbstractCellEditor;
 import javax.swing.JComboBox;
 import javax.swing.JTable;
@@ -31,37 +32,42 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
    StateItem item_;
    SliderPanel slider_ = new SliderPanel();
 
+   // True only after the user picks an item from the open dropdown.
+   // getCellEditorValue() returns the original value when false, making any
+   // external stopCellEditing() call (e.g. Tab) a no-op commit.
+   private boolean selectionMade_ = false;
+
    public StatePresetCellEditor() {
       super();
 
-      // Commit only when the user picks a *different* value from the dropdown.
-      // ActionListener fires spuriously on focus loss, so we use PopupMenuListener
-      // instead: snapshot the selection when the popup opens, then compare on close.
       combo_.addPopupMenuListener(new PopupMenuListener() {
-         private Object itemOnOpen_ = null;
-
          @Override
          public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
-            itemOnOpen_ = combo_.getSelectedItem();
+            combo_.putClientProperty("popupOpen", Boolean.TRUE);
          }
 
          @Override
          public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
-            // popupMenuCanceled fires first on Escape (on most L&Fs), so by the
-            // time we arrive here itemOnOpen_ has been nulled and we do nothing.
-            if (itemOnOpen_ != null && !itemOnOpen_.equals(combo_.getSelectedItem())) {
-               itemOnOpen_ = null;
-               fireEditingStopped();
-            } else {
-               itemOnOpen_ = null;
-               fireEditingCanceled();
-            }
+            combo_.putClientProperty("popupOpen", null);
          }
 
          @Override
          public void popupMenuCanceled(PopupMenuEvent e) {
-            itemOnOpen_ = null;
+            // Popup was dismissed without a selection (Escape or click outside).
+            // Clear the flag and cancel the cell edit in one step so the user
+            // does not need a second Escape/click to dismiss the editor too.
+            combo_.putClientProperty("popupOpen", null);
             fireEditingCanceled();
+         }
+      });
+
+      combo_.addActionListener(new ActionListener() {
+         @Override
+         public void actionPerformed(ActionEvent e) {
+            if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+               selectionMade_ = true;
+               fireEditingStopped();
+            }
          }
       });
 
@@ -151,11 +157,19 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
    }
 
    private void setComboBox(String[] allowed) {
+      selectionMade_ = false;
+      combo_.putClientProperty("popupOpen", null);
       combo_.removeAllItems();
       for (int i = 0; i < allowed.length; i++) {
          combo_.addItem(allowed[i]);
       }
+      // setSelectedItem silently fails when item_.config is not in the list
+      // (e.g. "" when no preset matches). Fall back to no selection (-1) so
+      // the combo shows blank rather than defaulting to item 0.
       combo_.setSelectedItem(item_.config);
+      if (!Objects.equals(item_.config, combo_.getSelectedItem())) {
+         combo_.setSelectedIndex(-1);
+      }
    }
 
    // This method is called when editing is completed.
@@ -168,10 +182,10 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
          } else if (item_.singlePropAllowed != null && item_.singlePropAllowed.length == 0) {
             return text_.getText();
          } else {
-            return combo_.getSelectedItem();
+            return selectionMade_ ? combo_.getSelectedItem() : item_.config;
          }
       } else {
-         return combo_.getSelectedItem();
+         return selectionMade_ ? combo_.getSelectedItem() : item_.config;
       }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
@@ -176,7 +176,9 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
    // It must return the new value to be stored in the cell.
    @Override
    public Object getCellEditorValue() {
-      if (item_.allowed.length == 1) {
+      if (item_.allowed.length == 0) {
+         return text_.getText();
+      } else if (item_.allowed.length == 1) {
          if (item_.singleProp && item_.hasLimits) {
             return slider_.getText();
          } else if (item_.singlePropAllowed != null && item_.singlePropAllowed.length == 0) {


### PR DESCRIPTION
The PopupMenuListener snapshot approach broke two cases: (1) selecting the first item when the current value was not in the allowed list (the snapshot was null, so the change was never detected), and (2) clicking away from an open popup left the editor visible and pre-selected the first item instead of reverting to the original value.

Root causes and fixes:
- Replace snapshot comparison with an ActionListener gated on a popupOpen client-property flag; ActionListener fires reliably for every genuine selection regardless of item index or L&F quirks.
- Call fireEditingCanceled() directly from popupMenuCanceled() so that Escape or click-outside dismisses both the popup and the cell editor in one step.
- Use setSelectedIndex(-1) when the current value is absent from the allowed list, so the editor shows blank rather than defaulting to item 0.
- getCellEditorValue() returns the original value when no selection was made, making Tab or any other external stopCellEditing() call a no-op.
- In ConfigGroupPad.refreshGroup(), skip fireTableDataChanged() while a cell is being edited to prevent hardware-poll events from tearing down the active editor via removeEditor().
- Use Objects.equals() for null-safe comparison of item value against combo selection.

Affects PropertyValueCellEditor, StatePresetCellEditor, AutofocusPropertyEditor, and ConfigGroupPad.