### PR TITLE
Explore and TiledDataViewer improvements

### DIFF
--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerDataViewerAPI.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerDataViewerAPI.java
@@ -106,4 +106,13 @@ public interface TiledDataViewerDataViewerAPI extends DataViewer {
     * @param axesList  list of NDViewer axes maps (one per image, same order)
     */
    void newTileArrived(List<Image> images, List<HashMap<String, Object>> axesList);
+
+   /**
+    * Return the live-explore acquisition controls for this viewer, if the underlying
+    * data source supports them.
+    *
+    * @return the explore controls, or null if the data source does not support
+    *     interrupting an acquisition (e.g. a read-only viewer).
+    */
+   TiledDataViewerExploreControls getExploreControls();
 }

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerExploreControls.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerExploreControls.java
@@ -1,0 +1,46 @@
+package org.micromanager.tileddataviewer;
+
+/**
+ * Optional capability a {@link TiledDataViewerDataSource} may implement to expose
+ * live-explore acquisition controls to the viewer's Inspector panel.
+ *
+ * <p>A live explore data source (e.g. the Explorer or Deskew Explore plugins) implements
+ * this so the shared "Explorer Controls" Inspector panel can offer an Interrupt button
+ * without the library depending on the plugins. Data sources that do not support
+ * interrupting (e.g. a read-only viewer opened from a saved dataset) simply do not
+ * implement it, and the panel hides the Interrupt button.</p>
+ */
+public interface TiledDataViewerExploreControls {
+
+   /**
+    * Stop all queued tile acquisitions after the current tile finishes.
+    */
+   void interruptAcquisition();
+
+   /**
+    * @return true if tiles are currently being acquired.
+    */
+   boolean isAcquisitionInProgress();
+
+   /**
+    * Register a listener notified when the acquisition-in-progress state changes.
+    *
+    * @param l the listener to add
+    */
+   void addAcquisitionStateListener(AcquisitionStateListener l);
+
+   /**
+    * Unregister a previously added acquisition-state listener.
+    *
+    * @param l the listener to remove
+    */
+   void removeAcquisitionStateListener(AcquisitionStateListener l);
+
+   /**
+    * Notified when the acquisition-in-progress state changes. May be called from any
+    * thread; listeners that touch Swing must marshal to the EDT themselves.
+    */
+   interface AcquisitionStateListener {
+      void acquisitionInProgressChanged(boolean inProgress);
+   }
+}

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerExploreControls.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerExploreControls.java
@@ -8,7 +8,7 @@ package org.micromanager.tileddataviewer;
  * this so the shared "Explorer Controls" Inspector panel can offer an Interrupt button
  * without the library depending on the plugins. Data sources that do not support
  * interrupting (e.g. a read-only viewer opened from a saved dataset) simply do not
- * implement it, and the panel hides the Interrupt button.</p>
+ * implement it, and the panel keeps the Interrupt button visible but disabled.</p>
  */
 public interface TiledDataViewerExploreControls {
 

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
@@ -30,6 +30,31 @@ import org.micromanager.tileddataprovider.TiledDataProviderAPI;
 public final class TiledDataViewerInspectorPanelController
       extends AbstractInspectorPanelController {
 
+   /**
+    * Shared help text describing the Explorer / TiledDataViewer mouse and button controls.
+    * Used by this panel's Help button and by the Explorer/Deskew plugin frames so the
+    * documentation stays in one place.
+    */
+   public static final String EXPLORE_HELP_TEXT =
+         "Navigation:\n"
+               + "  Left-drag: pan view\n"
+               + "  Scroll wheel: zoom in/out\n"
+               + "\n"
+               + "Tile selection (live explore):\n"
+               + "  Right-click: select tile\n"
+               + "  Right-drag: expand selection\n"
+               + "  Left-click: acquire (or queue) selected tiles\n"
+               + "  Interrupt: stop all queued and running acquisitions\n"
+               + "  Ctrl+left-click: move stage to position\n"
+               + "\n"
+               + "View controls:\n"
+               + "  Center: pan to center of dataset (keep zoom)\n"
+               + "  No Zoom: zoom to 1:1 and center on dataset\n"
+               + "\n"
+               + "Export:\n"
+               + "  Click Export, drag to draw ROI, then confirm export\n"
+               + "  Click anywhere to dismiss the ROI";
+
    private static final DecimalFormat FMT_POS = new DecimalFormat("000");
 
    private final Studio studio_;
@@ -90,25 +115,7 @@ public final class TiledDataViewerInspectorPanelController
 
    private void showHelp() {
       JOptionPane.showMessageDialog(SwingUtilities.getWindowAncestor(panel_),
-            "Navigation:\n"
-                  + "  Left-drag: pan view\n"
-                  + "  Scroll wheel: zoom in/out\n"
-                  + "\n"
-                  + "Tile selection (live explore):\n"
-                  + "  Right-click: select tile\n"
-                  + "  Right-drag: expand selection\n"
-                  + "  Left-click: acquire (or queue) selected tiles\n"
-                  + "  Interrupt: stop all queued and running acquisitions\n"
-                  + "  Ctrl+left-click: move stage to position\n"
-                  + "\n"
-                  + "View controls:\n"
-                  + "  Center: pan to center of dataset (keep zoom)\n"
-                  + "  No Zoom: zoom to 1:1 and center on dataset\n"
-                  + "\n"
-                  + "Export:\n"
-                  + "  Click Export, drag to draw ROI, then confirm export\n"
-                  + "  Click anywhere to dismiss the ROI",
-            "Explorer Help", JOptionPane.PLAIN_MESSAGE);
+            EXPLORE_HELP_TEXT, "Explorer Help", JOptionPane.PLAIN_MESSAGE);
    }
 
    /** Returns the center of the dataset in full-res pixel coordinates, or null if unknown. */
@@ -686,20 +693,26 @@ public final class TiledDataViewerInspectorPanelController
 
    @Override
    public void attachDataViewer(DataViewer viewer) {
+      // The Inspector reuses one controller instance and may re-attach without an
+      // intervening detach when the active viewer changes; detach first so we never
+      // leak a listener on the previous viewer's explore controls.
+      if (viewer_ != null) {
+         detachDataViewer();
+      }
       viewer_ = (TiledDataViewerDataViewerAPI) viewer;
       lastRoi_ = null;
 
       exploreControls_ = viewer_.getExploreControls();
+      final boolean inProgress =
+            exploreControls_ != null && exploreControls_.isAcquisitionInProgress();
+      // Interrupt is only meaningful for a live explore session; for a read-only
+      // viewer it stays present but disabled (matching the other panel buttons).
+      // Touch Swing on the EDT in case attach is ever called off-EDT.
+      SwingUtilities.invokeLater(() -> interruptButton_.setEnabled(inProgress));
       if (exploreControls_ != null) {
-         interruptButton_.setVisible(true);
-         interruptButton_.setEnabled(exploreControls_.isAcquisitionInProgress());
-         acqStateListener_ = inProgress ->
-               SwingUtilities.invokeLater(() -> interruptButton_.setEnabled(inProgress));
+         acqStateListener_ = changed ->
+               SwingUtilities.invokeLater(() -> interruptButton_.setEnabled(changed));
          exploreControls_.addAcquisitionStateListener(acqStateListener_);
-      } else {
-         // Read-only viewer (e.g. opened dataset): no acquisition to interrupt.
-         interruptButton_.setVisible(false);
-         interruptButton_.setEnabled(false);
       }
    }
 
@@ -710,7 +723,7 @@ public final class TiledDataViewerInspectorPanelController
       }
       exploreControls_ = null;
       acqStateListener_ = null;
-      interruptButton_.setEnabled(false);
+      SwingUtilities.invokeLater(() -> interruptButton_.setEnabled(false));
       viewer_ = null;
       lastRoi_ = null;
       setStatus(null);

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
@@ -37,8 +37,16 @@ public final class TiledDataViewerInspectorPanelController
    private final JLabel statusLabel_;
    private final JButton exportButton_;
    private final JButton posListButton_;
+   private final JButton interruptButton_;
+   private final JButton helpButton_;
    private TiledDataViewerDataViewerAPI viewer_;
    private static boolean expanded_ = true;
+
+   // Live-explore acquisition controls for the attached viewer, or null if the data
+   // source does not support interrupting (e.g. a read-only opened dataset).
+   private TiledDataViewerExploreControls exploreControls_;
+   // Listener registered on exploreControls_ while attached; updates the Interrupt button.
+   private TiledDataViewerExploreControls.AcquisitionStateListener acqStateListener_;
 
    // Last confirmed export ROI in full-resolution pixels [x, y, w, h]; null when none.
    private int[] lastRoi_ = null;
@@ -48,6 +56,8 @@ public final class TiledDataViewerInspectorPanelController
       statusLabel_ = new JLabel(" ");
       exportButton_ = new JButton("Export...");
       posListButton_ = new JButton("Create Positions...");
+      interruptButton_ = new JButton("Interrupt");
+      helpButton_ = new JButton("Help");
       panel_ = buildPanel();
    }
 
@@ -59,12 +69,46 @@ public final class TiledDataViewerInspectorPanelController
       noZoom.addActionListener(e -> onNoZoom());
       exportButton_.addActionListener(e -> onExportClicked());
       posListButton_.addActionListener(e -> onPosListClicked());
+      interruptButton_.setToolTipText(
+            "Stop tile acquisition after the current tile finishes.");
+      interruptButton_.setEnabled(false);
+      interruptButton_.addActionListener(e -> {
+         if (exploreControls_ != null) {
+            exploreControls_.interruptAcquisition();
+         }
+      });
+      helpButton_.addActionListener(e -> showHelp());
       p.add(center);
       p.add(noZoom, "wrap");
       p.add(exportButton_);
       p.add(posListButton_, "wrap");
+      p.add(interruptButton_);
+      p.add(helpButton_, "wrap");
       p.add(statusLabel_, "span 2, wrap");
       return p;
+   }
+
+   private void showHelp() {
+      JOptionPane.showMessageDialog(SwingUtilities.getWindowAncestor(panel_),
+            "Navigation:\n"
+                  + "  Left-drag: pan view\n"
+                  + "  Scroll wheel: zoom in/out\n"
+                  + "\n"
+                  + "Tile selection (live explore):\n"
+                  + "  Right-click: select tile\n"
+                  + "  Right-drag: expand selection\n"
+                  + "  Left-click: acquire (or queue) selected tiles\n"
+                  + "  Interrupt: stop all queued and running acquisitions\n"
+                  + "  Ctrl+left-click: move stage to position\n"
+                  + "\n"
+                  + "View controls:\n"
+                  + "  Center: pan to center of dataset (keep zoom)\n"
+                  + "  No Zoom: zoom to 1:1 and center on dataset\n"
+                  + "\n"
+                  + "Export:\n"
+                  + "  Click Export, drag to draw ROI, then confirm export\n"
+                  + "  Click anywhere to dismiss the ROI",
+            "Explorer Help", JOptionPane.PLAIN_MESSAGE);
    }
 
    /** Returns the center of the dataset in full-res pixel coordinates, or null if unknown. */
@@ -644,10 +688,29 @@ public final class TiledDataViewerInspectorPanelController
    public void attachDataViewer(DataViewer viewer) {
       viewer_ = (TiledDataViewerDataViewerAPI) viewer;
       lastRoi_ = null;
+
+      exploreControls_ = viewer_.getExploreControls();
+      if (exploreControls_ != null) {
+         interruptButton_.setVisible(true);
+         interruptButton_.setEnabled(exploreControls_.isAcquisitionInProgress());
+         acqStateListener_ = inProgress ->
+               SwingUtilities.invokeLater(() -> interruptButton_.setEnabled(inProgress));
+         exploreControls_.addAcquisitionStateListener(acqStateListener_);
+      } else {
+         // Read-only viewer (e.g. opened dataset): no acquisition to interrupt.
+         interruptButton_.setVisible(false);
+         interruptButton_.setEnabled(false);
+      }
    }
 
    @Override
    public void detachDataViewer() {
+      if (exploreControls_ != null && acqStateListener_ != null) {
+         exploreControls_.removeAcquisitionStateListener(acqStateListener_);
+      }
+      exploreControls_ = null;
+      acqStateListener_ = null;
+      interruptButton_.setEnabled(false);
       viewer_ = null;
       lastRoi_ = null;
       setStatus(null);

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
@@ -44,7 +44,7 @@ public final class TiledDataViewerInspectorPanelController
                + "  Right-click: select tile\n"
                + "  Right-drag: expand selection\n"
                + "  Left-click: acquire (or queue) selected tiles\n"
-               + "  Interrupt: stop all queued and running acquisitions\n"
+               + "  Interrupt: cancel queued tiles; the current tile finishes first\n"
                + "  Ctrl+left-click: move stage to position\n"
                + "\n"
                + "View controls:\n"

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataViewer.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataViewer.java
@@ -62,6 +62,7 @@ import org.micromanager.display.overlay.OverlaySupport;
 import org.micromanager.tileddataviewer.TiledDataViewerAcqInterface;
 import org.micromanager.tileddataviewer.TiledDataViewerDataSource;
 import org.micromanager.tileddataviewer.TiledDataViewerDataViewerAPI;
+import org.micromanager.tileddataviewer.TiledDataViewerExploreControls;
 import org.micromanager.tileddataviewer.TiledDataViewerOverlayerPlugin;
 import org.micromanager.tileddataviewer.internal.gui.ChannelRenderSettings;
 import org.micromanager.tileddataviewer.internal.gui.ContrastUpdateCallback;
@@ -1164,6 +1165,13 @@ public final class TiledDataViewerDataViewer extends AbstractDataViewer
    @Override
    public TiledDataViewer getNDViewer() {
       return ndViewer2_;
+   }
+
+   @Override
+   public TiledDataViewerExploreControls getExploreControls() {
+      TiledDataViewerDataSource ds = ndViewer2_.getDataSource();
+      return ds instanceof TiledDataViewerExploreControls
+            ? (TiledDataViewerExploreControls) ds : null;
    }
 
    /**

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreDataSource.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreDataSource.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import mmcorej.TaggedImage;
 import org.micromanager.ndtiffstorage.MultiresNDTiffAPI;
@@ -21,6 +22,7 @@ import org.micromanager.tileddataviewer.TiledDataViewerAPI;
 import org.micromanager.tileddataviewer.TiledDataViewerAcqInterface;
 import org.micromanager.tileddataviewer.TiledDataViewerCanvasMouseListenerInterface;
 import org.micromanager.tileddataviewer.TiledDataViewerDataSource;
+import org.micromanager.tileddataviewer.TiledDataViewerExploreControls;
 import org.micromanager.tileddataviewer.TiledDataViewerOverlayerPlugin;
 import org.micromanager.tileddataviewer.overlay.Overlay;
 import org.micromanager.tileddataviewer.overlay.Roi;
@@ -34,11 +36,14 @@ import org.micromanager.tileddataviewer.overlay.TextRoi;
 public class DeskewExploreDataSource implements TiledDataViewerDataSource,
          TiledDataViewerAcqInterface,
          TiledDataViewerCanvasMouseListenerInterface,
-         TiledDataViewerOverlayerPlugin {
+         TiledDataViewerOverlayerPlugin,
+         TiledDataViewerExploreControls {
 
    private static final double ZOOM_FACTOR = 1.4;
 
    private final DeskewExploreManager manager_;
+   private final CopyOnWriteArrayList<AcquisitionStateListener> acqStateListeners_ =
+         new CopyOnWriteArrayList<>();
    private volatile TiledDataViewerAPI viewer_;
    private volatile MultiresNDTiffAPI storage_;
    private volatile boolean finished_ = false;
@@ -141,6 +146,31 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
 
    public void setAcquisitionInProgress(boolean inProgress) {
       acquisitionInProgress_ = inProgress;
+      for (AcquisitionStateListener l : acqStateListeners_) {
+         l.acquisitionInProgressChanged(inProgress);
+      }
+   }
+
+   // ===================== TiledDataViewerExploreControls =====================
+
+   @Override
+   public void interruptAcquisition() {
+      manager_.interruptAcquisition();
+   }
+
+   @Override
+   public boolean isAcquisitionInProgress() {
+      return acquisitionInProgress_;
+   }
+
+   @Override
+   public void addAcquisitionStateListener(AcquisitionStateListener l) {
+      acqStateListeners_.add(l);
+   }
+
+   @Override
+   public void removeAcquisitionStateListener(AcquisitionStateListener l) {
+      acqStateListeners_.remove(l);
    }
 
    /**
@@ -466,16 +496,16 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
       int dx = dragStart_.x - current.x;
       int dy = dragStart_.y - current.y;
 
-      if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
-         // Left-drag extends the selection — blocked in read-only mode.
-         // Left takes priority over right: if left is held we do selection, not pan.
+      if (javax.swing.SwingUtilities.isRightMouseButton(e)) {
+         // Right-drag creates and extends the selection — blocked in read-only mode.
+         // Right-press already set selectionStart_ to the tile under the cursor.
          if (!readOnly_ && selectionStart_ != null
                  && tileWidth_ > 0 && tileHeight_ > 0) {
             if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
-               isLeftDragging_ = true;
+               isRightDragging_ = true;
             }
 
-            if (isLeftDragging_) {
+            if (isRightDragging_) {
                Point tile = getTileFromDisplayCoords(e.getX(), e.getY());
                if (tile != null && !tile.equals(selectionEnd_)) {
                   selectionEnd_ = tile;
@@ -483,16 +513,13 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
                }
             }
          }
-      } else if (javax.swing.SwingUtilities.isRightMouseButton(e)) {
-         // Right-drag pans the view — only when left is not also held.
+      } else if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+         // Left-drag pans the view.
          if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
-            isRightDragging_ = true;
-            // Clear selection when panning
-            selectionStart_ = null;
-            selectionEnd_ = null;
+            isLeftDragging_ = true;
          }
 
-         if (isRightDragging_) {
+         if (isLeftDragging_) {
             manager_.pan(dx, dy);
             dragStart_ = current;
          }
@@ -594,7 +621,7 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
          overlay.add(line1);
 
          TextRoi line2 = new TextRoi(centerX - 120, centerY - 10,
-                 "Left-drag: expand selection");
+                 "Right-drag: expand selection");
          line2.setStrokeColor(Color.WHITE);
          overlay.add(line2);
 
@@ -604,7 +631,7 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
          overlay.add(line3);
 
          TextRoi line4 = new TextRoi(centerX - 120, centerY + 30,
-                 "Right-drag: pan view");
+                 "Left-drag: pan view");
          line4.setStrokeColor(Color.WHITE);
          overlay.add(line4);
 
@@ -691,8 +718,8 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
          String instructions;
          if (selectionEnd_ == null) {
             instructions = acquisitionInProgress_
-                  ? "Left-drag to extend, left-click to queue"
-                  : "Left-drag to extend, left-click to acquire";
+                  ? "Right-drag to extend, left-click to queue"
+                  : "Right-drag to extend, left-click to acquire";
          } else {
             instructions = acquisitionInProgress_
                   ? "Left-click to queue " + tileCount + " tile(s)"

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreDataSource.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreDataSource.java
@@ -514,7 +514,9 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
             }
          }
       } else if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
-         // Left-drag pans the view.
+         // Left-drag pans the view. Note: panning intentionally does NOT clear any
+         // existing tile selection — a tentative single-tile selection set by a prior
+         // right-press is left in place so the user can pan and then keep selecting.
          if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
             isLeftDragging_ = true;
          }

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreManager.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreManager.java
@@ -272,8 +272,8 @@ public class DeskewExploreManager {
 
          viewer_ = mm2Viewer_.getNDViewer();
          dataSource_.setViewer(viewer_);
-         viewer_.setWindowTitle("Deskew Explore - Right-click to select, "
-               + "Left-drag to extend, Left-click to acquire");
+         viewer_.setWindowTitle("Deskew Explore - Right-click/drag to select, "
+               + "Left-drag to pan, Left-click to acquire");
 
          // Set up overlayer and mouse listener
          // Route through mm2Viewer_ so the bridge plugin chains this as externalOverlayerPlugin_

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
@@ -58,6 +58,7 @@ import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
+import org.micromanager.tileddataviewer.TiledDataViewerInspectorPanelController;
 
 
 /**
@@ -485,24 +486,7 @@ public class DeskewFrame extends JFrame implements ProcessorConfigurator {
       JButton exploreHelpButton = new JButton("Help");
       exploreHelpButton.addActionListener(e -> JOptionPane.showMessageDialog(
             this,
-            "Navigation:\n"
-                  + "  Left-drag: pan view\n"
-                  + "  Scroll wheel: zoom in/out\n"
-                  + "\n"
-                  + "Tile selection (live explore):\n"
-                  + "  Right-click: select tile\n"
-                  + "  Right-drag: expand selection\n"
-                  + "  Left-click: acquire (or queue) selected tiles\n"
-                  + "  Interrupt: stop all queued and running acquisitions\n"
-                  + "  Ctrl+left-click: move stage to position\n"
-                  + "\n"
-                  + "View controls:\n"
-                  + "  Center: pan to center of dataset (keep zoom)\n"
-                  + "  No Zoom: zoom to 1:1 and center on dataset\n"
-                  + "\n"
-                  + "Export:\n"
-                  + "  Click Export, drag to draw ROI, then confirm export\n"
-                  + "  Click anywhere to dismiss the ROI",
+            TiledDataViewerInspectorPanelController.EXPLORE_HELP_TEXT,
             "Deskew Explore Help", JOptionPane.PLAIN_MESSAGE));
       explorePanel.add(exploreHelpButton, "wrap");
 

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
@@ -486,12 +486,12 @@ public class DeskewFrame extends JFrame implements ProcessorConfigurator {
       exploreHelpButton.addActionListener(e -> JOptionPane.showMessageDialog(
             this,
             "Navigation:\n"
-                  + "  Right-drag: pan view\n"
+                  + "  Left-drag: pan view\n"
                   + "  Scroll wheel: zoom in/out\n"
                   + "\n"
                   + "Tile selection (live explore):\n"
                   + "  Right-click: select tile\n"
-                  + "  Left-drag: expand selection\n"
+                  + "  Right-drag: expand selection\n"
                   + "  Left-click: acquire (or queue) selected tiles\n"
                   + "  Interrupt: stop all queued and running acquisitions\n"
                   + "  Ctrl+left-click: move stage to position\n"

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import mmcorej.TaggedImage;
 import org.micromanager.ndtiffstorage.MultiresNDTiffAPI;
@@ -23,6 +24,7 @@ import org.micromanager.tileddataviewer.TiledDataViewerAPI;
 import org.micromanager.tileddataviewer.TiledDataViewerAcqInterface;
 import org.micromanager.tileddataviewer.TiledDataViewerCanvasMouseListenerInterface;
 import org.micromanager.tileddataviewer.TiledDataViewerDataSource;
+import org.micromanager.tileddataviewer.TiledDataViewerExploreControls;
 import org.micromanager.tileddataviewer.TiledDataViewerOverlayerPlugin;
 import org.micromanager.tileddataviewer.overlay.Overlay;
 import org.micromanager.tileddataviewer.overlay.Roi;
@@ -39,11 +41,14 @@ import org.micromanager.tileddataviewer.overlay.TextRoi;
  * in ExplorerManager (camera FOV in microns, fixed for the session).
  */
 public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataViewerAcqInterface,
-         TiledDataViewerCanvasMouseListenerInterface, TiledDataViewerOverlayerPlugin {
+         TiledDataViewerCanvasMouseListenerInterface, TiledDataViewerOverlayerPlugin,
+         TiledDataViewerExploreControls {
 
    private static final double ZOOM_FACTOR = 1.4;
 
    private final ExplorerManager manager_;
+   private final CopyOnWriteArrayList<AcquisitionStateListener> acqStateListeners_ =
+         new CopyOnWriteArrayList<>();
    private volatile TiledDataViewerAPI viewer_;
    private volatile MultiresNDTiffAPI storage_;
    private volatile boolean finished_ = false;
@@ -174,6 +179,31 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    public void setAcquisitionInProgress(boolean inProgress) {
       acquisitionInProgress_ = inProgress;
+      for (AcquisitionStateListener l : acqStateListeners_) {
+         l.acquisitionInProgressChanged(inProgress);
+      }
+   }
+
+   // ===================== TiledDataViewerExploreControls =====================
+
+   @Override
+   public void interruptAcquisition() {
+      manager_.interruptAcquisition();
+   }
+
+   @Override
+   public boolean isAcquisitionInProgress() {
+      return acquisitionInProgress_;
+   }
+
+   @Override
+   public void addAcquisitionStateListener(AcquisitionStateListener l) {
+      acqStateListeners_.add(l);
+   }
+
+   @Override
+   public void removeAcquisitionStateListener(AcquisitionStateListener l) {
+      acqStateListeners_.remove(l);
    }
 
    public void setSettingsMismatch(boolean mismatch) {
@@ -472,13 +502,15 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       int dx = dragStart_.x - current.x;
       int dy = dragStart_.y - current.y;
 
-      if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+      if (javax.swing.SwingUtilities.isRightMouseButton(e)) {
+         // Right-drag creates and extends the selection — blocked in read-only mode.
+         // Right-press already set selectionStart_ to the tile under the cursor.
          if (!readOnly_ && selectionStart_ != null
                  && tileWidth_ > 0 && tileHeight_ > 0) {
             if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
-               isLeftDragging_ = true;
+               isRightDragging_ = true;
             }
-            if (isLeftDragging_) {
+            if (isRightDragging_) {
                Point tile = getTileFromDisplayCoords(e.getX(), e.getY());
                if (tile != null && !tile.equals(selectionEnd_)) {
                   selectionEnd_ = tile;
@@ -486,13 +518,12 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
                }
             }
          }
-      } else if (javax.swing.SwingUtilities.isRightMouseButton(e)) {
+      } else if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+         // Left-drag pans the view.
          if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
-            isRightDragging_ = true;
-            selectionStart_ = null;
-            selectionEnd_ = null;
+            isLeftDragging_ = true;
          }
-         if (isRightDragging_) {
+         if (isLeftDragging_) {
             manager_.pan(dx, dy);
             dragStart_ = current;
          }
@@ -575,7 +606,7 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
          line1.setStrokeColor(Color.WHITE);
          overlay.add(line1);
 
-         TextRoi line2 = new TextRoi(centerX - 120, centerY - 10, "Left-drag: expand selection");
+         TextRoi line2 = new TextRoi(centerX - 120, centerY - 10, "Right-drag: expand selection");
          line2.setStrokeColor(Color.WHITE);
          overlay.add(line2);
 
@@ -584,7 +615,7 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
          line3.setStrokeColor(Color.WHITE);
          overlay.add(line3);
 
-         TextRoi line4 = new TextRoi(centerX - 120, centerY + 30, "Right-drag: pan view");
+         TextRoi line4 = new TextRoi(centerX - 120, centerY + 30, "Left-drag: pan view");
          line4.setStrokeColor(Color.WHITE);
          overlay.add(line4);
 
@@ -659,8 +690,8 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
          String instructions;
          if (selectionEnd_ == null) {
             instructions = acquisitionInProgress_
-                  ? "Left-drag to extend, left-click to queue"
-                  : "Left-drag to extend, left-click to acquire";
+                  ? "Right-drag to extend, left-click to queue"
+                  : "Right-drag to extend, left-click to acquire";
          } else {
             instructions = acquisitionInProgress_
                   ? "Left-click to queue " + tileCount + " tile(s)"

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -519,7 +519,9 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
             }
          }
       } else if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
-         // Left-drag pans the view.
+         // Left-drag pans the view. Note: panning intentionally does NOT clear any
+         // existing tile selection — a tentative single-tile selection set by a prior
+         // right-press is left in place so the user can pan and then keep selecting.
          if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
             isLeftDragging_ = true;
          }

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -136,12 +136,12 @@ public class ExplorerFrame extends JFrame {
       helpButton.addActionListener(e -> JOptionPane.showMessageDialog(
             this,
             "Navigation:\n"
-                  + "  Right-drag: pan view\n"
+                  + "  Left-drag: pan view\n"
                   + "  Scroll wheel: zoom in/out\n"
                   + "\n"
                   + "Tile selection (live explore):\n"
                   + "  Right-click: select tile\n"
-                  + "  Left-drag: expand selection\n"
+                  + "  Right-drag: expand selection\n"
                   + "  Left-click: acquire (or queue) selected tiles\n"
                   + "  Stop: stop all queued and running acquisitions\n"
                   + "  Ctrl+left-click: move stage to position\n"

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -19,6 +19,7 @@ import org.micromanager.Studio;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.WindowPositioning;
 import org.micromanager.propertymap.MutablePropertyMapView;
+import org.micromanager.tileddataviewer.TiledDataViewerInspectorPanelController;
 
 /**
  * Simple dialog for the Explorer plugin.
@@ -135,17 +136,8 @@ public class ExplorerFrame extends JFrame {
       JButton helpButton = new JButton("Help");
       helpButton.addActionListener(e -> JOptionPane.showMessageDialog(
             this,
-            "Navigation:\n"
-                  + "  Left-drag: pan view\n"
-                  + "  Scroll wheel: zoom in/out\n"
-                  + "\n"
-                  + "Tile selection (live explore):\n"
-                  + "  Right-click: select tile\n"
-                  + "  Right-drag: expand selection\n"
-                  + "  Left-click: acquire (or queue) selected tiles\n"
-                  + "  Stop: stop all queued and running acquisitions\n"
-                  + "  Ctrl+left-click: move stage to position\n"
-                  + "\n"
+            TiledDataViewerInspectorPanelController.EXPLORE_HELP_TEXT
+                  + "\n\n"
                   + "Images pass through the active Data Processing Pipeline.\n"
                   + "Configure the pipeline in MM's Data Processing Pipeline window.",
             "Explorer Help", JOptionPane.PLAIN_MESSAGE));

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -32,6 +32,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import mmcorej.org.json.JSONArray;
 import mmcorej.org.json.JSONObject;
+import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
 import org.micromanager.acqj.main.AcqEngMetadata;
 import org.micromanager.acquisition.SequenceSettings;
@@ -46,6 +47,7 @@ import org.micromanager.display.internal.RememberedDisplaySettings;
 import org.micromanager.events.PixelSizeAffineChangedEvent;
 import org.micromanager.events.PixelSizeChangedEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
+import org.micromanager.imageprocessing.ImageTransformUtils;
 import org.micromanager.internal.propertymap.NonPropertyMapJSONFormats;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.ColorPalettes;
@@ -147,6 +149,14 @@ public class ExplorerManager {
    private int initialCameraHeight_ = 512;
    private boolean isRGB_ = false;
 
+   // Camera orientation / Image Flipper correction
+   private int sessionCorrectionRotation_ = 0;    // 0/90/180/270
+   private boolean sessionCorrectionMirror_ = false; // horizontal mirror
+   private boolean flipperInPipeline_ = false;    // Flipper already corrected images
+   // Raw (pre-correction) affines so Flipper override can restart from them
+   private AffineTransform rawPixelSizeAffine_ = null;
+   private AffineTransform rawInitialPixelSizeAffine_ = null;
+
    public ExplorerManager(Studio studio, ExplorerFrame frame) {
       studio_ = studio;
       frame_ = frame;
@@ -217,6 +227,32 @@ public class ExplorerManager {
          loadPixelSizeAffine();
          initialPixelSizeAffine_ = pixelSizeAffine_;
          initialPixelSizeAffineInverse_ = pixelSizeAffineInverse_;
+
+         // Keep uncorrected copies so the Flipper-detection path can restart cleanly.
+         rawPixelSizeAffine_        = pixelSizeAffine_;
+         rawInitialPixelSizeAffine_ = pixelSizeAffine_;
+         sessionCorrectionRotation_ = 0;
+         sessionCorrectionMirror_   = false;
+         flipperInPipeline_         = false;
+
+         // Issue 1: detect camera mirror from the raw affine (det < 0 → mirror encoded).
+         // Rotation ≠ 0 is only logged; use the Image Flipper plugin for rotation correction.
+         if (pixelSizeAffine_ != null) {
+            int[] corr = ImageTransformUtils.correctionFromAffine(pixelSizeAffine_);
+            if (corr != null && (corr[0] != 0 || corr[1] != 0)) {
+               if (corr[0] != 0) {
+                  studio_.logs().logMessage("Explorer: camera rotation detected (="
+                        + corr[0] + "°); use the Image Flipper plugin for rotation correction");
+               } else {
+                  sessionCorrectionMirror_ = (corr[1] != 0);
+                  if (sessionCorrectionMirror_) {
+                     applyOrientationCorrectionToAffines(0, true);
+                     studio_.logs().logMessage("Explorer: camera mirror detected;"
+                           + " mirror correction applied to canvas affine");
+                  }
+               }
+            }
+         }
 
          // Initial tile-grid estimate uses camera dimensions (corrected after first acq)
          dataSource_.setTileDimensions(cameraWidth_, cameraHeight_);
@@ -530,6 +566,11 @@ public class ExplorerManager {
       acquisitionInterrupted_ = true;
       dismissMismatchAlert();
       pendingBatches_.set(0);
+      sessionCorrectionRotation_ = 0;
+      sessionCorrectionMirror_   = false;
+      flipperInPipeline_         = false;
+      rawPixelSizeAffine_        = null;
+      rawInitialPixelSizeAffine_ = null;
       if (dataSource_ != null) {
          dataSource_.clearPendingTiles();
       }
@@ -937,6 +978,57 @@ public class ExplorerManager {
    }
 
    /**
+    * Returns the inverse of the "mirror-X then rotate CW by rotation degrees" correction
+    * transform.  Composing this into the canvas affine (A_corrected = A_raw * corrInv)
+    * keeps canvas-pixel-delta → stage-micron-delta correct after tile images have been
+    * corrected by the same mirror+rotation.
+    */
+   private AffineTransform buildCorrectionAffineInverse(int rotation, boolean mirror) {
+      AffineTransform inv = new AffineTransform();
+      if (rotation == 90) {
+         inv.quadrantRotate(1); // CCW 90° = inverse of CW 90°
+      } else if (rotation == 180) {
+         inv.quadrantRotate(2);
+      } else if (rotation == 270) {
+         inv.quadrantRotate(3);
+      }
+      if (mirror) {
+         inv.preConcatenate(AffineTransform.getScaleInstance(-1.0, 1.0));
+      }
+      return inv;
+   }
+
+   /**
+    * Composes the orientation correction into both the current and session-start
+    * canvas affines and recomputes their inverses.
+    */
+   private void applyOrientationCorrectionToAffines(int rotation, boolean mirror) {
+      AffineTransform corrInv = buildCorrectionAffineInverse(rotation, mirror);
+      if (pixelSizeAffine_ != null) {
+         AffineTransform c = new AffineTransform(pixelSizeAffine_);
+         c.concatenate(corrInv);
+         pixelSizeAffine_ = c;
+         try {
+            pixelSizeAffineInverse_ = c.createInverse();
+         } catch (NoninvertibleTransformException e) {
+            pixelSizeAffine_ = null;
+            pixelSizeAffineInverse_ = null;
+         }
+      }
+      if (initialPixelSizeAffine_ != null) {
+         AffineTransform c = new AffineTransform(initialPixelSizeAffine_);
+         c.concatenate(corrInv);
+         initialPixelSizeAffine_ = c;
+         try {
+            initialPixelSizeAffineInverse_ = c.createInverse();
+         } catch (NoninvertibleTransformException e) {
+            initialPixelSizeAffine_ = null;
+            initialPixelSizeAffineInverse_ = null;
+         }
+      }
+   }
+
+   /**
     * Loads and validates the pixel-size affine transform from the core.
     * Sets pixelSizeAffine_ / pixelSizeAffineInverse_ on success, leaves both null
     * (scalar fallback) on any failure or if the affine does not match pixelSizeUm_.
@@ -970,6 +1062,22 @@ public class ExplorerManager {
       } catch (Exception e) {
          studio_.logs().logMessage("Explorer: could not load pixel-size affine ("
                + e.getMessage() + "); using scalar coordinate conversion");
+      }
+      // Re-apply session correction so that stage-movement affine stays consistent
+      // after an objective / pixel-size change.
+      if (pixelSizeAffine_ != null
+            && (sessionCorrectionMirror_ || sessionCorrectionRotation_ != 0)) {
+         AffineTransform corrInv = buildCorrectionAffineInverse(
+               sessionCorrectionRotation_, sessionCorrectionMirror_);
+         AffineTransform c = new AffineTransform(pixelSizeAffine_);
+         c.concatenate(corrInv);
+         pixelSizeAffine_ = c;
+         try {
+            pixelSizeAffineInverse_ = c.createInverse();
+         } catch (NoninvertibleTransformException e) {
+            pixelSizeAffine_ = null;
+            pixelSizeAffineInverse_ = null;
+         }
       }
    }
 
@@ -1119,6 +1227,52 @@ public class ExplorerManager {
                } catch (Exception e) {
                   studio_.logs().logError(e, "Explorer: failed to update overlap metadata");
                }
+
+               // Issue 2: detect Image Flipper in the pipeline from first-image metadata.
+               // If detected, override canvas affines with the Flipper's correction so that
+               // stageToPixel() and moveStageToPixelPosition() map to the correct canvas
+               // coordinates (the Flipper has already corrected the pixel data).
+               if (!flipperInPipeline_) {
+                  PropertyMap userData = firstImage.getMetadata().getUserData();
+                  if (userData != null
+                        && userData.containsInteger("ImageFlipper-Rotation")
+                        && userData.containsString("ImageFlipper-Mirror")) {
+                     final int flipRot = userData.getInteger("ImageFlipper-Rotation", 0);
+                     final boolean flipMirror = "On".equals(
+                           userData.getString("ImageFlipper-Mirror", "Off"));
+                     flipperInPipeline_ = true;
+                     // Restart from the raw (pre-camera-correction) affines so the
+                     // Flipper's correction does not compound with the camera correction.
+                     pixelSizeAffine_ = rawPixelSizeAffine_ != null
+                           ? new AffineTransform(rawPixelSizeAffine_) : null;
+                     pixelSizeAffineInverse_ = null;
+                     initialPixelSizeAffine_ = rawInitialPixelSizeAffine_ != null
+                           ? new AffineTransform(rawInitialPixelSizeAffine_) : null;
+                     initialPixelSizeAffineInverse_ = null;
+                     if (pixelSizeAffine_ != null) {
+                        try {
+                           pixelSizeAffineInverse_ = pixelSizeAffine_.createInverse();
+                        } catch (NoninvertibleTransformException ignored) {
+                           pixelSizeAffine_ = null;
+                        }
+                     }
+                     if (initialPixelSizeAffine_ != null) {
+                        try {
+                           initialPixelSizeAffineInverse_ = initialPixelSizeAffine_.createInverse();
+                        } catch (NoninvertibleTransformException ignored) {
+                           initialPixelSizeAffine_ = null;
+                        }
+                     }
+                     sessionCorrectionRotation_ = flipRot;
+                     sessionCorrectionMirror_   = flipMirror;
+                     if (flipRot != 0 || flipMirror) {
+                        applyOrientationCorrectionToAffines(flipRot, flipMirror);
+                     }
+                     studio_.logs().logMessage("Explorer: Image Flipper detected (rot="
+                           + flipRot + ", mirror=" + flipMirror
+                           + "); canvas affine adjusted");
+                  }
+               }
             }
          }
 
@@ -1136,6 +1290,23 @@ public class ExplorerManager {
             Image img = testStore.getImage(c);
             if (img == null) {
                continue;
+            }
+            // Issue 1: apply pixel correction when the Flipper is not in the pipeline.
+            // The Flipper (Issue 2) has already corrected images when flipperInPipeline_ is true.
+            if (!flipperInPipeline_
+                  && (sessionCorrectionMirror_ || sessionCorrectionRotation_ != 0)) {
+               try {
+                  Object[] result = ImageTransformUtils.transformPixels(
+                        img.getRawPixels(), img.getWidth(), img.getHeight(),
+                        img.getBytesPerPixel(), sessionCorrectionMirror_,
+                        sessionCorrectionRotation_);
+                  img = studio_.data().createImage(
+                        result[0], (Integer) result[1], (Integer) result[2],
+                        img.getBytesPerPixel(), img.getNumComponents(),
+                        img.getCoords(), img.getMetadata());
+               } catch (Exception e) {
+                  studio_.logs().logError(e, "Explorer: pixel orientation correction failed");
+               }
             }
             int channelIndex = c.getChannel();
             String channelName = summaryMeta.getSafeChannelName(channelIndex);

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -241,7 +241,7 @@ public class ExplorerManager {
             int[] corr = ImageTransformUtils.correctionFromAffine(pixelSizeAffine_);
             if (corr != null && (corr[0] != 0 || corr[1] != 0)) {
                if (corr[0] != 0) {
-                  studio_.logs().logMessage("Explorer: camera rotation detected (="
+                  studio_.logs().logMessage("Explorer: camera rotation detected ("
                         + corr[0] + "°); use the Image Flipper plugin for rotation correction");
                } else {
                   sessionCorrectionMirror_ = (corr[1] != 0);

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -282,8 +282,8 @@ public class ExplorerManager {
 
          viewer_ = mm2Viewer_.getNDViewer();
          dataSource_.setViewer(viewer_);
-         viewer_.setWindowTitle("Explorer - Right-click to select, "
-               + "Left-drag to extend, Left-click to acquire");
+         viewer_.setWindowTitle("Explorer - Right-click/drag to select, "
+               + "Left-drag to pan, Left-click to acquire");
 
          mm2Viewer_.setOverlayerPlugin(dataSource_);
          viewer_.setCustomCanvasMouseListener(dataSource_);


### PR DESCRIPTION
Explorer now handles affine transform and Image Flipper information better.
The viewer UI was changed so that Left-drag pans the image, and right-drag is used to expand the selection.
Adds Help and Interrupt buttons to the Inspector panel, which behave the same in the Deskew Epxlorer and standard Explorer.