### PR TITLE
Studio: MultiMDA: fix confusing behavior when use positions was not checked in the acquisition settings used in the MultiMDA.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MDASettingData.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MDASettingData.java
@@ -8,6 +8,11 @@ import org.micromanager.acquisition.SequenceSettings;
 /**
  * Data structure to remember the AcqSettings file, as well as
  * PositionList.
+ *
+ * <p>Note: the acqSettings_.usePositionList() flag is always derived from whether a
+ * position list with positions is currently loaded for this row; it is never taken
+ * directly from a user toggle. Both setPositionListFile() and setAcqSettings()
+ * re-derive it so the GUI explanation and the executor stay consistent.
  */
 public class MDASettingData {
    private final Studio studio_;

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MDASettingData.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MDASettingData.java
@@ -36,13 +36,21 @@ public class MDASettingData {
       PositionList positionList = new PositionList();
       try {
          positionList.load(positionListFile);
-         positionList_ = positionList;
-         positionListFile_ = positionListFile;
+         if (positionList.getNumberOfPositions() > 0) {
+            positionList_ = positionList;
+            positionListFile_ = positionListFile;
+         } else {
+            // An empty list is treated the same as "no position list": keep both
+            // references null so the UI shows "current position" instead of a filename
+            // that would not actually be used at run time.
+            positionList_ = null;
+            positionListFile_ = null;
+         }
          // A separate position list file does not flip the usePositionList flag that
          // came from the acquisition settings file, so set it here based on the loaded
          // list. Both the GUI explanation and the executor read this flag.
          acqSettings_ = new SequenceSettings.Builder(acqSettings_)
-               .usePositionList(positionList_.getNumberOfPositions() > 0).build();
+               .usePositionList(positionList_ != null).build();
       } catch (Exception e) {
          positionList_ = null;
          positionListFile_ = null;

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MDASettingData.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MDASettingData.java
@@ -29,7 +29,15 @@ public class MDASettingData {
       try {
          positionList_.load(positionListFile);
          positionListFile_ = positionListFile;
+         // A separate position list file does not flip the usePositionList flag that
+         // came from the acquisition settings file, so set it here based on the loaded
+         // list. Both the GUI explanation and the executor read this flag.
+         acqSettings_ = new SequenceSettings.Builder(acqSettings_)
+               .usePositionList(positionList_.getNumberOfPositions() > 0).build();
       } catch (Exception e) {
+         positionList_ = null;
+         acqSettings_ = new SequenceSettings.Builder(acqSettings_)
+               .usePositionList(false).build();
          studio_.logs().showError(e);
       }
    }
@@ -52,7 +60,11 @@ public class MDASettingData {
 
    public void setAcqSettings(File acqFile, SequenceSettings acqSettings) {
       acqSettingFile_ = acqFile;
-      acqSettings_ = acqSettings;
+      // A newly loaded acquisition settings file would clobber the usePositionList flag,
+      // so re-apply it based on whether a position list is currently loaded for this row.
+      acqSettings_ = new SequenceSettings.Builder(acqSettings)
+            .usePositionList(positionList_ != null
+                  && positionList_.getNumberOfPositions() > 0).build();
    }
 
    public void setPresetGroup(String presetGroup) {

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MDASettingData.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MDASettingData.java
@@ -25,9 +25,13 @@ public class MDASettingData {
    }
 
    public void setPositionListFile(File positionListFile) {
-      positionList_ = new PositionList();
+      // Load into a temporary list so a failed load does not leave a stale
+      // positionListFile_ around (which would otherwise be persisted on shutdown
+      // and keep the UI showing the old filename even though positions are disabled).
+      PositionList positionList = new PositionList();
       try {
-         positionList_.load(positionListFile);
+         positionList.load(positionListFile);
+         positionList_ = positionList;
          positionListFile_ = positionListFile;
          // A separate position list file does not flip the usePositionList flag that
          // came from the acquisition settings file, so set it here based on the loaded
@@ -36,6 +40,7 @@ public class MDASettingData {
                .usePositionList(positionList_.getNumberOfPositions() > 0).build();
       } catch (Exception e) {
          positionList_ = null;
+         positionListFile_ = null;
          acqSettings_ = new SequenceSettings.Builder(acqSettings_)
                .usePositionList(false).build();
          studio_.logs().showError(e);

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
@@ -241,7 +241,11 @@ public class MultiMDAFrame extends JFrame {
                continue;
             }
             acqs_.add(count, new MDASettingData(studio_, f, seqSb));
-            if (positionListFiles.size() > count) {
+            // Rows without a position list are persisted as an empty path (see the
+            // save logic). Skip those, otherwise setPositionListFile() tries to load
+            // "" and throws FileNotFoundException on every startup.
+            if (positionListFiles.size() > count
+                  && !positionListFiles.get(count).isEmpty()) {
                File posFile = new File(positionListFiles.get(count));
                acqs_.get(count).setPositionListFile(posFile);
             }
@@ -271,6 +275,12 @@ public class MultiMDAFrame extends JFrame {
    private int adjustNrSettings(int nr) {
       acqPanel_.removeAll();
       acqLabels_.clear();
+      // These are rebuilt below alongside acqLabels_; clear them too or they keep
+      // growing and the *.get(lineNr) lookups below return stale entries from a
+      // previous build (e.g. a newly added acquisition showing an earlier row's
+      // explanation/preset).
+      acqExplanations_.clear();
+      presetCombos_.clear();
       // add headers to the table
       acqPanel_.add(new JLabel("Acquisition Settings File"), "span 2, alignx center");
       acqPanel_.add(new JLabel("Preset"), "alignx center");
@@ -348,12 +358,15 @@ public class MultiMDAFrame extends JFrame {
          presetCombos_.add(presetCombo);
          acqPanel_.add(presetCombo, "gapx 20");
 
-         String positionListText = "current position";
+         String positionListText = "current position (at run time)";
          if (acqs_.get(lineNr).getPositionList() != null
                && acqs_.get(lineNr).getPositionListFile() != null) {
             positionListText = acqs_.get(lineNr).getPositionListFile().getName();
          }
          final JLabelC positionListLabel = new JLabelC(positionListText);
+         positionListLabel.setToolTipText("<html>When no position list is selected, the stage "
+               + "position<br>at the time the acquisition is run is used "
+               + "(not the<br>position when this acquisition was added).</html>");
          acqPanel_.add(positionListLabel, "gapx 20");
 
          JButton selectPosFile = new JButton("...");
@@ -530,12 +543,13 @@ public class MultiMDAFrame extends JFrame {
          }
       }
       if (mdaSettingData.getSequenceSettings().usePositionList()
+            && mdaSettingData.getPositionListFile() != null
             && mdaSettingData.getPositionList() != null
             && mdaSettingData.getPositionList().getNumberOfPositions() > 0) {
          sb.append("Positions: ").append(mdaSettingData.getPositionList().getNumberOfPositions());
          sb.append(".");
       } else {
-         sb.append("Positions: current only.");
+         sb.append("Positions: current at run time.");
       }
       if (mdaSettingData.getSequenceSettings().save()) {
          sb.append(" Saving.");

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
@@ -193,20 +193,24 @@ public class MultiMDAFrame extends JFrame {
       acquireButton_ = new JButton("Run Multi MDA");
       runButtonColor_ = acquireButton_.getForeground();
       acquireButton_.addActionListener(e -> {
-         // If an acquisition is already running, this button acts as a Stop button.
-         if (currentAcqj_ != null && currentAcqj_.isAcquisitionRunning()) {
+         // This handler runs on the EDT. If an acquisition is already running (or one
+         // is in the process of starting), this button acts as a Stop button.
+         if (currentAcqj_ != null) {
             currentAcqj_.abortRequest();
             return;
          }
+         // Claim the "running" slot here on the EDT, before starting the background
+         // thread, so a fast double-click cannot pass the guard above twice and start
+         // two acquisitions. The same adapter is reused inside run().
+         final MultiAcqEngJAdapter acqj = new MultiAcqEngJAdapter(studio_);
+         currentAcqj_ = acqj;
+         setRunningState(true);
          // All GUI event handlers are invoked on the EDT (Event Dispatch
          // Thread). Acquisitions are not allowed to be started from the
          // EDT. Therefore, we must make a new thread to run this.
          Thread acqThread = new Thread(new Runnable() {
             @Override
             public void run() {
-               final MultiAcqEngJAdapter acqj = new MultiAcqEngJAdapter(studio_);
-               currentAcqj_ = acqj;
-               setRunningState(true);
                SequenceSettings.Builder sb = new SequenceSettings.Builder();
                double multiplier = 1;
                String token = (String) timeUnitCombo_.getSelectedItem();

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
@@ -81,7 +81,9 @@ public class MultiMDAFrame extends JFrame {
    private static final String POSITION_LIST_PATHS = "PositionListPaths";
    private final JSpinner nrSpinner_;
    private JButton acquireButton_;
-   private MultiAcqEngJAdapter currentAcqj_;
+   // Written on the acquisition thread, read on the EDT (button handler); volatile so
+   // the EDT sees the start/clear promptly and the Run/Stop behavior stays consistent.
+   private volatile MultiAcqEngJAdapter currentAcqj_;
    private final Color runButtonColor_;
    private final CheckBoxPanel framesPanel_;
    private final CheckBoxPanel autoFocusPanel_;
@@ -413,12 +415,17 @@ public class MultiMDAFrame extends JFrame {
                   "Load position list", POSITION_LIST_FILE);
             if (f != null) {
                acqs_.get(lineNr).setPositionListFile(f);
+               // The load may have failed or yielded an empty list, in which case
+               // getPositionList()/getPositionListFile() are null; reflect that by
+               // showing "current position" rather than leaving a stale filename.
                if (acqs_.get(lineNr).getPositionList() != null) {
                   positionListLabel.setText(acqs_.get(lineNr).getPositionListFile().getName());
-                  JLabel explanation = acqExplanations_.get(lineNr);
-                  if (explanation != null) {
-                     explanation.setText(oneLineSummary(acqs_.get(lineNr)));
-                  }
+               } else {
+                  positionListLabel.setText("current position (at run time)");
+               }
+               JLabel explanation = acqExplanations_.get(lineNr);
+               if (explanation != null) {
+                  explanation.setText(oneLineSummary(acqs_.get(lineNr)));
                }
             }
          });

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
@@ -43,6 +43,7 @@ import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingUtilities;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.acquisition.ChannelSpec;
@@ -68,13 +69,20 @@ public class MultiMDAFrame extends JFrame {
    private final List<JLabel> acqExplanations_ = new ArrayList<>();
    private final List<JComboBox<String>> presetCombos_ = new ArrayList<>();
    private static final String USE_TIME_POINTS = "UseTimePoints";
+   private static final String NR_FRAMES = "NumberOfFrames";
+   private static final String INTERVAL = "Interval";
+   private static final String TIME_UNIT = "TimeUnit";
    private static final String USE_AUTOFOCUS = "UseAutofocus";
+   private static final String AF_SKIP_INTERVAL = "AutofocusSkipInterval";
    private static final String USE_PRESET = "UsePreset";
    private static final String PRESET_GROUP = "PresetGroup";
    private static final String NR_ACQ_SETTINGS = "NumberOfSettings";
    private static final String ACQ_PATHS = "AcquisitionPaths";
    private static final String POSITION_LIST_PATHS = "PositionListPaths";
    private final JSpinner nrSpinner_;
+   private JButton acquireButton_;
+   private MultiAcqEngJAdapter currentAcqj_;
+   private final Color runButtonColor_;
    private final CheckBoxPanel framesPanel_;
    private final CheckBoxPanel autoFocusPanel_;
    private final CheckBoxPanel presetPanel_;
@@ -180,8 +188,14 @@ public class MultiMDAFrame extends JFrame {
       super.add(new JLabel(""), "growx");
 
       // Run an acquisition using the current MDA parameters.
-      JButton acquireButton = new JButton("Run Multi MDA");
-      acquireButton.addActionListener(e -> {
+      acquireButton_ = new JButton("Run Multi MDA");
+      runButtonColor_ = acquireButton_.getForeground();
+      acquireButton_.addActionListener(e -> {
+         // If an acquisition is already running, this button acts as a Stop button.
+         if (currentAcqj_ != null && currentAcqj_.isAcquisitionRunning()) {
+            currentAcqj_.abortRequest();
+            return;
+         }
          // All GUI event handlers are invoked on the EDT (Event Dispatch
          // Thread). Acquisitions are not allowed to be started from the
          // EDT. Therefore, we must make a new thread to run this.
@@ -189,6 +203,8 @@ public class MultiMDAFrame extends JFrame {
             @Override
             public void run() {
                final MultiAcqEngJAdapter acqj = new MultiAcqEngJAdapter(studio_);
+               currentAcqj_ = acqj;
+               setRunningState(true);
                SequenceSettings.Builder sb = new SequenceSettings.Builder();
                double multiplier = 1;
                String token = (String) timeUnitCombo_.getSelectedItem();
@@ -208,13 +224,26 @@ public class MultiMDAFrame extends JFrame {
                   studio_.logs().logError(ex);
                }
                SequenceSettings baseSettings = sb.build();
-               acqj.runAcquisition(baseSettings, acqs_);
+               try {
+                  acqj.runAcquisition(baseSettings, acqs_);
+                  // runAcquisition() returns once events are submitted, but the engine
+                  // keeps running on its own threads. Wait for it to actually finish (or
+                  // be aborted) before reverting the button to "Run".
+                  while (acqj.isAcquisitionRunning()) {
+                     Thread.sleep(250);
+                  }
+               } catch (InterruptedException ex) {
+                  Thread.currentThread().interrupt();
+               } finally {
+                  currentAcqj_ = null;
+                  setRunningState(false);
+               }
             }
          });
          acqThread.start();
       });
 
-      super.add(acquireButton, "align right, push, gap 10, wrap");
+      super.add(acquireButton_, "align right, push, gap 10, wrap");
 
       super.setIconImage(Toolkit.getDefaultToolkit().getImage(
             getClass().getResource("/org/micromanager/icons/microscope.gif")));
@@ -224,15 +253,21 @@ public class MultiMDAFrame extends JFrame {
       // restore settings from previous session
       final MutablePropertyMapView settings = studio_.profile().getSettings(this.getClass());
       framesPanel_.setSelected(settings.getBoolean(USE_TIME_POINTS, false));
+      numFrames_.setValue(settings.getInteger(NR_FRAMES, (Integer) numFrames_.getValue()));
+      interval_.setValue(settings.getDouble(INTERVAL,
+            ((Number) interval_.getValue()).doubleValue()));
+      timeUnitCombo_.setSelectedItem(settings.getString(TIME_UNIT,
+            (String) timeUnitCombo_.getSelectedItem()));
       autoFocusPanel_.setSelected(settings.getBoolean(USE_AUTOFOCUS, false));
+      afSkipInterval_.setValue(settings.getInteger(AF_SKIP_INTERVAL,
+            (Integer) afSkipInterval_.getValue()));
       presetPanel_.setSelected(settings.getBoolean(USE_PRESET, false));
       int nrAcquisitions = settings.getInteger(NR_ACQ_SETTINGS, 0);
       if (nrAcquisitions > 0) {
          List<String> acqPaths = settings.getStringList(ACQ_PATHS);
          List<String> positionListFiles = settings.getStringList(POSITION_LIST_PATHS);
-         int count = 0;
-         for (String acqPath : acqPaths) {
-            File f = new File(acqPath);
+         for (int origIndex = 0; origIndex < acqPaths.size(); origIndex++) {
+            File f = new File(acqPaths.get(origIndex));
             SequenceSettings seqSb;
             try {
                seqSb = studio_.acquisitions().loadSequenceSettings(f.getPath());
@@ -240,18 +275,20 @@ public class MultiMDAFrame extends JFrame {
                studio_.logs().logError(ex, "Failed to load Acquisition setting file");
                continue;
             }
-            acqs_.add(count, new MDASettingData(studio_, f, seqSb));
+            MDASettingData mdaSettingData = new MDASettingData(studio_, f, seqSb);
+            acqs_.add(mdaSettingData);
+            // The position list paths are persisted parallel to acqPaths, so index them
+            // by the original position (not by the number of successfully loaded rows);
+            // otherwise a failed acquisition load would shift every later pairing.
             // Rows without a position list are persisted as an empty path (see the
             // save logic). Skip those, otherwise setPositionListFile() tries to load
             // "" and throws FileNotFoundException on every startup.
-            if (positionListFiles.size() > count
-                  && !positionListFiles.get(count).isEmpty()) {
-               File posFile = new File(positionListFiles.get(count));
-               acqs_.get(count).setPositionListFile(posFile);
+            if (positionListFiles.size() > origIndex
+                  && !positionListFiles.get(origIndex).isEmpty()) {
+               mdaSettingData.setPositionListFile(new File(positionListFiles.get(origIndex)));
             }
-            count++;
          }
-         nrSpinner_.setValue(count);
+         nrSpinner_.setValue(acqs_.size());
       }
 
       super.pack();
@@ -448,10 +485,6 @@ public class MultiMDAFrame extends JFrame {
       timeUnitCombo_.setEnabled(framesPanel.isEnabled());
       defaultTimesPanel.add(timeUnitCombo_, "pad 0 -15 0 0, wrap");
 
-      JLabelC overrideLabel = new JLabelC("Custom time intervals enabled");
-      overrideLabel.setFont(new Font("Arial", Font.BOLD, 12));
-      overrideLabel.setForeground(Color.red);
-
       return framesPanel;
    }
 
@@ -528,6 +561,30 @@ public class MultiMDAFrame extends JFrame {
       return presetPanel;
    }
 
+   /**
+    * Switches the Run/Stop button between its two states. Safe to call from any
+    * thread; the actual Swing mutation is marshalled onto the EDT.
+    *
+    * @param running true while an acquisition is running (button becomes a red
+    *                "Stop Multi MDA"), false otherwise ("Run Multi MDA").
+    */
+   private void setRunningState(boolean running) {
+      Runnable r = () -> {
+         if (running) {
+            acquireButton_.setText("Stop Multi MDA");
+            acquireButton_.setForeground(Color.RED);
+         } else {
+            acquireButton_.setText("Run Multi MDA");
+            acquireButton_.setForeground(runButtonColor_);
+         }
+      };
+      if (SwingUtilities.isEventDispatchThread()) {
+         r.run();
+      } else {
+         SwingUtilities.invokeLater(r);
+      }
+   }
+
    private String oneLineSummary(MDASettingData mdaSettingData) {
       StringBuilder sb = new StringBuilder();
       if (mdaSettingData.getSequenceSettings().useSlices()) {
@@ -571,7 +628,11 @@ public class MultiMDAFrame extends JFrame {
       MutablePropertyMapView settings = studio_.profile().getSettings(this.getClass());
       settings.putInteger(NR_ACQ_SETTINGS, (Integer) nrSpinner_.getValue());
       settings.putBoolean(USE_TIME_POINTS, framesPanel_.isSelected());
+      settings.putInteger(NR_FRAMES, (Integer) numFrames_.getValue());
+      settings.putDouble(INTERVAL, ((Number) interval_.getValue()).doubleValue());
+      settings.putString(TIME_UNIT, (String) timeUnitCombo_.getSelectedItem());
       settings.putBoolean(USE_AUTOFOCUS, autoFocusPanel_.isSelected());
+      settings.putInteger(AF_SKIP_INTERVAL, (Integer) afSkipInterval_.getValue());
       settings.putBoolean(USE_PRESET, presetPanel_.isSelected());
 
       List<String> acqPaths = new ArrayList<>(acqs_.size());

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
@@ -26,8 +26,10 @@ import java.awt.Component;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import javax.swing.JOptionPane;
 import mmcorej.CMMCore;
@@ -90,6 +92,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
    private String zStage_;
 
    private List<Datastore> stores_;
+   private final Set<Datastore> endedStores_ = new HashSet<>();
    private List<Pipeline> pipelines_;
    private SequenceSettings timeLapseSettings_ = null;
 
@@ -147,6 +150,10 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
          PositionList pl = acq.getPositionList();
          if (pl == null) {
             try {
+               // No position list for this acquisition: use the current stage position,
+               // evaluated now (at run time), not when the acquisition was added. Only XY
+               // is captured here; Z comes from the acquisition's own slice settings
+               // (see createAcqEventIterator, which uses core_.getPosition() as the Z origin).
                MultiStagePosition msp = new MultiStagePosition(studio_.core().getXYStageDevice(),
                        studio_.core().getXYStagePosition().getX(),
                        studio_.core().getXYStagePosition().getY(),
@@ -166,6 +173,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       }
       timeLapseSettings_ = basicSettings;
       stores_ = new ArrayList<>(sequenceSettings.size());
+      endedStores_.clear();
       pipelines_ = new ArrayList<>(sequenceSettings.size());
       for (int i = 0; i < sequenceSettings.size(); i++) {
          if (sequenceSettings.get(i).useCustomIntervals()) {
@@ -175,7 +183,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
          if (sequenceSettings.get(i).acqOrderMode() == AcqOrderMode.POS_TIME_CHANNEL_SLICE
                || sequenceSettings.get(i).acqOrderMode() == AcqOrderMode.POS_TIME_SLICE_CHANNEL) {
             // we only handle time first acquisitions (at least for now)
-            studio_.logs().showError("PLease select Time first for all acquisitions");
+            studio_.logs().showError("Please select Time first for all acquisitions");
             return null;
          }
          // Make sure computer can write to selected location and there is enough space to do so
@@ -197,7 +205,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
                   ReportingUtils.showMessage("Acquisition canceled.");
                   return null;
                }
-            } else if (!this.enoughDiskSpace(root)) {
+            } else if (!this.enoughDiskSpace(root, sequenceSettings.get(i))) {
                ReportingUtils.showError(
                      "Not enough space on disk to save the requested image set; "
                            + "acquisition canceled.");
@@ -479,7 +487,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       return sequenceSettings;
    }
 
-   private boolean enoughDiskSpace(File root) {
+   private boolean enoughDiskSpace(File root, SequenceSettings sequenceSettings) {
       // Need to find a file that exists to check space
       while (!root.exists()) {
          root = root.getParentFile();
@@ -488,7 +496,10 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
          }
       }
       long usableMB = root.getUsableSpace();
-      return (1.25 * getTotalMemory()) < usableMB;
+      // Use the multi-MDA overload that takes the specific acquisition's settings.
+      // The no-arg getTotalMemory() in the superclass relies on sequenceSettings_,
+      // which is never set in this adapter.
+      return (1.25 * getTotalMemory(sequenceSettings)) < usableMB;
    }
 
    private String getSource(ChannelSpec channel) {
@@ -680,27 +691,29 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
    @Override
    public boolean abortRequest() {
       if (isAcquisitionRunning()) {
-         boolean abortCancelled = false;
          String[] options = {"Abort", "Cancel"};
-         for (Datastore store : stores_) {
-            if (store != null) {
-               List<DisplayWindow> displays = studio_.displays().getDisplays((DataProvider) store);
-               Component parentComponent = null;
-               if (displays != null && !displays.isEmpty()) {
-                  parentComponent = displays.get(0).getWindow();
-               }
-               int result = JOptionPane.showOptionDialog(parentComponent,
-                       "Abort current acquisition task?",
-                       "Micro-Manager",
-                       JOptionPane.DEFAULT_OPTION,
-                       JOptionPane.QUESTION_MESSAGE, null,
-                       options, options[1]);
-               if (result != 0) {
-                  abortCancelled = true;
+         // Show a single confirmation for the whole Multi-MDA (all stores are aborted
+         // together), parented to the first available display window.
+         Component parentComponent = null;
+         if (stores_ != null) {
+            for (Datastore store : stores_) {
+               if (store != null) {
+                  List<DisplayWindow> displays =
+                        studio_.displays().getDisplays((DataProvider) store);
+                  if (displays != null && !displays.isEmpty()) {
+                     parentComponent = displays.get(0).getWindow();
+                     break;
+                  }
                }
             }
          }
-         if (!abortCancelled) {
+         int result = JOptionPane.showOptionDialog(parentComponent,
+                 "Abort current acquisition task?",
+                 "Micro-Manager",
+                 JOptionPane.DEFAULT_OPTION,
+                 JOptionPane.QUESTION_MESSAGE, null,
+                 options, options[1]);
+         if (result == 0) {
             stop(true);
             return true;
          } else {
@@ -803,10 +816,12 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
    }
 
    /**
-    * This is ignored by the Clojure engine, and also does not have any function
-    * in this engine.  Deprecate?  Do not rely on this to do anything.
+    * Sets the focus device label used for the Z-position restore at the end of the
+    * acquisition (see zStart_ / onAcquisitionEnded). Note that runAcquisition()
+    * overwrites this with core_.getFocusDevice() before each run, so callers should
+    * not rely on a value set here persisting across a run.
     *
-    * @param stageLabel Name of the focus drive to use.  Ignored.
+    * @param stageLabel Name of the focus drive to use.
     */
    public void setZStageDevice(String stageLabel) {
       zStage_ = stageLabel;
@@ -942,7 +957,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       }
 
       final int totalImages = getTotalImages(sequenceSettings);
-      final long totalMB = getTotalMemory() / (1024 * 1024);
+      final long totalMB = getTotalMemory(sequenceSettings) / (1024 * 1024);
 
       double totalDurationSec = 0;
       double interval = Math.max(sequenceSettings.intervalMs(), exposurePerTimePointMs);
@@ -1116,23 +1131,32 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
     */
    @Subscribe
    public void onAcquisitionEnded(AcquisitionEndedEvent event) {
-      if (event.getStore().equals(stores_)) {
-         // Restore original Z position and autofocus if applicable.
-         if (isFocusStageAvailable()) {
-            try {
-               core_.setPosition(zStage_, zStart_);
-               if (autofocusMethod_ != null) {
-                  autofocusMethod_.enableContinuousFocus(autofocusOn_);
-               }
-            } catch (Exception e) {
-               studio_.logs().logError(e);
-            }
-         }
-         stores_ = null;
-         pipelines_ = null;
-         currentMultiMDA_ = null;
-         studio_.events().unregisterForEvents(this);
+      // One AcquisitionEndedEvent fires per store. stores_ is the List of all stores
+      // for this Multi-MDA, so we must check membership (not equality with the List),
+      // and only tear down once every store has ended.
+      if (stores_ == null || !stores_.contains(event.getStore())) {
+         return;
       }
+      endedStores_.add(event.getStore());
+      if (endedStores_.size() < stores_.size()) {
+         return;
+      }
+      // All stores have ended: restore original Z position and autofocus if applicable.
+      if (isFocusStageAvailable()) {
+         try {
+            core_.setPosition(zStage_, zStart_);
+            if (autofocusMethod_ != null) {
+               autofocusMethod_.enableContinuousFocus(autofocusOn_);
+            }
+         } catch (Exception e) {
+            studio_.logs().logError(e);
+         }
+      }
+      stores_ = null;
+      pipelines_ = null;
+      currentMultiMDA_ = null;
+      endedStores_.clear();
+      studio_.events().unregisterForEvents(this);
    }
 
    @Subscribe

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
@@ -93,6 +93,9 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
 
    private List<Datastore> stores_;
    private final Set<Datastore> endedStores_ = new HashSet<>();
+   // Guards the ended-store bookkeeping and teardown in onAcquisitionEnded, which can
+   // be invoked concurrently for different stores on the EventBus posting thread.
+   private final Object endedStoresLock_ = new Object();
    private List<Pipeline> pipelines_;
    private SequenceSettings timeLapseSettings_ = null;
 
@@ -172,8 +175,10 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
          return null;
       }
       timeLapseSettings_ = basicSettings;
-      stores_ = new ArrayList<>(sequenceSettings.size());
-      endedStores_.clear();
+      synchronized (endedStoresLock_) {
+         stores_ = new ArrayList<>(sequenceSettings.size());
+         endedStores_.clear();
+      }
       pipelines_ = new ArrayList<>(sequenceSettings.size());
       for (int i = 0; i < sequenceSettings.size(); i++) {
          if (sequenceSettings.get(i).useCustomIntervals()) {
@@ -1133,15 +1138,27 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
    public void onAcquisitionEnded(AcquisitionEndedEvent event) {
       // One AcquisitionEndedEvent fires per store. stores_ is the List of all stores
       // for this Multi-MDA, so we must check membership (not equality with the List),
-      // and only tear down once every store has ended.
-      if (stores_ == null || !stores_.contains(event.getStore())) {
-         return;
-      }
-      endedStores_.add(event.getStore());
-      if (endedStores_.size() < stores_.size()) {
-         return;
+      // and only tear down once every store has ended. Guava's EventBus dispatches on
+      // the posting thread, so this handler can run concurrently for different stores;
+      // do the ended-store bookkeeping and the "am I the last one" decision under a lock
+      // so exactly one thread performs the teardown.
+      synchronized (endedStoresLock_) {
+         if (stores_ == null || !stores_.contains(event.getStore())) {
+            return;
+         }
+         endedStores_.add(event.getStore());
+         if (endedStores_.size() < stores_.size()) {
+            return;
+         }
+         // This thread observed the last store ending; clear shared state now so a
+         // concurrent invocation cannot also reach the teardown below.
+         stores_ = null;
+         pipelines_ = null;
+         currentMultiMDA_ = null;
+         endedStores_.clear();
       }
       // All stores have ended: restore original Z position and autofocus if applicable.
+      // Done outside the lock to avoid holding it during core/hardware calls.
       if (isFocusStageAvailable()) {
          try {
             core_.setPosition(zStage_, zStart_);
@@ -1152,10 +1169,6 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
             studio_.logs().logError(e);
          }
       }
-      stores_ = null;
-      pipelines_ = null;
-      currentMultiMDA_ = null;
-      endedStores_.clear();
       studio_.events().unregisterForEvents(this);
    }
 


### PR DESCRIPTION
MultiMDA: fix confusing behavior when use positions was not checked in the acquisition settings used in the MultiMDA.
Also persists all GUI settings and turns the run MultiMDA button into a Stop Multi MDA button while the Multi MDA is running.