### PR TITLE
Bumps AcqEngJ to 0.39.4 and reverts PR #2355.

### DIFF
--- a/buildscripts/ivy.xml
+++ b/buildscripts/ivy.xml
@@ -46,7 +46,7 @@
       <dependency org="org.micro-manager.pyjavaz" name="PyJavaZ" rev="1.0.0">
          <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
       </dependency>
-      <dependency org="org.micro-manager.acqengj" name="AcqEngJ" rev="0.39.3">
+      <dependency org="org.micro-manager.acqengj" name="AcqEngJ" rev="0.39.4">
          <exclude org="org.micro-manager.mmcorej" name="MMCoreJ"/>
       </dependency>
       <dependency org="org.micro-manager.ndviewer" name="NDViewer" rev="0.10.2">

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/MDAAcqEventModules.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/MDAAcqEventModules.java
@@ -94,6 +94,9 @@ public class MDAAcqEventModules {
                      throw new RuntimeException(e);
                   }
                }
+               if (positionList == null) {
+                  event.setStageCoordinate(Engine.getCore().getFocusDevice(), zOrigin);
+               }
                double zPos = 0.0;
 
                if (acquisitionSettings.acqOrderMode() == AcqOrderMode.POS_TIME_CHANNEL_SLICE


### PR DESCRIPTION
This seems to indeed fix issue #2352, and appears to be better in other situations. It would be highly beneficial to have more automated tests for different acquisition scenarios.

Closes issue #2360.