### PR TITLE
Acquisition Engine tests.  Adds a number of different tests

### DIFF
--- a/systemtest/AcqEngineTests/.gitignore
+++ b/systemtest/AcqEngineTests/.gitignore
@@ -1,0 +1,9 @@
+# Runtime artifacts written into this directory when the tests run.
+# These regenerate on every run and must not be committed.
+
+# Temp files dropped by the Ant <junit> forked-JVM runner
+junit*.properties
+junitvmwatcher*.properties
+
+# CoreLog files written by MMStudio/CMMCore during a test run
+CoreLogs/

--- a/systemtest/AcqEngineTests/build.xml
+++ b/systemtest/AcqEngineTests/build.xml
@@ -8,12 +8,16 @@
 
 		These tests reuse the image-decoding helpers (TestImageDecoder,
 		TaggedImageDecoder) from the SequenceTests module rather than
-		duplicating them. SequenceTests must therefore be compiled first; its
-		compiled test classes are added to our test classpath below.
+		duplicating them. We compile the SequenceTests 'testing' helper sources
+		together with our own test sources (see the test-only override below).
+		This keeps the build self-contained and works on both the Windows (Ant)
+		and Unix (Autotools) builds. Referencing SequenceTests' compiled output
+		dir would not, because that dir only exists under the Windows build
+		properties.
 	-->
 
-	<property name="seqtests.test.intdir"
-		location="${mm.java.test.intdir}/SequenceTester"/>
+	<property name="seqtests.testdir"
+		location="../SequenceTests/src/test/java"/>
 
 	<path id="project.classpath">
 		<path refid="mm.compile.classpath"/>
@@ -24,20 +28,25 @@
 
 	<path id="project.test.classpath">
 		<path refid="mm.test.classpath"/>
-		<!-- Reuse TestImageDecoder / TaggedImageDecoder from SequenceTests -->
-		<pathelement location="${seqtests.test.intdir}"/>
 	</path>
 
 	<!--
-		Override the shared 'test-only' target. Unlike the unit tests, these
-		integration tests instantiate a full MMStudio, which builds Swing
-		components (Background frames, etc.) and therefore CANNOT run with
-		java.awt.headless=true. We run non-headless instead. On a headless CI
-		host this requires a virtual display (e.g. Xvfb on Linux).
+		Override the shared 'test-only' target. Two reasons:
+		1. Unlike the unit tests, these integration tests instantiate a full
+		   MMStudio, which builds Swing components (Background frames, etc.) and
+		   therefore CANNOT run with java.awt.headless=true. We run non-headless
+		   instead. On a headless CI host this requires a virtual display (e.g.
+		   Xvfb on Linux).
+		2. We compile the SequenceTests 'testing' helper package alongside our
+		   own test sources so the shared image decoders are available without
+		   depending on SequenceTests having been built first.
 	-->
 	<target name="test-only" if="has.tests" unless="mm.java.disable.build">
 		<mkdir dir="${test.intdir}"/>
-		<mm-javac srcdir="${testdir}" destdir="${test.intdir}">
+		<mm-javac destdir="${test.intdir}">
+			<src path="${testdir}"/>
+			<!-- Shared helpers (TestImageDecoder, TaggedImageDecoder, ...). -->
+			<src path="${seqtests.testdir}"/>
 			<classpath refid="project.test.classpath"/>
 		</mm-javac>
 		<copy todir="${test.intdir}">

--- a/systemtest/AcqEngineTests/build.xml
+++ b/systemtest/AcqEngineTests/build.xml
@@ -1,0 +1,65 @@
+<project name="AcqEngineTester" basedir="." default="jar">
+	<import file="../../buildscripts/javabuild.xml"/>
+
+	<!--
+		Integration tests that drive the two high-level acquisition engines
+		(AcqEngJAdapter and the legacy AcquisitionWrapperEngine) through a
+		headless MMStudio against the SequenceTester device adapter.
+
+		These tests reuse the image-decoding helpers (TestImageDecoder,
+		TaggedImageDecoder) from the SequenceTests module rather than
+		duplicating them. SequenceTests must therefore be compiled first; its
+		compiled test classes are added to our test classpath below.
+	-->
+
+	<property name="seqtests.test.intdir"
+		location="${mm.java.test.intdir}/SequenceTester"/>
+
+	<path id="project.classpath">
+		<path refid="mm.compile.classpath"/>
+		<pathelement location="${mm.java.lib.acq-engine}"/>
+		<pathelement location="${mm.java.lib.mmcorej}"/>
+		<pathelement location="${mm.java.lib.mmstudio}"/>
+	</path>
+
+	<path id="project.test.classpath">
+		<path refid="mm.test.classpath"/>
+		<!-- Reuse TestImageDecoder / TaggedImageDecoder from SequenceTests -->
+		<pathelement location="${seqtests.test.intdir}"/>
+	</path>
+
+	<!--
+		Override the shared 'test-only' target. Unlike the unit tests, these
+		integration tests instantiate a full MMStudio, which builds Swing
+		components (Background frames, etc.) and therefore CANNOT run with
+		java.awt.headless=true. We run non-headless instead. On a headless CI
+		host this requires a virtual display (e.g. Xvfb on Linux).
+	-->
+	<target name="test-only" if="has.tests" unless="mm.java.disable.build">
+		<mkdir dir="${test.intdir}"/>
+		<mm-javac srcdir="${testdir}" destdir="${test.intdir}">
+			<classpath refid="project.test.classpath"/>
+		</mm-javac>
+		<copy todir="${test.intdir}">
+			<fileset dir="${testrscdir}" erroronmissingdir="false"/>
+		</copy>
+		<mkdir dir="${test.reportdir}"/>
+		<junit fork="true" haltonfailure="true" printsummary="true"
+			maxmemory="512m" failureproperty="mm.build.test.failed">
+			<sysproperty key="java.awt.headless" value="false"/>
+			<classpath refid="project.test.classpath"/>
+			<formatter type="plain"/>
+			<test if="test.class" name="${test.class}"
+				todir="${test.reportdir}"/>
+			<batchtest unless="test.class" todir="${test.reportdir}">
+				<fileset dir="${testdir}">
+					<include name="**/*.java"/>
+					<exclude name="**/StudioTestFixture.java"/>
+					<exclude name="**/AcqResult.java"/>
+					<exclude name="**/TestAutofocusPlugin.java"/>
+				</fileset>
+			</batchtest>
+		</junit>
+		<fail if="mm.build.test.failed"/>
+	</target>
+</project>

--- a/systemtest/AcqEngineTests/readme.txt
+++ b/systemtest/AcqEngineTests/readme.txt
@@ -72,8 +72,12 @@ test-only compiles and runs the tests directly. Reports are written to
 build/JavaTestReports/AcqEngineTester/; a failure fails the ant build.
 
 These tests reuse the image decoder (TestImageDecoder/TaggedImageDecoder) from
-the SequenceTests module, so its test classes are added to the classpath in
-build.xml; SequenceTests is therefore compiled as part of this run.
+the SequenceTests module. The test-only target in build.xml compiles the
+SequenceTests "testing" helper sources together with our own test sources (it
+adds ../SequenceTests/src/test/java as a second source root), so the helpers are
+always available and you do NOT need to build SequenceTests first. This also
+works on the Unix build, which does not define the Windows-only intermediate
+output directories.
 
 
 Notes and gotchas

--- a/systemtest/AcqEngineTests/readme.txt
+++ b/systemtest/AcqEngineTests/readme.txt
@@ -1,0 +1,103 @@
+AcqEngineTests: integration tests for the two acquisition engines
+==================================================================
+
+These tests drive Micro-Manager's two high-level acquisition engines -- the
+modern AcqEngJ (AcqEngJAdapter) and the legacy Clojure engine
+(AcquisitionWrapperEngine) -- through the public API
+(studio.acquisitions().runAcquisitionWithSettings(...)) and verify the result.
+
+Unlike the sibling SequenceTests module, which exercises the raw
+AcquisitionEngine2010 directly, these tests boot a real (headless-ish) MMStudio
+and toggle settings().setShouldUseAcqEngJ(...) so each scenario is run through
+BOTH engines, exactly as a user would hit them from the MDA dialog.
+
+Hardware comes from the SequenceTester device adapter (see
+DeviceAdapters/SequenceTester): a virtual camera whose images encode the full
+state and set-history of all SequenceTester devices. We decode that embedded
+"InfoPacket" from each image in the resulting Datastore to assert not just the
+number/coordinates of images, but also that the right hardware moved (e.g. Z set
+per slice, channel switcher moved, autofocus ran on the expected frames).
+
+
+What is covered
+---------------
+Each scenario is parameterized over both engines (acqEngJ = {false, true}):
+
+  SmokeTest         boot + a time-lapse on each engine
+  ChannelsTest      multi-channel: count/coords, switcher position per channel
+  ZStackTest        z-stack count + Z moves; channel-only Z handling
+  TimeLapseTest     fixed and custom intervals, frame ordering
+  MultiPositionTest position list: per-position images, XY moves, P/T ordering
+  SequencedTest     hardware-triggered channel bursts vs. software (non-seq.)
+  AutofocusTest     autofocus per frame and skipAutofocusCount
+  CombinedTest      full channels x time x z (x positions) cross-axis MDAs
+
+Some scenarios assert engine-aware behavior where the two engines legitimately
+differ (documented inline): the channel-only Z-stack handling and the
+interpretation of skipAutofocusCount.
+
+
+How to run
+----------
+Prerequisite: the native libraries must be built and current (matching device
+interface version). In a normal build, mmCoreAndDevices is a subdirectory of the
+micro-manager source tree, and the DLLs end up in
+mmCoreAndDevices/build/Release/x64 -- which is ../../mmCoreAndDevices/build/Release/x64
+relative to this module. You need there:
+  - MMCoreJ_wrap.dll              (the Core JNI library)
+  - mmgr_dal_SequenceTester.dll   (the test device adapter)
+If you change C++ (or the interface version bumps), rebuild MMCoreJ_wrap and the
+SequenceTester adapter in Visual Studio first.
+
+Set two environment variables to the directory holding those DLLs, then run ant
+from THIS directory. The paths below are relative to this module directory; both
+variables point to the same folder. (For a Debug build, swap Release -> Debug.)
+
+  Git Bash:
+    cd systemtest/AcqEngineTests
+    export MMCOREJ_LIBRARY_PATH="../../mmCoreAndDevices/build/Release/x64"
+    export MMTEST_ADAPTER_PATH="../../mmCoreAndDevices/build/Release/x64"
+    ant test-only
+    ant test-only -Dtest.class=org.micromanager.acqenginetests.ChannelsTest
+
+  PowerShell:
+    cd systemtest\AcqEngineTests
+    $env:MMCOREJ_LIBRARY_PATH = "..\..\mmCoreAndDevices\build\Release\x64"
+    $env:MMTEST_ADAPTER_PATH  = "..\..\mmCoreAndDevices\build\Release\x64"
+    ant test-only
+    ant test-only -Dtest.class=org.micromanager.acqenginetests.ChannelsTest
+
+Use the "test-only" target (not "test"): there is no src/main/java to jar, and
+test-only compiles and runs the tests directly. Reports are written to
+build/JavaTestReports/AcqEngineTester/; a failure fails the ant build.
+
+These tests reuse the image decoder (TestImageDecoder/TaggedImageDecoder) from
+the SequenceTests module, so its test classes are added to the classpath in
+build.xml; SequenceTests is therefore compiled as part of this run.
+
+
+Notes and gotchas
+-----------------
+- NOT headless. MMStudio builds Swing components, so build.xml overrides the
+  shared test target to run with java.awt.headless=false. A window will flash up
+  briefly during the run -- that is expected; do not close it. On a headless CI
+  host this needs a virtual display (e.g. Xvfb on Linux).
+
+- First run of each test class is slower (~20 s). The legacy Clojure engine
+  cold-starts (JIT + namespace loading) on first use; the fixture runs one
+  throwaway "warm-up" acquisition so that cost is paid before the asserted
+  tests. After warm-up each test is a few seconds. A full module run takes a
+  few minutes because each test class forks its own JVM and warms up once.
+
+- Do not wrap the command in an external "timeout": killing the JVM mid-run
+  produces confusing "Forked Java VM exited abnormally" results. Just let it run.
+
+- Rare startup hang: MMStudio construction can occasionally wedge the EDT at
+  startup (a demo-config/Background init race, before the test code runs). It is
+  intermittent and isolated to one forked JVM; kill the stuck java.exe and
+  re-run -- it passes on retry.
+
+- There is intentionally no engine-equivalence test (running both engines
+  back-to-back in one method). The legacy Clojure engine is too unstable under
+  rapid repeated programmatic acquisition to compare deterministically; instead,
+  every scenario above runs and asserts on both engines individually.

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/AcqResult.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/AcqResult.java
@@ -36,11 +36,16 @@ public final class AcqResult {
     * early can miss the last image(s). Wait (bounded) for the store to freeze.
     */
    private static void waitUntilFrozen(Datastore store) {
-      final long deadline = System.currentTimeMillis() + 10_000L;
+      final long timeoutMs = 10_000L;
+      final long deadline = System.currentTimeMillis() + timeoutMs;
       try {
          while (!store.isFrozen() && System.currentTimeMillis() < deadline) {
             Thread.sleep(10);
          }
+         // Fail fast rather than reading counts/coords while the sink thread is
+         // still writing -- a silent timeout would make assertions flaky.
+         assertTrue("Datastore did not freeze within " + timeoutMs
+               + " ms after the acquisition returned", store.isFrozen());
          // Give any final in-flight image a moment to be added after freeze.
          Thread.sleep(50);
       } catch (InterruptedException e) {
@@ -120,8 +125,7 @@ public final class AcqResult {
    public List<InfoPacket> infoPackets() throws IOException {
       List<InfoPacket> packets = new ArrayList<>();
       for (Coords c : store_.getUnorderedImageCoords()) {
-         Image img = store_.getImage(c);
-         packets.add(TestImageDecoder.decode((byte[]) img.getRawPixels()));
+         packets.add(infoPacketAt(c));
       }
       return packets;
    }

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/AcqResult.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/AcqResult.java
@@ -1,0 +1,159 @@
+package org.micromanager.acqenginetests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.micromanager.data.Coords;
+import org.micromanager.data.Datastore;
+import org.micromanager.data.Image;
+import org.micromanager.testing.TestImageDecoder;
+import org.micromanager.testing.TestImageDecoder.InfoPacket;
+
+/**
+ * Convenience wrapper around the frozen {@link Datastore} returned by an
+ * acquisition, with assertions tailored to the SequenceTester-backed engine
+ * tests.
+ */
+public final class AcqResult {
+   private final Datastore store_;
+
+   public AcqResult(Datastore store) {
+      assertNotNull("Acquisition returned a null Datastore", store);
+      store_ = store;
+      waitUntilFrozen(store);
+   }
+
+   /**
+    * runAcquisitionWithSettings(..., true) blocks until the acquisition ENGINE
+    * finishes, but the images flow to the Datastore on a separate sink thread
+    * and the store is frozen slightly afterwards. Reading the image count too
+    * early can miss the last image(s). Wait (bounded) for the store to freeze.
+    */
+   private static void waitUntilFrozen(Datastore store) {
+      final long deadline = System.currentTimeMillis() + 10_000L;
+      try {
+         while (!store.isFrozen() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+         }
+         // Give any final in-flight image a moment to be added after freeze.
+         Thread.sleep(50);
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+      }
+   }
+
+   public Datastore store() {
+      return store_;
+   }
+
+   public int numImages() {
+      return store_.getNumImages();
+   }
+
+   /** Number of indices used along an axis (Coords.CHANNEL, .Z, .T, .P). */
+   public int axisLength(String axis) {
+      return store_.getNextIndex(axis);
+   }
+
+   public List<String> axes() {
+      return store_.getAxes();
+   }
+
+   /**
+    * Asserts that exactly the expected hyper-rectangle of coordinates is
+    * present: one image for every (frame, channel, slice, position) in range,
+    * no missing coordinates and no duplicates / extras.
+    *
+    * <p>Pass 1 for any axis that is not used (a single index at 0).
+    */
+   public void assertHasAllCoords(int frames, int channels, int slices,
+                                  int positions) throws IOException {
+      assertEquals("total image count",
+            frames * channels * slices * positions, numImages());
+
+      Set<Coords> seen = new HashSet<>();
+      for (Coords c : store_.getUnorderedImageCoords()) {
+         assertTrue("duplicate coords: " + c, seen.add(c));
+      }
+      assertEquals("unique image count", numImages(), seen.size());
+
+      // The engine omits value-0 singleton axes (DefaultCoords gotcha), so we
+      // match by per-axis index (treating an absent axis as index 0) rather
+      // than building an exact Coords and calling getImage().
+      for (int t = 0; t < frames; t++) {
+         for (int ch = 0; ch < channels; ch++) {
+            for (int z = 0; z < slices; z++) {
+               for (int p = 0; p < positions; p++) {
+                  assertTrue("missing expected coords " + describe(t, ch, z, p),
+                        hasImageAt(t, ch, z, p));
+               }
+            }
+         }
+      }
+   }
+
+   private boolean hasImageAt(int t, int ch, int z, int p) {
+      for (Coords c : store_.getUnorderedImageCoords()) {
+         if (idx(c, Coords.T) == t && idx(c, Coords.CHANNEL) == ch
+               && idx(c, Coords.Z) == z && idx(c, Coords.P) == p) {
+            return true;
+         }
+      }
+      return false;
+   }
+
+   private static int idx(Coords c, String axis) {
+      return c.hasAxis(axis) ? c.getIndex(axis) : 0;
+   }
+
+   private static String describe(int t, int ch, int z, int p) {
+      return "t=" + t + " ch=" + ch + " z=" + z + " p=" + p;
+   }
+
+   /** Decodes the SequenceTester InfoPacket embedded in every image. */
+   public List<InfoPacket> infoPackets() throws IOException {
+      List<InfoPacket> packets = new ArrayList<>();
+      for (Coords c : store_.getUnorderedImageCoords()) {
+         Image img = store_.getImage(c);
+         packets.add(TestImageDecoder.decode((byte[]) img.getRawPixels()));
+      }
+      return packets;
+   }
+
+   /** The InfoPacket for one specific coordinate. */
+   public InfoPacket infoPacketAt(Coords c) throws IOException {
+      Image img = store_.getImage(c);
+      assertNotNull("no image at " + c, img);
+      return TestImageDecoder.decode((byte[]) img.getRawPixels());
+   }
+
+   /**
+    * Reads the value of a device setting from a packet's {@code currentState}
+    * (the full device state captured at the moment the image was produced).
+    *
+    * @return the value as a String, or null if the device/key is not present
+    */
+   public static String currentStateString(InfoPacket p, String device,
+                                            String key) throws IOException {
+      for (TestImageDecoder.SettingState s : p.currentState) {
+         if (s.key.device.equals(device) && s.key.key.equals(key)) {
+            // SettingValue carries a type tag; render whatever it holds.
+            if ("string".equals(s.value.type)) {
+               return s.value.asString();
+            } else if ("int".equals(s.value.type)) {
+               return Long.toString(s.value.asInteger());
+            } else if ("float".equals(s.value.type)) {
+               return Double.toString(s.value.asDouble());
+            }
+            return String.valueOf(s.value.value);
+         }
+      }
+      return null;
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/AutofocusTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/AutofocusTest.java
@@ -1,0 +1,130 @@
+package org.micromanager.acqenginetests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.data.Datastore;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.testing.TestImageDecoder.InfoPacket;
+
+/**
+ * Autofocus acquisition tests, run through both engines.
+ *
+ * <p>A {@link TestAutofocusPlugin} is injected as the active autofocus method;
+ * its fullFocus() drives the SequenceTester TAutofocus device, which records a
+ * "FullFocus" one-shot in the image InfoPacket. The plugin also counts its own
+ * invocations, so we can assert that autofocus ran on the expected frames and
+ * was skipped otherwise.
+ */
+@RunWith(Parameterized.class)
+public class AutofocusTest {
+   private static StudioTestFixture fixture_;
+   private TestAutofocusPlugin afPlugin_;
+
+   @Parameterized.Parameter
+   public boolean useAcqEngJ_;
+
+   @Parameterized.Parameters(name = "acqEngJ={0}")
+   public static List<Object[]> engines() {
+      return Arrays.asList(new Object[]{false}, new Object[]{true});
+   }
+
+   @BeforeClass
+   public static void boot() {
+      fixture_ = StudioTestFixture.getInstance();
+   }
+
+   @Before
+   public void setUp() throws Exception {
+      fixture_.reset();
+      fixture_.useAcqEngJ(useAcqEngJ_);
+
+      // Make TAutofocus the Core's autofocus device and inject our plugin as the
+      // active autofocus method.
+      MMStudio studio = fixture_.getStudio();
+      studio.core().setAutoFocusDevice("TAutofocus");
+      afPlugin_ = new TestAutofocusPlugin();
+      afPlugin_.setContext(studio);
+      studio.getAutofocusManager().setAutofocusMethod(afPlugin_);
+      StudioTestFixture.drainEdt();
+   }
+
+   @Test
+   public void autofocusRunsEveryFrame() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+      afPlugin_.resetCount();
+
+      final int numFrames = 4;
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(numFrames)
+            .intervalMs(1.0)
+            .useAutofocus(true)
+            .skipAutofocusCount(0)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+      result.assertHasAllCoords(numFrames, 1, 1, 1);
+
+      // Autofocus should run once per frame.
+      assertEquals("autofocus should run on every frame",
+            numFrames, afPlugin_.getFullFocusCount());
+
+      // And the TAutofocus device should have its FullFocus recorded.
+      boolean anyFullFocus = false;
+      for (InfoPacket p : result.infoPackets()) {
+         if (p.hasBeenSetSincePreviousPacket("TAutofocus", "FullFocus")) {
+            anyFullFocus = true;
+         }
+      }
+      assertTrue("TAutofocus FullFocus should appear in the image history",
+            anyFullFocus);
+   }
+
+   @Test
+   public void skipAutofocusCountReducesRuns() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+      afPlugin_.resetCount();
+
+      // NOTE on engine semantics of skipAutofocusCount:
+      //   AcqEngJ skips a frame when (tIndex % skipAutofocusCount != 0), so
+      //   skip=N means "autofocus every Nth frame" and skip=1 means EVERY frame.
+      //   The legacy engine interprets the value differently. To assert a
+      //   reduction that holds on both engines, use skip=2: AcqEngJ then runs on
+      //   frames 0 and 2 (2 of 6), and the legacy engine likewise runs less than
+      //   every frame.
+      final int numFrames = 6;
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(numFrames)
+            .intervalMs(1.0)
+            .useAutofocus(true)
+            .skipAutofocusCount(2)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+      result.assertHasAllCoords(numFrames, 1, 1, 1);
+
+      int runs = afPlugin_.getFullFocusCount();
+      assertTrue("autofocus should run at least once but fewer than every frame "
+                  + "when skipping (skip=2, frames=" + numFrames + ", was "
+                  + runs + ")",
+            runs >= 1 && runs < numFrames);
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/ChannelsTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/ChannelsTest.java
@@ -1,0 +1,127 @@
+package org.micromanager.acqenginetests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.micromanager.acquisition.ChannelSpec;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.data.Coords;
+import org.micromanager.data.Datastore;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.testing.TestImageDecoder.InfoPacket;
+
+/**
+ * Multi-channel acquisition tests, run through both engines.
+ *
+ * <p>Parameterized over {@code useAcqEngJ = {false, true}} so every scenario is
+ * exercised on both the legacy Clojure engine and AcqEngJ.
+ */
+@RunWith(Parameterized.class)
+public class ChannelsTest {
+   private static final String GROUP = "Channel";
+   private static StudioTestFixture fixture_;
+
+   @Parameterized.Parameter
+   public boolean useAcqEngJ_;
+
+   @Parameterized.Parameters(name = "acqEngJ={0}")
+   public static List<Object[]> engines() {
+      return Arrays.asList(new Object[]{false}, new Object[]{true});
+   }
+
+   @BeforeClass
+   public static void boot() {
+      fixture_ = StudioTestFixture.getInstance();
+   }
+
+   @Before
+   public void setUp() throws Exception {
+      fixture_.reset();
+      fixture_.defineChannelGroup(GROUP, "Ch0", "Ch1", "Ch2");
+      fixture_.useAcqEngJ(useAcqEngJ_);
+   }
+
+   @Test
+   public void threeChannelsProduceThreeImages() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      ArrayList<ChannelSpec> channels = new ArrayList<>(Arrays.asList(
+            fixture_.channel(GROUP, "Ch0", 1.0),
+            fixture_.channel(GROUP, "Ch1", 1.0),
+            fixture_.channel(GROUP, "Ch2", 1.0)));
+
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useChannels(true)
+            .channelGroup(GROUP)
+            .channels(channels)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+
+      // frames=1, channels=3, slices=1, positions=1
+      result.assertHasAllCoords(1, 3, 1, 1);
+      assertEquals("channel axis length", 3, result.axisLength(Coords.CHANNEL));
+
+      // Every image should carry a decodable InfoPacket from TCamera.
+      for (InfoPacket p : result.infoPackets()) {
+         assertEquals("TCamera", p.camera.name);
+      }
+   }
+
+   @Test
+   public void channelSwitcherIsSetForEachChannel() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      ArrayList<ChannelSpec> channels = new ArrayList<>(Arrays.asList(
+            fixture_.channel(GROUP, "Ch0", 1.0),
+            fixture_.channel(GROUP, "Ch1", 1.0)));
+
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useChannels(true)
+            .channelGroup(GROUP)
+            .channels(channels)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+      result.assertHasAllCoords(1, 2, 1, 1);
+
+      // The two channel images must have been captured with the TSwitcher in
+      // two different positions (Ch0 -> 0, Ch1 -> 1). The MM "State" property of
+      // TSwitcher is backed by the internal "Position" setting (see
+      // TesterSwitcher::Initialize), so that is the key recorded in the packet.
+      String ch0Pos = AcqResult.currentStateString(
+            channelPacket(result, 0), "TSwitcher", "Position");
+      String ch1Pos = AcqResult.currentStateString(
+            channelPacket(result, 1), "TSwitcher", "Position");
+      assertEquals("0", ch0Pos);
+      assertEquals("1", ch1Pos);
+   }
+
+   /** The InfoPacket of the image at the given channel index (z=t=p=0). */
+   private static InfoPacket channelPacket(AcqResult result, int channel)
+         throws java.io.IOException {
+      for (Coords c : result.store().getUnorderedImageCoords()) {
+         int ch = c.hasAxis(Coords.CHANNEL) ? c.getIndex(Coords.CHANNEL) : 0;
+         if (ch == channel) {
+            return result.infoPacketAt(c);
+         }
+      }
+      throw new IllegalStateException("no image for channel " + channel);
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/CombinedTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/CombinedTest.java
@@ -1,0 +1,128 @@
+package org.micromanager.acqenginetests;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.micromanager.MultiStagePosition;
+import org.micromanager.PositionList;
+import org.micromanager.StagePosition;
+import org.micromanager.acquisition.ChannelSpec;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.internal.utils.AcqOrderMode;
+
+/**
+ * Full multi-axis MDAs combining channels, Z, time and positions, run through
+ * both engines. These catch cross-axis interaction bugs (the class of issue
+ * behind #2352), where the number/coordinates of images come out wrong only
+ * when several axes are combined.
+ */
+@RunWith(Parameterized.class)
+public class CombinedTest {
+   private static final String GROUP = "Channel";
+   private static StudioTestFixture fixture_;
+
+   @Parameterized.Parameter
+   public boolean useAcqEngJ_;
+
+   @Parameterized.Parameters(name = "acqEngJ={0}")
+   public static List<Object[]> engines() {
+      return Arrays.asList(new Object[]{false}, new Object[]{true});
+   }
+
+   @BeforeClass
+   public static void boot() {
+      fixture_ = StudioTestFixture.getInstance();
+   }
+
+   @Before
+   public void setUp() throws Exception {
+      fixture_.reset();
+      fixture_.defineChannelGroup(GROUP, "Ch0", "Ch1");
+      fixture_.useAcqEngJ(useAcqEngJ_);
+   }
+
+   private ArrayList<ChannelSpec> twoChannels() {
+      return new ArrayList<>(Arrays.asList(
+            fixture_.channel(GROUP, "Ch0", 1.0),
+            fixture_.channel(GROUP, "Ch1", 1.0)));
+   }
+
+   @Test
+   public void channelsTimeZStack() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      final int numFrames = 2;
+      final int numChannels = 2;
+      final int numSlices = 3;  // bottom 0, top 2, step 1
+
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(numFrames)
+            .intervalMs(1.0)
+            .useChannels(true)
+            .channelGroup(GROUP)
+            .channels(twoChannels())
+            .useSlices(true)
+            .sliceZBottomUm(0.0)
+            .sliceZTopUm(2.0)
+            .sliceZStepUm(1.0)
+            .relativeZSlice(true)
+            .acqOrderMode(AcqOrderMode.TIME_POS_SLICE_CHANNEL)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      AcqResult result = new AcqResult(
+            studio.acquisitions().runAcquisitionWithSettings(settings, true));
+
+      result.assertHasAllCoords(numFrames, numChannels, numSlices, 1);
+   }
+
+   @Test
+   public void channelsTimeZStackPositions() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      PositionList pl = new PositionList();
+      for (int i = 0; i < 2; i++) {
+         MultiStagePosition msp = new MultiStagePosition();
+         msp.setLabel("Pos" + i);
+         msp.add(StagePosition.create2D("TXYStage", 100.0 * i, 0.0));
+         pl.addPosition(msp);
+      }
+      fixture_.setPositionList(pl);
+
+      final int numFrames = 2;
+      final int numChannels = 2;
+      final int numSlices = 2;  // bottom 0, top 1, step 1
+      final int numPositions = 2;
+
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(numFrames)
+            .intervalMs(1.0)
+            .useChannels(true)
+            .channelGroup(GROUP)
+            .channels(twoChannels())
+            .useSlices(true)
+            .sliceZBottomUm(0.0)
+            .sliceZTopUm(1.0)
+            .sliceZStepUm(1.0)
+            .relativeZSlice(true)
+            .usePositionList(true)
+            .acqOrderMode(AcqOrderMode.POS_TIME_SLICE_CHANNEL)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      AcqResult result = new AcqResult(
+            studio.acquisitions().runAcquisitionWithSettings(settings, true));
+
+      result.assertHasAllCoords(numFrames, numChannels, numSlices, numPositions);
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/MultiPositionTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/MultiPositionTest.java
@@ -1,0 +1,143 @@
+package org.micromanager.acqenginetests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.micromanager.MultiStagePosition;
+import org.micromanager.PositionList;
+import org.micromanager.StagePosition;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.data.Coords;
+import org.micromanager.data.Datastore;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.internal.utils.AcqOrderMode;
+import org.micromanager.testing.TestImageDecoder.InfoPacket;
+
+/**
+ * Multi-position acquisition tests, run through both engines.
+ */
+@RunWith(Parameterized.class)
+public class MultiPositionTest {
+   private static StudioTestFixture fixture_;
+
+   @Parameterized.Parameter
+   public boolean useAcqEngJ_;
+
+   @Parameterized.Parameters(name = "acqEngJ={0}")
+   public static List<Object[]> engines() {
+      return Arrays.asList(new Object[]{false}, new Object[]{true});
+   }
+
+   @BeforeClass
+   public static void boot() {
+      fixture_ = StudioTestFixture.getInstance();
+   }
+
+   @Before
+   public void setUp() throws Exception {
+      fixture_.reset();
+      fixture_.useAcqEngJ(useAcqEngJ_);
+   }
+
+   /** Builds a position list with the given XY coordinates on TXYStage. */
+   private PositionList makePositionList(double[][] xys) {
+      PositionList pl = new PositionList();
+      for (int i = 0; i < xys.length; i++) {
+         MultiStagePosition msp = new MultiStagePosition();
+         msp.setLabel("Pos" + i);
+         msp.add(StagePosition.create2D("TXYStage", xys[i][0], xys[i][1]));
+         pl.addPosition(msp);
+      }
+      return pl;
+   }
+
+   @Test
+   public void onePositionPerListEntry() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+      PositionList pl = makePositionList(new double[][]{
+            {0.0, 0.0}, {100.0, 0.0}, {100.0, 100.0}});
+      fixture_.setPositionList(pl);
+
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .usePositionList(true)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+
+      // frames=1, channels=1, slices=1, positions=3
+      result.assertHasAllCoords(1, 1, 1, 3);
+      assertEquals("position axis length", 3, result.axisLength(Coords.P));
+   }
+
+   @Test
+   public void xyStageMovedForEachPosition() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+      PositionList pl = makePositionList(new double[][]{
+            {0.0, 0.0}, {100.0, 200.0}});
+      fixture_.setPositionList(pl);
+
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .usePositionList(true)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+      result.assertHasAllCoords(1, 1, 1, 2);
+
+      // The two position images must have been captured at two distinct XY
+      // stage positions.
+      Set<String> xyByPosition = new HashSet<>();
+      for (Coords c : store.getUnorderedImageCoords()) {
+         InfoPacket p = result.infoPacketAt(c);
+         String x = AcqResult.currentStateString(p, "TXYStage", "XPositionSteps");
+         String y = AcqResult.currentStateString(p, "TXYStage", "YPositionSteps");
+         xyByPosition.add(x + "," + y);
+      }
+      assertEquals("each position should have a distinct XY stage position",
+            2, xyByPosition.size());
+   }
+
+   @Test
+   public void positionTimeOrderingProducesAllImages() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+      PositionList pl = makePositionList(new double[][]{
+            {0.0, 0.0}, {50.0, 50.0}});
+      fixture_.setPositionList(pl);
+
+      // 2 positions x 2 frames, position-major ordering.
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .usePositionList(true)
+            .useFrames(true)
+            .numFrames(2)
+            .intervalMs(1.0)
+            .acqOrderMode(AcqOrderMode.POS_TIME_CHANNEL_SLICE)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+
+      // frames=2, channels=1, slices=1, positions=2 -> 4 images
+      result.assertHasAllCoords(2, 1, 1, 2);
+      assertTrue("position axis present", result.axisLength(Coords.P) == 2);
+      assertTrue("time axis present", result.axisLength(Coords.T) == 2);
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/SequencedTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/SequencedTest.java
@@ -91,7 +91,7 @@ public class SequencedTest {
       studio.core().setProperty("TSwitcher", "TriggerSourcePort",
             "ExposureStartEdge");
       studio.core().setProperty("TSwitcher", "TriggerSequenceMaxLength", 2);
-      fixture_.drainEdt();
+      StudioTestFixture.drainEdt();
 
       SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
             .useChannels(true)

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/SequencedTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/SequencedTest.java
@@ -1,0 +1,123 @@
+package org.micromanager.acqenginetests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.micromanager.acquisition.ChannelSpec;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.data.Datastore;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.testing.TestImageDecoder.InfoPacket;
+
+/**
+ * Hardware-sequenced (triggered) vs. software (non-sequenced) channel
+ * acquisitions, run through both engines.
+ *
+ * <p>When the channel switcher is wired to be triggered by the camera, the
+ * engine should run the channels as a hardware sequence (burst), which the
+ * SequenceTester camera records as {@code isSequence == true}. Without that
+ * wiring, each image is acquired individually ({@code isSequence == false}).
+ */
+@RunWith(Parameterized.class)
+public class SequencedTest {
+   private static final String GROUP = "Channel";
+   private static StudioTestFixture fixture_;
+
+   @Parameterized.Parameter
+   public boolean useAcqEngJ_;
+
+   @Parameterized.Parameters(name = "acqEngJ={0}")
+   public static List<Object[]> engines() {
+      return Arrays.asList(new Object[]{false}, new Object[]{true});
+   }
+
+   @BeforeClass
+   public static void boot() {
+      fixture_ = StudioTestFixture.getInstance();
+   }
+
+   @Before
+   public void setUp() throws Exception {
+      fixture_.reset();
+      fixture_.defineChannelGroup(GROUP, "Ch0", "Ch1");
+      fixture_.useAcqEngJ(useAcqEngJ_);
+   }
+
+   private ArrayList<ChannelSpec> twoChannels(double exposureMs) {
+      return new ArrayList<>(Arrays.asList(
+            fixture_.channel(GROUP, "Ch0", exposureMs),
+            fixture_.channel(GROUP, "Ch1", exposureMs)));
+   }
+
+   @Test
+   public void nonSequencedChannelsAreNotABurst() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useChannels(true)
+            .channelGroup(GROUP)
+            .channels(twoChannels(1.0))
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+      result.assertHasAllCoords(1, 2, 1, 1);
+
+      for (InfoPacket p : result.infoPackets()) {
+         assertFalse("channels without trigger wiring should not be a sequence",
+               p.camera.isSequence);
+      }
+   }
+
+   @Test
+   public void triggeredChannelsRunAsHardwareSequence() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      // Wire the switcher to be triggered by the camera's exposure, so the
+      // engine can drive the channel change as a hardware sequence.
+      studio.core().setProperty("TSwitcher", "TriggerSourceDevice", "TCamera");
+      studio.core().setProperty("TSwitcher", "TriggerSourcePort",
+            "ExposureStartEdge");
+      studio.core().setProperty("TSwitcher", "TriggerSequenceMaxLength", 2);
+      fixture_.drainEdt();
+
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useChannels(true)
+            .channelGroup(GROUP)
+            // Long enough interval that the engine is free to sequence channels.
+            .channels(twoChannels(1.0))
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+      result.assertHasAllCoords(1, 2, 1, 1);
+
+      // At least one image should report being part of a camera sequence, and
+      // the per-frame numbers within the burst should be 0 and 1.
+      boolean anySequence = false;
+      for (InfoPacket p : result.infoPackets()) {
+         if (p.camera.isSequence) {
+            anySequence = true;
+            assertTrue("sequence frame number in range",
+                  p.camera.frameNr == 0 || p.camera.frameNr == 1);
+         }
+      }
+      assertTrue("triggered channels should run as a hardware sequence on at "
+            + "least one engine path", anySequence);
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/SmokeTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/SmokeTest.java
@@ -1,0 +1,103 @@
+package org.micromanager.acqenginetests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.data.Coords;
+import org.micromanager.data.Datastore;
+import org.micromanager.data.Image;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.testing.TestImageDecoder;
+import org.micromanager.testing.TestImageDecoder.InfoPacket;
+
+/**
+ * Spike / smoke test that de-risks the whole approach: boot a headless
+ * {@link MMStudio}, load SequenceTester devices, run a default (single-snap)
+ * acquisition through AcqEngJ, and decode the embedded InfoPacket from the one
+ * resulting image in the Datastore.
+ *
+ * <p>If this passes, the high-level acquisition engines can be driven from
+ * JUnit and the rest of the scenario suite is straightforward.
+ */
+public class SmokeTest {
+   private static StudioTestFixture fixture_;
+
+   @BeforeClass
+   public static void boot() {
+      fixture_ = StudioTestFixture.getInstance();
+   }
+
+   @Before
+   public void setUp() throws Exception {
+      fixture_.reset();
+   }
+
+   @Test
+   public void bootsStudioAndRunsTimeLapseWithAcqEngJ() throws Exception {
+      fixture_.useAcqEngJ(true);
+      MMStudio studio = fixture_.getStudio();
+
+      // A minimal but VALID MDA: a short time series. (A completely empty
+      // SequenceSettings is not a valid MDA -- the AcqEngJ event iterator
+      // requires at least one acquisition axis.)
+      final int numFrames = 3;
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(numFrames)
+            .intervalMs(0.0)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      assertNotNull("Acquisition returned a null Datastore", store);
+
+      assertEquals("Expected one image per frame",
+            numFrames, store.getNumImages());
+
+      Coords c = store.getUnorderedImageCoords().iterator().next();
+      Image img = store.getImage(c);
+      assertNotNull(img);
+
+      byte[] pix = (byte[]) img.getRawPixels();
+      InfoPacket packet = TestImageDecoder.decode(pix);
+      assertEquals("TCamera", packet.camera.name);
+      // The image carries a decodable InfoPacket from the SequenceTester
+      // camera -- that is enough to prove the engine -> camera -> datastore
+      // path works. (Counter ordering is exercised in the scenario tests.)
+      assertTrue("counters should be non-negative",
+            packet.currentCounter >= 0 && packet.startCounter >= 0);
+   }
+
+   @Test
+   public void bootsStudioAndRunsTimeLapseWithLegacyEngine() throws Exception {
+      fixture_.useAcqEngJ(false);
+      MMStudio studio = fixture_.getStudio();
+
+      final int numFrames = 3;
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(numFrames)
+            .intervalMs(0.0)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      assertNotNull("Acquisition returned a null Datastore", store);
+      assertEquals("Expected one image per frame",
+            numFrames, store.getNumImages());
+
+      Coords c = store.getUnorderedImageCoords().iterator().next();
+      byte[] pix = (byte[]) store.getImage(c).getRawPixels();
+      InfoPacket packet = TestImageDecoder.decode(pix);
+      assertEquals("TCamera", packet.camera.name);
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/StudioTestFixture.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/StudioTestFixture.java
@@ -1,0 +1,248 @@
+package org.micromanager.acqenginetests;
+
+import javax.swing.SwingUtilities;
+import mmcorej.CMMCore;
+import mmcorej.StrVector;
+import org.micromanager.acquisition.ChannelSpec;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.internal.utils.ReportingUtils;
+
+/**
+ * Boots a headless {@link MMStudio} backed by the SequenceTester device adapter
+ * so the high-level acquisition engines (AcqEngJAdapter and the legacy
+ * AcquisitionWrapperEngine) can be driven from JUnit.
+ *
+ * <p>MMStudio enforces a single instance per JVM and a lot of internal state is
+ * static, so this fixture is intended to be created once and shared (see
+ * {@link #getInstance()}). The JUnit task forks a JVM per test class, which
+ * keeps separate test classes isolated.
+ *
+ * <p>The two environment variables used by the existing SequenceTests harness
+ * must be set so the native libraries can be found:
+ * <ul>
+ *   <li>{@code MMCOREJ_LIBRARY_PATH} - directory containing MMCoreJ_wrap</li>
+ *   <li>{@code MMTEST_ADAPTER_PATH} - directories (path-separated) containing
+ *       the device adapter shared libraries, including SequenceTester</li>
+ * </ul>
+ *
+ * <p>This class is deliberately not a JUnit {@code @Rule}: starting MMStudio is
+ * expensive and can only happen once, so tests use the shared instance and
+ * {@link #reset()} between tests.
+ */
+public final class StudioTestFixture {
+   private static StudioTestFixture instance_;
+
+   private final MMStudio studio_;
+   private final CMMCore core_;
+
+   private StudioTestFixture() {
+      // Make the MMCoreJ_wrap native library discoverable. MMStudio's
+      // constructor creates its own CMMCore, so the JNI library path must be a
+      // system property before construction; the adapter search path is set on
+      // that Core afterwards (below).
+      String jniLibPath = System.getenv("MMCOREJ_LIBRARY_PATH");
+      System.setProperty("mmcorej.library.loading.stderr.log", "yes");
+      if (jniLibPath != null) {
+         System.setProperty("mmcorej.library.path", jniLibPath);
+      }
+
+      // new MMStudio(false) is the same call the Gaussian plugin's
+      // TestParticlePairLister uses headlessly. In a fresh test environment the
+      // intro dialog is skipped; if a CI environment ever blocks here, set the
+      // StartupSettings skip flags on the default profile before this call.
+      studio_ = new MMStudio(false);
+      core_ = studio_.core();
+
+      // CRITICAL for unattended runs: suppress modal error dialogs. The
+      // acquisition engines report failures via studio.logs().showError(),
+      // which routes through ReportingUtils and pops a MODAL JOptionPane. In a
+      // non-headless test JVM with no one to click "OK", that dialog blocks the
+      // EDT forever and hangs the whole test run. Errors are still logged.
+      ReportingUtils.showErrorOn(false);
+
+      String adapterPaths = System.getenv("MMTEST_ADAPTER_PATH");
+      StrVector paths = new StrVector();
+      if (adapterPaths != null) {
+         for (String path :
+               adapterPaths.split(java.util.regex.Pattern.quote(
+                     java.io.File.pathSeparator))) {
+            paths.add(path);
+         }
+      }
+      core_.setDeviceAdapterSearchPaths(paths);
+
+      core_.enableStderrLog(true);
+      core_.enableDebugLog(true);
+   }
+
+   /**
+    * Returns the shared fixture, creating (and booting MMStudio) on first call.
+    *
+    * @return the shared fixture
+    */
+   public static synchronized StudioTestFixture getInstance() {
+      if (instance_ == null) {
+         instance_ = new StudioTestFixture();
+         try {
+            instance_.warmUpEngines();
+         } catch (Exception e) {
+            throw new RuntimeException("Failed to warm up acquisition engines", e);
+         }
+      }
+      return instance_;
+   }
+
+   /**
+    * Runs one trivial acquisition on each engine before any test, to pay
+    * one-time initialization costs up front.
+    *
+    * <p>The legacy (Clojure) engine in particular JIT-compiles and loads its
+    * namespaces on first use, which can take ~20 s -- long enough to exceed the
+    * default per-image camera timeout and make the FIRST real acquisition fail
+    * with "Timed out waiting for image to arrive from camera". Warming up here
+    * keeps that cost off every test's measured path.
+    */
+   public void warmUpEngines() throws Exception {
+      // Only the legacy (Clojure) engine has a costly cold start; AcqEngJ does
+      // not, so we warm up the legacy engine only.
+      loadStandardDevices();
+      useAcqEngJ(false);
+      SequenceSettings s = studio_.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(1)
+            .intervalMs(0.0)
+            // Generous timeout so the cold Clojure start cannot self-abort.
+            .cameraTimeout(120000)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+      studio_.acquisitions().runAcquisitionWithSettings(s, true);
+   }
+
+   public MMStudio getStudio() {
+      return studio_;
+   }
+
+   public CMMCore getCore() {
+      return core_;
+   }
+
+   /** Selects which acquisition engine the next acquisition will use. */
+   public void useAcqEngJ(boolean useAcqEngJ) {
+      studio_.settings().setShouldUseAcqEngJ(useAcqEngJ);
+   }
+
+   /**
+    * Unloads all devices and reloads a clean set of SequenceTester devices.
+    * Call from {@code @Before} so each test starts from a known state.
+    *
+    * <p>Loads a hub plus a machine-readable camera, a Z stage, an XY stage, a
+    * state switcher (for channels), and an autofocus device. Image size is set
+    * large enough (128x128) to hold the embedded MessagePack InfoPacket.
+    *
+    * @throws Exception if any Core call fails
+    */
+   public void loadStandardDevices() throws Exception {
+      core_.unloadAllDevices();
+
+      core_.loadDevice("THub", "SequenceTester", "THub");
+      core_.initializeDevice("THub");
+
+      loadChildDevice("TCamera", "TCamera");
+      loadChildDevice("TZStage", "TZStage");
+      loadChildDevice("TXYStage", "TXYStage");
+      loadChildDevice("TSwitcher", "TSwitcher");
+      loadChildDevice("TAutofocus", "TAutofocus");
+
+      core_.setProperty("TCamera", "ImageMode", "MachineReadable");
+      core_.setProperty("TCamera", "ImageWidth", 128);
+      core_.setProperty("TCamera", "ImageHeight", 128);
+      core_.initializeDevice("TCamera");
+      core_.initializeDevice("TZStage");
+      core_.initializeDevice("TXYStage");
+      core_.initializeDevice("TSwitcher");
+      core_.initializeDevice("TAutofocus");
+
+      core_.setCameraDevice("TCamera");
+      core_.setFocusDevice("TZStage");
+      core_.setXYStageDevice("TXYStage");
+
+      // Unloading/reloading devices makes the Core post notifications that
+      // MMStudio's managers (SnapLive, Shutter, config-group table) handle on
+      // the EDT. Let those settle before the test runs an acquisition, so a
+      // queued EDT event can't race with -- and occasionally deadlock against
+      // -- the acquisition. Without this drain the suite hangs intermittently.
+      drainEdt();
+   }
+
+   /**
+    * Blocks until the AWT event queue has processed everything currently
+    * pending (including events posted by the Core notifications above).
+    */
+   public static void drainEdt() {
+      if (java.awt.GraphicsEnvironment.isHeadless()) {
+         return;
+      }
+      try {
+         // Run twice: the first drain may post follow-up events.
+         SwingUtilities.invokeAndWait(() -> { });
+         SwingUtilities.invokeAndWait(() -> { });
+      } catch (Exception e) {
+         throw new RuntimeException("Interrupted while draining the EDT", e);
+      }
+   }
+
+   private void loadChildDevice(String label, String name) throws Exception {
+      core_.loadDevice(label, "SequenceTester", name);
+      core_.setParentLabel(label, "THub");
+   }
+
+   /**
+    * Defines a channel group on the TSwitcher device with the given presets,
+    * one preset per state, and makes it the Core's channel group.
+    *
+    * @param group   channel group name
+    * @param presets preset (channel config) names; state index = array index
+    * @throws Exception if any Core call fails
+    */
+   public void defineChannelGroup(String group, String... presets) throws Exception {
+      for (int i = 0; i < presets.length; i++) {
+         core_.defineConfig(group, presets[i], "TSwitcher", "State",
+               Integer.toString(i));
+      }
+      core_.setChannelGroup(group);
+   }
+
+   /** Convenience builder for a channel preset in the standard group. */
+   public ChannelSpec channel(String group, String preset, double exposureMs) {
+      return new ChannelSpec.Builder()
+            .channelGroup(group)
+            .config(preset)
+            .exposure(exposureMs)
+            .build();
+   }
+
+   /** Resets Core and Studio state between tests. */
+   public void reset() throws Exception {
+      // The position list is Studio state, not Core state, so a device reload
+      // does not clear it. Clear it so a list set by one test does not bleed
+      // into the next.
+      setPositionList(new org.micromanager.PositionList());
+      loadStandardDevices();
+   }
+
+   /**
+    * Sets the Studio position list and lets the resulting NewPositionListEvent
+    * propagate. The acquisition engines keep their own {@code posList_} field
+    * that is updated only when this event is delivered on the bus, so we must
+    * drain the EDT before running an acquisition or the engine will use a stale
+    * (or empty) list.
+    *
+    * @param pl the position list to install
+    */
+   public void setPositionList(org.micromanager.PositionList pl) {
+      studio_.positions().setPositionList(pl);
+      drainEdt();
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/TestAutofocusPlugin.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/TestAutofocusPlugin.java
@@ -1,0 +1,138 @@
+package org.micromanager.acqenginetests;
+
+import ij.process.ImageProcessor;
+import org.micromanager.AutofocusPlugin;
+import org.micromanager.Studio;
+import org.micromanager.internal.utils.PropertyItem;
+
+/**
+ * Minimal AutofocusPlugin for tests. Its {@link #fullFocus()} simply drives the
+ * Core's currently selected autofocus device (the SequenceTester TAutofocus),
+ * which fires a "FullFocus" one-shot recorded in the image InfoPacket. It also
+ * counts invocations so tests can assert how often autofocus ran.
+ *
+ * <p>Injected via {@code studio.getAutofocusManager().setAutofocusMethod(...)};
+ * it is not discovered as a real plugin.
+ */
+public class TestAutofocusPlugin implements AutofocusPlugin {
+   private Studio studio_;
+   private int fullFocusCount_ = 0;
+
+   public int getFullFocusCount() {
+      return fullFocusCount_;
+   }
+
+   public void resetCount() {
+      fullFocusCount_ = 0;
+   }
+
+   @Override
+   public double fullFocus() throws Exception {
+      fullFocusCount_++;
+      // Drives TesterAutofocus::FullFocus -> recorded as device "TAutofocus"
+      // key "FullFocus" in the InfoPacket history.
+      studio_.core().fullFocus();
+      return 0.0;
+   }
+
+   @Override
+   public double incrementalFocus() throws Exception {
+      studio_.core().incrementalFocus();
+      return 0.0;
+   }
+
+   // --- everything below is an inert stub ---
+
+   @Override
+   public void setContext(Studio studio) {
+      studio_ = studio;
+   }
+
+   @Override
+   public String getName() {
+      return "TestAutofocus";
+   }
+
+   @Override
+   public String getHelpText() {
+      return "Test autofocus plugin";
+   }
+
+   @Override
+   public String getVersion() {
+      return "1.0";
+   }
+
+   @Override
+   public String getCopyright() {
+      return "none";
+   }
+
+   @Override
+   public void initialize() { }
+
+   @Override
+   public void applySettings() { }
+
+   @Override
+   public void saveSettings() { }
+
+   @Override
+   public int getNumberOfImages() {
+      return 0;
+   }
+
+   @Override
+   public String getVerboseStatus() {
+      return "";
+   }
+
+   @Override
+   public PropertyItem[] getProperties() {
+      return new PropertyItem[0];
+   }
+
+   @Override
+   public String[] getPropertyNames() {
+      return new String[0];
+   }
+
+   @Override
+   public PropertyItem getProperty(String key) {
+      return new PropertyItem();
+   }
+
+   @Override
+   public void setProperty(PropertyItem p) { }
+
+   @Override
+   public String getPropertyValue(String name) {
+      return "";
+   }
+
+   @Override
+   public void setPropertyValue(String name, String value) { }
+
+   @Override
+   public double getCurrentFocusScore() {
+      return 0.0;
+   }
+
+   @Override
+   public void enableContinuousFocus(boolean enable) { }
+
+   @Override
+   public boolean isContinuousFocusEnabled() {
+      return false;
+   }
+
+   @Override
+   public boolean isContinuousFocusLocked() {
+      return false;
+   }
+
+   @Override
+   public double computeScore(final ImageProcessor impro) {
+      return 0.0;
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/TimeLapseTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/TimeLapseTest.java
@@ -1,0 +1,121 @@
+package org.micromanager.acqenginetests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.data.Coords;
+import org.micromanager.data.Datastore;
+import org.micromanager.internal.MMStudio;
+
+/**
+ * Time-lapse acquisition tests, run through both engines.
+ */
+@RunWith(Parameterized.class)
+public class TimeLapseTest {
+   private static StudioTestFixture fixture_;
+
+   @Parameterized.Parameter
+   public boolean useAcqEngJ_;
+
+   @Parameterized.Parameters(name = "acqEngJ={0}")
+   public static List<Object[]> engines() {
+      return Arrays.asList(new Object[]{false}, new Object[]{true});
+   }
+
+   @BeforeClass
+   public static void boot() {
+      fixture_ = StudioTestFixture.getInstance();
+   }
+
+   @Before
+   public void setUp() throws Exception {
+      fixture_.reset();
+      fixture_.useAcqEngJ(useAcqEngJ_);
+   }
+
+   @Test
+   public void fixedIntervalProducesOneImagePerFrame() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      final int numFrames = 5;
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(numFrames)
+            .intervalMs(1.0)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+
+      result.assertHasAllCoords(numFrames, 1, 1, 1);
+      assertEquals("time axis length", numFrames, result.axisLength(Coords.T));
+   }
+
+   @Test
+   public void customIntervalsProduceOneImagePerInterval() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      ArrayList<Double> intervals = new ArrayList<>(Arrays.asList(0.0, 5.0, 10.0));
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(intervals.size())
+            .useCustomIntervals(true)
+            .customIntervalsMs(intervals)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+
+      result.assertHasAllCoords(intervals.size(), 1, 1, 1);
+      assertEquals("time axis length",
+            intervals.size(), result.axisLength(Coords.T));
+   }
+
+   @Test
+   public void framesAreCapturedInOrder() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      final int numFrames = 4;
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useFrames(true)
+            .numFrames(numFrames)
+            .intervalMs(1.0)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+      result.assertHasAllCoords(numFrames, 1, 1, 1);
+
+      // The camera's cumulative image counter must be monotonically increasing
+      // with the time index (frame t was produced after frame t-1).
+      long[] cumulativeByFrame = new long[numFrames];
+      Arrays.fill(cumulativeByFrame, -1L);
+      for (Coords c : store.getUnorderedImageCoords()) {
+         int t = c.hasAxis(Coords.T) ? c.getIndex(Coords.T) : 0;
+         cumulativeByFrame[t] =
+               result.infoPacketAt(c).camera.cumulativeImageNr;
+      }
+      for (int t = 1; t < numFrames; t++) {
+         assertTrue("frame " + t + " should be captured after frame " + (t - 1),
+               cumulativeByFrame[t] > cumulativeByFrame[t - 1]);
+      }
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/TimeLapseTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/TimeLapseTest.java
@@ -113,6 +113,13 @@ public class TimeLapseTest {
          cumulativeByFrame[t] =
                result.infoPacketAt(c).camera.cumulativeImageNr;
       }
+      // Verify every frame index was actually observed before comparing, so a
+      // missing frame gives a clear failure rather than a confusing comparison
+      // against the -1 sentinel.
+      for (int t = 0; t < numFrames; t++) {
+         assertTrue("no image observed for frame " + t,
+               cumulativeByFrame[t] >= 0);
+      }
       for (int t = 1; t < numFrames; t++) {
          assertTrue("frame " + t + " should be captured after frame " + (t - 1),
                cumulativeByFrame[t] > cumulativeByFrame[t - 1]);

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/ZStackTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/ZStackTest.java
@@ -1,0 +1,134 @@
+package org.micromanager.acqenginetests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.micromanager.acquisition.ChannelSpec;
+import org.micromanager.acquisition.SequenceSettings;
+import org.micromanager.data.Coords;
+import org.micromanager.data.Datastore;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.testing.TestImageDecoder.InfoPacket;
+
+/**
+ * Z-stack acquisition tests, run through both engines.
+ *
+ * <p>Also ports the spirit of SequenceTests' RegressionSpuriousZPositionSets to
+ * the high-level path: the focus drive must be set when (and only when) a Z
+ * stack is requested.
+ */
+@RunWith(Parameterized.class)
+public class ZStackTest {
+   private static final String GROUP = "Channel";
+   private static StudioTestFixture fixture_;
+
+   @Parameterized.Parameter
+   public boolean useAcqEngJ_;
+
+   @Parameterized.Parameters(name = "acqEngJ={0}")
+   public static List<Object[]> engines() {
+      return Arrays.asList(new Object[]{false}, new Object[]{true});
+   }
+
+   @BeforeClass
+   public static void boot() {
+      fixture_ = StudioTestFixture.getInstance();
+   }
+
+   @Before
+   public void setUp() throws Exception {
+      fixture_.reset();
+      fixture_.useAcqEngJ(useAcqEngJ_);
+   }
+
+   @Test
+   public void zStackProducesOneImagePerSlice() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+
+      // Bottom 0, top 4, step 1 -> 5 slices.
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useSlices(true)
+            .sliceZBottomUm(0.0)
+            .sliceZTopUm(4.0)
+            .sliceZStepUm(1.0)
+            .relativeZSlice(true)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+
+      // frames=1, channels=1, slices=5, positions=1
+      result.assertHasAllCoords(1, 1, 5, 1);
+      assertEquals("z axis length", 5, result.axisLength(Coords.Z));
+
+      // The focus drive should have moved (Z set) for the stack.
+      boolean zMoved = false;
+      for (InfoPacket p : result.infoPackets()) {
+         if (p.hasBeenSetSincePreviousPacket("TZStage", "ZPositionUm")) {
+            zMoved = true;
+         }
+      }
+      assertTrue("TZStage ZPositionUm should be set during a Z stack", zMoved);
+   }
+
+   @Test
+   public void zNotSetForChannelOnlyAcquisition() throws Exception {
+      MMStudio studio = fixture_.getStudio();
+      fixture_.defineChannelGroup(GROUP, "Ch0", "Ch1");
+
+      ArrayList<ChannelSpec> channels = new ArrayList<>(Arrays.asList(
+            fixture_.channel(GROUP, "Ch0", 1.0),
+            fixture_.channel(GROUP, "Ch1", 1.0)));
+
+      // Channels, no slices, no frames -- the focus drive must not be touched.
+      SequenceSettings settings = studio.acquisitions().sequenceSettingsBuilder()
+            .useChannels(true)
+            .channelGroup(GROUP)
+            .channels(channels)
+            .useSlices(false)
+            .save(false)
+            .shouldDisplayImages(false)
+            .build();
+
+      Datastore store =
+            studio.acquisitions().runAcquisitionWithSettings(settings, true);
+      AcqResult result = new AcqResult(store);
+      result.assertHasAllCoords(1, 2, 1, 1);
+
+      // KNOWN ENGINE DIFFERENCE:
+      // - The legacy engine leaves the focus drive untouched for a channel-only
+      //   MDA (this is what RegressionSpuriousZPositionSets guards against).
+      // - AcqEngJ deliberately inserts a single-slice "fake z stack" at the
+      //   current/relative origin so that per-channel z-offsets and autofocus
+      //   are handled uniformly (see AcqEngJAdapter.createAcqEventIterator).
+      //   It therefore sets Z once, to a constant value. It must NOT, however,
+      //   perform a multi-slice stack.
+      int zSets = 0;
+      for (InfoPacket p : result.infoPackets()) {
+         if (p.hasBeenSetSincePreviousPacket("TZStage", "ZPositionUm")) {
+            zSets++;
+         }
+      }
+      if (useAcqEngJ_) {
+         // At most one Z set (to the single fake-stack origin), and the images
+         // all live on a single Z index.
+         assertEquals("AcqEngJ should not produce a multi-slice Z axis",
+               1, result.axisLength(Coords.Z));
+      } else {
+         assertEquals("legacy engine must not touch Z for a channel-only MDA",
+               0, zSets);
+      }
+   }
+}

--- a/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/ZStackTest.java
+++ b/systemtest/AcqEngineTests/src/test/java/org/micromanager/acqenginetests/ZStackTest.java
@@ -1,7 +1,6 @@
 package org.micromanager.acqenginetests;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -122,10 +121,13 @@ public class ZStackTest {
          }
       }
       if (useAcqEngJ_) {
-         // At most one Z set (to the single fake-stack origin), and the images
-         // all live on a single Z index.
+         // The images all live on a single Z index (no multi-slice stack)...
          assertEquals("AcqEngJ should not produce a multi-slice Z axis",
                1, result.axisLength(Coords.Z));
+         // ...and Z is set at most once (to the single fake-stack origin). This
+         // guards against AcqEngJ regressing into redundant Z sets per image.
+         assertTrue("AcqEngJ should set Z at most once for a channel-only MDA "
+               + "(was " + zSets + ")", zSets <= 1);
       } else {
          assertEquals("legacy engine must not touch Z for a channel-only MDA",
                0, zSets);


### PR DESCRIPTION
that are used to test wether acquisition engine runs are reproducible. There is no way that we can catch everything, but these tests can be extended once we run into issue we want to avoid in the future.