### PR TITLE
Studio: Avoid NPE in the MultiMDAFrame dialog.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
@@ -349,7 +349,8 @@ public class MultiMDAFrame extends JFrame {
          acqPanel_.add(presetCombo, "gapx 20");
 
          String positionListText = "current position";
-         if (acqs_.get(lineNr).getPositionList() != null) {
+         if (acqs_.get(lineNr).getPositionList() != null
+               && acqs_.get(lineNr).getPositionListFile() != null) {
             positionListText = acqs_.get(lineNr).getPositionListFile().getName();
          }
          final JLabelC positionListLabel = new JLabelC(positionListText);


### PR DESCRIPTION
Observed this NPE in the wild.  Not quite sure how that could happen, but this is a good defense.