### PR TITLE
ClearVolume: Bumped up dependencies, mainly triggered by JOGL moving to 2.5.0.

### DIFF
--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -96,33 +96,33 @@
 
 
       <!-- ClearVolume dependencies -->
-      <dependency org="net.clearvolume" name="clearvolume" rev="1.4.3">
+      <dependency org="net.clearvolume" name="clearvolume" rev="1.4.4">
          <!-- coremem 0.4.4 no longer available from maven.scijava.org
-         (0.4.5 wins anyway) -->
+         (newer coremem wins anyway) -->
          <exclude org="net.coremem" name="coremem"/>
       </dependency>
-      <dependency org="net.clearvolume" name="cleargl" rev="2.2.6"/>
+      <dependency org="net.clearvolume" name="cleargl" rev="2.2.12"/>
       <!-- <dependency org="net.clearvolume" name="clearcuda" rev="0.9.4"/> -->
       <dependency org="net.clearcontrol" name="clearcl" rev="0.6.0"/>
-      <dependency org="net.clearcontrol" name="coremem" rev="0.4.5"/>
+      <dependency org="net.clearcontrol" name="coremem" rev="0.4.6"/>
 
       <!--jogl and gluegen are a pain! They are in central, but named in a way that is hard to re-concile with ivy. -->
       <!--thus, hard coding the artifact definitions solves the problem, and it is used here as a work-around -->
-      <dependency org="org.jogamp.jogl" name="jogl-all-main" rev="2.3.2">
+      <dependency org="org.jogamp.jogl" name="jogl-all-main" rev="2.5.0">
          <artifact name="jogl-all-main"/>
          <artifact name="jogl-all-main" e:classifier="sources"/>
          <artifact name="jogl-all-main" e:classifier="javadoc"/>
       </dependency>
-      <dependency org="org.jogamp.jogl" name="jogl-all" rev="2.3.2">
+      <dependency org="org.jogamp.jogl" name="jogl-all" rev="2.5.0">
          <artifact name="jogl-all"/>
          <artifact name="jogl-all" e:classifier="natives-linux-amd64"/>
          <artifact name="jogl-all" e:classifier="natives-macosx-universal"/>
          <artifact name="jogl-all" e:classifier="natives-windows-amd64"/>
       </dependency>
-      <dependency org="org.jogamp.gluegen" name="gluegen-rt-main" rev="2.3.2">
+      <dependency org="org.jogamp.gluegen" name="gluegen-rt-main" rev="2.5.0">
          <artifact name="gluegen-rt-main"/>
       </dependency>
-      <dependency org="org.jogamp.gluegen" name="gluegen-rt" rev="2.3.2">
+      <dependency org="org.jogamp.gluegen" name="gluegen-rt" rev="2.5.0">
          <artifact name="gluegen-rt"/>
          <artifact name="gluegen-rt" e:classifier="natives-linux-amd64"/>
          <artifact name="gluegen-rt" e:classifier="natives-macosx-universal"/>

--- a/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/uielements/ScriptAssistantDlg.java
+++ b/plugins/MMClearVolumePlugin/src/main/java/edu/ucsf/valelab/mmclearvolumeplugin/uielements/ScriptAssistantDlg.java
@@ -1,6 +1,7 @@
 package edu.ucsf.valelab.mmclearvolumeplugin.uielements;
 
 import com.jogamp.opengl.math.Quaternion;
+import com.jogamp.opengl.math.Vec3f;
 import edu.ucsf.valelab.mmclearvolumeplugin.CVViewer;
 import edu.ucsf.valelab.mmclearvolumeplugin.recorder.AnimationFrameRecorder;
 import java.awt.Color;
@@ -509,8 +510,10 @@ public final class ScriptAssistantDlg extends JDialog {
          // Work on a copy; toAngleAxis does not mutate but normalize does.
          Quaternion qCopy = new Quaternion(q);
          qCopy.normalize();
-         float[] axis = new float[3];
-         float angleRad = qCopy.toAngleAxis(axis);
+         // JOGL 2.5.0: toAngleAxis writes the axis into a Vec3f (was float[] in 2.3.2).
+         Vec3f axisVec = new Vec3f();
+         float angleRad = qCopy.toAngleAxis(axisVec);
+         float[] axis = axisVec.get(new float[3]);
          float angleDeg = (float) Math.toDegrees(angleRad);
          if (Math.abs(angleDeg) >= ROT_THRESHOLD_DEG) {
             float ax = axis[0];
@@ -644,8 +647,10 @@ public final class ScriptAssistantDlg extends JDialog {
       qDelta.mult(new Quaternion(q0).conjugate());
       qDelta.normalize();
 
-      float[] axis = new float[3];
-      float angleRad = qDelta.toAngleAxis(axis);
+      // JOGL 2.5.0: toAngleAxis writes the axis into a Vec3f (was float[] in 2.3.2).
+      Vec3f axisVec = new Vec3f();
+      float angleRad = qDelta.toAngleAxis(axisVec);
+      float[] axis = axisVec.get(new float[3]);
       float angleDeg = (float) Math.toDegrees(angleRad);
 
       if (Math.abs(angleDeg) < ROT_THRESHOLD_DEG) {


### PR DESCRIPTION
  This makes a couple of upgrades in cleargl, clearvolume and coremem needed, which are not yet in the upstream repos.  Nevertheless, this code has been tested (on windows only), so when those dependencies have been updated this PR can be merged. Only one minor change was needed in our own code.