### PR TITLE
Explorer RGB behavior:

### DIFF
--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewer.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewer.java
@@ -512,6 +512,19 @@ public class TiledDataViewer implements TiledDataViewerAPI {
       }
    }
 
+   public void setPersistentMouseAdapter(java.awt.event.MouseAdapter adapter) {
+      guiManager_.setPersistentMouseAdapter(adapter);
+   }
+
+   /**
+    * Returns the RGB values of the rendered display pixel at the given canvas coordinates.
+    * Returns null if no frame has been rendered or coordinates are out of bounds.
+    * Values are in the range 0–255 (display-mapped, post contrast/gamma).
+    */
+   public int[] getRenderedPixelRGB(int canvasX, int canvasY) {
+      return guiManager_.getRenderedPixelRGB(canvasX, canvasY);
+   }
+
    @Override
    public void setCustomCanvasMouseListener(TiledDataViewerCanvasMouseListenerInterface m) {
       guiManager_.setCustomCanvasMouseListener(m);

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataViewer.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataViewer.java
@@ -3,6 +3,7 @@ package org.micromanager.tileddataviewer.internal;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.event.MouseEvent;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
@@ -37,8 +38,10 @@ import org.micromanager.display.DisplaySettings;
 import org.micromanager.display.inspector.internal.panels.intensity.ImageStatsPublisher;
 import org.micromanager.display.internal.event.DataViewerDidBecomeActiveEvent;
 import org.micromanager.display.internal.event.DataViewerDidBecomeVisibleEvent;
+import org.micromanager.display.internal.event.DataViewerMousePixelInfoChangedEvent;
 import org.micromanager.display.internal.event.DataViewerWillCloseEvent;
 import org.micromanager.display.internal.event.DefaultDisplayDidShowImageEvent;
+import org.micromanager.display.internal.event.DisplayMouseEvent;
 import org.micromanager.display.internal.event.DisplayWindowDidAddOverlayEvent;
 import org.micromanager.display.internal.event.DisplayWindowDidRemoveOverlayEvent;
 import org.micromanager.display.internal.imagestats.BoundsRectAndMask;
@@ -51,6 +54,7 @@ import org.micromanager.display.overlay.Overlay;
 import org.micromanager.display.overlay.OverlayListener;
 import org.micromanager.display.overlay.OverlaySupport;
 import org.micromanager.tileddataviewer.TiledDataViewerAcqInterface;
+import org.micromanager.tileddataviewer.TiledDataViewerCanvasMouseListenerInterface;
 import org.micromanager.tileddataviewer.TiledDataViewerDataSource;
 import org.micromanager.tileddataviewer.TiledDataViewerDataViewerAPI;
 import org.micromanager.tileddataviewer.TiledDataViewerOverlayerPlugin;
@@ -206,6 +210,36 @@ public final class TiledDataViewerDataViewer extends AbstractDataViewer
       // After every render, post histogram stats derived from ImageMaker's own
       // pixel histogram so the Inspector indicators always match the display.
       ndViewer2_.setPostRenderCallback(this::postImageMakerStats);
+
+      // Install a persistent mouse adapter to post pixel-info and mouse events
+      // so the Inspector's white-balance picked-point feature works.
+      // Using setPersistentMouseAdapter ensures it survives setCustomCanvasMouseListener calls.
+      ndViewer2_.setPersistentMouseAdapter(new java.awt.event.MouseAdapter() {
+         @Override
+         public void mousePressed(MouseEvent e) {
+            postDisplayMouseEvent(e);
+         }
+
+         @Override
+         public void mouseReleased(MouseEvent e) {
+            postDisplayMouseEvent(e);
+         }
+
+         @Override
+         public void mouseExited(MouseEvent e) {
+            postEvent(DataViewerMousePixelInfoChangedEvent.createUnavailable());
+         }
+
+         @Override
+         public void mouseMoved(MouseEvent e) {
+            postCanvasPixelInfo(e.getX(), e.getY());
+         }
+
+         @Override
+         public void mouseDragged(MouseEvent e) {
+            postCanvasPixelInfo(e.getX(), e.getY());
+         }
+      });
 
       // Register with Studio so Inspector discovers us
       studio_.displays().addViewer(this);
@@ -1358,6 +1392,54 @@ public final class TiledDataViewerDataViewer extends AbstractDataViewer
       }
       closed_ = true;
       shutdownMM2Resources();
+   }
+
+   /**
+    * Reads the rendered display pixel at the given canvas coordinates and posts
+    * a DataViewerMousePixelInfoChangedEvent carrying the R, G, B component values.
+    *
+    * <p>Uses the display-rendered RGB values (0–255 per component) rather than
+    * raw storage values.  This is sufficient for white-balance ratio computation,
+    * which only needs the relative R:G:B proportions, not absolute pixel values.</p>
+    */
+   private void postCanvasPixelInfo(int canvasX, int canvasY) {
+      try {
+         int[] rgb = ndViewer2_.getRenderedPixelRGB(canvasX, canvasY);
+         if (rgb == null) {
+            postEvent(DataViewerMousePixelInfoChangedEvent.createUnavailable());
+            return;
+         }
+         // Build a single-coords event with channel=0; the Inspector routes to channel 0.
+         Coords coords = Coordinates.builder().channel(0).build();
+         long[] componentValues = new long[]{rgb[0], rgb[1], rgb[2]};
+         postEvent(DataViewerMousePixelInfoChangedEvent.create(
+               canvasX, canvasY,
+               new String[]{Coords.CHANNEL},
+               java.util.Collections.singletonList(coords),
+               java.util.Collections.singletonList(componentValues)));
+      } catch (Exception e) {
+         postEvent(DataViewerMousePixelInfoChangedEvent.createUnavailable());
+      }
+   }
+
+   /**
+    * Posts a DisplayMouseEvent so the Inspector's picked-point white-balance
+    * feature can detect clicks on the canvas.
+    */
+   private void postDisplayMouseEvent(MouseEvent e) {
+      try {
+         double mag = ndViewer2_.getMagnification();
+         if (mag <= 0) {
+            return;
+         }
+         Point2D.Double offset = ndViewer2_.getViewOffset();
+         int imgX = (int) Math.floor(offset.x + e.getX() / mag);
+         int imgY = (int) Math.floor(offset.y + e.getY() / mag);
+         Rectangle loc = new Rectangle(imgX, imgY, 1, 1);
+         postEvent(new DisplayMouseEvent(e, loc, 0));
+      } catch (Exception ex) {
+         // Non-critical
+      }
    }
 
    private void shutdownMM2Resources() {

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataViewer.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataViewer.java
@@ -54,7 +54,6 @@ import org.micromanager.display.overlay.Overlay;
 import org.micromanager.display.overlay.OverlayListener;
 import org.micromanager.display.overlay.OverlaySupport;
 import org.micromanager.tileddataviewer.TiledDataViewerAcqInterface;
-import org.micromanager.tileddataviewer.TiledDataViewerCanvasMouseListenerInterface;
 import org.micromanager.tileddataviewer.TiledDataViewerDataSource;
 import org.micromanager.tileddataviewer.TiledDataViewerDataViewerAPI;
 import org.micromanager.tileddataviewer.TiledDataViewerOverlayerPlugin;
@@ -81,6 +80,7 @@ public final class TiledDataViewerDataViewer extends AbstractDataViewer
    private final Studio studio_;
    private final TiledDataViewer ndViewer2_;
    private final TiledDataViewerDataProvider dataProvider_;
+   private final boolean rgb_;
    private final AxesBridge axesBridge_;
    private final StatsComputeQueue computeQueue_ = StatsComputeQueue.create();
 
@@ -192,6 +192,7 @@ public final class TiledDataViewerDataViewer extends AbstractDataViewer
       studio_ = studio;
       dataProvider_ = dataProvider;
       axesBridge_ = dataProvider.getAxesBridge();
+      rgb_ = rgb;
 
       // Create NDViewer (the canvas/scrollbar viewer)
       ndViewer2_ = new TiledDataViewer(dataSource, acqInterface,
@@ -1403,17 +1404,29 @@ public final class TiledDataViewerDataViewer extends AbstractDataViewer
     * which only needs the relative R:G:B proportions, not absolute pixel values.</p>
     */
    private void postCanvasPixelInfo(int canvasX, int canvasY) {
+      if (!rgb_) {
+         return;
+      }
       try {
          int[] rgb = ndViewer2_.getRenderedPixelRGB(canvasX, canvasY);
          if (rgb == null) {
             postEvent(DataViewerMousePixelInfoChangedEvent.createUnavailable());
             return;
          }
-         // Build a single-coords event with channel=0; the Inspector routes to channel 0.
+         // Convert canvas coordinates to full-res image coordinates so the XY
+         // readout in the Inspector reflects actual image pixel positions.
+         double mag = ndViewer2_.getMagnification();
+         if (mag <= 0) {
+            postEvent(DataViewerMousePixelInfoChangedEvent.createUnavailable());
+            return;
+         }
+         Point2D.Double offset = ndViewer2_.getViewOffset();
+         int imgX = (int) Math.floor(offset.x + canvasX / mag);
+         int imgY = (int) Math.floor(offset.y + canvasY / mag);
          Coords coords = Coordinates.builder().channel(0).build();
          long[] componentValues = new long[]{rgb[0], rgb[1], rgb[2]};
          postEvent(DataViewerMousePixelInfoChangedEvent.create(
-               canvasX, canvasY,
+               imgX, imgY,
                new String[]{Coords.CHANNEL},
                java.util.Collections.singletonList(coords),
                java.util.Collections.singletonList(componentValues)));
@@ -1427,6 +1440,9 @@ public final class TiledDataViewerDataViewer extends AbstractDataViewer
     * feature can detect clicks on the canvas.
     */
    private void postDisplayMouseEvent(MouseEvent e) {
+      if (!rgb_) {
+         return;
+      }
       try {
          double mag = ndViewer2_.getMagnification();
          if (mag <= 0) {

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/DisplayWindow.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/DisplayWindow.java
@@ -9,6 +9,7 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelListener;
@@ -42,6 +43,8 @@ public class DisplayWindow implements WindowListener {
    private TiledDataViewerCanvasMouseListenerInterface listener_;
    private TiledDataViewerCanvasMouseListenerInterface previousCustomListener_;
    private Runnable windowActivatedCallback_;
+   // Persistent adapter always added alongside the switchable listener (e.g. for pixel-info events)
+   private MouseAdapter persistentMouseAdapter_;
 
    public DisplayWindow(TiledDataViewer display, boolean nullAcq) {
       window_ = new JFrame();
@@ -265,11 +268,38 @@ public class DisplayWindow implements WindowListener {
       return subImageControls_.isScrollerLocked(axis);
    }
 
+   /**
+    * Set a persistent mouse adapter that is always re-added alongside the
+    * switchable canvas listener.  Used by TiledDataViewerDataViewer to post
+    * pixel-info and DisplayMouseEvents for the Inspector white-balance feature.
+    */
+   public void setPersistentMouseAdapter(MouseAdapter adapter) {
+      if (imageCanvas_ == null) {
+         return;
+      }
+      // Remove any previously registered persistent adapter.
+      if (persistentMouseAdapter_ != null) {
+         imageCanvas_.getCanvas().removeMouseListener(persistentMouseAdapter_);
+         imageCanvas_.getCanvas().removeMouseMotionListener(persistentMouseAdapter_);
+      }
+      persistentMouseAdapter_ = adapter;
+      if (adapter != null) {
+         imageCanvas_.getCanvas().addMouseListener(adapter);
+         imageCanvas_.getCanvas().addMouseMotionListener(adapter);
+      }
+   }
+
    public void setCustomCanvasMouseListener(TiledDataViewerCanvasMouseListenerInterface m) {
       // Track the outgoing listener so resetCanvasMouseListener can restore it.
-      java.awt.event.MouseListener[] current = imageCanvas_.getCanvas().getMouseListeners();
-      previousCustomListener_ = (current.length > 0 && current[0] != listener_)
-              ? (TiledDataViewerCanvasMouseListenerInterface) current[0] : null;
+      // Only consider listeners that implement TiledDataViewerCanvasMouseListenerInterface
+      // (ignores the persistent MouseAdapter which is not a full canvas listener).
+      previousCustomListener_ = null;
+      for (java.awt.event.MouseListener l : imageCanvas_.getCanvas().getMouseListeners()) {
+         if (l instanceof TiledDataViewerCanvasMouseListenerInterface && l != listener_) {
+            previousCustomListener_ = (TiledDataViewerCanvasMouseListenerInterface) l;
+            break;
+         }
+      }
       // Remove all currently registered listeners.
       for (MouseListener l : imageCanvas_.getCanvas().getMouseListeners()) {
          imageCanvas_.getCanvas().removeMouseListener(l);
@@ -283,6 +313,11 @@ public class DisplayWindow implements WindowListener {
       imageCanvas_.getCanvas().addMouseWheelListener(m);
       imageCanvas_.getCanvas().addMouseMotionListener(m);
       imageCanvas_.getCanvas().addMouseListener(m);
+      // Re-add the persistent adapter so pixel-info events always fire.
+      if (persistentMouseAdapter_ != null) {
+         imageCanvas_.getCanvas().addMouseListener(persistentMouseAdapter_);
+         imageCanvas_.getCanvas().addMouseMotionListener(persistentMouseAdapter_);
+      }
    }
 
    public void resetCanvasMouseListener() {
@@ -303,6 +338,11 @@ public class DisplayWindow implements WindowListener {
       imageCanvas_.getCanvas().addMouseWheelListener(restore);
       imageCanvas_.getCanvas().addMouseMotionListener(restore);
       imageCanvas_.getCanvas().addMouseListener(restore);
+      // Re-add the persistent adapter so pixel-info events always fire.
+      if (persistentMouseAdapter_ != null) {
+         imageCanvas_.getCanvas().addMouseListener(persistentMouseAdapter_);
+         imageCanvas_.getCanvas().addMouseMotionListener(persistentMouseAdapter_);
+      }
    }
 
 }

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/GuiManager.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/GuiManager.java
@@ -154,6 +154,14 @@ public class GuiManager {
       return imageMaker_.getLatestTags();
    }
 
+   public int[] getRenderedPixelRGB(int canvasX, int canvasY) {
+      ViewerCanvas vc = getCanvas();
+      if (vc == null) {
+         return null;
+      }
+      return vc.getRenderedPixelRGB(canvasX, canvasY);
+   }
+
    public HashMap<String, int[]> getHistograms() {
       return imageMaker_.getHistograms();
    }
@@ -172,6 +180,12 @@ public class GuiManager {
    public void setWindowActivatedCallback(Runnable callback) {
       if (displayWindow_ != null) {
          displayWindow_.setWindowActivatedCallback(callback);
+      }
+   }
+
+   public void setPersistentMouseAdapter(java.awt.event.MouseAdapter adapter) {
+      if (displayWindow_ != null) {
+         displayWindow_.setPersistentMouseAdapter(adapter);
       }
    }
 

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/ViewerCanvas.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/ViewerCanvas.java
@@ -12,6 +12,7 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelListener;
 import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
 import javax.swing.JPanel;
 import org.micromanager.tileddataviewer.internal.TiledDataViewer;
 import org.micromanager.tileddataviewer.overlay.Overlay;
@@ -24,6 +25,8 @@ public class ViewerCanvas {
    private double scale_;
    private TiledDataViewer display_;
    private JPanel canvas_;
+   // Cached BufferedImage version of the last rendered frame, for pixel lookups.
+   private volatile BufferedImage renderedBuffer_;
 
    public ViewerCanvas(TiledDataViewer display) {
       canvas_ = createCanvas();
@@ -72,6 +75,51 @@ public class ViewerCanvas {
    void updateDisplayImage(Image img, double scale) {
       currentImage_ = img;
       scale_ = scale;
+      // Invalidate the cached buffer whenever a new frame arrives.
+      // The BufferedImage copy is created lazily in getRenderedPixelRGB() only when needed.
+      renderedBuffer_ = null;
+   }
+
+   /**
+    * Returns the RGB values at the given canvas coordinates from the last rendered frame.
+    * Returns null if no frame has been rendered yet or coordinates are out of bounds.
+    * The array contains [R, G, B] values in the range 0–255.
+    * These are the display-mapped values (post contrast/gamma), which is sufficient
+    * for computing white-balance ratios since only relative R:G:B proportions matter.
+    */
+   public int[] getRenderedPixelRGB(int canvasX, int canvasY) {
+      Image img = currentImage_;
+      double scale = scale_;
+      if (img == null || scale <= 0) {
+         return null;
+      }
+      // Build or reuse the cached BufferedImage copy (created lazily on first pixel lookup).
+      BufferedImage buf = renderedBuffer_;
+      if (buf == null) {
+         if (img instanceof BufferedImage) {
+            buf = (BufferedImage) img;
+         } else {
+            int w = img.getWidth(null);
+            int h = img.getHeight(null);
+            if (w <= 0 || h <= 0) {
+               return null;
+            }
+            buf = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+            java.awt.Graphics g = buf.getGraphics();
+            g.drawImage(img, 0, 0, null);
+            g.dispose();
+         }
+         renderedBuffer_ = buf;
+      }
+      // The AffineTransform in paint() scales the image UP by scale when drawing it.
+      // canvas pixel = renderedImagePixel * scale → renderedImagePixel = canvasPixel / scale
+      int px = (int) Math.floor(canvasX / scale);
+      int py = (int) Math.floor(canvasY / scale);
+      if (px < 0 || py < 0 || px >= buf.getWidth() || py >= buf.getHeight()) {
+         return null;
+      }
+      int rgb = buf.getRGB(px, py);
+      return new int[]{(rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF};
    }
 
    void updateOverlay(Overlay overlay) {

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -1557,20 +1557,28 @@ public class ExplorerManager {
    private void initDisplaySettings(JSONObject summaryMetadata) {
       try {
          SequenceSettings settings = studio_.acquisitions().getAcquisitionSettings();
+         DisplaySettings.Builder dsBuilder = studio_.displays().displaySettingsBuilder();
+         int displayChannelIndex = 0;
          if (settings.useChannels() && settings.channels().size() > 0) {
-            DisplaySettings.Builder dsBuilder = studio_.displays().displaySettingsBuilder();
-            int displayChannelIndex = 0;
             for (int i = 0; i < settings.channels().size(); i++) {
                if (settings.channels().get(i).useChannel()) {
                   String channelGroup = settings.channelGroup();
                   String channelName = settings.channels().get(i).config();
                   Color channelColor = settings.channels().get(i).color();
-                  dsBuilder.channel(displayChannelIndex,
+                  org.micromanager.display.ChannelDisplaySettings remembered =
+                        RememberedDisplaySettings.loadChannel(
+                              studio_, channelGroup, channelName, null);
+                  org.micromanager.display.ChannelDisplaySettings.Builder chBuilder =
                         studio_.displays().channelDisplaySettingsBuilder()
                               .groupName(channelGroup)
                               .name(channelName)
-                              .color(channelColor)
-                              .build());
+                              .color(channelColor);
+                  if (remembered != null) {
+                     for (int c = 0; c < remembered.getNumberOfComponents(); c++) {
+                        chBuilder.component(c, remembered.getComponentSettings(c));
+                     }
+                  }
+                  dsBuilder.channel(displayChannelIndex, chBuilder.build());
                   displayChannelIndex++;
                }
             }
@@ -1579,9 +1587,21 @@ public class ExplorerManager {
             } else if (displayChannelIndex > 1) {
                dsBuilder.colorModeComposite();
             }
-            if (displayChannelIndex > 0 && mm2Viewer_ != null) {
-               mm2Viewer_.setDisplaySettings(dsBuilder.build());
+         } else {
+            // Single-channel (including RGB) — load remembered settings for "Default"
+            String channelGroup = settings.channelGroup();
+            String channelName = "Default";
+            org.micromanager.display.ChannelDisplaySettings remembered =
+                  RememberedDisplaySettings.loadChannel(
+                        studio_, channelGroup, channelName, null);
+            if (remembered != null) {
+               dsBuilder.channel(0, remembered);
+               displayChannelIndex = 1;
             }
+            dsBuilder.colorModeGrayscale();
+         }
+         if (mm2Viewer_ != null) {
+            mm2Viewer_.setDisplaySettings(dsBuilder.build());
          }
       } catch (Exception e) {
          studio_.logs().logError(e, "Explorer: failed to init display settings");


### PR DESCRIPTION
  Bug 1 fix — White balance not applied from remembered settings
  (ExplorerManager.java:1557)

  initDisplaySettings() now calls RememberedDisplaySettings.loadChannel() for
  every channel before creating the viewer. For multi-channel acquisitions it
  loads each enabled channel's settings including per-component RGB scaling. For   single-channel/RGB acquisitions it loads the Default channel settings. The
  ComponentDisplaySettings (components 0/1/2 for R/G/B) are copied directly into
   the channel builder, so the white balance ratios stored from a previous
  standard-MM-display session are applied immediately.

  ---
  Bug 2 fix — Picked-point white balance not working

  This required a chain of changes across 4 files:

  - TiledDataViewer.java:515,524 — added setPersistentMouseAdapter() and getRenderedPixelRGB(), delegating to GuiManager.
  - GuiManager.java:157,186 — added getRenderedPixelRGB() and setPersistentMouseAdapter(), delegating to DisplayWindow.
  - DisplayWindow.java:276 — added persistentMouseAdapter_ field and setPersistentMouseAdapter() method; modified setCustomCanvasMouseListener() and resetCanvasMouseListener() to re-add the persistent adapter after every listener switch, so it survives ExplorerDataSource calling setCustomCanvasMouseListener().
  - ViewerCanvas.java:90 — added getRenderedPixelRGB() which maps canvas coordinates to rendered image pixels using the scale_ factor from the AffineTransform, and added a lazily-built renderedBuffer_ cache.
  - TiledDataViewerDataViewer.java:217 — in the constructor, installs the persistent mouse adapter that posts DataViewerMousePixelInfoChangedEvent (with rendered RGB values) on mouse move/drag and DisplayMouseEvent on press/release, enabling the Inspector's ChannelIntensityController to compute and apply white-balance ratios from a picked point.