### PR TITLE
Explorer: Adds different vessels, adds novel ways to create position lists

### DIFF
--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerInspectorPanelController.java
@@ -3,9 +3,7 @@ package org.micromanager.tileddataviewer;
 import java.awt.Cursor;
 import java.awt.Point;
 import java.awt.Window;
-import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
-import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.List;
 import javax.swing.JButton;
@@ -13,19 +11,12 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
-import javax.swing.SwingWorker;
-import mmcorej.TaggedImage;
 import mmcorej.org.json.JSONObject;
 import net.miginfocom.swing.MigLayout;
-import org.micromanager.MultiStagePosition;
-import org.micromanager.PositionList;
-import org.micromanager.StagePosition;
 import org.micromanager.Studio;
 import org.micromanager.display.DataViewer;
 import org.micromanager.display.inspector.AbstractInspectorPanelController;
 import org.micromanager.exporttiles.ExportTiles;
-import org.micromanager.internal.utils.AffineUtils;
-import org.micromanager.tileddataprovider.TiledDataProviderAPI;
 
 public final class TiledDataViewerInspectorPanelController
       extends AbstractInspectorPanelController {
@@ -55,13 +46,10 @@ public final class TiledDataViewerInspectorPanelController
                + "  Click Export, drag to draw ROI, then confirm export\n"
                + "  Click anywhere to dismiss the ROI";
 
-   private static final DecimalFormat FMT_POS = new DecimalFormat("000");
-
    private final Studio studio_;
    private final JPanel panel_;
    private final JLabel statusLabel_;
    private final JButton exportButton_;
-   private final JButton posListButton_;
    private final JButton interruptButton_;
    private final JButton helpButton_;
    private TiledDataViewerDataViewerAPI viewer_;
@@ -80,7 +68,6 @@ public final class TiledDataViewerInspectorPanelController
       studio_ = studio;
       statusLabel_ = new JLabel(" ");
       exportButton_ = new JButton("Export...");
-      posListButton_ = new JButton("Create Positions...");
       interruptButton_ = new JButton("Interrupt");
       helpButton_ = new JButton("Help");
       panel_ = buildPanel();
@@ -93,7 +80,6 @@ public final class TiledDataViewerInspectorPanelController
       center.addActionListener(e -> onCenter());
       noZoom.addActionListener(e -> onNoZoom());
       exportButton_.addActionListener(e -> onExportClicked());
-      posListButton_.addActionListener(e -> onPosListClicked());
       interruptButton_.setToolTipText(
             "Stop tile acquisition after the current tile finishes.");
       interruptButton_.setEnabled(false);
@@ -105,8 +91,7 @@ public final class TiledDataViewerInspectorPanelController
       helpButton_.addActionListener(e -> showHelp());
       p.add(center);
       p.add(noZoom, "wrap");
-      p.add(exportButton_);
-      p.add(posListButton_, "wrap");
+      p.add(exportButton_, "wrap");
       p.add(interruptButton_);
       p.add(helpButton_, "wrap");
       p.add(statusLabel_, "span 2, wrap");
@@ -236,455 +221,6 @@ public final class TiledDataViewerInspectorPanelController
 
    private JSONObject buildDisplaySettingsJSON() {
       return viewer_.buildExportDisplaySettingsJSON();
-   }
-
-   // ---- Create Position List ----
-
-   private void onPosListClicked() {
-      if (viewer_ == null) {
-         return;
-      }
-      startPositionListMode();
-   }
-
-   private void startPositionListMode() {
-      TiledDataViewerAPI v = viewer_.getTiledDataViewer();
-      v.getCanvasJPanel().setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
-      setStatus("Draw a selection for the position list");
-
-      TiledDataViewerOverlayerPlugin previousOverlay = viewer_.getOverlayerPlugin();
-      ExportSelectionOverlay selectionOverlay = new ExportSelectionOverlay(v);
-      viewer_.setOverlayerPlugin(selectionOverlay);
-
-      // roiAccepted[0] is set to true when a valid drag completes.
-      // Used by the completion handler to decide whether to freeze the overlay; a local
-      // flag avoids any race with the async SwingWorker done().
-      boolean[] roiAccepted = {false};
-      ExportMouseListener[] el = new ExportMouseListener[1];
-      el[0] = new ExportMouseListener(v,
-              () -> {
-                 v.getCanvasJPanel().setCursor(Cursor.getDefaultCursor());
-                 if (roiAccepted[0]) {
-                    selectionOverlay.freezeRoi(el[0].mouseDragStartPoint_,
-                            el[0].currentMouseLocation_);
-                    el[0].setOnDismiss(() -> {
-                       viewer_.setOverlayerPlugin(previousOverlay);
-                       v.resetCanvasMouseListener();
-                       v.update();
-                       setStatus(null);
-                    });
-                    setStatus("Click to dismiss selection");
-                 } else {
-                    viewer_.setOverlayerPlugin(previousOverlay);
-                    v.resetCanvasMouseListener();
-                    v.update();
-                    setStatus(null);
-                 }
-              },
-              (dragStart, dragEnd) -> {
-                 roiAccepted[0] = true;
-                 onPosListRoiSelected(dragStart, dragEnd);
-              });
-      selectionOverlay.setExportMouseListener(el[0]);
-      v.setCustomCanvasMouseListener(el[0]);
-   }
-
-   private void onPosListRoiSelected(Point dragStart, Point dragEnd) {
-      TiledDataViewerAPI v = viewer_.getTiledDataViewer();
-      Point2D.Double viewOffset = v.getViewOffset();
-      double mag = v.getMagnification();
-      int x1 = (int) (viewOffset.x + Math.min(dragStart.x, dragEnd.x) / mag);
-      int y1 = (int) (viewOffset.y + Math.min(dragStart.y, dragEnd.y) / mag);
-      int x2 = (int) (viewOffset.x + Math.max(dragStart.x, dragEnd.x) / mag);
-      int y2 = (int) (viewOffset.y + Math.max(dragStart.y, dragEnd.y) / mag);
-      int roiW = Math.max(1, x2 - x1);
-      int roiH = Math.max(1, y2 - y1);
-      int[] roi = new int[]{x1, y1, roiW, roiH};
-      createPositionListFromRoi(roi);
-   }
-
-   /**
-    * Converts a full-resolution pixel ROI to a stage-coordinate position list and
-    * installs it as the active MM position list.
-    *
-    * <p>Two independent sources are used:</p>
-    * <ul>
-    *   <li><b>Dataset metadata</b> — the stored {@code XPositionUm}/{@code YPositionUm}
-    *       tile tags and the stored {@code PixelSize_um} are used to convert canvas
-    *       pixels to stage coordinates. These always reflect the original acquisition,
-    *       regardless of which microscope is currently connected.</li>
-    *   <li><b>Live hardware</b> — the current camera FOV ({@code CMMCore.getImageWidth()}/
-    *       {@code getImageHeight()}) and pixel-size affine
-    *       ({@code CMMCore.getPixelSizeAffine(true)})
-    *       determine the grid step and tile size for the new position list. This allows
-    *       the user to plan a re-acquisition with a different objective.</li>
-    * </ul>
-    * <p>If the live pixel size differs from the stored one a warning is shown in the
-    * status bar (but the position list is still created). Falls back to stored tile
-    * dimensions / scalar pixel size when the camera or affine is unavailable.</p>
-    * <p>The tile overlap is read from the dataset's summary metadata. Positions are
-    * ordered in a serpentine pattern to minimise stage travel.</p>
-    * <p>The storage probe and grid computation run on a background thread so the EDT
-    * is not blocked. The button is disabled for the duration.</p>
-    */
-   private void createPositionListFromRoi(int[] roi) {
-      posListButton_.setEnabled(false);
-      setStatus("Computing positions...");
-
-      TiledDataViewerDataProviderAPI dp =
-               (TiledDataViewerDataProviderAPI) viewer_.getDataProvider();
-      TiledDataProviderAPI storage = dp.getStorage();
-
-      new SwingWorker<PositionList, Void>() {
-         // Warning text produced during computation; shown on EDT after done().
-         String warning = null;
-
-         @Override
-         protected PositionList doInBackground() throws Exception {
-            // ---- 1. Probe one tile for a reference stage position and stored pixel size ----
-            JSONObject summary = storage.getSummaryMetadata();
-
-            // Find a representative tile: any axes that has XPositionUm/YPositionUm in tags.
-            TaggedImage probeTile = null;
-            HashMap<String, Object> probeAxes = null;
-            for (HashMap<String, Object> axes : storage.getAxesSet()) {
-               TaggedImage img = storage.getImage(axes);
-               if (img != null && img.tags != null
-                     && img.tags.has("XPositionUm") && img.tags.has("YPositionUm")) {
-                  probeTile = img;
-                  probeAxes = axes;
-                  break;
-               }
-            }
-
-            if (probeTile == null) {
-               throw new Exception(
-                     "Cannot create position list: no stage-position metadata found "
-                     + "in this dataset.");
-            }
-
-            // Stored pixel size — used only for canvas-pixel → stage-coordinate conversion,
-            // so the ROI drawn on the dataset maps correctly to stage space regardless of
-            // which objective is currently on the microscope.
-            double storedPixelSizeUm =
-                  summary != null ? summary.optDouble("PixelSize_um", 0.0) : 0.0;
-            if (storedPixelSizeUm <= 0.0) {
-               storedPixelSizeUm = probeTile.tags.optDouble("PixelSizeUm", 1.0);
-            }
-            if (storedPixelSizeUm <= 0.0) {
-               storedPixelSizeUm = 1.0;
-            }
-
-            // ---- 2. Live hardware: affine + FOV for the new position grid ----
-            // These reflect the current objective and are independent of storedPixelSizeUm.
-            AffineTransform pixToStage = null;
-            double livePixelSizeUm = 0.0;
-            try {
-               AffineTransform at = AffineUtils.doubleToAffine(
-                     studio_.core().getPixelSizeAffine(true));
-               livePixelSizeUm = AffineUtils.deducePixelSize(at);
-               if (livePixelSizeUm > 0.0) {
-                  pixToStage = at;
-               }
-            } catch (Exception ignore) {
-               // No live core or no affine configured — scalar fallback below.
-            }
-            if (livePixelSizeUm <= 0.0) {
-               livePixelSizeUm = storedPixelSizeUm;
-            }
-
-            // Camera FOV from live hardware; fall back to stored tile dimensions.
-            int tileW = 0;
-            int tileH = 0;
-            boolean liveHardwareAvailable = false;
-            try {
-               tileW = (int) studio_.core().getImageWidth();
-               tileH = (int) studio_.core().getImageHeight();
-               liveHardwareAvailable = tileW > 0 && tileH > 0;
-            } catch (Exception ignore) {
-               // Camera unavailable — use stored tile dimensions below.
-            }
-            if (!liveHardwareAvailable) {
-               tileW = probeTile.tags.optInt("Width", 0);
-               if (tileW <= 0 && summary != null) {
-                  tileW = summary.optInt("Width", 512);
-               }
-               if (tileW <= 0) {
-                  tileW = 512;
-               }
-               tileH = probeTile.tags.optInt("Height", 0);
-               if (tileH <= 0 && summary != null) {
-                  tileH = summary.optInt("Height", tileW);
-               }
-               if (tileH <= 0) {
-                  tileH = tileW;
-               }
-            }
-
-            // Record warning if pixel size changed (different objective), but still proceed.
-            if (liveHardwareAvailable
-                  && Math.abs(livePixelSizeUm - storedPixelSizeUm) > 0.01 * storedPixelSizeUm) {
-               warning = String.format(
-                     "Warning: live pixel size (%.4f µm) differs from dataset (%.4f µm) — "
-                     + "positions sized for current objective",
-                     livePixelSizeUm, storedPixelSizeUm);
-            }
-
-            // Overlap from summary metadata (dataset property, not hardware-dependent).
-            int overlapX = summary != null ? summary.optInt("GridPixelOverlapX", 0) : 0;
-            int overlapY = summary != null ? summary.optInt("GridPixelOverlapY", 0) : 0;
-            if (overlapX >= tileW || overlapY >= tileH) {
-               throw new Exception(String.format(
-                     "Cannot create position list: overlap (%d×%d px) is >= "
-                     + "tile size (%d×%d px).", overlapX, overlapY, tileW, tileH));
-            }
-
-            // ---- 3. Reference point: map one stored tile's canvas position to stage ----
-            // The canvas pixel grid was laid out with the stored tile dims and stored pixel size.
-            int storedTileW = probeTile.tags.optInt("Width", tileW);
-            int storedTileH = probeTile.tags.optInt("Height", tileH);
-            if (storedTileW <= 0) {
-               storedTileW = tileW;
-            }
-            if (storedTileH <= 0) {
-               storedTileH = tileH;
-            }
-            int refRow = probeAxes.get("row") instanceof Integer
-                  ? (Integer) probeAxes.get("row") : 0;
-            int refCol = probeAxes.get("column") instanceof Integer
-                  ? (Integer) probeAxes.get("column") : 0;
-            int storedStepPxX = storedTileW - overlapX;
-            int storedStepPxY = storedTileH - overlapY;
-            double refPixCenterX = refCol * storedStepPxX + storedTileW / 2.0;
-            double refPixCenterY = refRow * storedStepPxY + storedTileH / 2.0;
-
-            double refStageX;
-            double refStageY;
-            try {
-               refStageX = probeTile.tags.getDouble("XPositionUm");
-               refStageY = probeTile.tags.getDouble("YPositionUm");
-            } catch (Exception e) {
-               throw new Exception(
-                     "Cannot create position list: failed to read stage position from metadata.");
-            }
-
-            // ---- 4. Compute ROI corners in stage space ----
-            int roiX = roi[0];
-            int roiY = roi[1];
-            int roiW = roi[2];
-            int roiH = roi[3];
-
-            // Canvas pixels → stage must use the STORED pixel size, because the canvas was
-            // laid out using the dataset's pixel size (not the current objective).
-            // If the live affine is available we scale it to match the stored pixel size so that
-            // axis orientation (camera-X/stage-X inversion, rotation) is preserved while the
-            // scale matches the stored dataset.  Without the live affine we fall back to the
-            // stored scalar.
-            AffineTransform storedPixToStage = null;
-            if (pixToStage != null && livePixelSizeUm > 0.0) {
-               double scale = storedPixelSizeUm / livePixelSizeUm;
-               storedPixToStage = new AffineTransform(pixToStage);
-               storedPixToStage.scale(scale, scale);
-            }
-            Point2D.Double stageTL = pixelToStage(roiX,        roiY,
-                  refPixCenterX, refPixCenterY, refStageX, refStageY, storedPixelSizeUm,
-                  storedPixToStage);
-            Point2D.Double stageTR = pixelToStage(roiX + roiW, roiY,
-                  refPixCenterX, refPixCenterY, refStageX, refStageY, storedPixelSizeUm,
-                  storedPixToStage);
-            Point2D.Double stageBL = pixelToStage(roiX,        roiY + roiH,
-                  refPixCenterX, refPixCenterY, refStageX, refStageY, storedPixelSizeUm,
-                  storedPixToStage);
-            Point2D.Double stageBR = pixelToStage(roiX + roiW, roiY + roiH,
-                  refPixCenterX, refPixCenterY, refStageX, refStageY, storedPixelSizeUm,
-                  storedPixToStage);
-
-            // ---- 5. Compute step vectors for the new acquisition grid ----
-            int stepPxX = tileW - overlapX;
-            int stepPxY = tileH - overlapY;
-            final double stageStepXdx;
-            final double stageStepXdy;
-            final double stageStepYdx;
-            final double stageStepYdy;
-            if (pixToStage != null) {
-               Point2D.Double sx = new Point2D.Double();
-               Point2D.Double sy = new Point2D.Double();
-               pixToStage.transform(new Point2D.Double(stepPxX, 0), sx);
-               pixToStage.transform(new Point2D.Double(0, stepPxY), sy);
-               stageStepXdx = sx.x;
-               stageStepXdy = sx.y;
-               stageStepYdx = sy.x;
-               stageStepYdy = sy.y;
-            } else {
-               stageStepXdx = stepPxX * livePixelSizeUm;
-               stageStepXdy = 0;
-               stageStepYdx = 0;
-               stageStepYdy = stepPxY * livePixelSizeUm;
-            }
-
-            double stepMagX = Math.sqrt(
-                  stageStepXdx * stageStepXdx + stageStepXdy * stageStepXdy);
-            double stepMagY = Math.sqrt(
-                  stageStepYdx * stageStepYdx + stageStepYdy * stageStepYdy);
-            if (stepMagX <= 0 || stepMagY <= 0) {
-               throw new Exception(
-                     "Cannot create position list: degenerate step size.");
-            }
-
-            // ---- 6. Grid dimensions and center: project all 4 corners onto step axes ----
-            double uxX = stageStepXdx / stepMagX;
-            double uxY = stageStepXdy / stepMagX;
-            double uyX = stageStepYdx / stepMagY;
-            double uyY = stageStepYdy / stepMagY;
-
-            double[] projX = {
-               stageTL.x * uxX + stageTL.y * uxY,
-               stageTR.x * uxX + stageTR.y * uxY,
-               stageBL.x * uxX + stageBL.y * uxY,
-               stageBR.x * uxX + stageBR.y * uxY
-            };
-            double[] projY = {
-               stageTL.x * uyX + stageTL.y * uyY,
-               stageTR.x * uyX + stageTR.y * uyY,
-               stageBL.x * uyX + stageBL.y * uyY,
-               stageBR.x * uyX + stageBR.y * uyY
-            };
-
-            double projXMin = Math.min(
-                  Math.min(projX[0], projX[1]), Math.min(projX[2], projX[3]));
-            double projXMax = Math.max(
-                  Math.max(projX[0], projX[1]), Math.max(projX[2], projX[3]));
-            double projYMin = Math.min(
-                  Math.min(projY[0], projY[1]), Math.min(projY[2], projY[3]));
-            double projYMax = Math.max(
-                  Math.max(projY[0], projY[1]), Math.max(projY[2], projY[3]));
-
-            double roiExtentX = projXMax - projXMin;
-            double roiExtentY = projYMax - projYMin;
-
-            double fovW = pixToStage != null
-                  ? Math.sqrt(stageStepXdx * stageStepXdx / (stepPxX * stepPxX) * tileW * tileW
-                              + stageStepXdy * stageStepXdy / (stepPxX * stepPxX) * tileW * tileW)
-                  : tileW * livePixelSizeUm;
-            double fovH = pixToStage != null
-                  ? Math.sqrt(stageStepYdx * stageStepYdx / (stepPxY * stepPxY) * tileH * tileH
-                              + stageStepYdy * stageStepYdy / (stepPxY * stepPxY) * tileH * tileH)
-                  : tileH * livePixelSizeUm;
-
-            int nCols = Math.max(1,
-                  (int) Math.ceil((roiExtentX + fovW - stepMagX) / stepMagX));
-            int nRows = Math.max(1,
-                  (int) Math.ceil((roiExtentY + fovH - stepMagY) / stepMagY));
-
-            // ---- 7. Grid origin: center over the ROI ----
-            // Use the average of the 4 stage-corner points as the ROI center.
-            // This is correct for any affine (including shear); reconstructing stage
-            // coordinates from projection-space scalars is only valid when ux and uy
-            // are orthogonal.
-            double roiStageCX = (stageTL.x + stageTR.x + stageBL.x + stageBR.x) / 4.0;
-            double roiStageCY = (stageTL.y + stageTR.y + stageBL.y + stageBR.y) / 4.0;
-            // Offset from the grid center (tile [nRows/2, nCols/2]) back to tile [0,0].
-            double originX = roiStageCX
-                  - (nCols - 1) / 2.0 * stageStepXdx
-                  - (nRows - 1) / 2.0 * stageStepYdx;
-            double originY = roiStageCY
-                  - (nCols - 1) / 2.0 * stageStepXdy
-                  - (nRows - 1) / 2.0 * stageStepYdy;
-
-            // ---- 8. XY stage device ----
-            String xyStage;
-            try {
-               xyStage = studio_.core().getXYStageDevice();
-            } catch (Exception e) {
-               xyStage = null;
-            }
-            if (xyStage == null || xyStage.isEmpty()) {
-               throw new Exception(
-                     "Cannot create position list: no XY stage device is configured.");
-            }
-
-            // ---- 9. Build position list (serpentine) ----
-            PositionList posList = new PositionList();
-            final double overlapXUm = overlapX * livePixelSizeUm;
-            final double overlapYUm = overlapY * livePixelSizeUm;
-
-            for (int row = 0; row < nRows; row++) {
-               for (int col = 0; col < nCols; col++) {
-                  int c = ((row & 1) == 0) ? col : (nCols - 1 - col); // serpentine
-                  double dx = c * stageStepXdx + row * stageStepYdx;
-                  double dy = c * stageStepXdy + row * stageStepYdy;
-                  double stageX = originX + dx;
-                  double stageY = originY + dy;
-
-                  MultiStagePosition msp = new MultiStagePosition();
-                  msp.setDefaultXYStage(xyStage);
-                  msp.add(StagePosition.create2D(xyStage, stageX, stageY));
-                  msp.setLabel("Pos-" + FMT_POS.format(row) + "_" + FMT_POS.format(c));
-                  msp.setGridCoordinates(row, c);
-                  msp.setProperty("OverlapUmX", String.valueOf(overlapXUm));
-                  msp.setProperty("OverlapUmY", String.valueOf(overlapYUm));
-                  msp.setProperty("OverlapPixelsX", String.valueOf(overlapX));
-                  msp.setProperty("OverlapPixelsY", String.valueOf(overlapY));
-                  msp.setProperty("Source", "TiledDataViewerInspectorPanel");
-                  posList.addPosition(msp);
-               }
-            }
-            return posList;
-         }
-
-         @Override
-         protected void done() {
-            posListButton_.setEnabled(true);
-            PositionList posList;
-            try {
-               posList = get();
-            } catch (Exception ex) {
-               String msg = ex.getCause() != null
-                     ? ex.getCause().getMessage() : ex.getMessage();
-               JOptionPane.showMessageDialog(SwingUtilities.getWindowAncestor(panel_),
-                     msg, "Create Position List", JOptionPane.WARNING_MESSAGE);
-               setStatus(null);
-               return;
-            }
-            if (warning != null) {
-               setStatus(warning);
-            }
-            PositionList existing = studio_.positions().getPositionList();
-            for (int i = 0; i < posList.getNumberOfPositions(); i++) {
-               existing.addPosition(posList.getPosition(i));
-            }
-            studio_.positions().setPositionList(existing);
-            studio_.app().showPositionList();
-            if (warning == null) {
-               setStatus("Added " + posList.getNumberOfPositions() + " positions");
-            } else {
-               // Warning is already in the status bar; append the count.
-               setStatus(warning + " (" + posList.getNumberOfPositions() + " positions added)");
-            }
-         }
-      }.execute();
-   }
-
-   /**
-    * Convert a full-resolution canvas pixel coordinate to a stage coordinate,
-    * given a reference tile's pixel center and stage center.
-    */
-   private static Point2D.Double pixelToStage(double pixX, double pixY,
-                                               double refPixCX, double refPixCY,
-                                               double refStageX, double refStageY,
-                                               double pixelSizeUm,
-                                               AffineTransform pixToStage) {
-      double dPixX = pixX - refPixCX;
-      double dPixY = pixY - refPixCY;
-      if (pixToStage != null) {
-         Point2D.Double delta = new Point2D.Double();
-         pixToStage.transform(new Point2D.Double(dPixX, dPixY), delta);
-         return new Point2D.Double(refStageX + delta.x, refStageY + delta.y);
-      } else {
-         return new Point2D.Double(
-               refStageX + dPixX * pixelSizeUm,
-               refStageY + dPixY * pixelSizeUm);
-      }
    }
 
    private void setStatus(String text) {

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewer.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewer.java
@@ -358,7 +358,9 @@ public class TiledDataViewer implements TiledDataViewerAPI {
    }
 
    public void redrawOverlay() {
-      //this will automatically trigger overlay redrawing in a coalescent fashion
+      if (displayCalculationExecutor_ == null) {
+         return;
+      }
       displayCalculationExecutor_.invokeAsLateAsPossibleWithCoalescence(
             new DisplayImageComputationRunnable());
    }

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/overlay/ImageRoi.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/overlay/ImageRoi.java
@@ -1,0 +1,36 @@
+package org.micromanager.tileddataviewer.overlay;
+
+
+import java.awt.Graphics;
+import java.awt.Image;
+
+/**
+ * An overlay element that draws a raster image (e.g. a snapped microscope thumbnail) at a fixed
+ * rectangle. Like the other overlay {@link Roi} classes, its x/y/width/height are in display
+ * (screen) pixel coordinates; the canvas applies no transform to overlay ROIs.
+ */
+public class ImageRoi extends Roi {
+
+   private final Image img_;
+
+   /**
+    * Creates an ImageRoi.
+    *
+    * @param x      left edge in display pixels
+    * @param y      top edge in display pixels
+    * @param width  width in display pixels
+    * @param height height in display pixels
+    * @param img    the image to draw (scaled to width x height); may be null
+    */
+   public ImageRoi(int x, int y, int width, int height, Image img) {
+      super(x, y, width, height);
+      img_ = img;
+   }
+
+   @Override
+   public void draw(Graphics g) {
+      if (img_ != null) {
+         g.drawImage(img_, x, y, width, height, null);
+      }
+   }
+}

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/overlay/PolygonRoi.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/overlay/PolygonRoi.java
@@ -1,0 +1,91 @@
+package org.micromanager.tileddataviewer.overlay;
+
+
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+
+/**
+ * A polygon or polyline region of interest defined by an ordered list of points
+ * (in display/screen pixel coordinates, like the other overlay Roi classes).
+ *
+ * <p>When {@code closed} is true the points form a closed polygon; otherwise they
+ * are drawn as an open polyline (used for an in-progress polygon or a freehand trace).
+ * This Roi is drawn directly via the Graphics polygon/polyline primitives because the
+ * base {@link Roi} only supports rectangles.</p>
+ */
+public class PolygonRoi extends Roi {
+
+   private final int[] xs_;
+   private final int[] ys_;
+   private final boolean closed_;
+
+   /**
+    * Creates a PolygonRoi from arrays of display-pixel coordinates.
+    *
+    * @param xs x coordinates (display pixels)
+    * @param ys y coordinates (display pixels)
+    * @param closed true to draw a closed polygon, false for an open polyline
+    */
+   public PolygonRoi(int[] xs, int[] ys, boolean closed) {
+      super(boundsX(xs), boundsY(ys), boundsW(xs), boundsH(ys));
+      xs_ = xs.clone();
+      ys_ = ys.clone();
+      closed_ = closed;
+      type = closed ? POLYGON : POLYLINE;
+   }
+
+   private static int boundsX(int[] xs) {
+      int min = Integer.MAX_VALUE;
+      for (int v : xs) {
+         min = Math.min(min, v);
+      }
+      return xs.length == 0 ? 0 : min;
+   }
+
+   private static int boundsY(int[] ys) {
+      int min = Integer.MAX_VALUE;
+      for (int v : ys) {
+         min = Math.min(min, v);
+      }
+      return ys.length == 0 ? 0 : min;
+   }
+
+   private static int boundsW(int[] xs) {
+      int min = Integer.MAX_VALUE;
+      int max = Integer.MIN_VALUE;
+      for (int v : xs) {
+         min = Math.min(min, v);
+         max = Math.max(max, v);
+      }
+      return xs.length == 0 ? 1 : Math.max(1, max - min);
+   }
+
+   private static int boundsH(int[] ys) {
+      int min = Integer.MAX_VALUE;
+      int max = Integer.MIN_VALUE;
+      for (int v : ys) {
+         min = Math.min(min, v);
+         max = Math.max(max, v);
+      }
+      return ys.length == 0 ? 1 : Math.max(1, max - min);
+   }
+
+   @Override
+   public void draw(Graphics g) {
+      Color color = strokeColor != null ? strokeColor : ROIColor;
+      g.setColor(color);
+      Graphics2D g2d = (Graphics2D) g;
+      if (stroke != null) {
+         g2d.setStroke(stroke);
+      }
+      if (xs_.length == 0) {
+         return;
+      }
+      if (closed_) {
+         g.drawPolygon(xs_, ys_, xs_.length);
+      } else {
+         g.drawPolyline(xs_, ys_, xs_.length);
+      }
+   }
+}

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -121,6 +121,12 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
    // light grey until the operator leaves draw mode. Empty = none generated yet.
    private final ArrayList<Rectangle2D.Double> positionFovsPx_ = new ArrayList<>();
 
+   // Refine-Z mode: when active, ctrl+left-click moves the stage to that tile (for manual focus)
+   // instead of the normal move-stage behavior. Reference-point markers (full-res pixels) are
+   // drawn until the operator leaves draw mode.
+   private volatile boolean refineZActive_ = false;
+   private final ArrayList<Point2D.Double> refineZMarkersPx_ = new ArrayList<>();
+
    public ExplorerDataSource(ExplorerManager manager) {
       manager_ = manager;
    }
@@ -232,9 +238,13 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       positionFovsPx_.clear();
    }
 
-   /** True when a drawing tool is active. */
+   /**
+    * True when a drawing tool is active AND Refine Z is not open. While the Refine Z window is
+    * open, ROI drawing is suppressed so clicks drive refinement (Ctrl-click navigation, Set Z)
+    * instead of redrawing the ROI; the existing ROI/preview stays put.
+    */
    public boolean isPositionDrawMode() {
-      return positionTool_ != PositionTool.NONE;
+      return positionTool_ != PositionTool.NONE && !refineZActive_;
    }
 
    /** Discards the current ROI (and any generated positions) but keeps the active tool. */
@@ -253,6 +263,24 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       positionFovsPx_.clear();
       if (fovs != null) {
          positionFovsPx_.addAll(fovs);
+      }
+   }
+
+   /** Enables/disables manual Refine-Z mode (ctrl-click moves the stage to focus a tile). */
+   public void setRefineZActive(boolean active) {
+      refineZActive_ = active;
+   }
+
+   /** True when manual Refine-Z mode is active. */
+   public boolean isRefineZActive() {
+      return refineZActive_;
+   }
+
+   /** Sets the Refine-Z reference-point markers (full-res pixels) to draw on the overlay. */
+   public synchronized void setRefineZMarkers(java.util.List<Point2D.Double> markers) {
+      refineZMarkersPx_.clear();
+      if (markers != null) {
+         refineZMarkersPx_.addAll(markers);
       }
    }
 
@@ -628,6 +656,12 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
    @Override
    public void mousePressed(MouseEvent e) {
       dragStart_ = e.getPoint();
+      // Refine-Z manual navigation: a ctrl+left-click moves the stage, even while a drawing
+      // tool is selected, so it must take precedence over ROI drawing. Handled on release.
+      if (refineZActive_ && e.isControlDown()
+            && javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+         return;
+      }
       if (isPositionDrawMode()) {
          // RECTANGLE/OVAL start a drag; FREEHAND starts collecting points.
          // POLYGON is click-driven and handled in mouseClicked.
@@ -669,6 +703,18 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    @Override
    public void mouseReleased(MouseEvent e) {
+      // Refine-Z manual navigation: ctrl+left-click moves the stage to the clicked tile,
+      // taking precedence over ROI drawing so the operator can focus there and click Set Z.
+      if (refineZActive_ && e.isControlDown()
+            && javax.swing.SwingUtilities.isLeftMouseButton(e) && !isLeftDragging_) {
+         Point2D.Double px = getFullResPixelCoords(e.getX(), e.getY());
+         if (px != null) {
+            manager_.refineZManualMove(px.x, px.y);
+         }
+         dragStart_ = null;
+         isLeftDragging_ = false;
+         return;
+      }
       if (isPositionDrawMode()) {
          if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
             Point2D.Double px = getFullResPixelCoords(e.getX(), e.getY());
@@ -714,9 +760,11 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
          if (!readOnly_ && e.isControlDown()) {
             Point2D.Double pixelPos = getFullResPixelCoords(e.getX(), e.getY());
             if (pixelPos != null) {
+               // In refine-Z mode this navigates to a tile so the operator can focus it.
                manager_.moveStageToPixelPosition(pixelPos.x, pixelPos.y);
             }
-         } else if (!readOnly_) {
+         } else if (!readOnly_ && !refineZActive_) {
+            // Plain left-click acquires selected tiles, but not while refining Z.
             List<Point> selectedTiles = getSelectedTiles();
             if (!selectedTiles.isEmpty()) {
                manager_.acquireMultipleTiles(selectedTiles);
@@ -777,6 +825,10 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    @Override
    public void mouseDragged(MouseEvent e) {
+      // Don't draw while ctrl-navigating during Refine Z.
+      if (refineZActive_ && e.isControlDown()) {
+         return;
+      }
       if (isPositionDrawMode()) {
          if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
             Point2D.Double px = getFullResPixelCoords(e.getX(), e.getY());
@@ -1101,10 +1153,35 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       // Generated-position FOV rectangles (light grey), drawn under the ROI outline.
       addGeneratedPositionFovs(overlay, magnification, viewOffset);
 
+      // Refine-Z reference-point markers (green crosses), drawn over the FOVs.
+      addRefineZMarkers(overlay, magnification, viewOffset);
+
       // Create-Positions ROI — added last so it draws on top of everything (including the
       // vessel) and never hides the vessel outline. Added as Roi objects (not drawn straight
       // to Graphics) so it persists across repaints, like every other overlay element.
       addPositionRoi(overlay, magnification, viewOffset);
+   }
+
+   /** Adds the Refine-Z reference-point markers (small green filled squares) to the overlay. */
+   private void addRefineZMarkers(Overlay overlay, double magnification,
+                                  Point2D.Double viewOffset) {
+      ArrayList<Point2D.Double> markers;
+      synchronized (this) {
+         if (refineZMarkersPx_.isEmpty()) {
+            return;
+         }
+         markers = new ArrayList<>(refineZMarkersPx_);
+      }
+      Color green = new Color(60, 200, 90);
+      int half = 5;
+      for (Point2D.Double p : markers) {
+         int x = (int) ((p.x - viewOffset.x) * magnification);
+         int y = (int) ((p.y - viewOffset.y) * magnification);
+         Roi marker = new Roi(x - half, y - half, 2 * half, 2 * half);
+         marker.setStrokeColor(green);
+         marker.setFillColor(green);
+         overlay.add(marker);
+      }
    }
 
    /** Adds the most recently generated positions' FOV rectangles to the overlay (light grey). */

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -10,6 +10,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import org.micromanager.tileddataviewer.TiledDataViewerCanvasMouseListenerInterf
 import org.micromanager.tileddataviewer.TiledDataViewerDataSource;
 import org.micromanager.tileddataviewer.TiledDataViewerExploreControls;
 import org.micromanager.tileddataviewer.TiledDataViewerOverlayerPlugin;
+import org.micromanager.tileddataviewer.overlay.ImageRoi;
 import org.micromanager.tileddataviewer.overlay.OvalRoi;
 import org.micromanager.tileddataviewer.overlay.Overlay;
 import org.micromanager.tileddataviewer.overlay.PolygonRoi;
@@ -126,6 +128,26 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
    // drawn until the operator leaves draw mode.
    private volatile boolean refineZActive_ = false;
    private final ArrayList<Point2D.Double> refineZMarkersPx_ = new ArrayList<>();
+
+   /** A Refine-Z in-focus thumbnail to draw at a full-resolution pixel rectangle. */
+   public static final class RefineZThumb {
+      public final double fullResX;
+      public final double fullResY;
+      public final double fullResW;
+      public final double fullResH;
+      public final BufferedImage img;
+
+      public RefineZThumb(double fullResX, double fullResY, double fullResW, double fullResH,
+            BufferedImage img) {
+         this.fullResX = fullResX;
+         this.fullResY = fullResY;
+         this.fullResW = fullResW;
+         this.fullResH = fullResH;
+         this.img = img;
+      }
+   }
+
+   private final ArrayList<RefineZThumb> refineZThumbs_ = new ArrayList<>();
 
    public ExplorerDataSource(ExplorerManager manager) {
       manager_ = manager;
@@ -236,6 +258,7 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       roiClosed_ = false;
       rubberBandPx_ = null;
       positionFovsPx_.clear();
+      refineZThumbs_.clear();
    }
 
    /**
@@ -253,6 +276,7 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       roiClosed_ = false;
       rubberBandPx_ = null;
       positionFovsPx_.clear();
+      refineZThumbs_.clear();
    }
 
    /**
@@ -281,6 +305,14 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       refineZMarkersPx_.clear();
       if (markers != null) {
          refineZMarkersPx_.addAll(markers);
+      }
+   }
+
+   /** Sets the Refine-Z in-focus thumbnails (full-res rectangles) to draw on the overlay. */
+   public synchronized void setRefineZThumbnails(java.util.List<RefineZThumb> thumbs) {
+      refineZThumbs_.clear();
+      if (thumbs != null) {
+         refineZThumbs_.addAll(thumbs);
       }
    }
 
@@ -1153,7 +1185,10 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       // Generated-position FOV rectangles (light grey), drawn under the ROI outline.
       addGeneratedPositionFovs(overlay, magnification, viewOffset);
 
-      // Refine-Z reference-point markers (green crosses), drawn over the FOVs.
+      // Refine-Z in-focus thumbnails (under the markers).
+      addRefineZThumbnails(overlay, magnification, viewOffset);
+
+      // Refine-Z reference-point markers (green crosses), drawn over the FOVs/thumbnails.
       addRefineZMarkers(overlay, magnification, viewOffset);
 
       // Create-Positions ROI — added last so it draws on top of everything (including the
@@ -1181,6 +1216,28 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
          marker.setStrokeColor(green);
          marker.setFillColor(green);
          overlay.add(marker);
+      }
+   }
+
+   /** Adds the Refine-Z in-focus thumbnails to the overlay as ImageRois. */
+   private void addRefineZThumbnails(Overlay overlay, double magnification,
+                                     Point2D.Double viewOffset) {
+      ArrayList<RefineZThumb> thumbs;
+      synchronized (this) {
+         if (refineZThumbs_.isEmpty()) {
+            return;
+         }
+         thumbs = new ArrayList<>(refineZThumbs_);
+      }
+      for (RefineZThumb t : thumbs) {
+         if (t.img == null) {
+            continue;
+         }
+         int x = (int) ((t.fullResX - viewOffset.x) * magnification);
+         int y = (int) ((t.fullResY - viewOffset.y) * magnification);
+         int w = (int) (t.fullResW * magnification);
+         int h = (int) (t.fullResH * magnification);
+         overlay.add(new ImageRoi(x, y, Math.max(1, w), Math.max(1, h), t.img));
       }
    }
 

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -258,7 +258,8 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       roiClosed_ = false;
       rubberBandPx_ = null;
       positionFovsPx_.clear();
-      refineZThumbs_.clear();
+      // Refine-Z markers/thumbnails are NOT cleared here: they belong to the Refine-Z lifecycle
+      // (managed by ExplorerManager), which preserves reference points across ROI-tool switches.
    }
 
    /**
@@ -276,7 +277,7 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       roiClosed_ = false;
       rubberBandPx_ = null;
       positionFovsPx_.clear();
-      refineZThumbs_.clear();
+      // Refine-Z markers/thumbnails are managed separately (see setPositionTool); not cleared here.
    }
 
    /**
@@ -1132,7 +1133,8 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
          overlay.add(stageRoi);
       }
 
-      // Green vessel outline — drawn last so it appears on top.
+      // Green vessel outline, drawn over the tiles/stage-FOV. The generated-position FOVs,
+      // Refine-Z overlays, and the in-progress ROI are added afterward so they appear on top.
       VesselType vessel;
       double tlX;
       double tlY;
@@ -1188,7 +1190,7 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
       // Refine-Z in-focus thumbnails (under the markers).
       addRefineZThumbnails(overlay, magnification, viewOffset);
 
-      // Refine-Z reference-point markers (green crosses), drawn over the FOVs/thumbnails.
+      // Refine-Z reference-point markers (green filled squares), drawn over the FOVs/thumbnails.
       addRefineZMarkers(overlay, magnification, viewOffset);
 
       // Create-Positions ROI — added last so it draws on top of everything (including the

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -26,6 +26,7 @@ import org.micromanager.tileddataviewer.TiledDataViewerCanvasMouseListenerInterf
 import org.micromanager.tileddataviewer.TiledDataViewerDataSource;
 import org.micromanager.tileddataviewer.TiledDataViewerExploreControls;
 import org.micromanager.tileddataviewer.TiledDataViewerOverlayerPlugin;
+import org.micromanager.tileddataviewer.overlay.OvalRoi;
 import org.micromanager.tileddataviewer.overlay.Overlay;
 import org.micromanager.tileddataviewer.overlay.Roi;
 import org.micromanager.tileddataviewer.overlay.TextRoi;
@@ -87,6 +88,13 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
    // Display tile dimensions (pipeline-output size; set after first acquisition)
    private int tileWidth_ = -1;
    private int tileHeight_ = -1;
+
+   // Vessel outline — set by ExplorerManager when anchor is confirmed; null = not set.
+   private VesselType vesselType_ = null;
+   private double vesselTlX_ = 0;
+   private double vesselTlY_ = 0;
+   private double vesselWidthPx_ = 0;
+   private double vesselHeightPx_ = 0;
 
    public ExplorerDataSource(ExplorerManager manager) {
       manager_ = manager;
@@ -165,6 +173,24 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    public void clearPendingTiles() {
       pendingTiles_.clear();
+   }
+
+   /**
+    * Sets the vessel outline to be drawn in the overlay.
+    * All coordinates are in full-resolution pixel space (tile-grid coordinates).
+    */
+   public synchronized void setVesselOutline(VesselType type,
+         double tlX, double tlY, double widthPx, double heightPx) {
+      vesselType_     = type;
+      vesselTlX_      = tlX;
+      vesselTlY_      = tlY;
+      vesselWidthPx_  = widthPx;
+      vesselHeightPx_ = heightPx;
+   }
+
+   /** Removes the vessel outline from the overlay. */
+   public synchronized void clearVesselOutline() {
+      vesselType_ = null;
    }
 
    public void clearSelection() {
@@ -733,6 +759,56 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
          stageRoi.setStrokeColor(Color.RED);
          stageRoi.setStrokeWidth(2);
          overlay.add(stageRoi);
+      }
+
+      // Green vessel outline — drawn last so it appears on top.
+      VesselType vessel;
+      double tlX;
+      double tlY;
+      double widthPx;
+      double heightPx;
+      synchronized (this) {
+         vessel   = vesselType_;
+         tlX      = vesselTlX_;
+         tlY      = vesselTlY_;
+         widthPx  = vesselWidthPx_;
+         heightPx = vesselHeightPx_;
+      }
+      if (vessel != null && !vessel.isNone() && widthPx > 0 && heightPx > 0) {
+         int bx = (int) ((tlX - viewOffset.x) * magnification);
+         int by = (int) ((tlY - viewOffset.y) * magnification);
+         int bw = (int) (widthPx  * magnification);
+         int bh = (int) (heightPx * magnification);
+         Roi border = new Roi(bx, by, bw, bh);
+         border.setStrokeColor(new Color(0, 220, 80));
+         border.setStrokeWidth(3);
+         overlay.add(border);
+
+         if (vessel.isMultiWell()) {
+            double pxPerUm  = widthPx / vessel.getWidthUm();
+            double wellW    = vessel.getWellWidthUm()    * pxPerUm;
+            double wellH    = vessel.getWellHeightUm()   * pxPerUm;
+            double spacX    = vessel.getWellSpacingXUm() * pxPerUm;
+            double spacY    = vessel.getWellSpacingYUm() * pxPerUm;
+            double firstWx  = vessel.getFirstWellXUm()  * pxPerUm;
+            double firstWy  = vessel.getFirstWellYUm()  * pxPerUm;
+            for (int r = 0; r < vessel.getWellRows(); r++) {
+               for (int c = 0; c < vessel.getWellCols(); c++) {
+                  double cx = tlX + firstWx + c * spacX;
+                  double cy = tlY + firstWy + r * spacY;
+                  int wx = (int) ((cx - wellW / 2.0 - viewOffset.x) * magnification);
+                  int wy = (int) ((cy - wellH / 2.0 - viewOffset.y) * magnification);
+                  int ww = (int) (wellW * magnification);
+                  int wh = (int) (wellH * magnification);
+                  Roi wellRoi = vessel.isWellsCircular()
+                        ? new OvalRoi(wx, wy, ww, wh)
+                        : new Roi(wx, wy, ww, wh);
+                  wellRoi.setStrokeColor(new Color(0, 180, 60));
+                  wellRoi.setStrokeWidth(1);
+                  overlay.add(wellRoi);
+               }
+            }
+         }
       }
    }
 }

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -5,7 +5,11 @@ import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
+import java.awt.geom.Area;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,6 +32,7 @@ import org.micromanager.tileddataviewer.TiledDataViewerExploreControls;
 import org.micromanager.tileddataviewer.TiledDataViewerOverlayerPlugin;
 import org.micromanager.tileddataviewer.overlay.OvalRoi;
 import org.micromanager.tileddataviewer.overlay.Overlay;
+import org.micromanager.tileddataviewer.overlay.PolygonRoi;
 import org.micromanager.tileddataviewer.overlay.Roi;
 import org.micromanager.tileddataviewer.overlay.TextRoi;
 
@@ -95,6 +100,26 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
    private double vesselTlY_ = 0;
    private double vesselWidthPx_ = 0;
    private double vesselHeightPx_ = 0;
+
+   /** Drawing tool for the Create-Positions ROI; NONE means draw mode is off. */
+   public enum PositionTool { NONE, RECTANGLE, OVAL, POLYGON, FREEHAND }
+
+   // Position-draw mode state. All coordinates are full-resolution canvas pixels.
+   // Read by drawOverlay (paint thread) and written by the mouse handlers (EDT),
+   // so every access is guarded by synchronized(this) (like the vessel state).
+   private volatile PositionTool positionTool_ = PositionTool.NONE;
+   // For RECTANGLE/OVAL: [start, end]. For POLYGON/FREEHAND: ordered vertices.
+   private final ArrayList<Point2D.Double> roiPointsPx_ = new ArrayList<>();
+   // True once the shape is complete (drag finished, or polygon closed).
+   private boolean roiClosed_ = false;
+   // Elastic point that follows the cursor while drawing (rubber-band rect/oval edge
+   // or the in-progress polygon segment); null when not dragging / not hovering.
+   private Point2D.Double rubberBandPx_ = null;
+   // Distance (display pixels) within which a polygon click snaps to the first vertex to close.
+   private static final int POLYGON_CLOSE_TOLERANCE = 8;
+   // FOV rectangles (full-res pixels) of the most recently generated positions, drawn in
+   // light grey until the operator leaves draw mode. Empty = none generated yet.
+   private final ArrayList<Rectangle2D.Double> positionFovsPx_ = new ArrayList<>();
 
    public ExplorerDataSource(ExplorerManager manager) {
       manager_ = manager;
@@ -191,6 +216,142 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
    /** Removes the vessel outline from the overlay. */
    public synchronized void clearVesselOutline() {
       vesselType_ = null;
+   }
+
+   // ===================== Create-Positions draw mode =====================
+
+   /**
+    * Selects the drawing tool. {@link PositionTool#NONE} turns draw mode off.
+    * Switching tools discards any in-progress ROI.
+    */
+   public synchronized void setPositionTool(PositionTool tool) {
+      positionTool_ = tool != null ? tool : PositionTool.NONE;
+      roiPointsPx_.clear();
+      roiClosed_ = false;
+      rubberBandPx_ = null;
+      positionFovsPx_.clear();
+   }
+
+   /** True when a drawing tool is active. */
+   public boolean isPositionDrawMode() {
+      return positionTool_ != PositionTool.NONE;
+   }
+
+   /** Discards the current ROI (and any generated positions) but keeps the active tool. */
+   public synchronized void clearPositionRoi() {
+      roiPointsPx_.clear();
+      roiClosed_ = false;
+      rubberBandPx_ = null;
+      positionFovsPx_.clear();
+   }
+
+   /**
+    * Sets the FOV rectangles (full-resolution pixels) of the just-generated positions, to be
+    * drawn in light grey until the operator leaves draw mode.
+    */
+   public synchronized void setGeneratedPositionFovs(java.util.List<Rectangle2D.Double> fovs) {
+      positionFovsPx_.clear();
+      if (fovs != null) {
+         positionFovsPx_.addAll(fovs);
+      }
+   }
+
+   /** True when a completed ROI is available for position generation. */
+   public synchronized boolean hasPositionRoi() {
+      if (!roiClosed_) {
+         return false;
+      }
+      switch (positionTool_) {
+         case RECTANGLE:
+         case OVAL:
+            return roiPointsPx_.size() == 2;
+         case POLYGON:
+         case FREEHAND:
+            return roiPointsPx_.size() >= 3;
+         default:
+            return false;
+      }
+   }
+
+   /**
+    * Returns the completed ROI as an {@link Area} in full-resolution pixel space,
+    * or null if no completed ROI exists.
+    */
+   public synchronized Area getPositionRoiAreaPx() {
+      if (!hasPositionRoi()) {
+         return null;
+      }
+      switch (positionTool_) {
+         case RECTANGLE: {
+            Point2D.Double a = roiPointsPx_.get(0);
+            Point2D.Double b = roiPointsPx_.get(1);
+            double x = Math.min(a.x, b.x);
+            double y = Math.min(a.y, b.y);
+            double w = Math.abs(a.x - b.x);
+            double h = Math.abs(a.y - b.y);
+            return new Area(new Rectangle2D.Double(x, y, w, h));
+         }
+         case OVAL: {
+            Point2D.Double a = roiPointsPx_.get(0);
+            Point2D.Double b = roiPointsPx_.get(1);
+            double x = Math.min(a.x, b.x);
+            double y = Math.min(a.y, b.y);
+            double w = Math.abs(a.x - b.x);
+            double h = Math.abs(a.y - b.y);
+            return new Area(new Ellipse2D.Double(x, y, w, h));
+         }
+         case POLYGON:
+         case FREEHAND: {
+            Path2D.Double path = new Path2D.Double();
+            Point2D.Double first = roiPointsPx_.get(0);
+            path.moveTo(first.x, first.y);
+            for (int i = 1; i < roiPointsPx_.size(); i++) {
+               Point2D.Double p = roiPointsPx_.get(i);
+               path.lineTo(p.x, p.y);
+            }
+            path.closePath();
+            return new Area(path);
+         }
+         default:
+            return null;
+      }
+   }
+
+   /**
+    * Returns the vessel boundary as an {@link Area} in full-resolution pixel space,
+    * or null when no vessel is set. Simple vessels yield the rectangular outline;
+    * multi-well plates yield the union of the individual well shapes.
+    */
+   public synchronized Area getVesselAreaPx() {
+      VesselType vessel = vesselType_;
+      if (vessel == null || vessel.isNone() || vesselWidthPx_ <= 0 || vesselHeightPx_ <= 0) {
+         return null;
+      }
+      if (!vessel.isMultiWell()) {
+         return new Area(new Rectangle2D.Double(
+               vesselTlX_, vesselTlY_, vesselWidthPx_, vesselHeightPx_));
+      }
+      double pxPerUm = vesselWidthPx_ / vessel.getWidthUm();
+      double wellW = vessel.getWellWidthUm()   * pxPerUm;
+      double wellH = vessel.getWellHeightUm()  * pxPerUm;
+      double spacX = vessel.getWellSpacingXUm() * pxPerUm;
+      double spacY = vessel.getWellSpacingYUm() * pxPerUm;
+      double firstWx = vessel.getFirstWellXUm() * pxPerUm;
+      double firstWy = vessel.getFirstWellYUm() * pxPerUm;
+      Area area = new Area();
+      for (int r = 0; r < vessel.getWellRows(); r++) {
+         for (int c = 0; c < vessel.getWellCols(); c++) {
+            double cx = vesselTlX_ + firstWx + c * spacX;
+            double cy = vesselTlY_ + firstWy + r * spacY;
+            double wx = cx - wellW / 2.0;
+            double wy = cy - wellH / 2.0;
+            Area well = vessel.isWellsCircular()
+                  ? new Area(new Ellipse2D.Double(wx, wy, wellW, wellH))
+                  : new Area(new Rectangle2D.Double(wx, wy, wellW, wellH));
+            area.add(well);
+         }
+      }
+      return area;
    }
 
    public void clearSelection() {
@@ -467,6 +628,30 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
    @Override
    public void mousePressed(MouseEvent e) {
       dragStart_ = e.getPoint();
+      if (isPositionDrawMode()) {
+         // RECTANGLE/OVAL start a drag; FREEHAND starts collecting points.
+         // POLYGON is click-driven and handled in mouseClicked.
+         if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+            Point2D.Double px = getFullResPixelCoords(e.getX(), e.getY());
+            if (px != null) {
+               synchronized (this) {
+                  if (positionTool_ == PositionTool.RECTANGLE
+                        || positionTool_ == PositionTool.OVAL) {
+                     roiPointsPx_.clear();
+                     roiClosed_ = false;
+                     roiPointsPx_.add(px);
+                     rubberBandPx_ = px;
+                  } else if (positionTool_ == PositionTool.FREEHAND) {
+                     roiPointsPx_.clear();
+                     roiClosed_ = false;
+                     roiPointsPx_.add(px);
+                  }
+               }
+               manager_.redrawOverlay();
+            }
+         }
+         return;
+      }
       if (javax.swing.SwingUtilities.isRightMouseButton(e)) {
          isRightDragging_ = false;
          if (!readOnly_ && tileWidth_ > 0 && tileHeight_ > 0) {
@@ -484,6 +669,38 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    @Override
    public void mouseReleased(MouseEvent e) {
+      if (isPositionDrawMode()) {
+         if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+            Point2D.Double px = getFullResPixelCoords(e.getX(), e.getY());
+            boolean changed = false;
+            synchronized (this) {
+               if (positionTool_ == PositionTool.RECTANGLE
+                     || positionTool_ == PositionTool.OVAL) {
+                  if (px != null && roiPointsPx_.size() == 1) {
+                     roiPointsPx_.add(px);
+                     roiClosed_ = true;
+                     rubberBandPx_ = null;
+                     changed = true;
+                  }
+               } else if (positionTool_ == PositionTool.FREEHAND) {
+                  if (px != null) {
+                     roiPointsPx_.add(px);
+                  }
+                  if (roiPointsPx_.size() >= 3) {
+                     roiClosed_ = true;
+                     changed = true;
+                  }
+               }
+            }
+            manager_.redrawOverlay();
+            if (changed) {
+               manager_.onPositionRoiChanged();
+            }
+         }
+         dragStart_ = null;
+         isLeftDragging_ = false;
+         return;
+      }
       if (javax.swing.SwingUtilities.isRightMouseButton(e) && !isRightDragging_) {
          if (!readOnly_ && !settingsMismatch_ && tileWidth_ > 0 && tileHeight_ > 0) {
             Point tile = getTileFromDisplayCoords(e.getX(), e.getY());
@@ -516,10 +733,67 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    @Override
    public void mouseClicked(MouseEvent e) {
+      if (!isPositionDrawMode() || positionTool_ != PositionTool.POLYGON
+            || !javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+         return;
+      }
+      Point2D.Double px = getFullResPixelCoords(e.getX(), e.getY());
+      if (px == null) {
+         return;
+      }
+      boolean closed = false;
+      synchronized (this) {
+         if (roiClosed_) {
+            // Start a fresh polygon when clicking after one was completed.
+            roiPointsPx_.clear();
+            roiClosed_ = false;
+         }
+         double mag = manager_.getMagnification();
+         boolean closeRequested = e.getClickCount() >= 2;
+         // Also close when clicking near the first vertex.
+         if (!closeRequested && roiPointsPx_.size() >= 3) {
+            Point2D.Double first = roiPointsPx_.get(0);
+            double dispDx = (px.x - first.x) * mag;
+            double dispDy = (px.y - first.y) * mag;
+            if (Math.hypot(dispDx, dispDy) <= POLYGON_CLOSE_TOLERANCE) {
+               closeRequested = true;
+            }
+         }
+         if (closeRequested) {
+            if (roiPointsPx_.size() >= 3) {
+               roiClosed_ = true;
+               rubberBandPx_ = null;
+               closed = true;
+            }
+         } else {
+            roiPointsPx_.add(px);
+         }
+      }
+      manager_.redrawOverlay();
+      if (closed) {
+         manager_.onPositionRoiChanged();
+      }
    }
 
    @Override
    public void mouseDragged(MouseEvent e) {
+      if (isPositionDrawMode()) {
+         if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+            Point2D.Double px = getFullResPixelCoords(e.getX(), e.getY());
+            if (px != null) {
+               synchronized (this) {
+                  if (positionTool_ == PositionTool.RECTANGLE
+                        || positionTool_ == PositionTool.OVAL) {
+                     rubberBandPx_ = px;
+                  } else if (positionTool_ == PositionTool.FREEHAND && !roiClosed_) {
+                     roiPointsPx_.add(px);
+                  }
+               }
+               manager_.redrawOverlay();
+            }
+         }
+         return;
+      }
       if (dragStart_ == null) {
          return;
       }
@@ -570,6 +844,19 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    @Override
    public void mouseMoved(MouseEvent e) {
+      if (isPositionDrawMode() && positionTool_ == PositionTool.POLYGON) {
+         Point2D.Double px = getFullResPixelCoords(e.getX(), e.getY());
+         boolean redraw = false;
+         synchronized (this) {
+            if (!roiClosed_ && !roiPointsPx_.isEmpty()) {
+               rubberBandPx_ = px;
+               redraw = true;
+            }
+         }
+         if (redraw) {
+            manager_.redrawOverlay();
+         }
+      }
    }
 
    @Override
@@ -808,6 +1095,101 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
                   overlay.add(wellRoi);
                }
             }
+         }
+      }
+
+      // Generated-position FOV rectangles (light grey), drawn under the ROI outline.
+      addGeneratedPositionFovs(overlay, magnification, viewOffset);
+
+      // Create-Positions ROI — added last so it draws on top of everything (including the
+      // vessel) and never hides the vessel outline. Added as Roi objects (not drawn straight
+      // to Graphics) so it persists across repaints, like every other overlay element.
+      addPositionRoi(overlay, magnification, viewOffset);
+   }
+
+   /** Adds the most recently generated positions' FOV rectangles to the overlay (light grey). */
+   private void addGeneratedPositionFovs(Overlay overlay, double magnification,
+                                         Point2D.Double viewOffset) {
+      ArrayList<Rectangle2D.Double> fovs;
+      synchronized (this) {
+         if (positionFovsPx_.isEmpty()) {
+            return;
+         }
+         fovs = new ArrayList<>(positionFovsPx_);
+      }
+      Color grey = new Color(200, 200, 200);
+      for (Rectangle2D.Double r : fovs) {
+         int x = (int) ((r.x - viewOffset.x) * magnification);
+         int y = (int) ((r.y - viewOffset.y) * magnification);
+         int w = (int) (r.width * magnification);
+         int h = (int) (r.height * magnification);
+         Roi roi = new Roi(x, y, Math.max(1, w), Math.max(1, h));
+         roi.setStrokeColor(grey);
+         roi.setStrokeWidth(1);
+         overlay.add(roi);
+      }
+   }
+
+   /**
+    * Adds the in-progress / completed Create-Positions ROI to the overlay, converting the
+    * stored full-resolution pixel coordinates to display coordinates. Snapshots the ROI state
+    * under the instance lock first.
+    */
+   private void addPositionRoi(Overlay overlay, double magnification, Point2D.Double viewOffset) {
+      PositionTool tool;
+      boolean closed;
+      Point2D.Double rubber;
+      ArrayList<Point2D.Double> pts;
+      synchronized (this) {
+         tool = positionTool_;
+         if (tool == PositionTool.NONE || roiPointsPx_.isEmpty()) {
+            return;
+         }
+         closed = roiClosed_;
+         rubber = rubberBandPx_;
+         pts = new ArrayList<>(roiPointsPx_);
+      }
+
+      final Color roiColor = Color.MAGENTA;
+      if (tool == PositionTool.RECTANGLE || tool == PositionTool.OVAL) {
+         Point2D.Double a = pts.get(0);
+         Point2D.Double b = closed && pts.size() == 2 ? pts.get(1) : rubber;
+         if (b != null) {
+            int x = (int) ((Math.min(a.x, b.x) - viewOffset.x) * magnification);
+            int y = (int) ((Math.min(a.y, b.y) - viewOffset.y) * magnification);
+            int w = (int) (Math.abs(a.x - b.x) * magnification);
+            int h = (int) (Math.abs(a.y - b.y) * magnification);
+            Roi roi = tool == PositionTool.RECTANGLE
+                  ? new Roi(x, y, Math.max(1, w), Math.max(1, h))
+                  : new OvalRoi(x, y, Math.max(1, w), Math.max(1, h));
+            roi.setStrokeColor(roiColor);
+            roi.setStrokeWidth(2);
+            overlay.add(roi);
+         }
+      } else {
+         // POLYGON / FREEHAND
+         int n = pts.size();
+         int extra = (!closed && rubber != null) ? 1 : 0;
+         int[] xs = new int[n + extra];
+         int[] ys = new int[n + extra];
+         for (int i = 0; i < n; i++) {
+            xs[i] = (int) ((pts.get(i).x - viewOffset.x) * magnification);
+            ys[i] = (int) ((pts.get(i).y - viewOffset.y) * magnification);
+         }
+         if (extra == 1) {
+            xs[n] = (int) ((rubber.x - viewOffset.x) * magnification);
+            ys[n] = (int) ((rubber.y - viewOffset.y) * magnification);
+         }
+         PolygonRoi poly = new PolygonRoi(xs, ys, closed);
+         poly.setStrokeColor(roiColor);
+         poly.setStrokeWidth(2);
+         overlay.add(poly);
+         // Mark the first vertex so the user can see where to close an open polygon.
+         if (!closed && tool == PositionTool.POLYGON && xs.length > 0) {
+            Roi marker = new Roi(xs[0] - 3, ys[0] - 3, 7, 7);
+            marker.setStrokeColor(roiColor);
+            marker.setFillColor(roiColor);
+            overlay.add(marker);
          }
       }
    }

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -239,6 +239,11 @@ public class ExplorerFrame extends JFrame {
       withinVesselCheck_.setToolTipText(
             "Generate positions only where they fall within the vessel boundary");
       withinVesselCheck_.setEnabled(false);
+      withinVesselCheck_.addActionListener(e -> {
+         if (positionDrawActive_) {
+            explorerManager_.updatePositionPreview(withinVesselCheck_.isSelected());
+         }
+      });
       positionPanel.add(withinVesselCheck_);
 
       generatePositionsButton_ = new JButton("Add to Position List");
@@ -345,6 +350,11 @@ public class ExplorerFrame extends JFrame {
          hcsStatusLabel_.setText(found ? "Found ✓" : "Not found");
          updateAnchorPanels();
       });
+   }
+
+   /** Returns whether the "Only within vessel" checkbox is selected. */
+   public boolean isWithinVesselSelected() {
+      return withinVesselCheck_ != null && withinVesselCheck_.isSelected();
    }
 
    /** Returns the vessel currently selected in the combo box. */
@@ -454,7 +464,9 @@ public class ExplorerFrame extends JFrame {
       }
       createPositionsButton_.setEnabled(liveSession_);
       boolean drawing = liveSession_ && positionDrawActive_;
-      positionToolCombo_.setEnabled(drawing);
+      // The shape can be chosen before entering draw mode, so it follows the session, not
+      // the draw-mode state.
+      positionToolCombo_.setEnabled(liveSession_);
       clearRoiButton_.setEnabled(drawing);
       boolean vesselSelected = !getSelectedVessel().isNone();
       withinVesselCheck_.setEnabled(drawing && vesselSelected);

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
@@ -44,9 +45,20 @@ public class ExplorerFrame extends JFrame {
    private final ExplorerManager explorerManager_;
 
    private boolean sessionActive_ = false;
+   // True only for a live (Started) session; false for an opened (read-only) dataset.
+   private boolean liveSession_ = false;
 
    private JButton stopButton_;
    private JComboBox<VesselType> vesselCombo_;
+
+   // Create-Positions controls (live session only).
+   private JButton createPositionsButton_;
+   private JComboBox<String> positionToolCombo_;
+   private JCheckBox withinVesselCheck_;
+   private JButton generatePositionsButton_;
+   private JButton clearRoiButton_;
+   private JLabel positionStatusLabel_;
+   private boolean positionDrawActive_ = false;
 
    // Simple-vessel anchor (coverslips): 5 corner/center buttons.
    private JPanel simpleAnchorPanel_;
@@ -152,6 +164,7 @@ public class ExplorerFrame extends JFrame {
             explorerManager_.setVesselType(selected);
          }
          updateAnchorPanels();
+         updatePositionToolsEnabled();
       });
       add(vesselCombo_, "wrap");
 
@@ -201,6 +214,54 @@ public class ExplorerFrame extends JFrame {
       wellAnchorPanel_.add(setWellAnchorButton_, "wrap");
       wellAnchorPanel_.setVisible(false);
       add(wellAnchorPanel_, "growx, wrap");
+
+      // Create Positions panel (live session only).
+      final JPanel positionPanel = new JPanel(new MigLayout("insets 0, fillx"));
+      createPositionsButton_ = new JButton("Create Positions");
+      createPositionsButton_.setToolTipText(
+            "Draw an ROI on the image, then add a tiled position list covering it.");
+      createPositionsButton_.setEnabled(false);
+      createPositionsButton_.addActionListener(e -> togglePositionDraw());
+      positionPanel.add(createPositionsButton_);
+
+      positionToolCombo_ = new JComboBox<>(
+            new String[] {"Rectangle", "Oval", "Polygon", "Freehand"});
+      positionToolCombo_.setToolTipText("Shape to draw for the position region");
+      positionToolCombo_.setEnabled(false);
+      positionToolCombo_.addActionListener(e -> {
+         if (positionDrawActive_) {
+            explorerManager_.setPositionDrawTool(selectedPositionTool());
+         }
+      });
+      positionPanel.add(positionToolCombo_);
+
+      withinVesselCheck_ = new JCheckBox("Only within vessel");
+      withinVesselCheck_.setToolTipText(
+            "Generate positions only where they fall within the vessel boundary");
+      withinVesselCheck_.setEnabled(false);
+      positionPanel.add(withinVesselCheck_);
+
+      generatePositionsButton_ = new JButton("Add to Position List");
+      generatePositionsButton_.setToolTipText(
+            "Generate positions covering the drawn ROI using the current pixel size");
+      generatePositionsButton_.setEnabled(false);
+      generatePositionsButton_.addActionListener(e ->
+            explorerManager_.createPositionsFromRoi(withinVesselCheck_.isSelected()));
+      positionPanel.add(generatePositionsButton_);
+
+      clearRoiButton_ = new JButton("Clear");
+      clearRoiButton_.setToolTipText("Clear the drawn ROI");
+      clearRoiButton_.setEnabled(false);
+      clearRoiButton_.addActionListener(e -> {
+         explorerManager_.clearPositionRoi();
+         setGenerateEnabled(false);
+         setPositionStatus("Draw an ROI.");
+      });
+      positionPanel.add(clearRoiButton_, "wrap");
+
+      positionStatusLabel_ = new JLabel(" ");
+      positionPanel.add(positionStatusLabel_, "span, growx, wrap");
+      add(positionPanel, "growx, wrap");
 
       JButton openButton = new JButton("Open Existing");
       openButton.setToolTipText("Open a previously saved Explorer dataset.");
@@ -259,13 +320,19 @@ public class ExplorerFrame extends JFrame {
 
    /**
     * Notifies the frame that an explore session has started or stopped.
-    * Enables or disables anchor controls accordingly.
+    * Enables or disables anchor controls accordingly. {@code live} is true only for a
+    * Started session (not an opened, read-only dataset); Create-Positions tools are gated on it.
     * Called from ExplorerManager; switches to EDT.
     */
-   public void setExploringActive(boolean active) {
+   public void setExploringActive(boolean active, boolean live) {
       SwingUtilities.invokeLater(() -> {
          sessionActive_ = active;
+         liveSession_ = active && live;
+         if (!liveSession_ && positionDrawActive_) {
+            exitPositionDraw();
+         }
          updateAnchorPanels();
+         updatePositionToolsEnabled();
       });
    }
 
@@ -327,6 +394,73 @@ public class ExplorerFrame extends JFrame {
       SpinnerNumberModel model = new SpinnerNumberModel(
             Math.min(currentCol, v.getWellCols()), 1, v.getWellCols(), 1);
       wellColSpinner_.setModel(model);
+   }
+
+   private ExplorerDataSource.PositionTool selectedPositionTool() {
+      Object sel = positionToolCombo_.getSelectedItem();
+      String name = sel != null ? sel.toString() : "Rectangle";
+      switch (name) {
+         case "Oval":
+            return ExplorerDataSource.PositionTool.OVAL;
+         case "Polygon":
+            return ExplorerDataSource.PositionTool.POLYGON;
+         case "Freehand":
+            return ExplorerDataSource.PositionTool.FREEHAND;
+         case "Rectangle":
+         default:
+            return ExplorerDataSource.PositionTool.RECTANGLE;
+      }
+   }
+
+   private void togglePositionDraw() {
+      if (positionDrawActive_) {
+         exitPositionDraw();
+      } else {
+         positionDrawActive_ = true;
+         createPositionsButton_.setText("Stop Drawing");
+         explorerManager_.setPositionDrawTool(selectedPositionTool());
+         setPositionStatus("Draw an ROI on the image.");
+         updatePositionToolsEnabled();
+      }
+   }
+
+   private void exitPositionDraw() {
+      positionDrawActive_ = false;
+      if (createPositionsButton_ != null) {
+         createPositionsButton_.setText("Create Positions");
+      }
+      explorerManager_.setPositionDrawTool(ExplorerDataSource.PositionTool.NONE);
+      updatePositionToolsEnabled();
+   }
+
+   /** Enables/disables the Generate button. Called from ExplorerManager; switches to EDT. */
+   public void setGenerateEnabled(boolean enabled) {
+      SwingUtilities.invokeLater(() -> {
+         if (generatePositionsButton_ != null) {
+            generatePositionsButton_.setEnabled(enabled && liveSession_ && positionDrawActive_);
+         }
+      });
+   }
+
+   /** Sets the Create-Positions status text. Called from ExplorerManager; switches to EDT. */
+   public void setPositionStatus(String text) {
+      SwingUtilities.invokeLater(() ->
+            positionStatusLabel_.setText(text == null || text.isEmpty() ? " " : text));
+   }
+
+   private void updatePositionToolsEnabled() {
+      if (createPositionsButton_ == null) {
+         return;
+      }
+      createPositionsButton_.setEnabled(liveSession_);
+      boolean drawing = liveSession_ && positionDrawActive_;
+      positionToolCombo_.setEnabled(drawing);
+      clearRoiButton_.setEnabled(drawing);
+      boolean vesselSelected = !getSelectedVessel().isNone();
+      withinVesselCheck_.setEnabled(drawing && vesselSelected);
+      if (!drawing) {
+         generatePositionsButton_.setEnabled(false);
+      }
    }
 
    private static String anchorLabel(VesselType.AnchorType at) {

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -60,6 +60,9 @@ public class ExplorerFrame extends JFrame {
    private JLabel positionStatusLabel_;
    private boolean positionDrawActive_ = false;
 
+   // Refine-Z control (opens a separate RefineZFrame).
+   private JButton refineZButton_;
+
    // Simple-vessel anchor (coverslips): 5 corner/center buttons.
    private JPanel simpleAnchorPanel_;
    private final List<JButton> simpleAnchorButtons_ = new ArrayList<>();
@@ -264,6 +267,8 @@ public class ExplorerFrame extends JFrame {
       });
       positionPanel.add(clearRoiButton_, "wrap");
 
+      buildRefineZPanel(positionPanel);
+
       positionStatusLabel_ = new JLabel(" ");
       positionPanel.add(positionStatusLabel_, "span, growx, wrap");
       add(positionPanel, "growx, wrap");
@@ -439,6 +444,7 @@ public class ExplorerFrame extends JFrame {
       if (createPositionsButton_ != null) {
          createPositionsButton_.setText("Create Positions");
       }
+      // setPositionDrawTool(NONE) also closes the Refine Z window and drops its points.
       explorerManager_.setPositionDrawTool(ExplorerDataSource.PositionTool.NONE);
       updatePositionToolsEnabled();
    }
@@ -449,6 +455,7 @@ public class ExplorerFrame extends JFrame {
          if (generatePositionsButton_ != null) {
             generatePositionsButton_.setEnabled(enabled && liveSession_ && positionDrawActive_);
          }
+         updateRefineZEnabled();
       });
    }
 
@@ -473,6 +480,28 @@ public class ExplorerFrame extends JFrame {
       if (!drawing) {
          generatePositionsButton_.setEnabled(false);
       }
+      updateRefineZEnabled();
+   }
+
+   // ===================== Refine Z =====================
+
+   private void buildRefineZPanel(JPanel parent) {
+      refineZButton_ = new JButton("Refine Z...");
+      refineZButton_.setToolTipText(
+            "Open the Refine Z window to measure focus at reference points and interpolate it "
+            + "across the generated positions.");
+      refineZButton_.setEnabled(false);
+      refineZButton_.addActionListener(e -> explorerManager_.showRefineZFrame());
+      parent.add(refineZButton_, "wrap");
+   }
+
+   /** Enables the "Refine Z..." button when a position preview exists to refine over. */
+   private void updateRefineZEnabled() {
+      if (refineZButton_ == null) {
+         return;
+      }
+      refineZButton_.setEnabled(liveSession_ && positionDrawActive_
+            && generatePositionsButton_.isEnabled());
    }
 
    private static String anchorLabel(VesselType.AnchorType at) {

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -3,11 +3,15 @@ package org.micromanager.explorer;
 import java.awt.Toolkit;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import javax.swing.JButton;
+import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
@@ -33,12 +37,28 @@ public class ExplorerFrame extends JFrame {
 
    static final String EXPLORE_TMP_PATH = "ExploreTmpPath";
    static final String EXPLORE_OVERLAP_PERCENT = "ExploreOverlapPercent";
+   static final String VESSEL_TYPE = "VesselType";
 
    private final Studio studio_;
    private final MutablePropertyMapView settings_;
    private final ExplorerManager explorerManager_;
 
+   private boolean sessionActive_ = false;
+
    private JButton stopButton_;
+   private JComboBox<VesselType> vesselCombo_;
+
+   // Simple-vessel anchor (coverslips): 5 corner/center buttons.
+   private JPanel simpleAnchorPanel_;
+   private final List<JButton> simpleAnchorButtons_ = new ArrayList<>();
+
+   // Multi-well anchor panel: HCS calibration status + optional well selector.
+   private JPanel wellAnchorPanel_;
+   private JLabel hcsStatusLabel_;
+   private JButton refreshHcsButton_;
+   private JComboBox<String> wellRowCombo_;
+   private JSpinner wellColSpinner_;
+   private JButton setWellAnchorButton_;
 
    public org.micromanager.PropertyMap getSettings() {
       return settings_.toPropertyMap();
@@ -116,6 +136,72 @@ public class ExplorerFrame extends JFrame {
             settings_.putInteger(EXPLORE_OVERLAP_PERCENT, (Integer) overlapSpinner.getValue()));
       add(overlapSpinner, "wrap");
 
+      // Vessel type selector
+      add(new JLabel("Vessel:"), "split 2");
+      vesselCombo_ = new JComboBox<>(VesselType.builtIn().toArray(new VesselType[0]));
+      String savedVessel = settings_.getString(VESSEL_TYPE, VesselType.NONE.getName());
+      VesselType.builtIn().stream()
+            .filter(v -> v.getName().equals(savedVessel))
+            .findFirst()
+            .ifPresent(vesselCombo_::setSelectedItem);
+      vesselCombo_.setToolTipText("Select the type of vessel on the stage");
+      vesselCombo_.addActionListener(e -> {
+         VesselType selected = (VesselType) vesselCombo_.getSelectedItem();
+         if (selected != null) {
+            settings_.putString(VESSEL_TYPE, selected.getName());
+            explorerManager_.setVesselType(selected);
+         }
+         updateAnchorPanels();
+      });
+      add(vesselCombo_, "wrap");
+
+      // ── Panel A: simple-vessel corner/center anchor (coverslips) ──────────────
+      simpleAnchorPanel_ = new JPanel(new MigLayout("insets 0"));
+      simpleAnchorPanel_.add(new JLabel("Anchor:"));
+      for (VesselType.AnchorType at : VesselType.AnchorType.values()) {
+         String label = anchorLabel(at);
+         JButton btn = new JButton(label);
+         btn.setToolTipText("Set current stage position as the " + label + " of the vessel");
+         btn.setEnabled(false);
+         btn.addActionListener(e -> explorerManager_.setVesselAnchor(at));
+         simpleAnchorButtons_.add(btn);
+         simpleAnchorPanel_.add(btn);
+      }
+      simpleAnchorPanel_.setVisible(false);
+      add(simpleAnchorPanel_, "growx, wrap");
+
+      // ── Panel B: multi-well anchor (HCS calibration + well selector) ──────────
+      wellAnchorPanel_ = new JPanel(new MigLayout("insets 0, fillx"));
+      wellAnchorPanel_.add(new JLabel("HCS cal:"));
+      hcsStatusLabel_ = new JLabel("Not found");
+      wellAnchorPanel_.add(hcsStatusLabel_);
+      refreshHcsButton_ = new JButton("Refresh");
+      refreshHcsButton_.setToolTipText(
+            "Re-read HCS plugin calibration from the profile and apply it");
+      refreshHcsButton_.setEnabled(false);
+      refreshHcsButton_.addActionListener(e -> explorerManager_.refreshHcsCalibration());
+      wellAnchorPanel_.add(refreshHcsButton_, "wrap");
+
+      wellAnchorPanel_.add(new JLabel("Anchor well:"));
+      wellRowCombo_ = new JComboBox<>();
+      wellRowCombo_.setToolTipText("Row of the well to use as anchor");
+      wellAnchorPanel_.add(wellRowCombo_);
+      wellColSpinner_ = new JSpinner(new SpinnerNumberModel(1, 1, 1, 1));
+      wellColSpinner_.setToolTipText("Column of the well to use as anchor");
+      wellAnchorPanel_.add(wellColSpinner_);
+      setWellAnchorButton_ = new JButton("Set Anchor");
+      setWellAnchorButton_.setToolTipText(
+            "Set current stage position as the center of the selected well");
+      setWellAnchorButton_.setEnabled(false);
+      setWellAnchorButton_.addActionListener(e -> {
+         int row = wellRowCombo_.getSelectedIndex();
+         int col = (Integer) wellColSpinner_.getValue() - 1;
+         explorerManager_.setVesselWellAnchor(row, col);
+      });
+      wellAnchorPanel_.add(setWellAnchorButton_, "wrap");
+      wellAnchorPanel_.setVisible(false);
+      add(wellAnchorPanel_, "growx, wrap");
+
       JButton openButton = new JButton("Open Existing");
       openButton.setToolTipText("Open a previously saved Explorer dataset.");
       openButton.addActionListener(e -> openExplore());
@@ -169,5 +255,88 @@ public class ExplorerFrame extends JFrame {
             stopButton_.setEnabled(inProgress);
          }
       });
+   }
+
+   /**
+    * Notifies the frame that an explore session has started or stopped.
+    * Enables or disables anchor controls accordingly.
+    * Called from ExplorerManager; switches to EDT.
+    */
+   public void setExploringActive(boolean active) {
+      SwingUtilities.invokeLater(() -> {
+         sessionActive_ = active;
+         updateAnchorPanels();
+      });
+   }
+
+   /**
+    * Updates the HCS calibration status label and re-evaluates well-selector enable state.
+    * Called from ExplorerManager; switches to EDT.
+    */
+   public void setHcsCalibrationStatus(boolean found) {
+      SwingUtilities.invokeLater(() -> {
+         hcsStatusLabel_.setText(found ? "Found ✓" : "Not found");
+         updateAnchorPanels();
+      });
+   }
+
+   /** Returns the vessel currently selected in the combo box. */
+   public VesselType getSelectedVessel() {
+      VesselType v = (VesselType) vesselCombo_.getSelectedItem();
+      return v != null ? v : VesselType.NONE;
+   }
+
+   private void updateAnchorPanels() {
+      VesselType v = (VesselType) vesselCombo_.getSelectedItem();
+      if (v == null) {
+         v = VesselType.NONE;
+      }
+      boolean isMultiWell = !v.isNone() && v.isMultiWell();
+      boolean isSimple    = !v.isNone() && !v.isMultiWell();
+
+      simpleAnchorPanel_.setVisible(isSimple);
+      wellAnchorPanel_.setVisible(isMultiWell);
+
+      simpleAnchorButtons_.forEach(b -> b.setEnabled(sessionActive_ && isSimple));
+
+      refreshHcsButton_.setEnabled(sessionActive_ && isMultiWell);
+
+      boolean hcsFound = hcsStatusLabel_.getText().startsWith("Found");
+      boolean wellAnchorEnabled = sessionActive_ && isMultiWell && !hcsFound;
+      wellRowCombo_.setEnabled(wellAnchorEnabled);
+      wellColSpinner_.setEnabled(wellAnchorEnabled);
+      setWellAnchorButton_.setEnabled(wellAnchorEnabled);
+
+      if (isMultiWell) {
+         populateWellSelector(v);
+      }
+
+      pack();
+   }
+
+   private void populateWellSelector(VesselType v) {
+      int currentRow = wellRowCombo_.getSelectedIndex();
+      wellRowCombo_.removeAllItems();
+      for (int r = 0; r < v.getWellRows(); r++) {
+         wellRowCombo_.addItem(VesselType.getRowLabel(r));
+      }
+      if (currentRow >= 0 && currentRow < v.getWellRows()) {
+         wellRowCombo_.setSelectedIndex(currentRow);
+      }
+      int currentCol = (Integer) wellColSpinner_.getValue();
+      SpinnerNumberModel model = new SpinnerNumberModel(
+            Math.min(currentCol, v.getWellCols()), 1, v.getWellCols(), 1);
+      wellColSpinner_.setModel(model);
+   }
+
+   private static String anchorLabel(VesselType.AnchorType at) {
+      switch (at) {
+         case TOP_LEFT:     return "Top-Left";
+         case TOP_RIGHT:    return "Top-Right";
+         case BOTTOM_LEFT:  return "Bot-Left";
+         case BOTTOM_RIGHT: return "Bot-Right";
+         case CENTER:       return "Center";
+         default:           return at.name();
+      }
    }
 }

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -14,9 +14,11 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
+import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import net.miginfocom.swing.MigLayout;
@@ -57,7 +59,7 @@ public class ExplorerFrame extends JFrame {
    private JCheckBox withinVesselCheck_;
    private JButton generatePositionsButton_;
    private JButton clearRoiButton_;
-   private JLabel positionStatusLabel_;
+   private JTextArea positionStatusLabel_;
    private boolean positionDrawActive_ = false;
 
    // Refine-Z control (opens a separate RefineZFrame).
@@ -269,8 +271,19 @@ public class ExplorerFrame extends JFrame {
 
       buildRefineZPanel(positionPanel);
 
-      positionStatusLabel_ = new JLabel(" ");
-      positionPanel.add(positionStatusLabel_, "span, growx, wrap");
+      // A read-only, word-wrapping JTextArea styled as a label: long status/Note text wraps to
+      // multiple lines (reporting its true height to the layout, so nothing is clipped) instead
+      // of widening the window.
+      positionStatusLabel_ = new JTextArea(" ");
+      positionStatusLabel_.setEditable(false);
+      positionStatusLabel_.setFocusable(false);
+      positionStatusLabel_.setLineWrap(true);
+      positionStatusLabel_.setWrapStyleWord(true);
+      positionStatusLabel_.setOpaque(false);
+      positionStatusLabel_.setBorder(null);
+      positionStatusLabel_.setFont(UIManager.getFont("Label.font"));
+      // wmin 0 lets the cell shrink with the panel; wmax caps the width so text wraps.
+      positionPanel.add(positionStatusLabel_, "span, growx, wmin 0, wmax 400, wrap");
       add(positionPanel, "growx, wrap");
 
       JButton openButton = new JButton("Open Existing");
@@ -459,10 +472,17 @@ public class ExplorerFrame extends JFrame {
       });
    }
 
-   /** Sets the Create-Positions status text. Called from ExplorerManager; switches to EDT. */
+   /**
+    * Sets the Create-Positions status text. Long messages (e.g. the pixel-size Note) wrap to
+    * multiple lines rather than widening the window. Called from ExplorerManager; switches to EDT.
+    */
    public void setPositionStatus(String text) {
-      SwingUtilities.invokeLater(() ->
-            positionStatusLabel_.setText(text == null || text.isEmpty() ? " " : text));
+      final String shown = (text == null || text.isEmpty()) ? " " : text;
+      SwingUtilities.invokeLater(() -> {
+         positionStatusLabel_.setText(shown);
+         // Re-pack so the window grows taller for a wrapped (multi-line) status, never wider.
+         pack();
+      });
    }
 
    private void updatePositionToolsEnabled() {

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -2728,8 +2728,22 @@ public class ExplorerManager {
             return null;
          }
          Image img = images.get(0);
+         Object pixels = img.getRawPixels();
+         int w = img.getWidth();
+         int h = img.getHeight();
+         // Apply the same camera orientation correction (mirror + rotation) the canvas applies to
+         // acquired tiles, so thumbnails match the main images. Skip if the Flipper already did it.
+         if (!flipperInPipeline_
+               && (sessionCorrectionMirror_ || sessionCorrectionRotation_ != 0)) {
+            Object[] result = ImageTransformUtils.transformPixels(
+                  pixels, w, h, img.getBytesPerPixel(),
+                  sessionCorrectionMirror_, sessionCorrectionRotation_);
+            pixels = result[0];
+            w = (Integer) result[1];
+            h = (Integer) result[2];
+         }
          ij.process.ImageProcessor proc = ImageUtils.makeProcessor(
-               img.getImageJPixelType(), img.getWidth(), img.getHeight(), img.getRawPixels());
+               img.getImageJPixelType(), w, h, pixels);
          if (proc == null) {
             return null;
          }

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -34,7 +34,8 @@ import java.util.stream.Stream;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
-import javax.swing.SwingWorker;
+import mmcorej.DeviceType;
+import mmcorej.StrVector;
 import mmcorej.org.json.JSONArray;
 import mmcorej.org.json.JSONObject;
 import org.micromanager.MultiStagePosition;
@@ -62,6 +63,7 @@ import org.micromanager.internal.utils.ColorPalettes;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.ndtiffstorage.EssentialImageMetadata;
 import org.micromanager.ndtiffstorage.NDTiffStorage;
+import org.micromanager.propertymap.MutablePropertyMapView;
 import org.micromanager.tileddataprovider.NDTiffProviderAdapter;
 import org.micromanager.tileddataviewer.TiledDataViewerAPI;
 import org.micromanager.tileddataviewer.TiledDataViewerAcqInterface;
@@ -185,6 +187,9 @@ public class ExplorerManager {
    private boolean vesselUsedHcsCal_ = false;
    // True when anchor is set but stageToPixel() was not ready; retry after first tile.
    private boolean vesselOutlinePending_ = false;
+
+   // Create-Positions: number of regions already committed this session (for "Reg<n>" labels).
+   private int regionCounter_ = 0;
 
    // Camera orientation / Image Flipper correction
    private int sessionCorrectionRotation_ = 0;    // 0/90/180/270
@@ -361,6 +366,7 @@ public class ExplorerManager {
          vesselAnchorType_ = null;
          vesselUsedHcsCal_ = false;
          vesselOutlinePending_ = false;
+         regionCounter_ = 0;
          frame_.setExploringActive(true, true);
          if (vesselType_.isMultiWell()) {
             Point2D.Double hcsOffset = tryReadHcsCalibration();
@@ -1849,29 +1855,113 @@ public class ExplorerManager {
       return dataSource_ != null && dataSource_.hasPositionRoi();
    }
 
-   /** Notifies the frame that the ROI state changed so it can update the Generate button. */
+   /**
+    * Notifies that the ROI state changed: refreshes the live position preview (grey FOVs) and
+    * the Generate button. Called from ExplorerDataSource when an ROI is completed or cleared.
+    */
    public void onPositionRoiChanged() {
-      final boolean has = hasPositionRoi();
-      SwingUtilities.invokeLater(() -> frame_.setGenerateEnabled(has));
+      SwingUtilities.invokeLater(() -> updatePositionPreview(frame_.isWithinVesselSelected()));
    }
 
    /**
-    * Generates a tile-grid position list covering the drawn ROI and adds it to the MM position
-    * list. Positions are sized using the CURRENT pixel size and camera FOV (which may differ
-    * from the session-start objective). When {@code withinVesselOnly} is true the ROI is first
-    * intersected with the vessel boundary.
-    *
-    * <p>A tile is included if its FOV rectangle overlaps the (clipped) ROI shape. Positions are
-    * ordered in a serpentine pattern. The computation runs off the EDT.</p>
+    * Recomputes the position grid for the current ROI and shows it as grey FOV rectangles on
+    * the overlay WITHOUT committing it to the MM position list. Safe to call repeatedly (on ROI
+    * completion and when the "within vessel" checkbox toggles). Clears the preview when there is
+    * no usable ROI.
     */
-   public void createPositionsFromRoi(boolean withinVesselOnly) {
-      if (dataSource_ == null || !exploring_ || loadedData_) {
+   public void updatePositionPreview(boolean withinVesselOnly) {
+      if (dataSource_ == null || !exploring_ || loadedData_ || !hasPositionRoi()) {
+         if (dataSource_ != null) {
+            dataSource_.setGeneratedPositionFovs(null);
+            redrawOverlay();
+         }
+         frame_.setGenerateEnabled(false);
          return;
       }
-      final Area roiAreaPx = dataSource_.getPositionRoiAreaPx();
-      if (roiAreaPx == null) {
+      try {
+         PositionGridResult preview = computePositionGrid(withinVesselOnly);
+         dataSource_.setGeneratedPositionFovs(preview.fovsPx);
+         redrawOverlay();
+         String status = preview.posList.getNumberOfPositions() + " positions ("
+               + preview.regionLabel + ")";
+         if (preview.warning != null) {
+            status = preview.warning + " (" + status + ")";
+         }
+         frame_.setPositionStatus(status);
+         frame_.setGenerateEnabled(true);
+      } catch (Exception ex) {
+         dataSource_.setGeneratedPositionFovs(null);
+         redrawOverlay();
+         frame_.setPositionStatus(ex.getMessage());
+         frame_.setGenerateEnabled(false);
+      }
+   }
+
+   /**
+    * Commits the previewed positions to the MM position list. Positions are sized using the
+    * CURRENT pixel size and camera FOV. When {@code withinVesselOnly} is true the ROI is first
+    * intersected with the vessel boundary. The grid is recomputed so the committed list reflects
+    * the latest hardware/checkbox state, then a region counter is advanced so the next region
+    * gets a fresh identifier.
+    */
+   public void createPositionsFromRoi(boolean withinVesselOnly) {
+      if (dataSource_ == null || !exploring_ || loadedData_ || !hasPositionRoi()) {
          frame_.setPositionStatus("Draw an ROI first.");
          return;
+      }
+      PositionGridResult result;
+      try {
+         result = computePositionGrid(withinVesselOnly);
+      } catch (Exception ex) {
+         frame_.setPositionStatus(ex.getMessage());
+         return;
+      }
+      PositionList existing = studio_.positions().getPositionList();
+      for (int i = 0; i < result.posList.getNumberOfPositions(); i++) {
+         existing.addPosition(result.posList.getPosition(i));
+      }
+      studio_.positions().setPositionList(existing);
+      studio_.app().showPositionList();
+      dataSource_.setGeneratedPositionFovs(result.fovsPx);
+      redrawOverlay();
+      // Advance the region counter so a subsequent ROI gets the next identifier.
+      regionCounter_++;
+      String status = "Added " + result.posList.getNumberOfPositions() + " positions ("
+            + result.regionLabel + ")";
+      if (result.warning != null) {
+         status = result.warning + " (" + status + ")";
+      }
+      frame_.setPositionStatus(status);
+      // Refresh the preview (now showing the NEXT region's identifier) and keep the ROI.
+      updatePositionPreview(withinVesselOnly);
+   }
+
+   /** Holds the result of a position-grid computation. */
+   private static final class PositionGridResult {
+      private final PositionList posList;
+      private final java.util.List<Rectangle2D.Double> fovsPx;
+      private final String warning;
+      private final String regionLabel;
+
+      private PositionGridResult(PositionList posList,
+            java.util.List<Rectangle2D.Double> fovsPx, String warning, String regionLabel) {
+         this.posList = posList;
+         this.fovsPx = fovsPx;
+         this.warning = warning;
+         this.regionLabel = regionLabel;
+      }
+   }
+
+   /**
+    * Computes the tile-grid position list and FOV rectangles for the current ROI. Pure
+    * computation (plus current-hardware reads); does not mutate the MM position list. A tile is
+    * included if its FOV rectangle overlaps the (optionally vessel-clipped) ROI shape. Positions
+    * are ordered serpentine, prefixed with a region identifier, and include every checked stage.
+    */
+   private PositionGridResult computePositionGrid(boolean withinVesselOnly) throws Exception {
+      final Area roiAreaPx = dataSource_.getPositionRoiAreaPx();
+      if (roiAreaPx == null) {
+         throw new Exception("Draw an ROI first.");
       }
       if (withinVesselOnly) {
          Area vesselArea = dataSource_.getVesselAreaPx();
@@ -1880,237 +1970,381 @@ public class ExplorerManager {
          }
       }
       if (roiAreaPx.isEmpty()) {
-         frame_.setPositionStatus("ROI does not overlap the vessel.");
-         return;
+         throw new Exception("ROI does not overlap the vessel.");
       }
 
-      frame_.setPositionStatus("Computing positions...");
-      frame_.setGenerateEnabled(false);
+      String warning = null;
 
-      new SwingWorker<PositionList, Void>() {
-         private String warning = null;
-         // FOV rectangles (full-res pixels) of accepted positions, for the grey overlay.
-         private final java.util.List<Rectangle2D.Double> fovsPx =
-               new java.util.ArrayList<>();
+      // ---- Live hardware: affine + FOV for the new position grid ----
+      AffineTransform pixToStage = null;
+      double livePixelSizeUm = 0.0;
+      try {
+         AffineTransform at = AffineUtils.doubleToAffine(
+               studio_.core().getPixelSizeAffine(true));
+         livePixelSizeUm = AffineUtils.deducePixelSize(at);
+         if (livePixelSizeUm > 0.0) {
+            pixToStage = at;
+         }
+      } catch (Exception ignore) {
+         // No affine configured -- scalar fallback below.
+      }
+      if (livePixelSizeUm <= 0.0) {
+         livePixelSizeUm = pixelSizeUm_ > 0 ? pixelSizeUm_ : 1.0;
+      }
 
-         @Override
-         protected PositionList doInBackground() throws Exception {
-            // ---- Live hardware: affine + FOV for the new position grid ----
-            AffineTransform pixToStage = null;
-            double livePixelSizeUm = 0.0;
-            try {
-               AffineTransform at = AffineUtils.doubleToAffine(
-                     studio_.core().getPixelSizeAffine(true));
-               livePixelSizeUm = AffineUtils.deducePixelSize(at);
-               if (livePixelSizeUm > 0.0) {
-                  pixToStage = at;
+      int tileW = (int) studio_.core().getImageWidth();
+      int tileH = (int) studio_.core().getImageHeight();
+      if (tileW <= 0 || tileH <= 0) {
+         throw new Exception("Cannot create positions: camera image size unavailable.");
+      }
+
+      int overlapX = (int) Math.round(tileW * overlapPercentage_ / 100.0);
+      int overlapY = (int) Math.round(tileH * overlapPercentage_ / 100.0);
+      int stepPxX = tileW - overlapX;
+      int stepPxY = tileH - overlapY;
+      if (stepPxX <= 0 || stepPxY <= 0) {
+         throw new Exception("Cannot create positions: overlap is >= tile size.");
+      }
+
+      if (Math.abs(livePixelSizeUm - initialPixelSizeUm_) > 0.01 * initialPixelSizeUm_) {
+         warning = String.format(
+               "Note: current pixel size (%.4f um) differs from session start (%.4f um) "
+               + "- positions sized for the current objective.",
+               livePixelSizeUm, initialPixelSizeUm_);
+      }
+
+      // ---- Step vectors and FOV magnitudes in stage space (current hardware) ----
+      final double stageStepXdx;
+      final double stageStepXdy;
+      final double stageStepYdx;
+      final double stageStepYdy;
+      double fovW;
+      double fovH;
+      if (pixToStage != null) {
+         Point2D.Double sx = new Point2D.Double();
+         Point2D.Double sy = new Point2D.Double();
+         Point2D.Double fx = new Point2D.Double();
+         Point2D.Double fy = new Point2D.Double();
+         pixToStage.deltaTransform(new Point2D.Double(stepPxX, 0), sx);
+         pixToStage.deltaTransform(new Point2D.Double(0, stepPxY), sy);
+         pixToStage.deltaTransform(new Point2D.Double(tileW, 0), fx);
+         pixToStage.deltaTransform(new Point2D.Double(0, tileH), fy);
+         stageStepXdx = sx.x;
+         stageStepXdy = sx.y;
+         stageStepYdx = sy.x;
+         stageStepYdy = sy.y;
+         fovW = Math.hypot(fx.x, fx.y);
+         fovH = Math.hypot(fy.x, fy.y);
+      } else {
+         stageStepXdx = stepPxX * livePixelSizeUm;
+         stageStepXdy = 0;
+         stageStepYdx = 0;
+         stageStepYdy = stepPxY * livePixelSizeUm;
+         fovW = tileW * livePixelSizeUm;
+         fovH = tileH * livePixelSizeUm;
+      }
+      double stepMagX = Math.hypot(stageStepXdx, stageStepXdy);
+      double stepMagY = Math.hypot(stageStepYdx, stageStepYdy);
+      if (stepMagX <= 0 || stepMagY <= 0) {
+         throw new Exception("Cannot create positions: degenerate step size.");
+      }
+
+      // ---- ROI corners -> stage space (session-start frame) ----
+      Rectangle2D bbox = roiAreaPx.getBounds2D();
+      Point2D.Double[] cornersPx = new Point2D.Double[] {
+         new Point2D.Double(bbox.getMinX(), bbox.getMinY()),
+         new Point2D.Double(bbox.getMaxX(), bbox.getMinY()),
+         new Point2D.Double(bbox.getMinX(), bbox.getMaxY()),
+         new Point2D.Double(bbox.getMaxX(), bbox.getMaxY())
+      };
+      Point2D.Double[] cornersStage = new Point2D.Double[4];
+      for (int i = 0; i < 4; i++) {
+         cornersStage[i] = pixelToStageSessionFrame(cornersPx[i].x, cornersPx[i].y);
+         if (cornersStage[i] == null) {
+            throw new Exception("Cannot create positions: tile dimensions not ready.");
+         }
+      }
+
+      // ---- Grid dimensions: project corners onto unit step axes ----
+      double uxX = stageStepXdx / stepMagX;
+      double uxY = stageStepXdy / stepMagX;
+      double uyX = stageStepYdx / stepMagY;
+      double uyY = stageStepYdy / stepMagY;
+      double projXMin = Double.MAX_VALUE;
+      double projXMax = -Double.MAX_VALUE;
+      double projYMin = Double.MAX_VALUE;
+      double projYMax = -Double.MAX_VALUE;
+      double sumX = 0;
+      double sumY = 0;
+      for (Point2D.Double c : cornersStage) {
+         double px = c.x * uxX + c.y * uxY;
+         double py = c.x * uyX + c.y * uyY;
+         projXMin = Math.min(projXMin, px);
+         projXMax = Math.max(projXMax, px);
+         projYMin = Math.min(projYMin, py);
+         projYMax = Math.max(projYMax, py);
+         sumX += c.x;
+         sumY += c.y;
+      }
+      double roiExtentX = projXMax - projXMin;
+      double roiExtentY = projYMax - projYMin;
+      int nCols = Math.max(1, (int) Math.ceil((roiExtentX + fovW - stepMagX) / stepMagX));
+      int nRows = Math.max(1, (int) Math.ceil((roiExtentY + fovH - stepMagY) / stepMagY));
+
+      // ---- Grid origin: center over the ROI bounding box ----
+      double roiStageCX = sumX / 4.0;
+      double roiStageCY = sumY / 4.0;
+      double originX = roiStageCX
+            - (nCols - 1) / 2.0 * stageStepXdx
+            - (nRows - 1) / 2.0 * stageStepYdx;
+      double originY = roiStageCY
+            - (nCols - 1) / 2.0 * stageStepXdy
+            - (nRows - 1) / 2.0 * stageStepYdy;
+
+      String xyStage;
+      try {
+         xyStage = studio_.core().getXYStageDevice();
+      } catch (Exception e) {
+         xyStage = null;
+      }
+      if (xyStage == null || xyStage.isEmpty()) {
+         throw new Exception("Cannot create positions: no XY stage device is configured.");
+      }
+
+      // FOV size in full-resolution pixels (session frame), for the overlap test.
+      double pxPerUm = computePxPerUm();
+      double fovPxW = pxPerUm > 0 ? fovW * pxPerUm : tileW;
+      double fovPxH = pxPerUm > 0 ? fovH * pxPerUm : tileH;
+
+      final double overlapXUm = overlapX * livePixelSizeUm;
+      final double overlapYUm = overlapY * livePixelSizeUm;
+
+      // Region number (shared by all positions in this ROI). The per-position well prefix is
+      // computed individually below so an ROI spanning several wells labels each correctly.
+      // Use the NEXT region number; createPositionsFromRoi advances it on commit.
+      int regionNumber = regionCounter_ + 1;
+      String regionLabel = "Reg" + regionNumber;
+      boolean multiWell = vesselType_ != null && vesselType_.isMultiWell();
+
+      // Snapshot the checked auxiliary stages (e.g. Z) once, applied to every position.
+      java.util.List<StagePosition> auxStages = readCheckedAuxStages(xyStage);
+
+      // Group positions by well only when clipping to a multi-well vessel; otherwise the whole
+      // ROI is one contiguous region and the global serpentine already minimizes travel.
+      boolean groupByWell = multiWell && withinVesselOnly;
+
+      // ---- Pass 1: collect accepted tiles (already in global serpentine row/col order) ----
+      java.util.List<Tile> tiles = new java.util.ArrayList<>();
+      java.util.List<Rectangle2D.Double> fovsPx = new java.util.ArrayList<>();
+      for (int row = 0; row < nRows; row++) {
+         for (int col = 0; col < nCols; col++) {
+            int c = ((row & 1) == 0) ? col : (nCols - 1 - col); // serpentine
+            double dx = c * stageStepXdx + row * stageStepYdx;
+            double dy = c * stageStepXdy + row * stageStepYdy;
+            double stageX = originX + dx;
+            double stageY = originY + dy;
+
+            // Include the tile if its FOV rectangle overlaps the ROI shape.
+            Point2D.Double centerPx = stageToPixel(stageX, stageY);
+            Rectangle2D.Double fovRect = null;
+            if (centerPx != null) {
+               fovRect = new Rectangle2D.Double(
+                     centerPx.x - fovPxW / 2.0, centerPx.y - fovPxH / 2.0, fovPxW, fovPxH);
+               if (!roiAreaPx.intersects(fovRect)) {
+                  continue;
                }
-            } catch (Exception ignore) {
-               // No affine configured -- scalar fallback below.
             }
-            if (livePixelSizeUm <= 0.0) {
-               livePixelSizeUm = pixelSizeUm_ > 0 ? pixelSizeUm_ : 1.0;
+            if (fovRect != null) {
+               fovsPx.add(fovRect);
             }
+            int[] well = groupByWell ? wellIndexForStage(stageX, stageY) : null;
+            tiles.add(new Tile(row, c, stageX, stageY, well));
+         }
+      }
+      if (tiles.isEmpty()) {
+         throw new Exception("No positions fall within the ROI.");
+      }
 
-            int tileW = (int) studio_.core().getImageWidth();
-            int tileH = (int) studio_.core().getImageHeight();
-            if (tileW <= 0 || tileH <= 0) {
-               throw new Exception("Cannot create positions: camera image size unavailable.");
-            }
+      // ---- Pass 2: order tiles. When grouping by well, visit wells in a boustrophedon
+      // (snake) pattern across the plate and snake the tiles within each well, so the stage
+      // never jumps back and forth between wells. ----
+      if (groupByWell) {
+         orderTilesByWell(tiles);
+      }
 
-            int overlapX = (int) Math.round(tileW * overlapPercentage_ / 100.0);
-            int overlapY = (int) Math.round(tileH * overlapPercentage_ / 100.0);
-            int stepPxX = tileW - overlapX;
-            int stepPxY = tileH - overlapY;
-            if (stepPxX <= 0 || stepPxY <= 0) {
-               throw new Exception("Cannot create positions: overlap is >= tile size.");
+      // ---- Pass 3: build the position list in the chosen order ----
+      PositionList posList = new PositionList();
+      for (Tile t : tiles) {
+         String prefix = regionLabel;
+         if (multiWell) {
+            String well = t.well != null
+                  ? VesselType.getWellLabel(t.well[0], t.well[1])
+                  : wellLabelForStage(t.stageX, t.stageY);
+            if (well != null) {
+               prefix = well + "-" + regionLabel;
             }
+         }
 
-            if (Math.abs(livePixelSizeUm - initialPixelSizeUm_) > 0.01 * initialPixelSizeUm_) {
-               warning = String.format(
-                     "Note: current pixel size (%.4f um) differs from session start (%.4f um) "
-                     + "- positions sized for the current objective.",
-                     livePixelSizeUm, initialPixelSizeUm_);
+         MultiStagePosition msp = new MultiStagePosition();
+         msp.setDefaultXYStage(xyStage);
+         msp.add(StagePosition.create2D(xyStage, t.stageX, t.stageY));
+         for (StagePosition aux : auxStages) {
+            msp.add(StagePosition.newInstance(aux));
+         }
+         msp.setLabel(prefix + "-Pos-" + FMT_POS.format(t.row) + "_" + FMT_POS.format(t.col));
+         msp.setGridCoordinates(t.row, t.col);
+         msp.setProperty("OverlapUmX", String.valueOf(overlapXUm));
+         msp.setProperty("OverlapUmY", String.valueOf(overlapYUm));
+         msp.setProperty("OverlapPixelsX", String.valueOf(overlapX));
+         msp.setProperty("OverlapPixelsY", String.valueOf(overlapY));
+         msp.setProperty("Source", "ExplorerCreatePositions");
+         msp.setProperty("Region", regionLabel);
+         posList.addPosition(msp);
+      }
+      return new PositionGridResult(posList, fovsPx, warning, regionLabel);
+   }
+
+   /** One accepted grid tile, before being turned into a MultiStagePosition. */
+   private static final class Tile {
+      private final int row;
+      private final int col;
+      private final double stageX;
+      private final double stageY;
+      private final int[] well; // {wellRow, wellCol} when grouping by well, else null
+
+      private Tile(int row, int col, double stageX, double stageY, int[] well) {
+         this.row = row;
+         this.col = col;
+         this.stageX = stageX;
+         this.stageY = stageY;
+         this.well = well;
+      }
+   }
+
+   /**
+    * Re-orders the tiles in place so that all tiles of one well are visited consecutively, the
+    * wells themselves are traversed in a boustrophedon (snake) pattern (left-to-right on even
+    * well-rows, right-to-left on odd ones), and within each well the tiles snake by grid row/col.
+    * Minimizes stage travel by never jumping back and forth between wells.
+    */
+   private void orderTilesByWell(java.util.List<Tile> tiles) {
+      // Bucket tiles by well. LinkedHashMap keeps first-seen order as a stable fallback.
+      java.util.Map<Long, java.util.List<Tile>> byWell = new java.util.LinkedHashMap<>();
+      for (Tile t : tiles) {
+         int wr = t.well != null ? t.well[0] : 0;
+         int wc = t.well != null ? t.well[1] : 0;
+         long key = ((long) wr << 32) | (wc & 0xffffffffL);
+         byWell.computeIfAbsent(key, k -> new java.util.ArrayList<>()).add(t);
+      }
+      // Sort wells: row ascending; column ascending on even rows, descending on odd rows.
+      java.util.List<Long> wellKeys = new java.util.ArrayList<>(byWell.keySet());
+      wellKeys.sort((a, b) -> {
+         int ra = (int) (a >> 32);
+         int rb = (int) (b >> 32);
+         if (ra != rb) {
+            return Integer.compare(ra, rb);
+         }
+         int ca = (int) (a & 0xffffffffL);
+         int cb = (int) (b & 0xffffffffL);
+         return (ra & 1) == 0 ? Integer.compare(ca, cb) : Integer.compare(cb, ca);
+      });
+      tiles.clear();
+      for (Long key : wellKeys) {
+         java.util.List<Tile> wellTiles = byWell.get(key);
+         // Snake within the well: grid row ascending; col ascending on even rows, desc on odd.
+         wellTiles.sort((a, b) -> {
+            if (a.row != b.row) {
+               return Integer.compare(a.row, b.row);
             }
+            return (a.row & 1) == 0 ? Integer.compare(a.col, b.col) : Integer.compare(b.col, a.col);
+         });
+         tiles.addAll(wellTiles);
+      }
+   }
 
-            // ---- Step vectors and FOV magnitudes in stage space (current hardware) ----
-            final double stageStepXdx;
-            final double stageStepXdy;
-            final double stageStepYdx;
-            final double stageStepYdy;
-            double fovW;
-            double fovH;
-            if (pixToStage != null) {
-               Point2D.Double sx = new Point2D.Double();
-               Point2D.Double sy = new Point2D.Double();
-               Point2D.Double fx = new Point2D.Double();
-               Point2D.Double fy = new Point2D.Double();
-               pixToStage.deltaTransform(new Point2D.Double(stepPxX, 0), sx);
-               pixToStage.deltaTransform(new Point2D.Double(0, stepPxY), sy);
-               pixToStage.deltaTransform(new Point2D.Double(tileW, 0), fx);
-               pixToStage.deltaTransform(new Point2D.Double(0, tileH), fy);
-               stageStepXdx = sx.x;
-               stageStepXdy = sx.y;
-               stageStepYdx = sy.x;
-               stageStepYdy = sy.y;
-               fovW = Math.hypot(fx.x, fx.y);
-               fovH = Math.hypot(fy.x, fy.y);
-            } else {
-               stageStepXdx = stepPxX * livePixelSizeUm;
-               stageStepXdy = 0;
-               stageStepYdx = 0;
-               stageStepYdy = stepPxY * livePixelSizeUm;
-               fovW = tileW * livePixelSizeUm;
-               fovH = tileH * livePixelSizeUm;
+   /**
+    * Returns the well label (e.g. "B7") whose center is nearest the given stage coordinate for
+    * the current multi-well vessel, or null if no vessel/anchor is available. The plate top-left
+    * in stage coordinates is {@code vesselAnchorStageX_/Y_}; wells are laid out by the vessel
+    * geometry (axes assumed parallel to stage X/Y).
+    */
+   private String wellLabelForStage(double stageX, double stageY) {
+      int[] well = wellIndexForStage(stageX, stageY);
+      return well != null ? VesselType.getWellLabel(well[0], well[1]) : null;
+   }
+
+   /**
+    * Returns the 0-based {@code {row, col}} of the well whose center is nearest the given stage
+    * coordinate for the current multi-well vessel, or null if no vessel/anchor is available.
+    */
+   private int[] wellIndexForStage(double stageX, double stageY) {
+      if (vesselType_ == null || !vesselType_.isMultiWell()) {
+         return null;
+      }
+      double relX = stageX - vesselAnchorStageX_ - vesselType_.getFirstWellXUm();
+      double relY = stageY - vesselAnchorStageY_ - vesselType_.getFirstWellYUm();
+      double spacX = vesselType_.getWellSpacingXUm();
+      double spacY = vesselType_.getWellSpacingYUm();
+      if (spacX <= 0 || spacY <= 0) {
+         return null;
+      }
+      int col = (int) Math.round(relX / spacX);
+      int row = (int) Math.round(relY / spacY);
+      col = Math.max(0, Math.min(vesselType_.getWellCols() - 1, col));
+      row = Math.max(0, Math.min(vesselType_.getWellRows() - 1, row));
+      return new int[]{row, col};
+   }
+
+   /**
+    * Reads the current positions of every stage that is checked ("use") in the MM Stage Position
+    * List, EXCLUDING the main XY stage (which carries the grid position). The checked state is the
+    * same profile setting the Position List editor uses. Failures are logged and skipped.
+    */
+   private java.util.List<StagePosition> readCheckedAuxStages(String mainXyStage) {
+      java.util.List<StagePosition> result = new java.util.ArrayList<>();
+      MutablePropertyMapView axisSettings = null;
+      try {
+         Class<?> axisModel = Class.forName(
+               "org.micromanager.internal.positionlist.AxisTableModel");
+         axisSettings = studio_.profile().getSettings(axisModel);
+      } catch (Exception e) {
+         // Can't read the checked state -- fall back to including all stages.
+      }
+      try {
+         StrVector oneDStages = studio_.core().getLoadedDevicesOfType(DeviceType.StageDevice);
+         for (int i = 0; i < oneDStages.size(); i++) {
+            String name = oneDStages.get(i);
+            if (axisSettings != null && !axisSettings.getBoolean(name, true)) {
+               continue;
             }
-            double stepMagX = Math.hypot(stageStepXdx, stageStepXdy);
-            double stepMagY = Math.hypot(stageStepYdx, stageStepYdy);
-            if (stepMagX <= 0 || stepMagY <= 0) {
-               throw new Exception("Cannot create positions: degenerate step size.");
-            }
-
-            // ---- ROI corners -> stage space (session-start frame) ----
-            Rectangle2D bbox = roiAreaPx.getBounds2D();
-            Point2D.Double[] cornersPx = new Point2D.Double[] {
-               new Point2D.Double(bbox.getMinX(), bbox.getMinY()),
-               new Point2D.Double(bbox.getMaxX(), bbox.getMinY()),
-               new Point2D.Double(bbox.getMinX(), bbox.getMaxY()),
-               new Point2D.Double(bbox.getMaxX(), bbox.getMaxY())
-            };
-            Point2D.Double[] cornersStage = new Point2D.Double[4];
-            for (int i = 0; i < 4; i++) {
-               cornersStage[i] = pixelToStageSessionFrame(cornersPx[i].x, cornersPx[i].y);
-               if (cornersStage[i] == null) {
-                  throw new Exception("Cannot create positions: tile dimensions not ready.");
-               }
-            }
-
-            // ---- Grid dimensions: project corners onto unit step axes ----
-            double uxX = stageStepXdx / stepMagX;
-            double uxY = stageStepXdy / stepMagX;
-            double uyX = stageStepYdx / stepMagY;
-            double uyY = stageStepYdy / stepMagY;
-            double projXMin = Double.MAX_VALUE;
-            double projXMax = -Double.MAX_VALUE;
-            double projYMin = Double.MAX_VALUE;
-            double projYMax = -Double.MAX_VALUE;
-            double sumX = 0;
-            double sumY = 0;
-            for (Point2D.Double c : cornersStage) {
-               double px = c.x * uxX + c.y * uxY;
-               double py = c.x * uyX + c.y * uyY;
-               projXMin = Math.min(projXMin, px);
-               projXMax = Math.max(projXMax, px);
-               projYMin = Math.min(projYMin, py);
-               projYMax = Math.max(projYMax, py);
-               sumX += c.x;
-               sumY += c.y;
-            }
-            double roiExtentX = projXMax - projXMin;
-            double roiExtentY = projYMax - projYMin;
-            int nCols = Math.max(1, (int) Math.ceil((roiExtentX + fovW - stepMagX) / stepMagX));
-            int nRows = Math.max(1, (int) Math.ceil((roiExtentY + fovH - stepMagY) / stepMagY));
-
-            // ---- Grid origin: center over the ROI bounding box ----
-            double roiStageCX = sumX / 4.0;
-            double roiStageCY = sumY / 4.0;
-            double originX = roiStageCX
-                  - (nCols - 1) / 2.0 * stageStepXdx
-                  - (nRows - 1) / 2.0 * stageStepYdx;
-            double originY = roiStageCY
-                  - (nCols - 1) / 2.0 * stageStepXdy
-                  - (nRows - 1) / 2.0 * stageStepYdy;
-
-            String xyStage;
             try {
-               xyStage = studio_.core().getXYStageDevice();
+               double pos = studio_.core().getPosition(name);
+               result.add(StagePosition.create1D(name, pos));
             } catch (Exception e) {
-               xyStage = null;
+               studio_.logs().logError(e, "Explorer: could not read position of " + name);
             }
-            if (xyStage == null || xyStage.isEmpty()) {
-               throw new Exception("Cannot create positions: no XY stage device is configured.");
-            }
-
-            // FOV size in full-resolution pixels (session frame), for the overlap test.
-            double pxPerUm = computePxPerUm();
-            double fovPxW = pxPerUm > 0 ? fovW * pxPerUm : tileW;
-            double fovPxH = pxPerUm > 0 ? fovH * pxPerUm : tileH;
-
-            final double overlapXUm = overlapX * livePixelSizeUm;
-            final double overlapYUm = overlapY * livePixelSizeUm;
-
-            PositionList posList = new PositionList();
-            for (int row = 0; row < nRows; row++) {
-               for (int col = 0; col < nCols; col++) {
-                  int c = ((row & 1) == 0) ? col : (nCols - 1 - col); // serpentine
-                  double dx = c * stageStepXdx + row * stageStepYdx;
-                  double dy = c * stageStepXdy + row * stageStepYdy;
-                  double stageX = originX + dx;
-                  double stageY = originY + dy;
-
-                  // Include the tile if its FOV rectangle overlaps the ROI shape.
-                  Point2D.Double centerPx = stageToPixel(stageX, stageY);
-                  Rectangle2D.Double fovRect = null;
-                  if (centerPx != null) {
-                     fovRect = new Rectangle2D.Double(
-                           centerPx.x - fovPxW / 2.0, centerPx.y - fovPxH / 2.0, fovPxW, fovPxH);
-                     if (!roiAreaPx.intersects(fovRect)) {
-                        continue;
-                     }
-                  }
-                  if (fovRect != null) {
-                     fovsPx.add(fovRect);
-                  }
-
-                  MultiStagePosition msp = new MultiStagePosition();
-                  msp.setDefaultXYStage(xyStage);
-                  msp.add(StagePosition.create2D(xyStage, stageX, stageY));
-                  msp.setLabel("Pos-" + FMT_POS.format(row) + "_" + FMT_POS.format(c));
-                  msp.setGridCoordinates(row, c);
-                  msp.setProperty("OverlapUmX", String.valueOf(overlapXUm));
-                  msp.setProperty("OverlapUmY", String.valueOf(overlapYUm));
-                  msp.setProperty("OverlapPixelsX", String.valueOf(overlapX));
-                  msp.setProperty("OverlapPixelsY", String.valueOf(overlapY));
-                  msp.setProperty("Source", "ExplorerCreatePositions");
-                  posList.addPosition(msp);
-               }
-            }
-            if (posList.getNumberOfPositions() == 0) {
-               throw new Exception("No positions fall within the ROI.");
-            }
-            return posList;
          }
-
-         @Override
-         protected void done() {
-            PositionList posList;
+         StrVector xyStages = studio_.core().getLoadedDevicesOfType(DeviceType.XYStageDevice);
+         for (int i = 0; i < xyStages.size(); i++) {
+            String name = xyStages.get(i);
+            if (name.equals(mainXyStage)) {
+               continue;
+            }
+            if (axisSettings != null && !axisSettings.getBoolean(name, true)) {
+               continue;
+            }
             try {
-               posList = get();
-            } catch (Exception ex) {
-               String msg = ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage();
-               frame_.setPositionStatus(msg);
-               frame_.setGenerateEnabled(hasPositionRoi());
-               return;
+               double x = studio_.core().getXPosition(name);
+               double y = studio_.core().getYPosition(name);
+               result.add(StagePosition.create2D(name, x, y));
+            } catch (Exception e) {
+               studio_.logs().logError(e, "Explorer: could not read position of " + name);
             }
-            PositionList existing = studio_.positions().getPositionList();
-            for (int i = 0; i < posList.getNumberOfPositions(); i++) {
-               existing.addPosition(posList.getPosition(i));
-            }
-            studio_.positions().setPositionList(existing);
-            studio_.app().showPositionList();
-            if (dataSource_ != null) {
-               dataSource_.setGeneratedPositionFovs(fovsPx);
-               redrawOverlay();
-            }
-            String status = "Added " + posList.getNumberOfPositions() + " positions";
-            if (warning != null) {
-               status = warning + " (" + posList.getNumberOfPositions() + " added)";
-            }
-            frame_.setPositionStatus(status);
-            // Keep the ROI so the operator can tweak / regenerate.
-            frame_.setGenerateEnabled(hasPositionRoi());
          }
-      }.execute();
+      } catch (Exception e) {
+         studio_.logs().logError(e, "Explorer: could not enumerate stage devices");
+      }
+      return result;
    }
 
    // ===================== Private helpers =====================

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -34,10 +34,12 @@ import java.util.stream.Stream;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
 import mmcorej.DeviceType;
 import mmcorej.StrVector;
 import mmcorej.org.json.JSONArray;
 import mmcorej.org.json.JSONObject;
+import org.micromanager.AutofocusPlugin;
 import org.micromanager.MultiStagePosition;
 import org.micromanager.PositionList;
 import org.micromanager.PropertyMap;
@@ -57,6 +59,7 @@ import org.micromanager.events.PixelSizeAffineChangedEvent;
 import org.micromanager.events.PixelSizeChangedEvent;
 import org.micromanager.events.ShutdownCommencingEvent;
 import org.micromanager.imageprocessing.ImageTransformUtils;
+import org.micromanager.internal.positionlist.utils.ZGenerator;
 import org.micromanager.internal.propertymap.NonPropertyMapJSONFormats;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.ColorPalettes;
@@ -190,6 +193,15 @@ public class ExplorerManager {
 
    // Create-Positions: number of regions already committed this session (for "Reg<n>" labels).
    private int regionCounter_ = 0;
+
+   // Refine-Z state. Reference points (stage XY + measured Z per checked Z stage), the chosen
+   // interpolation method, and the pending manual tile. Read on the EDT; the automatic collection
+   // runs on a SwingWorker. Guarded where shared.
+   private final java.util.List<RefineZPoint> refineZPoints_ = new java.util.ArrayList<>();
+   private ZGenerator.Type refineZMethod_ = ZGenerator.Type.SHEPINTERPOLATE;
+   private RefineZWorker refineZWorker_ = null;
+   // The Refine Z window while it is open (status/running route here), else null.
+   private RefineZFrame refineZFrame_ = null;
 
    // Camera orientation / Image Flipper correction
    private int sessionCorrectionRotation_ = 0;    // 0/90/180/270
@@ -367,6 +379,9 @@ public class ExplorerManager {
          vesselUsedHcsCal_ = false;
          vesselOutlinePending_ = false;
          regionCounter_ = 0;
+         synchronized (refineZPoints_) {
+            refineZPoints_.clear();
+         }
          frame_.setExploringActive(true, true);
          if (vesselType_.isMultiWell()) {
             Point2D.Double hcsOffset = tryReadHcsCalibration();
@@ -1833,9 +1848,20 @@ public class ExplorerManager {
          dataSource_.setPositionTool(ExplorerDataSource.PositionTool.NONE);
          return;
       }
+      boolean drawing = tool != null && tool != ExplorerDataSource.PositionTool.NONE;
+      if (!drawing) {
+         // Leaving draw mode ends the whole Create-Positions flow: close Refine Z and drop points.
+         cancelRefineZ();
+         if (refineZFrame_ != null) {
+            refineZFrame_.dispose(); // disposes -> onRefineZFrameClosed disarms the canvas
+         }
+         synchronized (refineZPoints_) {
+            refineZPoints_.clear();
+         }
+         dataSource_.setRefineZMarkers(null);
+      }
       dataSource_.setPositionTool(tool);
       if (viewer_ != null) {
-         boolean drawing = tool != null && tool != ExplorerDataSource.PositionTool.NONE;
          viewer_.getCanvasJPanel().setCursor(java.awt.Cursor.getPredefinedCursor(
                drawing ? java.awt.Cursor.CROSSHAIR_CURSOR : java.awt.Cursor.DEFAULT_CURSOR));
       }
@@ -1940,16 +1966,110 @@ public class ExplorerManager {
    private static final class PositionGridResult {
       private final PositionList posList;
       private final java.util.List<Rectangle2D.Double> fovsPx;
+      private final java.util.List<Tile> tiles;
       private final String warning;
       private final String regionLabel;
 
       private PositionGridResult(PositionList posList,
-            java.util.List<Rectangle2D.Double> fovsPx, String warning, String regionLabel) {
+            java.util.List<Rectangle2D.Double> fovsPx, java.util.List<Tile> tiles,
+            String warning, String regionLabel) {
          this.posList = posList;
          this.fovsPx = fovsPx;
+         this.tiles = tiles;
          this.warning = warning;
          this.regionLabel = regionLabel;
       }
+   }
+
+   /** Returns the accepted, ordered tiles for the current ROI (used by automatic Refine Z). */
+   private java.util.List<Tile> collectAcceptedTiles(boolean withinVesselOnly) throws Exception {
+      return computePositionGrid(withinVesselOnly).tiles;
+   }
+
+   /**
+    * Chooses up to {@code n} tiles spread across the given set using farthest-point sampling in
+    * stage space. On multi-well plates the budget is split across wells so each gets coverage.
+    */
+   private java.util.List<Tile> chooseSpreadTiles(java.util.List<Tile> tiles, int n) {
+      java.util.List<Tile> result = new java.util.ArrayList<>();
+      if (tiles.isEmpty() || n <= 0) {
+         return result;
+      }
+      // Group by well so each well is sampled; non-plate -> single group.
+      java.util.Map<Long, java.util.List<Tile>> byWell = new java.util.LinkedHashMap<>();
+      boolean multiWell = false;
+      for (Tile t : tiles) {
+         long key = 0;
+         if (t.well != null) {
+            multiWell = true;
+            key = ((long) t.well[0] << 32) | (t.well[1] & 0xffffffffL);
+         }
+         byWell.computeIfAbsent(key, k -> new java.util.ArrayList<>()).add(t);
+      }
+      int nWells = byWell.size();
+      for (java.util.List<Tile> group : byWell.values()) {
+         int budget = multiWell ? Math.max(1, n) : n; // n points per well on plates, else n total
+         result.addAll(farthestPointSample(group, Math.min(budget, group.size())));
+      }
+      // On non-plate the loop ran once; on plates each well got up to n points.
+      if (!multiWell && result.size() > n) {
+         return result.subList(0, n);
+      }
+      return result;
+   }
+
+   /** Farthest-point sampling of {@code count} tiles from {@code group} (Euclidean stage XY). */
+   private java.util.List<Tile> farthestPointSample(java.util.List<Tile> group, int count) {
+      java.util.List<Tile> chosen = new java.util.ArrayList<>();
+      if (group.isEmpty() || count <= 0) {
+         return chosen;
+      }
+      // Seed with the tile nearest the group's centroid for a stable first pick.
+      double cx = 0;
+      double cy = 0;
+      for (Tile t : group) {
+         cx += t.stageX;
+         cy += t.stageY;
+      }
+      cx /= group.size();
+      cy /= group.size();
+      Tile seed = group.get(0);
+      double best = Double.MAX_VALUE;
+      for (Tile t : group) {
+         double d = (t.stageX - cx) * (t.stageX - cx) + (t.stageY - cy) * (t.stageY - cy);
+         if (d < best) {
+            best = d;
+            seed = t;
+         }
+      }
+      chosen.add(seed);
+      while (chosen.size() < count) {
+         Tile bestTile = null;
+         double bestDist = -1.0;
+         for (Tile t : group) {
+            if (chosen.contains(t)) {
+               continue;
+            }
+            double nearest = Double.MAX_VALUE;
+            for (Tile c : chosen) {
+               double dx = t.stageX - c.stageX;
+               double dy = t.stageY - c.stageY;
+               double d = dx * dx + dy * dy;
+               if (d < nearest) {
+                  nearest = d;
+               }
+            }
+            if (nearest > bestDist) {
+               bestDist = nearest;
+               bestTile = t;
+            }
+         }
+         if (bestTile == null) {
+            break;
+         }
+         chosen.add(bestTile);
+      }
+      return chosen;
    }
 
    /**
@@ -2127,7 +2247,17 @@ public class ExplorerManager {
       boolean multiWell = vesselType_ != null && vesselType_.isMultiWell();
 
       // Snapshot the checked auxiliary stages (e.g. Z) once, applied to every position.
+      // When Refine Z has reference points, the 1D (Z) stages it measured are interpolated
+      // per tile instead of using this snapshot; other aux stages keep the snapshot.
       java.util.List<StagePosition> auxStages = readCheckedAuxStages(xyStage);
+      boolean haveRefineZ = hasRefineZPoints();
+      java.util.Set<String> refinedZStages = haveRefineZ
+            ? new java.util.HashSet<>(getCheckedZStages()) : java.util.Collections.emptySet();
+      // ZGenerators keyed by well key (or one global generator under key 0 when not per-well).
+      java.util.Map<Long, java.util.Map<String, ZGenerator>> zGenByWell =
+            new java.util.HashMap<>();
+      java.util.Map<String, ZGenerator> zGenGlobal = haveRefineZ
+            ? buildZGenerators(null) : java.util.Collections.emptyMap();
 
       // Group positions by well only when clipping to a multi-well vessel; otherwise the whole
       // ROI is one contiguous region and the global serpentine already minimizes travel.
@@ -2157,7 +2287,9 @@ public class ExplorerManager {
             if (fovRect != null) {
                fovsPx.add(fovRect);
             }
-            int[] well = groupByWell ? wellIndexForStage(stageX, stageY) : null;
+            // Compute the well whenever multi-well so both per-well ordering and per-well Z
+            // interpolation work, even without within-vessel clipping.
+            int[] well = multiWell ? wellIndexForStage(stageX, stageY) : null;
             tiles.add(new Tile(row, c, stageX, stageY, well));
          }
       }
@@ -2188,8 +2320,40 @@ public class ExplorerManager {
          MultiStagePosition msp = new MultiStagePosition();
          msp.setDefaultXYStage(xyStage);
          msp.add(StagePosition.create2D(xyStage, t.stageX, t.stageY));
+         // Non-refined aux stages keep their snapshot; refined Z stages are interpolated below.
          for (StagePosition aux : auxStages) {
+            if (refinedZStages.contains(aux.getStageDeviceLabel())) {
+               continue;
+            }
             msp.add(StagePosition.newInstance(aux));
+         }
+         if (haveRefineZ) {
+            // Per-well generator when this tile has a well and that well was refined, else global.
+            java.util.Map<String, ZGenerator> gens = zGenGlobal;
+            if (t.well != null) {
+               long wkey = ((long) t.well[0] << 32) | (t.well[1] & 0xffffffffL);
+               java.util.Map<String, ZGenerator> perWell = zGenByWell.get(wkey);
+               if (perWell == null) {
+                  perWell = buildZGenerators(t.well);
+                  zGenByWell.put(wkey, perWell);
+               }
+               if (!perWell.isEmpty()) {
+                  gens = perWell;
+               }
+            }
+            String defaultZ = null;
+            for (String zStage : refinedZStages) {
+               ZGenerator gen = gens.get(zStage);
+               if (gen != null) {
+                  msp.add(StagePosition.create1D(zStage, gen.getZ(t.stageX, t.stageY, zStage)));
+                  if (defaultZ == null) {
+                     defaultZ = zStage;
+                  }
+               }
+            }
+            if (defaultZ != null) {
+               msp.setDefaultZStage(defaultZ);
+            }
          }
          msp.setLabel(prefix + "-Pos-" + FMT_POS.format(t.row) + "_" + FMT_POS.format(t.col));
          msp.setGridCoordinates(t.row, t.col);
@@ -2201,7 +2365,7 @@ public class ExplorerManager {
          msp.setProperty("Region", regionLabel);
          posList.addPosition(msp);
       }
-      return new PositionGridResult(posList, fovsPx, warning, regionLabel);
+      return new PositionGridResult(posList, fovsPx, tiles, warning, regionLabel);
    }
 
    /** One accepted grid tile, before being turned into a MultiStagePosition. */
@@ -2302,19 +2466,12 @@ public class ExplorerManager {
     */
    private java.util.List<StagePosition> readCheckedAuxStages(String mainXyStage) {
       java.util.List<StagePosition> result = new java.util.ArrayList<>();
-      MutablePropertyMapView axisSettings = null;
-      try {
-         Class<?> axisModel = Class.forName(
-               "org.micromanager.internal.positionlist.AxisTableModel");
-         axisSettings = studio_.profile().getSettings(axisModel);
-      } catch (Exception e) {
-         // Can't read the checked state -- fall back to including all stages.
-      }
+      MutablePropertyMapView axisSettings = axisCheckedSettings();
       try {
          StrVector oneDStages = studio_.core().getLoadedDevicesOfType(DeviceType.StageDevice);
          for (int i = 0; i < oneDStages.size(); i++) {
             String name = oneDStages.get(i);
-            if (axisSettings != null && !axisSettings.getBoolean(name, true)) {
+            if (!axisChecked(axisSettings, name)) {
                continue;
             }
             try {
@@ -2330,7 +2487,7 @@ public class ExplorerManager {
             if (name.equals(mainXyStage)) {
                continue;
             }
-            if (axisSettings != null && !axisSettings.getBoolean(name, true)) {
+            if (!axisChecked(axisSettings, name)) {
                continue;
             }
             try {
@@ -2345,6 +2502,483 @@ public class ExplorerManager {
          studio_.logs().logError(e, "Explorer: could not enumerate stage devices");
       }
       return result;
+   }
+
+   /**
+    * Returns the profile settings node the MM Position List editor uses to persist which stage
+    * axes are checked ("use"), or null if it cannot be read (then all axes are treated as checked).
+    */
+   private MutablePropertyMapView axisCheckedSettings() {
+      try {
+         Class<?> axisModel = Class.forName(
+               "org.micromanager.internal.positionlist.AxisTableModel");
+         return studio_.profile().getSettings(axisModel);
+      } catch (Exception e) {
+         return null;
+      }
+   }
+
+   /** True if the named stage axis is checked in the Position List editor (default true). */
+   private boolean axisChecked(MutablePropertyMapView axisSettings, String name) {
+      return axisSettings == null || axisSettings.getBoolean(name, true);
+   }
+
+   /** Returns the checked 1D stage (Z) device names, in core order. */
+   private java.util.List<String> getCheckedZStages() {
+      java.util.List<String> zStages = new java.util.ArrayList<>();
+      MutablePropertyMapView axisSettings = axisCheckedSettings();
+      try {
+         StrVector oneDStages = studio_.core().getLoadedDevicesOfType(DeviceType.StageDevice);
+         for (int i = 0; i < oneDStages.size(); i++) {
+            String name = oneDStages.get(i);
+            if (axisChecked(axisSettings, name)) {
+               zStages.add(name);
+            }
+         }
+      } catch (Exception e) {
+         studio_.logs().logError(e, "Explorer: could not enumerate Z stages");
+      }
+      return zStages;
+   }
+
+   // ===================== Refine Z =====================
+
+   /** Opens (or brings to front) the Refine Z window for the current session. */
+   public void showRefineZFrame() {
+      if (!exploring_ || loadedData_) {
+         return;
+      }
+      if (refineZFrame_ == null || !refineZFrame_.isDisplayable()) {
+         refineZFrame_ = new RefineZFrame(studio_, this, frame_);
+      }
+      // While the window is open, suppress ROI drawing so canvas clicks drive refinement.
+      if (dataSource_ != null) {
+         dataSource_.setRefineZActive(true);
+      }
+      refineZFrame_.setVisible(true);
+      refineZFrame_.toFront();
+   }
+
+   /** Called by the Refine Z window when it is disposed. */
+   public void onRefineZFrameClosed(RefineZFrame frame) {
+      if (refineZFrame_ == frame) {
+         refineZFrame_ = null;
+      }
+      if (dataSource_ != null) {
+         dataSource_.setRefineZActive(false);
+      }
+   }
+
+   /** True while the Refine Z window is open. */
+   public boolean isRefineZFrameOpen() {
+      return refineZFrame_ != null && refineZFrame_.isDisplayable();
+   }
+
+   /** Routes a Refine-Z status message to the Refine Z window if open. */
+   private void setRefineZStatus(String text) {
+      if (refineZFrame_ != null) {
+         refineZFrame_.setRefineZStatus(text);
+      }
+   }
+
+   /** Routes the running state to the Refine Z window if open. */
+   private void setRefineZRunningUi(boolean running) {
+      if (refineZFrame_ != null) {
+         refineZFrame_.setRefineZRunning(running);
+      }
+   }
+
+   /** One Refine-Z reference point: stage XY, measured Z per checked stage, and well index. */
+   private static final class RefineZPoint {
+      private final double stageX;
+      private final double stageY;
+      private final java.util.Map<String, Double> z;
+      private final int[] well; // {wellRow, wellCol} on multi-well plates, else null
+
+      private RefineZPoint(double stageX, double stageY,
+            java.util.Map<String, Double> z, int[] well) {
+         this.stageX = stageX;
+         this.stageY = stageY;
+         this.z = z;
+         this.well = well;
+      }
+   }
+
+   /** Sets the Z interpolation method (Weighted / Average). */
+   public void setRefineZMethod(ZGenerator.Type method) {
+      if (method != null) {
+         refineZMethod_ = method;
+      }
+   }
+
+   /** True when at least one Refine-Z reference point has been collected. */
+   public boolean hasRefineZPoints() {
+      synchronized (refineZPoints_) {
+         return !refineZPoints_.isEmpty();
+      }
+   }
+
+   /** Discards all collected Refine-Z reference points and clears their markers. */
+   public void clearRefineZ() {
+      synchronized (refineZPoints_) {
+         refineZPoints_.clear();
+      }
+      pushRefineZMarkers();
+      setRefineZStatus("Refine Z cleared.");
+   }
+
+   /** Pushes the current reference-point markers (stage->pixel) to the data source overlay. */
+   private void pushRefineZMarkers() {
+      if (dataSource_ == null) {
+         return;
+      }
+      java.util.List<Point2D.Double> markers = new java.util.ArrayList<>();
+      synchronized (refineZPoints_) {
+         for (RefineZPoint p : refineZPoints_) {
+            Point2D.Double px = stageToPixel(p.stageX, p.stageY);
+            if (px != null) {
+               markers.add(px);
+            }
+         }
+      }
+      dataSource_.setRefineZMarkers(markers);
+      redrawOverlay();
+   }
+
+   /** True while the automatic Refine-Z worker is running. */
+   public boolean isRefineZRunning() {
+      return refineZWorker_ != null && !refineZWorker_.isDone();
+   }
+
+   /** Cancels a running automatic Refine-Z run. */
+   public void cancelRefineZ() {
+      if (refineZWorker_ != null) {
+         refineZWorker_.cancel(true);
+      }
+   }
+
+   /**
+    * Starts automatic Refine Z: chooses up to {@code nPoints} reference tiles spread across the
+    * current previewed grid (per well on multi-well plates), then for each one moves the stage,
+    * runs the selected autofocus method, and records the resulting Z of every checked Z stage.
+    * Runs off the EDT.
+    */
+   public void startRefineZAutomatic(int nPoints, String afMethodName, boolean withinVesselOnly) {
+      if (dataSource_ == null || !exploring_ || loadedData_ || !hasPositionRoi()) {
+         setRefineZStatus("Draw an ROI first.");
+         return;
+      }
+      if (isRefineZRunning()) {
+         return;
+      }
+      final java.util.List<String> zStages = getCheckedZStages();
+      if (zStages.isEmpty()) {
+         setRefineZStatus("No Z stage is checked in the Position List.");
+         return;
+      }
+      java.util.List<Tile> tiles;
+      try {
+         tiles = collectAcceptedTiles(withinVesselOnly);
+      } catch (Exception ex) {
+         setRefineZStatus(ex.getMessage());
+         return;
+      }
+      java.util.List<Tile> chosen = chooseSpreadTiles(tiles, nPoints);
+      if (chosen.isEmpty()) {
+         setRefineZStatus("No tiles to refine.");
+         return;
+      }
+      setRefineZRunningUi(true);
+      setRefineZStatus("Refining Z...");
+      refineZWorker_ = new RefineZWorker(chosen, zStages, afMethodName);
+      refineZWorker_.execute();
+   }
+
+   /** SwingWorker that visits chosen tiles, autofocuses, and records Z. */
+   private final class RefineZWorker extends SwingWorker<Void, RefineZPoint> {
+      private final java.util.List<Tile> cells_;
+      private final java.util.List<String> zStages_;
+      private final String afMethodName_;
+      private final java.util.List<String> failures_ = new java.util.ArrayList<>();
+
+      private RefineZWorker(java.util.List<Tile> cells, java.util.List<String> zStages,
+            String afMethodName) {
+         cells_ = cells;
+         zStages_ = zStages;
+         afMethodName_ = afMethodName;
+      }
+
+      @Override
+      protected Void doInBackground() {
+         AutofocusPlugin af = null;
+         try {
+            if (afMethodName_ != null && !afMethodName_.isEmpty()) {
+               studio_.getAutofocusManager().setAutofocusMethodByName(afMethodName_);
+            }
+            af = studio_.getAutofocusManager().getAutofocusMethod();
+         } catch (Exception e) {
+            studio_.logs().logError(e, "Refine Z: could not select autofocus method");
+         }
+         int done = 0;
+         for (Tile t : cells_) {
+            if (isCancelled()) {
+               break;
+            }
+            String failure = refineOneTile(af, t);
+            if (failure != null) {
+               failures_.add(failure);
+            }
+            done++;
+            setProgress(100 * done / cells_.size());
+         }
+         return null;
+      }
+
+      private String refineOneTile(AutofocusPlugin af, Tile t) {
+         // Snap to the Explorer grid cell center under this tile so the reference point, the
+         // autofocus measurement, and the acquired image all coincide on the canvas grid.
+         int[] cell = explorerGridCellForStage(t.stageX, t.stageY);
+         Point2D.Double target = cell != null
+               ? stageForExplorerCell(cell[0], cell[1]) : new Point2D.Double(t.stageX, t.stageY);
+         try {
+            studio_.core().setXYPosition(studio_.core().getXYStageDevice(), target.x, target.y);
+            studio_.core().waitForDevice(studio_.core().getXYStageDevice());
+         } catch (Exception e) {
+            studio_.logs().logError(e, "Refine Z: move failed");
+            return "tile (move failed: " + e.getMessage() + ")";
+         }
+         if (af == null) {
+            return "tile (no autofocus method)";
+         }
+         try {
+            af.fullFocus();
+         } catch (Exception e) {
+            studio_.logs().logError(e, "Refine Z: autofocus failed");
+            return "tile (autofocus failed: " + e.getMessage() + ")";
+         }
+         java.util.Map<String, Double> zVals = new java.util.LinkedHashMap<>();
+         try {
+            for (String z : zStages_) {
+               zVals.put(z, studio_.core().getPosition(z));
+            }
+         } catch (Exception e) {
+            studio_.logs().logError(e, "Refine Z: read Z failed");
+            return "tile (Z read failed)";
+         }
+         // Acquire the in-focus image so it shows on the canvas like a normal tile.
+         acquireRefineZTileAtCurrentStage();
+         publish(new RefineZPoint(target.x, target.y, zVals, t.well));
+         return null;
+      }
+
+      @Override
+      protected void process(java.util.List<RefineZPoint> chunks) {
+         synchronized (refineZPoints_) {
+            refineZPoints_.addAll(chunks);
+         }
+         pushRefineZMarkers();
+         setRefineZStatus("Refined " + refineZPointCount() + " point(s)...");
+      }
+
+      @Override
+      protected void done() {
+         setRefineZRunningUi(false);
+         if (isCancelled()) {
+            setRefineZStatus("Refine Z cancelled (" + refineZPointCount() + " points).");
+            return;
+         }
+         if (!failures_.isEmpty()) {
+            StringBuilder sb = new StringBuilder("Autofocus skipped some tiles:\n");
+            for (String f : failures_) {
+               sb.append("  ").append(f).append('\n');
+            }
+            JOptionPane.showMessageDialog(refineZFrame_ != null ? refineZFrame_ : frame_,
+                  sb.toString(), "Refine Z", JOptionPane.WARNING_MESSAGE);
+         }
+         setRefineZStatus("Refine Z done (" + refineZPointCount() + " points).");
+         pushRefineZMarkers();
+      }
+   }
+
+   private int refineZPointCount() {
+      synchronized (refineZPoints_) {
+         return refineZPoints_.size();
+      }
+   }
+
+   /**
+    * Returns the Explorer session tile-grid cell {row, col} that contains the given stage
+    * position, or null if the tile grid is not ready. Uses the same mapping the canvas uses to
+    * place tiles, so acquiring this cell shows the image at the expected canvas location.
+    */
+   private int[] explorerGridCellForStage(double stageX, double stageY) {
+      Point2D.Double px = stageToPixel(stageX, stageY);
+      int tw = dataSource_ != null ? dataSource_.getTileWidth() : -1;
+      int th = dataSource_ != null ? dataSource_.getTileHeight() : -1;
+      if (px == null || tw <= 0 || th <= 0) {
+         return null;
+      }
+      int overlapPixelsX = (int) Math.round(tw * overlapPercentage_ / 100.0);
+      int overlapPixelsY = (int) Math.round(th * overlapPercentage_ / 100.0);
+      double effW = tw - overlapPixelsX;
+      double effH = th - overlapPixelsY;
+      int col = (int) Math.floor(px.x / effW);
+      int row = (int) Math.floor(px.y / effH);
+      return new int[]{row, col};
+   }
+
+   /**
+    * Returns the stage XY of the center of the Explorer session tile-grid cell {row, col}, using
+    * the same grid->stage mapping as acquireMultipleTiles so the cell aligns with the canvas.
+    */
+   private Point2D.Double stageForExplorerCell(int row, int col) {
+      double overlapFraction = overlapPercentage_ / 100.0;
+      double effectivePixelStepX = cameraWidth_  * (1.0 - overlapFraction);
+      double effectivePixelStepY = cameraHeight_ * (1.0 - overlapFraction);
+      if (pixelSizeAffine_ != null) {
+         Point2D.Double pixelOffset = new Point2D.Double(
+               col * effectivePixelStepX, row * effectivePixelStepY);
+         Point2D.Double stageOffset = new Point2D.Double();
+         pixelSizeAffine_.transform(pixelOffset, stageOffset);
+         return new Point2D.Double(initialStageX_ + stageOffset.x, initialStageY_ + stageOffset.y);
+      }
+      double effectiveStepWidthUm  = stageTileWidthUm_  * (1.0 - overlapFraction);
+      double effectiveStepHeightUm = stageTileHeightUm_ * (1.0 - overlapFraction);
+      return new Point2D.Double(initialStageX_ + col * effectiveStepWidthUm,
+            initialStageY_ + row * effectiveStepHeightUm);
+   }
+
+   /**
+    * Moves the stage to the center of the Explorer grid cell under the current position and
+    * acquires that tile so the in-focus image appears on the canvas (exactly like a left-click
+    * acquisition) at the correct cell. Runs synchronously; must be called off the EDT. Returns
+    * the cell-center stage XY actually acquired, or null on failure.
+    */
+   private Point2D.Double acquireRefineZTileAtCurrentStage() {
+      try {
+         double stageX = studio_.core().getXPosition();
+         double stageY = studio_.core().getYPosition();
+         int[] cell = explorerGridCellForStage(stageX, stageY);
+         if (cell == null) {
+            return null;
+         }
+         int row = cell[0];
+         int col = cell[1];
+         // Snap to the exact cell center so the stored tile aligns with the canvas grid.
+         Point2D.Double cellCenter = stageForExplorerCell(row, col);
+         studio_.core().setXYPosition(cellCenter.x, cellCenter.y);
+         studio_.core().waitForDevice(studio_.core().getXYStageDevice());
+         if (!dataSource_.isTileAcquired(row, col)) {
+            acquireSingleTileBlocking(row, col);
+            dataSource_.markTileAcquired(row, col);
+            dataSource_.invalidateImageKeysCache();
+            redrawOverlay();
+         }
+         return cellCenter;
+      } catch (Exception e) {
+         studio_.logs().logError(e, "Refine Z: could not acquire in-focus tile");
+         return null;
+      }
+   }
+
+   /**
+    * Manual Refine Z: moves the stage so the clicked full-res pixel becomes the FOV center, so the
+    * operator can focus there and then capture with {@link #addManualRefineZ()}.
+    */
+   public void refineZManualMove(double fullResX, double fullResY) {
+      if (!exploring_ || loadedData_) {
+         return;
+      }
+      moveStageToPixelPosition(fullResX, fullResY);
+   }
+
+   /**
+    * Captures the current Z of every checked Z stage at the current stage XY as a Refine-Z
+    * reference point.
+    */
+   public void addManualRefineZ() {
+      if (!exploring_ || loadedData_) {
+         return;
+      }
+      java.util.List<String> zStages = getCheckedZStages();
+      if (zStages.isEmpty()) {
+         setRefineZStatus("No Z stage is checked in the Position List.");
+         return;
+      }
+      try {
+         double stageX = studio_.core().getXPosition();
+         double stageY = studio_.core().getYPosition();
+         java.util.Map<String, Double> zVals = new java.util.LinkedHashMap<>();
+         for (String z : zStages) {
+            zVals.put(z, studio_.core().getPosition(z));
+         }
+         // Record the point at the Explorer grid cell center so the marker, the reference point,
+         // and the acquired tile all coincide on the canvas grid.
+         int[] cell = explorerGridCellForStage(stageX, stageY);
+         Point2D.Double refXy = cell != null
+               ? stageForExplorerCell(cell[0], cell[1]) : new Point2D.Double(stageX, stageY);
+         int[] well = (vesselType_ != null && vesselType_.isMultiWell())
+               ? wellIndexForStage(refXy.x, refXy.y) : null;
+         synchronized (refineZPoints_) {
+            refineZPoints_.add(new RefineZPoint(refXy.x, refXy.y, zVals, well));
+         }
+         pushRefineZMarkers();
+         setRefineZStatus("Set Z (" + refineZPointCount() + " points).");
+         // Acquire the in-focus image (off the EDT) so it shows on the canvas.
+         if (acquisitionExecutor_ != null) {
+            acquisitionExecutor_.submit(this::acquireRefineZTileAtCurrentStage);
+         }
+      } catch (Exception e) {
+         studio_.logs().showError(e, "Refine Z: could not read stage position.");
+      }
+   }
+
+   /**
+    * Builds, per Z stage, a ZGenerator from the collected reference points (optionally restricted
+    * to a single well). Returns an empty map when there are no usable reference points.
+    */
+   private java.util.Map<String, ZGenerator> buildZGenerators(int[] well) {
+      java.util.List<RefineZPoint> pts = new java.util.ArrayList<>();
+      synchronized (refineZPoints_) {
+         for (RefineZPoint p : refineZPoints_) {
+            if (well == null || p.well == null
+                  || (p.well[0] == well[0] && p.well[1] == well[1])) {
+               pts.add(p);
+            }
+         }
+      }
+      java.util.Map<String, ZGenerator> generators = new java.util.HashMap<>();
+      if (pts.isEmpty()) {
+         return generators;
+      }
+      // ZGenerator builds one interpolator per 1D stage present on the first position, so each
+      // reference MultiStagePosition must carry every checked Z stage.
+      PositionList refList = new PositionList();
+      String xyStage;
+      try {
+         xyStage = studio_.core().getXYStageDevice();
+      } catch (Exception e) {
+         xyStage = "XY";
+      }
+      for (RefineZPoint p : pts) {
+         MultiStagePosition msp = new MultiStagePosition();
+         // setDefaultXYStage is REQUIRED: ZGeneratorShepard reads each reference point's XY via
+         // MultiStagePosition.getX()/getY(), which return 0 unless the default XY stage is set.
+         // Without it every reference point reads (0,0) and the interpolator returns a constant.
+         msp.setDefaultXYStage(xyStage);
+         msp.add(StagePosition.create2D(xyStage, p.stageX, p.stageY));
+         for (java.util.Map.Entry<String, Double> e : p.z.entrySet()) {
+            msp.add(StagePosition.create1D(e.getKey(), e.getValue()));
+         }
+         refList.addPosition(msp);
+      }
+      ZGenerator gen = ZGenerator.create(refineZMethod_, refList);
+      synchronized (refineZPoints_) {
+         for (String z : pts.get(0).z.keySet()) {
+            generators.put(z, gen);
+         }
+      }
+      return generators;
    }
 
    // ===================== Private helpers =====================

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -64,6 +64,7 @@ import org.micromanager.internal.propertymap.NonPropertyMapJSONFormats;
 import org.micromanager.internal.utils.AffineUtils;
 import org.micromanager.internal.utils.ColorPalettes;
 import org.micromanager.internal.utils.FileDialogs;
+import org.micromanager.internal.utils.imageanalysis.ImageUtils;
 import org.micromanager.ndtiffstorage.EssentialImageMetadata;
 import org.micromanager.ndtiffstorage.NDTiffStorage;
 import org.micromanager.propertymap.MutablePropertyMapView;
@@ -200,6 +201,7 @@ public class ExplorerManager {
    private final java.util.List<RefineZPoint> refineZPoints_ = new java.util.ArrayList<>();
    private ZGenerator.Type refineZMethod_ = ZGenerator.Type.SHEPINTERPOLATE;
    private RefineZWorker refineZWorker_ = null;
+   private static final int REFINE_Z_THUMB_PX = 256;
    // The Refine Z window while it is open (status/running route here), else null.
    private RefineZFrame refineZFrame_ = null;
 
@@ -1859,6 +1861,7 @@ public class ExplorerManager {
             refineZPoints_.clear();
          }
          dataSource_.setRefineZMarkers(null);
+         dataSource_.setRefineZThumbnails(null);
       }
       dataSource_.setPositionTool(tool);
       if (viewer_ != null) {
@@ -2096,20 +2099,32 @@ public class ExplorerManager {
       String warning = null;
 
       // ---- Live hardware: affine + FOV for the new position grid ----
-      AffineTransform pixToStage = null;
+      // The grid is sized by the CURRENT pixel size from getPixelSizeUm(); the affine is used only
+      // for step-vector DIRECTION (rotation/shear). The affine's own scale can be stale (it does
+      // not always vary per objective), so we normalize it to the current pixel size below.
       double livePixelSizeUm = 0.0;
       try {
-         AffineTransform at = AffineUtils.doubleToAffine(
-               studio_.core().getPixelSizeAffine(true));
-         livePixelSizeUm = AffineUtils.deducePixelSize(at);
-         if (livePixelSizeUm > 0.0) {
-            pixToStage = at;
-         }
+         livePixelSizeUm = studio_.core().getPixelSizeUm();
       } catch (Exception ignore) {
-         // No affine configured -- scalar fallback below.
+         // Core unavailable -- fall back below.
       }
       if (livePixelSizeUm <= 0.0) {
          livePixelSizeUm = pixelSizeUm_ > 0 ? pixelSizeUm_ : 1.0;
+      }
+      AffineTransform pixToStage = null;
+      double affineScale = 1.0;
+      try {
+         AffineTransform at = AffineUtils.doubleToAffine(
+               studio_.core().getPixelSizeAffine(true));
+         double affinePixelSize = AffineUtils.deducePixelSize(at);
+         if (affinePixelSize > 0.0) {
+            pixToStage = at;
+            // Rescale the affine's vectors from its (possibly stale) pixel size to the current one
+            // so directions are preserved but magnitudes match getPixelSizeUm().
+            affineScale = livePixelSizeUm / affinePixelSize;
+         }
+      } catch (Exception ignore) {
+         // No affine configured -- scalar fallback below.
       }
 
       int tileW = (int) studio_.core().getImageWidth();
@@ -2149,12 +2164,13 @@ public class ExplorerManager {
          pixToStage.deltaTransform(new Point2D.Double(0, stepPxY), sy);
          pixToStage.deltaTransform(new Point2D.Double(tileW, 0), fx);
          pixToStage.deltaTransform(new Point2D.Double(0, tileH), fy);
-         stageStepXdx = sx.x;
-         stageStepXdy = sx.y;
-         stageStepYdx = sy.x;
-         stageStepYdy = sy.y;
-         fovW = Math.hypot(fx.x, fx.y);
-         fovH = Math.hypot(fy.x, fy.y);
+         // Normalize the affine's scale to the current pixel size (see affineScale above).
+         stageStepXdx = sx.x * affineScale;
+         stageStepXdy = sx.y * affineScale;
+         stageStepYdx = sy.x * affineScale;
+         stageStepYdy = sy.y * affineScale;
+         fovW = Math.hypot(fx.x, fx.y) * affineScale;
+         fovH = Math.hypot(fy.x, fy.y) * affineScale;
       } else {
          stageStepXdx = stepPxX * livePixelSizeUm;
          stageStepXdy = 0;
@@ -2231,10 +2247,26 @@ public class ExplorerManager {
          throw new Exception("Cannot create positions: no XY stage device is configured.");
       }
 
-      // FOV size in full-resolution pixels (session frame), for the overlap test.
-      double pxPerUm = computePxPerUm();
-      double fovPxW = pxPerUm > 0 ? fovW * pxPerUm : tileW;
-      double fovPxH = pxPerUm > 0 ? fovH * pxPerUm : tileH;
+      // FOV size in full-resolution (session-frame) canvas pixels, for the overlap test and the
+      // grey preview. Sized identically to the red live-FOV indicator so the two coincide:
+      // session-frame effective tile px * current/session pixel-size ratio * camera-ROI scale.
+      // This is robust to a stale or rotated pixel-size affine and to camera-ROI (WxH) changes.
+      final double fovPxW;
+      final double fovPxH;
+      final int twCanvas = dataSource_ != null ? dataSource_.getTileWidth() : -1;
+      final int thCanvas = dataSource_ != null ? dataSource_.getTileHeight() : -1;
+      if (twCanvas > 0 && thCanvas > 0 && initialCameraWidth_ > 0 && initialCameraHeight_ > 0) {
+         final double ratio = getPixelSizeRatio();
+         final double widthScale  = (double) tileW / initialCameraWidth_;
+         final double heightScale = (double) tileH / initialCameraHeight_;
+         final int ovCanvasX = (int) Math.round(twCanvas * overlapPercentage_ / 100.0);
+         final int ovCanvasY = (int) Math.round(thCanvas * overlapPercentage_ / 100.0);
+         fovPxW = (twCanvas - ovCanvasX) * ratio * widthScale;
+         fovPxH = (thCanvas - ovCanvasY) * ratio * heightScale;
+      } else {
+         fovPxW = tileW;
+         fovPxH = tileH;
+      }
 
       final double overlapXUm = overlapX * livePixelSizeUm;
       final double overlapYUm = overlapY * livePixelSizeUm;
@@ -2594,6 +2626,8 @@ public class ExplorerManager {
       private final double stageY;
       private final java.util.Map<String, Double> z;
       private final int[] well; // {wellRow, wellCol} on multi-well plates, else null
+      // In-focus thumbnail captured at this point (immutable once set); null until snapped.
+      private volatile java.awt.image.BufferedImage thumb;
 
       private RefineZPoint(double stageX, double stageY,
             java.util.Map<String, Double> z, int[] well) {
@@ -2618,12 +2652,13 @@ public class ExplorerManager {
       }
    }
 
-   /** Discards all collected Refine-Z reference points and clears their markers. */
+   /** Discards all collected Refine-Z reference points and clears their markers/thumbnails. */
    public void clearRefineZ() {
       synchronized (refineZPoints_) {
          refineZPoints_.clear();
       }
       pushRefineZMarkers();
+      pushRefineZThumbnails();
       setRefineZStatus("Refine Z cleared.");
    }
 
@@ -2643,6 +2678,68 @@ public class ExplorerManager {
       }
       dataSource_.setRefineZMarkers(markers);
       redrawOverlay();
+   }
+
+   /**
+    * Pushes the in-focus thumbnails to the overlay, sizing each to the current FOV in
+    * session-frame canvas pixels (the same formula as the red live-FOV indicator), centered at the
+    * reference point. Recomputed on every push so it tracks pan/zoom and objective/camera changes.
+    */
+   private void pushRefineZThumbnails() {
+      if (dataSource_ == null) {
+         return;
+      }
+      int tw = dataSource_.getTileWidth();
+      int th = dataSource_.getTileHeight();
+      java.util.List<ExplorerDataSource.RefineZThumb> thumbs = new java.util.ArrayList<>();
+      if (tw > 0 && th > 0) {
+         double ratio = getPixelSizeRatio();
+         double widthScale  = initialCameraWidth_  > 0
+               ? (double) cameraWidth_  / initialCameraWidth_  : 1.0;
+         double heightScale = initialCameraHeight_ > 0
+               ? (double) cameraHeight_ / initialCameraHeight_ : 1.0;
+         int ovX = (int) Math.round(tw * overlapPercentage_ / 100.0);
+         int ovY = (int) Math.round(th * overlapPercentage_ / 100.0);
+         double fovW = (tw - ovX) * ratio * widthScale;
+         double fovH = (th - ovY) * ratio * heightScale;
+         synchronized (refineZPoints_) {
+            for (RefineZPoint p : refineZPoints_) {
+               if (p.thumb == null) {
+                  continue;
+               }
+               Point2D.Double centerPx = stageToPixel(p.stageX, p.stageY);
+               if (centerPx == null) {
+                  continue;
+               }
+               thumbs.add(new ExplorerDataSource.RefineZThumb(
+                     centerPx.x - fovW / 2.0, centerPx.y - fovH / 2.0, fovW, fovH, p.thumb));
+            }
+         }
+      }
+      dataSource_.setRefineZThumbnails(thumbs);
+      redrawOverlay();
+   }
+
+   /** Best-effort in-focus thumbnail from a snap; returns null on any failure. Call off the EDT. */
+   private java.awt.image.BufferedImage grabRefineZThumbnail() {
+      try {
+         java.util.List<Image> images = studio_.live().snap(false);
+         if (images == null || images.isEmpty()) {
+            return null;
+         }
+         Image img = images.get(0);
+         ij.process.ImageProcessor proc = ImageUtils.makeProcessor(
+               img.getImageJPixelType(), img.getWidth(), img.getHeight(), img.getRawPixels());
+         if (proc == null) {
+            return null;
+         }
+         proc.setInterpolationMethod(ij.process.ImageProcessor.BILINEAR);
+         ij.process.ImageProcessor scaled = proc.resize(REFINE_Z_THUMB_PX, REFINE_Z_THUMB_PX);
+         return scaled.getBufferedImage();
+      } catch (Exception e) {
+         studio_.logs().logError(e, "Refine Z: failed to grab thumbnail");
+         return null;
+      }
    }
 
    /** True while the automatic Refine-Z worker is running. */
@@ -2735,13 +2832,8 @@ public class ExplorerManager {
       }
 
       private String refineOneTile(AutofocusPlugin af, Tile t) {
-         // Snap to the Explorer grid cell center under this tile so the reference point, the
-         // autofocus measurement, and the acquired image all coincide on the canvas grid.
-         int[] cell = explorerGridCellForStage(t.stageX, t.stageY);
-         Point2D.Double target = cell != null
-               ? stageForExplorerCell(cell[0], cell[1]) : new Point2D.Double(t.stageX, t.stageY);
          try {
-            studio_.core().setXYPosition(studio_.core().getXYStageDevice(), target.x, target.y);
+            studio_.core().setXYPosition(studio_.core().getXYStageDevice(), t.stageX, t.stageY);
             studio_.core().waitForDevice(studio_.core().getXYStageDevice());
          } catch (Exception e) {
             studio_.logs().logError(e, "Refine Z: move failed");
@@ -2765,9 +2857,10 @@ public class ExplorerManager {
             studio_.logs().logError(e, "Refine Z: read Z failed");
             return "tile (Z read failed)";
          }
-         // Acquire the in-focus image so it shows on the canvas like a normal tile.
-         acquireRefineZTileAtCurrentStage();
-         publish(new RefineZPoint(target.x, target.y, zVals, t.well));
+         RefineZPoint rp = new RefineZPoint(t.stageX, t.stageY, zVals, t.well);
+         // Grab the in-focus image for the overlay thumbnail (no NDTiff tile is stored).
+         rp.thumb = grabRefineZThumbnail();
+         publish(rp);
          return null;
       }
 
@@ -2777,6 +2870,7 @@ public class ExplorerManager {
             refineZPoints_.addAll(chunks);
          }
          pushRefineZMarkers();
+         pushRefineZThumbnails();
          setRefineZStatus("Refined " + refineZPointCount() + " point(s)...");
       }
 
@@ -2807,81 +2901,6 @@ public class ExplorerManager {
    }
 
    /**
-    * Returns the Explorer session tile-grid cell {row, col} that contains the given stage
-    * position, or null if the tile grid is not ready. Uses the same mapping the canvas uses to
-    * place tiles, so acquiring this cell shows the image at the expected canvas location.
-    */
-   private int[] explorerGridCellForStage(double stageX, double stageY) {
-      Point2D.Double px = stageToPixel(stageX, stageY);
-      int tw = dataSource_ != null ? dataSource_.getTileWidth() : -1;
-      int th = dataSource_ != null ? dataSource_.getTileHeight() : -1;
-      if (px == null || tw <= 0 || th <= 0) {
-         return null;
-      }
-      int overlapPixelsX = (int) Math.round(tw * overlapPercentage_ / 100.0);
-      int overlapPixelsY = (int) Math.round(th * overlapPercentage_ / 100.0);
-      double effW = tw - overlapPixelsX;
-      double effH = th - overlapPixelsY;
-      int col = (int) Math.floor(px.x / effW);
-      int row = (int) Math.floor(px.y / effH);
-      return new int[]{row, col};
-   }
-
-   /**
-    * Returns the stage XY of the center of the Explorer session tile-grid cell {row, col}, using
-    * the same grid->stage mapping as acquireMultipleTiles so the cell aligns with the canvas.
-    */
-   private Point2D.Double stageForExplorerCell(int row, int col) {
-      double overlapFraction = overlapPercentage_ / 100.0;
-      double effectivePixelStepX = cameraWidth_  * (1.0 - overlapFraction);
-      double effectivePixelStepY = cameraHeight_ * (1.0 - overlapFraction);
-      if (pixelSizeAffine_ != null) {
-         Point2D.Double pixelOffset = new Point2D.Double(
-               col * effectivePixelStepX, row * effectivePixelStepY);
-         Point2D.Double stageOffset = new Point2D.Double();
-         pixelSizeAffine_.transform(pixelOffset, stageOffset);
-         return new Point2D.Double(initialStageX_ + stageOffset.x, initialStageY_ + stageOffset.y);
-      }
-      double effectiveStepWidthUm  = stageTileWidthUm_  * (1.0 - overlapFraction);
-      double effectiveStepHeightUm = stageTileHeightUm_ * (1.0 - overlapFraction);
-      return new Point2D.Double(initialStageX_ + col * effectiveStepWidthUm,
-            initialStageY_ + row * effectiveStepHeightUm);
-   }
-
-   /**
-    * Moves the stage to the center of the Explorer grid cell under the current position and
-    * acquires that tile so the in-focus image appears on the canvas (exactly like a left-click
-    * acquisition) at the correct cell. Runs synchronously; must be called off the EDT. Returns
-    * the cell-center stage XY actually acquired, or null on failure.
-    */
-   private Point2D.Double acquireRefineZTileAtCurrentStage() {
-      try {
-         double stageX = studio_.core().getXPosition();
-         double stageY = studio_.core().getYPosition();
-         int[] cell = explorerGridCellForStage(stageX, stageY);
-         if (cell == null) {
-            return null;
-         }
-         int row = cell[0];
-         int col = cell[1];
-         // Snap to the exact cell center so the stored tile aligns with the canvas grid.
-         Point2D.Double cellCenter = stageForExplorerCell(row, col);
-         studio_.core().setXYPosition(cellCenter.x, cellCenter.y);
-         studio_.core().waitForDevice(studio_.core().getXYStageDevice());
-         if (!dataSource_.isTileAcquired(row, col)) {
-            acquireSingleTileBlocking(row, col);
-            dataSource_.markTileAcquired(row, col);
-            dataSource_.invalidateImageKeysCache();
-            redrawOverlay();
-         }
-         return cellCenter;
-      } catch (Exception e) {
-         studio_.logs().logError(e, "Refine Z: could not acquire in-focus tile");
-         return null;
-      }
-   }
-
-   /**
     * Manual Refine Z: moves the stage so the clicked full-res pixel becomes the FOV center, so the
     * operator can focus there and then capture with {@link #addManualRefineZ()}.
     */
@@ -2894,7 +2913,7 @@ public class ExplorerManager {
 
    /**
     * Captures the current Z of every checked Z stage at the current stage XY as a Refine-Z
-    * reference point.
+    * reference point, then snaps an in-focus thumbnail (off the EDT) for the overlay.
     */
    public void addManualRefineZ() {
       if (!exploring_ || loadedData_) {
@@ -2912,21 +2931,20 @@ public class ExplorerManager {
          for (String z : zStages) {
             zVals.put(z, studio_.core().getPosition(z));
          }
-         // Record the point at the Explorer grid cell center so the marker, the reference point,
-         // and the acquired tile all coincide on the canvas grid.
-         int[] cell = explorerGridCellForStage(stageX, stageY);
-         Point2D.Double refXy = cell != null
-               ? stageForExplorerCell(cell[0], cell[1]) : new Point2D.Double(stageX, stageY);
          int[] well = (vesselType_ != null && vesselType_.isMultiWell())
-               ? wellIndexForStage(refXy.x, refXy.y) : null;
+               ? wellIndexForStage(stageX, stageY) : null;
+         final RefineZPoint rp = new RefineZPoint(stageX, stageY, zVals, well);
          synchronized (refineZPoints_) {
-            refineZPoints_.add(new RefineZPoint(refXy.x, refXy.y, zVals, well));
+            refineZPoints_.add(rp);
          }
          pushRefineZMarkers();
          setRefineZStatus("Set Z (" + refineZPointCount() + " points).");
-         // Acquire the in-focus image (off the EDT) so it shows on the canvas.
+         // Snap the in-focus image off the EDT, then push thumbnails on the EDT.
          if (acquisitionExecutor_ != null) {
-            acquisitionExecutor_.submit(this::acquireRefineZTileAtCurrentStage);
+            acquisitionExecutor_.submit(() -> {
+               rp.thumb = grabRefineZThumbnail();
+               SwingUtilities.invokeLater(this::pushRefineZThumbnails);
+            });
          }
       } catch (Exception e) {
          studio_.logs().showError(e, "Refine Z: could not read stage position.");

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 import mmcorej.org.json.JSONArray;
 import mmcorej.org.json.JSONObject;
 import org.micromanager.PropertyMap;
@@ -160,6 +161,9 @@ public class ExplorerManager {
    // Slice positions captured at session start, applied to every tile acquisition so the
    // z-axis shape is independent of later MDA slice edits. Empty when not using slices.
    private java.util.ArrayList<Double> sessionSlices_ = new java.util.ArrayList<>();
+   // Set to true after the first time we notify the user that MDA slice settings were
+   // overridden; prevents showing the same dialog on every subsequent tile.
+   private volatile boolean mdaSliceOverrideWarningShown_ = false;
 
    // Camera orientation / Image Flipper correction
    private int sessionCorrectionRotation_ = 0;    // 0/90/180/270
@@ -237,6 +241,7 @@ public class ExplorerManager {
          sessionSlices_ = sessionUseSlices_
                  ? new java.util.ArrayList<>(startSettings.slices())
                  : new java.util.ArrayList<>();
+         mdaSliceOverrideWarningShown_ = false;
 
          initialStageX_ = studio_.core().getXPosition();
          initialStageY_ = studio_.core().getYPosition();
@@ -1193,6 +1198,32 @@ public class ExplorerManager {
    private void acquireSingleTileBlocking(int row, int col) {
       try {
          SequenceSettings settings = studio_.acquisitions().getAcquisitionSettings();
+
+         // Detect if the user changed MDA slice settings mid-session and warn once.
+         if (!mdaSliceOverrideWarningShown_) {
+            boolean currentUseSlices = settings.useSlices() && !settings.slices().isEmpty();
+            boolean slicesDiffer = (currentUseSlices != sessionUseSlices_)
+                    || (sessionUseSlices_ && !settings.slices().equals(sessionSlices_));
+            if (slicesDiffer) {
+               mdaSliceOverrideWarningShown_ = true;
+               SwingUtilities.invokeLater(() ->
+                     JOptionPane.showMessageDialog(
+                           frame_,
+                           "<html><body style='width:350px'>"
+                           + "The MDA slice (z-stack) settings were changed after this "
+                           + "Explorer session started.<br><br>"
+                           + "To keep the z-axis consistent across all tiles already "
+                           + "acquired, the Explorer will continue using the "
+                           + "<b>original slice settings</b> for the rest of this session."
+                           + "<br><br>"
+                           + "Start a new Explorer session if you want the updated "
+                           + "slice settings to take effect."
+                           + "</body></html>",
+                           "Explorer: MDA Settings Override",
+                           JOptionPane.INFORMATION_MESSAGE));
+            }
+         }
+
          // Use the z-axis decision locked at session start, not the current MDA
          // settings, so every tile in this session has the same axes shape.
          boolean useSlices = sessionUseSlices_;

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -1990,33 +1990,37 @@ public class ExplorerManager {
    }
 
    /**
-    * Chooses up to {@code n} tiles spread across the given set using farthest-point sampling in
-    * stage space. On multi-well plates the budget is split across wells so each gets coverage.
+    * Chooses up to {@code n} tiles TOTAL, spread across the given set using farthest-point sampling
+    * in stage space. On multi-well plates the total budget {@code n} is distributed across the
+    * occupied wells (each occupied well gets at least one point until the budget is exhausted), so
+    * dense plates do not explode into hundreds of autofocus points.
     */
    private java.util.List<Tile> chooseSpreadTiles(java.util.List<Tile> tiles, int n) {
       java.util.List<Tile> result = new java.util.ArrayList<>();
       if (tiles.isEmpty() || n <= 0) {
          return result;
       }
-      // Group by well so each well is sampled; non-plate -> single group.
+      // Group by well so the budget is spread across wells; non-plate -> single group.
       java.util.Map<Long, java.util.List<Tile>> byWell = new java.util.LinkedHashMap<>();
-      boolean multiWell = false;
       for (Tile t : tiles) {
          long key = 0;
          if (t.well != null) {
-            multiWell = true;
             key = ((long) t.well[0] << 32) | (t.well[1] & 0xffffffffL);
          }
          byWell.computeIfAbsent(key, k -> new java.util.ArrayList<>()).add(t);
       }
       int nWells = byWell.size();
+      // Distribute n across wells: a base count each, plus one extra to the first 'remainder'
+      // wells. When n < nWells only the first n wells get a point (base 0, remainder n).
+      int base = n / nWells;
+      int remainder = n % nWells;
+      int idx = 0;
       for (java.util.List<Tile> group : byWell.values()) {
-         int budget = multiWell ? Math.max(1, n) : n; // n points per well on plates, else n total
-         result.addAll(farthestPointSample(group, Math.min(budget, group.size())));
-      }
-      // On non-plate the loop ran once; on plates each well got up to n points.
-      if (!multiWell && result.size() > n) {
-         return result.subList(0, n);
+         int budget = base + (idx < remainder ? 1 : 0);
+         if (budget > 0) {
+            result.addAll(farthestPointSample(group, Math.min(budget, group.size())));
+         }
+         idx++;
       }
       return result;
    }

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -4,14 +4,17 @@ import com.google.common.eventbus.Subscribe;
 import java.awt.Color;
 import java.awt.Point;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -31,9 +34,13 @@ import java.util.stream.Stream;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
 import mmcorej.org.json.JSONArray;
 import mmcorej.org.json.JSONObject;
+import org.micromanager.MultiStagePosition;
+import org.micromanager.PositionList;
 import org.micromanager.PropertyMap;
+import org.micromanager.StagePosition;
 import org.micromanager.Studio;
 import org.micromanager.acqj.main.AcqEngMetadata;
 import org.micromanager.acquisition.SequenceSettings;
@@ -354,7 +361,7 @@ public class ExplorerManager {
          vesselAnchorType_ = null;
          vesselUsedHcsCal_ = false;
          vesselOutlinePending_ = false;
-         frame_.setExploringActive(true);
+         frame_.setExploringActive(true, true);
          if (vesselType_.isMultiWell()) {
             Point2D.Double hcsOffset = tryReadHcsCalibration();
             frame_.setHcsCalibrationStatus(hcsOffset != null);
@@ -641,13 +648,14 @@ public class ExplorerManager {
       flipperInPipeline_         = false;
       rawPixelSizeAffine_        = null;
       rawInitialPixelSizeAffine_ = null;
-      frame_.setExploringActive(false);
+      frame_.setExploringActive(false, false);
       vesselAnchorType_ = null;
       vesselUsedHcsCal_ = false;
       vesselOutlinePending_ = false;
       if (dataSource_ != null) {
          dataSource_.clearPendingTiles();
          dataSource_.clearVesselOutline();
+         dataSource_.setPositionTool(ExplorerDataSource.PositionTool.NONE);
       }
 
       if (displayExecutor_ != null) {
@@ -1747,50 +1755,362 @@ public class ExplorerManager {
       }
       acquisitionExecutor_.submit(() -> {
          try {
-            int tw = dataSource_ != null ? dataSource_.getTileWidth() : cameraWidth_;
-            int th = dataSource_ != null ? dataSource_.getTileHeight() : cameraHeight_;
-            int overlapPixelsX = (int) Math.round(tw * overlapPercentage_ / 100.0);
-            int overlapPixelsY = (int) Math.round(th * overlapPercentage_ / 100.0);
-            double effectiveTileWidth = tw - overlapPixelsX;
-            double effectiveTileHeight = th - overlapPixelsY;
-
-            double offsetPixelX = pixelX - effectiveTileWidth / 2.0;
-            double offsetPixelY = pixelY - effectiveTileHeight / 2.0;
-
-            double targetX;
-            double targetY;
-            // Always invert using the session-start pixel size / affine so that clicks on
-            // the tile grid map to consistent physical stage positions regardless of the
-            // current objective.
-            if (initialPixelSizeAffine_ != null) {
-               // Convert canvas-pixel delta to camera-pixel delta using initial camera dims,
-               // then apply the session-start affine (forward: camera-pixel → stage-micron).
-               double pipelineScaleX = (tw > 0 && initialCameraWidth_  > 0)
-                     ? (double) initialCameraWidth_  / tw : 1.0;
-               double pipelineScaleY = (th > 0 && initialCameraHeight_ > 0)
-                     ? (double) initialCameraHeight_ / th : 1.0;
-               Point2D.Double camPixelDelta = new Point2D.Double(
-                     offsetPixelX * pipelineScaleX, offsetPixelY * pipelineScaleY);
-               Point2D.Double stageOffset = new Point2D.Double();
-               initialPixelSizeAffine_.transform(camPixelDelta, stageOffset);
-               targetX = initialStageX_ + stageOffset.x;
-               targetY = initialStageY_ + stageOffset.y;
-            } else {
-               double pipelineScaleX = (tw > 0 && initialCameraWidth_  > 0)
-                     ? (double) initialCameraWidth_  / tw : 1.0;
-               double pipelineScaleY = (th > 0 && initialCameraHeight_ > 0)
-                     ? (double) initialCameraHeight_ / th : 1.0;
-               targetX = initialStageX_ + offsetPixelX * pipelineScaleX * initialPixelSizeUm_;
-               targetY = initialStageY_ + offsetPixelY * pipelineScaleY * initialPixelSizeUm_;
+            Point2D.Double target = pixelToStageSessionFrame(pixelX, pixelY);
+            if (target == null) {
+               return;
             }
-
-            studio_.core().setXYPosition(targetX, targetY);
+            studio_.core().setXYPosition(target.x, target.y);
             studio_.core().waitForDevice(studio_.core().getXYStageDevice());
-
          } catch (Exception e) {
             studio_.logs().logError(e, "Explorer: error moving stage");
          }
       });
+   }
+
+   /**
+    * Converts a full-resolution canvas pixel coordinate (the center of a tile/FOV) to the
+    * stage coordinate it represents, using the SESSION-START pixel size / affine. This keeps
+    * canvas positions mapped to consistent physical stage positions regardless of the current
+    * objective. Returns null if the conversion is not possible (no tile dimensions yet).
+    */
+   private Point2D.Double pixelToStageSessionFrame(double pixelX, double pixelY) {
+      int tw = dataSource_ != null ? dataSource_.getTileWidth() : cameraWidth_;
+      int th = dataSource_ != null ? dataSource_.getTileHeight() : cameraHeight_;
+      if (tw <= 0 || th <= 0) {
+         return null;
+      }
+      int overlapPixelsX = (int) Math.round(tw * overlapPercentage_ / 100.0);
+      int overlapPixelsY = (int) Math.round(th * overlapPercentage_ / 100.0);
+      double effectiveTileWidth = tw - overlapPixelsX;
+      double effectiveTileHeight = th - overlapPixelsY;
+
+      double offsetPixelX = pixelX - effectiveTileWidth / 2.0;
+      double offsetPixelY = pixelY - effectiveTileHeight / 2.0;
+
+      double pipelineScaleX = (tw > 0 && initialCameraWidth_  > 0)
+            ? (double) initialCameraWidth_  / tw : 1.0;
+      double pipelineScaleY = (th > 0 && initialCameraHeight_ > 0)
+            ? (double) initialCameraHeight_ / th : 1.0;
+
+      double targetX;
+      double targetY;
+      if (initialPixelSizeAffine_ != null) {
+         // Convert canvas-pixel delta to camera-pixel delta using initial camera dims,
+         // then apply the session-start affine (forward: camera-pixel -> stage-micron).
+         Point2D.Double camPixelDelta = new Point2D.Double(
+               offsetPixelX * pipelineScaleX, offsetPixelY * pipelineScaleY);
+         Point2D.Double stageOffset = new Point2D.Double();
+         initialPixelSizeAffine_.transform(camPixelDelta, stageOffset);
+         targetX = initialStageX_ + stageOffset.x;
+         targetY = initialStageY_ + stageOffset.y;
+      } else {
+         targetX = initialStageX_ + offsetPixelX * pipelineScaleX * initialPixelSizeUm_;
+         targetY = initialStageY_ + offsetPixelY * pipelineScaleY * initialPixelSizeUm_;
+      }
+      return new Point2D.Double(targetX, targetY);
+   }
+
+   // ===================== Create Positions =====================
+
+   private static final DecimalFormat FMT_POS = new DecimalFormat("000");
+
+   /**
+    * Enters or leaves position-draw mode. Only allowed for a live (Started) session, not for
+    * an opened (read-only) dataset. Passing {@link ExplorerDataSource.PositionTool#NONE} leaves
+    * draw mode. Sets the canvas cursor accordingly.
+    */
+   public void setPositionDrawTool(ExplorerDataSource.PositionTool tool) {
+      if (dataSource_ == null) {
+         return;
+      }
+      if (!exploring_ || loadedData_) {
+         dataSource_.setPositionTool(ExplorerDataSource.PositionTool.NONE);
+         return;
+      }
+      dataSource_.setPositionTool(tool);
+      if (viewer_ != null) {
+         boolean drawing = tool != null && tool != ExplorerDataSource.PositionTool.NONE;
+         viewer_.getCanvasJPanel().setCursor(java.awt.Cursor.getPredefinedCursor(
+               drawing ? java.awt.Cursor.CROSSHAIR_CURSOR : java.awt.Cursor.DEFAULT_CURSOR));
+      }
+      redrawOverlay();
+   }
+
+   /** Discards the current Create-Positions ROI. */
+   public void clearPositionRoi() {
+      if (dataSource_ != null) {
+         dataSource_.clearPositionRoi();
+         redrawOverlay();
+      }
+   }
+
+   /** True when a completed Create-Positions ROI exists. */
+   public boolean hasPositionRoi() {
+      return dataSource_ != null && dataSource_.hasPositionRoi();
+   }
+
+   /** Notifies the frame that the ROI state changed so it can update the Generate button. */
+   public void onPositionRoiChanged() {
+      final boolean has = hasPositionRoi();
+      SwingUtilities.invokeLater(() -> frame_.setGenerateEnabled(has));
+   }
+
+   /**
+    * Generates a tile-grid position list covering the drawn ROI and adds it to the MM position
+    * list. Positions are sized using the CURRENT pixel size and camera FOV (which may differ
+    * from the session-start objective). When {@code withinVesselOnly} is true the ROI is first
+    * intersected with the vessel boundary.
+    *
+    * <p>A tile is included if its FOV rectangle overlaps the (clipped) ROI shape. Positions are
+    * ordered in a serpentine pattern. The computation runs off the EDT.</p>
+    */
+   public void createPositionsFromRoi(boolean withinVesselOnly) {
+      if (dataSource_ == null || !exploring_ || loadedData_) {
+         return;
+      }
+      final Area roiAreaPx = dataSource_.getPositionRoiAreaPx();
+      if (roiAreaPx == null) {
+         frame_.setPositionStatus("Draw an ROI first.");
+         return;
+      }
+      if (withinVesselOnly) {
+         Area vesselArea = dataSource_.getVesselAreaPx();
+         if (vesselArea != null) {
+            roiAreaPx.intersect(vesselArea);
+         }
+      }
+      if (roiAreaPx.isEmpty()) {
+         frame_.setPositionStatus("ROI does not overlap the vessel.");
+         return;
+      }
+
+      frame_.setPositionStatus("Computing positions...");
+      frame_.setGenerateEnabled(false);
+
+      new SwingWorker<PositionList, Void>() {
+         private String warning = null;
+         // FOV rectangles (full-res pixels) of accepted positions, for the grey overlay.
+         private final java.util.List<Rectangle2D.Double> fovsPx =
+               new java.util.ArrayList<>();
+
+         @Override
+         protected PositionList doInBackground() throws Exception {
+            // ---- Live hardware: affine + FOV for the new position grid ----
+            AffineTransform pixToStage = null;
+            double livePixelSizeUm = 0.0;
+            try {
+               AffineTransform at = AffineUtils.doubleToAffine(
+                     studio_.core().getPixelSizeAffine(true));
+               livePixelSizeUm = AffineUtils.deducePixelSize(at);
+               if (livePixelSizeUm > 0.0) {
+                  pixToStage = at;
+               }
+            } catch (Exception ignore) {
+               // No affine configured -- scalar fallback below.
+            }
+            if (livePixelSizeUm <= 0.0) {
+               livePixelSizeUm = pixelSizeUm_ > 0 ? pixelSizeUm_ : 1.0;
+            }
+
+            int tileW = (int) studio_.core().getImageWidth();
+            int tileH = (int) studio_.core().getImageHeight();
+            if (tileW <= 0 || tileH <= 0) {
+               throw new Exception("Cannot create positions: camera image size unavailable.");
+            }
+
+            int overlapX = (int) Math.round(tileW * overlapPercentage_ / 100.0);
+            int overlapY = (int) Math.round(tileH * overlapPercentage_ / 100.0);
+            int stepPxX = tileW - overlapX;
+            int stepPxY = tileH - overlapY;
+            if (stepPxX <= 0 || stepPxY <= 0) {
+               throw new Exception("Cannot create positions: overlap is >= tile size.");
+            }
+
+            if (Math.abs(livePixelSizeUm - initialPixelSizeUm_) > 0.01 * initialPixelSizeUm_) {
+               warning = String.format(
+                     "Note: current pixel size (%.4f um) differs from session start (%.4f um) "
+                     + "- positions sized for the current objective.",
+                     livePixelSizeUm, initialPixelSizeUm_);
+            }
+
+            // ---- Step vectors and FOV magnitudes in stage space (current hardware) ----
+            final double stageStepXdx;
+            final double stageStepXdy;
+            final double stageStepYdx;
+            final double stageStepYdy;
+            double fovW;
+            double fovH;
+            if (pixToStage != null) {
+               Point2D.Double sx = new Point2D.Double();
+               Point2D.Double sy = new Point2D.Double();
+               Point2D.Double fx = new Point2D.Double();
+               Point2D.Double fy = new Point2D.Double();
+               pixToStage.deltaTransform(new Point2D.Double(stepPxX, 0), sx);
+               pixToStage.deltaTransform(new Point2D.Double(0, stepPxY), sy);
+               pixToStage.deltaTransform(new Point2D.Double(tileW, 0), fx);
+               pixToStage.deltaTransform(new Point2D.Double(0, tileH), fy);
+               stageStepXdx = sx.x;
+               stageStepXdy = sx.y;
+               stageStepYdx = sy.x;
+               stageStepYdy = sy.y;
+               fovW = Math.hypot(fx.x, fx.y);
+               fovH = Math.hypot(fy.x, fy.y);
+            } else {
+               stageStepXdx = stepPxX * livePixelSizeUm;
+               stageStepXdy = 0;
+               stageStepYdx = 0;
+               stageStepYdy = stepPxY * livePixelSizeUm;
+               fovW = tileW * livePixelSizeUm;
+               fovH = tileH * livePixelSizeUm;
+            }
+            double stepMagX = Math.hypot(stageStepXdx, stageStepXdy);
+            double stepMagY = Math.hypot(stageStepYdx, stageStepYdy);
+            if (stepMagX <= 0 || stepMagY <= 0) {
+               throw new Exception("Cannot create positions: degenerate step size.");
+            }
+
+            // ---- ROI corners -> stage space (session-start frame) ----
+            Rectangle2D bbox = roiAreaPx.getBounds2D();
+            Point2D.Double[] cornersPx = new Point2D.Double[] {
+               new Point2D.Double(bbox.getMinX(), bbox.getMinY()),
+               new Point2D.Double(bbox.getMaxX(), bbox.getMinY()),
+               new Point2D.Double(bbox.getMinX(), bbox.getMaxY()),
+               new Point2D.Double(bbox.getMaxX(), bbox.getMaxY())
+            };
+            Point2D.Double[] cornersStage = new Point2D.Double[4];
+            for (int i = 0; i < 4; i++) {
+               cornersStage[i] = pixelToStageSessionFrame(cornersPx[i].x, cornersPx[i].y);
+               if (cornersStage[i] == null) {
+                  throw new Exception("Cannot create positions: tile dimensions not ready.");
+               }
+            }
+
+            // ---- Grid dimensions: project corners onto unit step axes ----
+            double uxX = stageStepXdx / stepMagX;
+            double uxY = stageStepXdy / stepMagX;
+            double uyX = stageStepYdx / stepMagY;
+            double uyY = stageStepYdy / stepMagY;
+            double projXMin = Double.MAX_VALUE;
+            double projXMax = -Double.MAX_VALUE;
+            double projYMin = Double.MAX_VALUE;
+            double projYMax = -Double.MAX_VALUE;
+            double sumX = 0;
+            double sumY = 0;
+            for (Point2D.Double c : cornersStage) {
+               double px = c.x * uxX + c.y * uxY;
+               double py = c.x * uyX + c.y * uyY;
+               projXMin = Math.min(projXMin, px);
+               projXMax = Math.max(projXMax, px);
+               projYMin = Math.min(projYMin, py);
+               projYMax = Math.max(projYMax, py);
+               sumX += c.x;
+               sumY += c.y;
+            }
+            double roiExtentX = projXMax - projXMin;
+            double roiExtentY = projYMax - projYMin;
+            int nCols = Math.max(1, (int) Math.ceil((roiExtentX + fovW - stepMagX) / stepMagX));
+            int nRows = Math.max(1, (int) Math.ceil((roiExtentY + fovH - stepMagY) / stepMagY));
+
+            // ---- Grid origin: center over the ROI bounding box ----
+            double roiStageCX = sumX / 4.0;
+            double roiStageCY = sumY / 4.0;
+            double originX = roiStageCX
+                  - (nCols - 1) / 2.0 * stageStepXdx
+                  - (nRows - 1) / 2.0 * stageStepYdx;
+            double originY = roiStageCY
+                  - (nCols - 1) / 2.0 * stageStepXdy
+                  - (nRows - 1) / 2.0 * stageStepYdy;
+
+            String xyStage;
+            try {
+               xyStage = studio_.core().getXYStageDevice();
+            } catch (Exception e) {
+               xyStage = null;
+            }
+            if (xyStage == null || xyStage.isEmpty()) {
+               throw new Exception("Cannot create positions: no XY stage device is configured.");
+            }
+
+            // FOV size in full-resolution pixels (session frame), for the overlap test.
+            double pxPerUm = computePxPerUm();
+            double fovPxW = pxPerUm > 0 ? fovW * pxPerUm : tileW;
+            double fovPxH = pxPerUm > 0 ? fovH * pxPerUm : tileH;
+
+            final double overlapXUm = overlapX * livePixelSizeUm;
+            final double overlapYUm = overlapY * livePixelSizeUm;
+
+            PositionList posList = new PositionList();
+            for (int row = 0; row < nRows; row++) {
+               for (int col = 0; col < nCols; col++) {
+                  int c = ((row & 1) == 0) ? col : (nCols - 1 - col); // serpentine
+                  double dx = c * stageStepXdx + row * stageStepYdx;
+                  double dy = c * stageStepXdy + row * stageStepYdy;
+                  double stageX = originX + dx;
+                  double stageY = originY + dy;
+
+                  // Include the tile if its FOV rectangle overlaps the ROI shape.
+                  Point2D.Double centerPx = stageToPixel(stageX, stageY);
+                  Rectangle2D.Double fovRect = null;
+                  if (centerPx != null) {
+                     fovRect = new Rectangle2D.Double(
+                           centerPx.x - fovPxW / 2.0, centerPx.y - fovPxH / 2.0, fovPxW, fovPxH);
+                     if (!roiAreaPx.intersects(fovRect)) {
+                        continue;
+                     }
+                  }
+                  if (fovRect != null) {
+                     fovsPx.add(fovRect);
+                  }
+
+                  MultiStagePosition msp = new MultiStagePosition();
+                  msp.setDefaultXYStage(xyStage);
+                  msp.add(StagePosition.create2D(xyStage, stageX, stageY));
+                  msp.setLabel("Pos-" + FMT_POS.format(row) + "_" + FMT_POS.format(c));
+                  msp.setGridCoordinates(row, c);
+                  msp.setProperty("OverlapUmX", String.valueOf(overlapXUm));
+                  msp.setProperty("OverlapUmY", String.valueOf(overlapYUm));
+                  msp.setProperty("OverlapPixelsX", String.valueOf(overlapX));
+                  msp.setProperty("OverlapPixelsY", String.valueOf(overlapY));
+                  msp.setProperty("Source", "ExplorerCreatePositions");
+                  posList.addPosition(msp);
+               }
+            }
+            if (posList.getNumberOfPositions() == 0) {
+               throw new Exception("No positions fall within the ROI.");
+            }
+            return posList;
+         }
+
+         @Override
+         protected void done() {
+            PositionList posList;
+            try {
+               posList = get();
+            } catch (Exception ex) {
+               String msg = ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage();
+               frame_.setPositionStatus(msg);
+               frame_.setGenerateEnabled(hasPositionRoi());
+               return;
+            }
+            PositionList existing = studio_.positions().getPositionList();
+            for (int i = 0; i < posList.getNumberOfPositions(); i++) {
+               existing.addPosition(posList.getPosition(i));
+            }
+            studio_.positions().setPositionList(existing);
+            studio_.app().showPositionList();
+            if (dataSource_ != null) {
+               dataSource_.setGeneratedPositionFovs(fovsPx);
+               redrawOverlay();
+            }
+            String status = "Added " + posList.getNumberOfPositions() + " positions";
+            if (warning != null) {
+               status = warning + " (" + posList.getNumberOfPositions() + " added)";
+            }
+            frame_.setPositionStatus(status);
+            // Keep the ROI so the operator can tweak / regenerate.
+            frame_.setGenerateEnabled(hasPositionRoi());
+         }
+      }.execute();
    }
 
    // ===================== Private helpers =====================
@@ -2057,7 +2377,7 @@ public class ExplorerManager {
       } else {
          frame_.setHcsCalibrationStatus(false);
       }
-      frame_.setExploringActive(exploring_);
+      frame_.setExploringActive(exploring_, exploring_ && !loadedData_);
    }
 
    /**

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -165,6 +165,20 @@ public class ExplorerManager {
    // overridden; prevents showing the same dialog on every subsequent tile.
    private volatile boolean mdaSliceOverrideWarningShown_ = false;
 
+   // Vessel outline: type selected in ExplorerFrame, anchor set at runtime.
+   // Vessel axes are assumed parallel to stage X/Y (standard setup).
+   private VesselType vesselType_ = VesselType.NONE;
+   private VesselType.AnchorType vesselAnchorType_ = null;
+   // For simple vessels: stage position of the named anchor point.
+   // For multi-well plates: stage position of the plate top-left corner.
+   private double vesselAnchorStageX_ = 0;
+   private double vesselAnchorStageY_ = 0;
+   private int vesselAnchorWellRow_ = 0;
+   private int vesselAnchorWellCol_ = 0;
+   private boolean vesselUsedHcsCal_ = false;
+   // True when anchor is set but stageToPixel() was not ready; retry after first tile.
+   private boolean vesselOutlinePending_ = false;
+
    // Camera orientation / Image Flipper correction
    private int sessionCorrectionRotation_ = 0;    // 0/90/180/270
    private boolean sessionCorrectionMirror_ = false; // horizontal mirror
@@ -330,6 +344,26 @@ public class ExplorerManager {
 
          startStagePositionPolling();
          studio_.events().registerForEvents(this);
+
+         // Restore vessel type from profile; anchor is always re-set per session.
+         String savedVessel = studio_.profile().getSettings(ExplorerFrame.class)
+               .getString(ExplorerFrame.VESSEL_TYPE, VesselType.NONE.getName());
+         vesselType_ = VesselType.builtIn().stream()
+               .filter(v -> v.getName().equals(savedVessel))
+               .findFirst().orElse(VesselType.NONE);
+         vesselAnchorType_ = null;
+         vesselUsedHcsCal_ = false;
+         vesselOutlinePending_ = false;
+         frame_.setExploringActive(true);
+         if (vesselType_.isMultiWell()) {
+            Point2D.Double hcsOffset = tryReadHcsCalibration();
+            frame_.setHcsCalibrationStatus(hcsOffset != null);
+            if (hcsOffset != null) {
+               applyHcsCalibration(hcsOffset);
+            }
+         } else {
+            frame_.setHcsCalibrationStatus(false);
+         }
 
       } catch (Exception e) {
          studio_.logs().showError(e, "Failed to start Explorer.");
@@ -598,8 +632,13 @@ public class ExplorerManager {
       flipperInPipeline_         = false;
       rawPixelSizeAffine_        = null;
       rawInitialPixelSizeAffine_ = null;
+      frame_.setExploringActive(false);
+      vesselAnchorType_ = null;
+      vesselUsedHcsCal_ = false;
+      vesselOutlinePending_ = false;
       if (dataSource_ != null) {
          dataSource_.clearPendingTiles();
+         dataSource_.clearVesselOutline();
       }
 
       if (displayExecutor_ != null) {
@@ -1275,6 +1314,9 @@ public class ExplorerManager {
                tileWidth_ = firstImage.getWidth();
                tileHeight_ = firstImage.getHeight();
                dataSource_.setTileDimensions(tileWidth_, tileHeight_);
+               if (vesselOutlinePending_) {
+                  updateVesselOutline();
+               }
 
                // Update storage overlap metadata with actual tile dimensions
                int overlapX = (int) Math.round(tileWidth_ * overlapPercentage_ / 100.0);
@@ -1979,5 +2021,222 @@ public class ExplorerManager {
       } catch (Exception e) {
          return null;
       }
+   }
+
+   // ===================== Vessel outline =====================
+
+   /**
+    * Called from ExplorerFrame when the operator changes the vessel type dropdown.
+    * Clears any existing anchor and outline so the new vessel starts fresh.
+    */
+   public void setVesselType(VesselType v) {
+      vesselType_ = (v != null) ? v : VesselType.NONE;
+      vesselAnchorType_ = null;
+      vesselUsedHcsCal_ = false;
+      vesselOutlinePending_ = false;
+      if (dataSource_ != null) {
+         dataSource_.clearVesselOutline();
+         redrawOverlay();
+      }
+      if (exploring_ && vesselType_.isMultiWell()) {
+         Point2D.Double hcsOffset = tryReadHcsCalibration();
+         frame_.setHcsCalibrationStatus(hcsOffset != null);
+         if (hcsOffset != null) {
+            applyHcsCalibration(hcsOffset);
+         }
+      } else {
+         frame_.setHcsCalibrationStatus(false);
+      }
+      frame_.setExploringActive(exploring_);
+   }
+
+   /**
+    * Called from ExplorerFrame when an anchor button is clicked.
+    * Reads the current stage position, computes the vessel outline in pixel space,
+    * pushes it to ExplorerDataSource, triggers a redraw, and zooms to show the vessel.
+    */
+   public void setVesselAnchor(VesselType.AnchorType anchorType) {
+      if (!exploring_ || vesselType_.isNone()) {
+         return;
+      }
+      try {
+         vesselAnchorStageX_ = studio_.core().getXPosition();
+         vesselAnchorStageY_ = studio_.core().getYPosition();
+         vesselAnchorType_   = anchorType;
+         updateVesselOutline();
+      } catch (Exception e) {
+         studio_.logs().showError(e,
+               "Explorer: could not read stage position for vessel anchor.");
+      }
+   }
+
+   private void updateVesselOutline() {
+      if (dataSource_ == null || vesselType_.isNone()) {
+         return;
+      }
+      if (!vesselType_.isMultiWell() && vesselAnchorType_ == null) {
+         return;
+      }
+
+      double pxPerUm = computePxPerUm();
+      if (pxPerUm <= 0) {
+         vesselOutlinePending_ = true;
+         return;
+      }
+      vesselOutlinePending_ = false;
+
+      double widthPx  = vesselType_.getWidthUm()  * pxPerUm;
+      double heightPx = vesselType_.getHeightUm() * pxPerUm;
+
+      double tlX;
+      double tlY;
+      if (vesselType_.isMultiWell()) {
+         // vesselAnchorStageX_/Y_ holds the plate top-left in stage coordinates
+         // (set by applyHcsCalibration or setVesselWellAnchor).
+         Point2D.Double plateTlPx = stageToPixel(vesselAnchorStageX_, vesselAnchorStageY_);
+         if (plateTlPx == null) {
+            vesselOutlinePending_ = true;
+            return;
+         }
+         tlX = plateTlPx.x;
+         tlY = plateTlPx.y;
+      } else {
+         Point2D.Double anchorPx = stageToPixel(vesselAnchorStageX_, vesselAnchorStageY_);
+         if (anchorPx == null) {
+            vesselOutlinePending_ = true;
+            return;
+         }
+         switch (vesselAnchorType_) {
+            case TOP_LEFT:
+               tlX = anchorPx.x;
+               tlY = anchorPx.y;
+               break;
+            case TOP_RIGHT:
+               tlX = anchorPx.x - widthPx;
+               tlY = anchorPx.y;
+               break;
+            case BOTTOM_LEFT:
+               tlX = anchorPx.x;
+               tlY = anchorPx.y - heightPx;
+               break;
+            case BOTTOM_RIGHT:
+               tlX = anchorPx.x - widthPx;
+               tlY = anchorPx.y - heightPx;
+               break;
+            case CENTER:
+            default:
+               tlX = anchorPx.x - widthPx / 2.0;
+               tlY = anchorPx.y - heightPx / 2.0;
+               break;
+         }
+      }
+      dataSource_.setVesselOutline(vesselType_, tlX, tlY, widthPx, heightPx);
+      redrawOverlay();
+      zoomToVessel(tlX, tlY, widthPx, heightPx);
+   }
+
+   private double computePxPerUm() {
+      int tw = dataSource_ != null ? dataSource_.getTileWidth() : -1;
+      if (tw <= 0 || initialCameraWidth_ <= 0 || initialPixelSizeUm_ <= 0) {
+         return -1;
+      }
+      return ((double) tw / initialCameraWidth_) / initialPixelSizeUm_;
+   }
+
+   private void zoomToVessel(double tlX, double tlY, double widthPx, double heightPx) {
+      if (viewer_ == null) {
+         return;
+      }
+      final double margin = 0.15;
+      final double displayW = widthPx  * (1.0 + 2 * margin);
+      final double displayH = heightPx * (1.0 + 2 * margin);
+      final double offsetX  = tlX - widthPx  * margin;
+      final double offsetY  = tlY - heightPx * margin;
+      SwingUtilities.invokeLater(() -> {
+         viewer_.setViewOffset(offsetX, offsetY);
+         viewer_.setFullResSourceDataSizeAspectCorrected(displayW, displayH);
+      });
+   }
+
+   /**
+    * Re-reads the HCS calibration from the profile and applies it if found.
+    * Called from ExplorerFrame when the operator clicks "Refresh".
+    */
+   public void refreshHcsCalibration() {
+      if (!exploring_ || !vesselType_.isMultiWell()) {
+         return;
+      }
+      Point2D.Double hcsOffset = tryReadHcsCalibration();
+      frame_.setHcsCalibrationStatus(hcsOffset != null);
+      if (hcsOffset != null) {
+         applyHcsCalibration(hcsOffset);
+      }
+   }
+
+   private void applyHcsCalibration(Point2D.Double offset) {
+      // HCS formula: stage_XY = plate_definition_XY + offset.
+      // Plate top-left is at plate definition (0, 0), so plateTL in stage coords = offset.
+      vesselAnchorStageX_ = offset.x;
+      vesselAnchorStageY_ = offset.y;
+      vesselUsedHcsCal_   = true;
+      vesselAnchorWellRow_ = 0;
+      vesselAnchorWellCol_ = 0;
+      updateVesselOutline();
+   }
+
+   /**
+    * Sets the vessel anchor from the current stage position, interpreted as the center of
+    * the given well (0-based row/col).  Computes the plate top-left from the well geometry.
+    * Called from ExplorerFrame when the operator clicks "Set Anchor".
+    */
+   public void setVesselWellAnchor(int row, int col) {
+      if (!exploring_ || !vesselType_.isMultiWell()) {
+         return;
+      }
+      try {
+         double stageX = studio_.core().getXPosition();
+         double stageY = studio_.core().getYPosition();
+         // Stage position of plate top-left = stage position of well center minus
+         // how far that well's center is from the plate's top-left corner.
+         vesselAnchorStageX_ = stageX
+               - vesselType_.getFirstWellXUm()
+               - col * vesselType_.getWellSpacingXUm();
+         vesselAnchorStageY_ = stageY
+               - vesselType_.getFirstWellYUm()
+               - row * vesselType_.getWellSpacingYUm();
+         vesselAnchorWellRow_ = row;
+         vesselAnchorWellCol_ = col;
+         vesselUsedHcsCal_ = false;
+         vesselAnchorType_ = null;
+         updateVesselOutline();
+      } catch (Exception e) {
+         studio_.logs().showError(e,
+               "Explorer: could not read stage position for vessel well anchor.");
+      }
+   }
+
+   /**
+    * Reads the HCS SiteGenerator offset from the profile via reflection.
+    * Returns null if HCS is not installed, not calibrated, or calibration values are NaN.
+    * The returned offset satisfies: stage_XY = plate_definition_XY + offset.
+    */
+   private Point2D.Double tryReadHcsCalibration() {
+      try {
+         Class<?> sgClass = Class.forName("org.micromanager.hcs.SiteGenerator");
+         java.util.List<Double> offset = studio_.profile()
+               .getSettings(sgClass)
+               .getDoubleList("site_offset",
+                     java.util.Arrays.asList(Double.NaN, Double.NaN));
+         if (offset.size() >= 2
+               && Double.isFinite(offset.get(0))
+               && Double.isFinite(offset.get(1))) {
+            return new Point2D.Double(offset.get(0), offset.get(1));
+         }
+      } catch (ClassNotFoundException ignored) {
+         // HCS plugin not installed
+      } catch (Exception e) {
+         studio_.logs().logError(e, "Explorer: error reading HCS calibration");
+      }
+      return null;
    }
 }

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/RefineZFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/RefineZFrame.java
@@ -1,0 +1,206 @@
+package org.micromanager.explorer;
+
+import java.awt.Toolkit;
+import java.net.URL;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingUtilities;
+import net.miginfocom.swing.MigLayout;
+import org.micromanager.Studio;
+import org.micromanager.internal.positionlist.utils.ZGenerator;
+import org.micromanager.internal.utils.WindowPositioning;
+
+/**
+ * Stand-alone window for Refine Z. Opened from the Explorer dialog's "Refine Z..." button so the
+ * Explorer dialog stays compact. Lets the operator measure Z at reference points (Automatic via
+ * autofocus, or Manual by focusing) and pick the interpolation method; the measured surface is
+ * baked into the generated positions when "Add to Position List" is pressed in the Explorer dialog.
+ *
+ * <p>All actions delegate to {@link ExplorerManager}; the manager pushes status and running state
+ * back here. Manual mode arms the Explorer canvas so a ctrl+left-click navigates to a tile.</p>
+ */
+public class RefineZFrame extends JFrame {
+
+   private final Studio studio_;
+   private final ExplorerManager explorerManager_;
+   private final ExplorerFrame explorerFrame_;
+
+   private final JRadioButton autoRadio_;
+   private final JRadioButton manualRadio_;
+   private final JComboBox<ZGenerator.Type> interpCombo_;
+   private final JComboBox<String> afCombo_;
+   private final JSpinner pointsSpinner_;
+   private final JButton startButton_;
+   private final JButton cancelButton_;
+   private final JButton setButton_;
+   private final JButton clearButton_;
+   private final JButton addButton_;
+   private final JButton closeButton_;
+   private final JLabel statusLabel_;
+
+   private boolean running_ = false;
+
+   /**
+    * Constructs the Refine Z window.
+    *
+    * @param studio the Studio
+    * @param explorerManager the manager that performs the refinement
+    * @param explorerFrame the owning Explorer dialog (read for the within-vessel option)
+    */
+   public RefineZFrame(Studio studio, ExplorerManager explorerManager,
+                       ExplorerFrame explorerFrame) {
+      studio_ = studio;
+      explorerManager_ = explorerManager;
+      explorerFrame_ = explorerFrame;
+
+      setTitle("Refine Z");
+      URL iconUrl = getClass().getResource("/org/micromanager/icons/microscope.gif");
+      if (iconUrl != null) {
+         setIconImage(Toolkit.getDefaultToolkit().getImage(iconUrl));
+      }
+      setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
+      setLayout(new MigLayout("fillx", "[grow,fill]"));
+
+      JPanel panel = new JPanel(new MigLayout("insets 6", "[]8[]", "[]6[]"));
+
+      panel.add(new JLabel("Interpolation:"), "split 2");
+      interpCombo_ = new JComboBox<>(new ZGenerator.Type[] {
+            ZGenerator.Type.SHEPINTERPOLATE, ZGenerator.Type.AVERAGE});
+      interpCombo_.setToolTipText("Z interpolation method");
+      interpCombo_.addActionListener(e ->
+            explorerManager_.setRefineZMethod((ZGenerator.Type) interpCombo_.getSelectedItem()));
+      panel.add(interpCombo_, "wrap");
+
+      autoRadio_ = new JRadioButton("Automatic", true);
+      manualRadio_ = new JRadioButton("Manual", false);
+      ButtonGroup modeGroup = new ButtonGroup();
+      modeGroup.add(autoRadio_);
+      modeGroup.add(manualRadio_);
+      // The canvas is armed for refinement whenever this window is open (both modes use
+      // Ctrl-click navigation + Set Z), so the mode radios only toggle which controls are live.
+      autoRadio_.addActionListener(e -> updateEnabled());
+      manualRadio_.addActionListener(e -> updateEnabled());
+      panel.add(autoRadio_, "split 2");
+      panel.add(manualRadio_, "wrap");
+
+      panel.add(new JLabel("Points:"), "split 4");
+      pointsSpinner_ = new JSpinner(new SpinnerNumberModel(5, 1, 999, 1));
+      pointsSpinner_.setToolTipText("Number of autofocus reference points");
+      panel.add(pointsSpinner_);
+      afCombo_ = new JComboBox<>();
+      afCombo_.setToolTipText("Autofocus method to run at each reference point");
+      panel.add(afCombo_);
+      startButton_ = new JButton("Start");
+      startButton_.addActionListener(e -> {
+         Object af = afCombo_.getSelectedItem();
+         explorerManager_.startRefineZAutomatic(
+               (Integer) pointsSpinner_.getValue(),
+               af != null ? af.toString() : null,
+               explorerFrame_.isWithinVesselSelected());
+      });
+      panel.add(startButton_, "wrap");
+
+      cancelButton_ = new JButton("Cancel");
+      cancelButton_.setToolTipText("Cancel the running automatic Refine Z");
+      cancelButton_.addActionListener(e -> explorerManager_.cancelRefineZ());
+      panel.add(cancelButton_, "split 3");
+      setButton_ = new JButton("Set Z");
+      setButton_.setToolTipText(
+            "Manual mode: Ctrl-click a tile, focus, then click Set Z to record it.");
+      setButton_.addActionListener(e -> explorerManager_.addManualRefineZ());
+      panel.add(setButton_);
+      clearButton_ = new JButton("Clear Z");
+      clearButton_.setToolTipText("Discard all Refine-Z reference points");
+      clearButton_.addActionListener(e -> explorerManager_.clearRefineZ());
+      panel.add(clearButton_, "wrap");
+
+      addButton_ = new JButton("Add to Position List");
+      addButton_.setToolTipText(
+            "Bake the interpolated Z into the positions, add them to the MM position list, "
+            + "and close this window.");
+      addButton_.addActionListener(e -> {
+         explorerManager_.createPositionsFromRoi(explorerFrame_.isWithinVesselSelected());
+         dispose();
+      });
+      panel.add(addButton_, "split 2");
+      closeButton_ = new JButton("Close");
+      closeButton_.setToolTipText("Close this window without adding positions.");
+      closeButton_.addActionListener(e -> dispose());
+      panel.add(closeButton_, "wrap");
+
+      statusLabel_ = new JLabel(" ");
+      panel.add(statusLabel_, "span, growx, wrap");
+
+      add(panel, "growx, wrap");
+
+      // Populate autofocus methods and select the current interpolation method.
+      refreshAfMethods();
+      explorerManager_.setRefineZMethod((ZGenerator.Type) interpCombo_.getSelectedItem());
+
+      pack();
+      setLocationRelativeTo(explorerFrame);
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+      updateEnabled();
+   }
+
+   private void refreshAfMethods() {
+      Object selected = afCombo_.getSelectedItem();
+      afCombo_.removeAllItems();
+      try {
+         for (String name : studio_.getAutofocusManager().getAllAutofocusMethods()) {
+            afCombo_.addItem(name);
+         }
+      } catch (Exception e) {
+         // No autofocus methods available; combo stays empty.
+      }
+      if (selected != null) {
+         afCombo_.setSelectedItem(selected);
+      }
+   }
+
+   /** Notifies whether an automatic Refine-Z run is in progress; switches to EDT. */
+   public void setRefineZRunning(boolean running) {
+      SwingUtilities.invokeLater(() -> {
+         running_ = running;
+         updateEnabled();
+      });
+   }
+
+   /** Sets the status text shown at the bottom of the window; switches to EDT. */
+   public void setRefineZStatus(String text) {
+      SwingUtilities.invokeLater(() ->
+            statusLabel_.setText(text == null || text.isEmpty() ? " " : text));
+   }
+
+   private void updateEnabled() {
+      final boolean auto = autoRadio_.isSelected();
+      final boolean manual = manualRadio_.isSelected();
+      interpCombo_.setEnabled(!running_);
+      autoRadio_.setEnabled(!running_);
+      manualRadio_.setEnabled(!running_);
+      pointsSpinner_.setEnabled(auto && !running_);
+      afCombo_.setEnabled(auto && !running_);
+      startButton_.setEnabled(auto && !running_);
+      cancelButton_.setEnabled(auto && running_);
+      setButton_.setEnabled(manual && !running_);
+      clearButton_.setEnabled(!running_);
+      addButton_.setEnabled(!running_);
+      closeButton_.setEnabled(!running_);
+   }
+
+   @Override
+   public void dispose() {
+      // Closing disarms the canvas (re-enables ROI drawing). The manager keeps any collected
+      // points until the Explorer draw session ends, so re-opening preserves the surface.
+      explorerManager_.cancelRefineZ();
+      explorerManager_.onRefineZFrameClosed(this);
+      super.dispose();
+   }
+}

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/RefineZFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/RefineZFrame.java
@@ -46,6 +46,9 @@ public class RefineZFrame extends JFrame {
    private final JLabel statusLabel_;
 
    private boolean running_ = false;
+   // True while we are programmatically syncing the AF combo to the main method, to avoid the
+   // combo's action listener echoing the change back to the AutofocusManager.
+   private boolean syncingAf_ = false;
 
    /**
     * Constructs the Refine Z window.
@@ -95,7 +98,19 @@ public class RefineZFrame extends JFrame {
       pointsSpinner_.setToolTipText("Number of autofocus reference points");
       panel.add(pointsSpinner_);
       afCombo_ = new JComboBox<>();
-      afCombo_.setToolTipText("Autofocus method to run at each reference point");
+      afCombo_.setToolTipText(
+            "Autofocus method to run at each reference point (shared with the main MM window)");
+      // Selecting a method here switches the main MM autofocus method too, keeping them in sync.
+      afCombo_.addActionListener(e -> {
+         Object sel = afCombo_.getSelectedItem();
+         if (sel != null && !syncingAf_) {
+            try {
+               studio_.getAutofocusManager().setAutofocusMethodByName(sel.toString());
+            } catch (Exception ex) {
+               studio_.logs().logError(ex, "Refine Z: could not select autofocus method");
+            }
+         }
+      });
       panel.add(afCombo_);
       startButton_ = new JButton("Start");
       startButton_.addActionListener(e -> {
@@ -144,24 +159,41 @@ public class RefineZFrame extends JFrame {
       refreshAfMethods();
       explorerManager_.setRefineZMethod((ZGenerator.Type) interpCombo_.getSelectedItem());
 
+      // Re-sync the AF method from the main window each time this window regains focus, since the
+      // AutofocusManager has no change event to subscribe to.
+      addWindowFocusListener(new java.awt.event.WindowAdapter() {
+         @Override
+         public void windowGainedFocus(java.awt.event.WindowEvent e) {
+            refreshAfMethods();
+         }
+      });
+
       pack();
       setLocationRelativeTo(explorerFrame);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
       updateEnabled();
    }
 
+   /**
+    * Repopulates the autofocus list and selects the method currently active in the main MM window,
+    * so the Refine Z device stays in sync with the rest of the application.
+    */
    private void refreshAfMethods() {
-      Object selected = afCombo_.getSelectedItem();
-      afCombo_.removeAllItems();
+      syncingAf_ = true;
       try {
+         afCombo_.removeAllItems();
          for (String name : studio_.getAutofocusManager().getAllAutofocusMethods()) {
             afCombo_.addItem(name);
          }
+         org.micromanager.AutofocusPlugin current =
+               studio_.getAutofocusManager().getAutofocusMethod();
+         if (current != null) {
+            afCombo_.setSelectedItem(current.getName());
+         }
       } catch (Exception e) {
          // No autofocus methods available; combo stays empty.
-      }
-      if (selected != null) {
-         afCombo_.setSelectedItem(selected);
+      } finally {
+         syncingAf_ = false;
       }
    }
 

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/VesselType.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/VesselType.java
@@ -1,0 +1,171 @@
+package org.micromanager.explorer;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Describes the physical geometry of a sample vessel (coverslip or multi-well plate).
+ * Used by the Explorer to draw an outline overlay and auto-zoom to the vessel extent.
+ *
+ * <p>Simple coverslips carry only overall width/height. Multi-well plates additionally
+ * specify the well layout (position, size, and shape of each well).
+ *
+ * <p>Built-in types are available via {@link #builtIn()}. The class is immutable and
+ * can be extended with additional types without modifying existing code.
+ */
+public final class VesselType {
+
+   /** Identifies which physical point on the vessel the operator placed the stage on. */
+   public enum AnchorType {
+      TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT, CENTER
+   }
+
+   private final String name;
+   private final double widthUm;
+   private final double heightUm;
+   // Multi-well fields — all zero for simple coverslips.
+   private final int wellCols;
+   private final int wellRows;
+   private final double wellWidthUm;
+   private final double wellHeightUm;
+   private final double wellSpacingXUm;
+   private final double wellSpacingYUm;
+   private final double firstWellXUm; // distance from vessel left edge to first well center
+   private final double firstWellYUm; // distance from vessel top edge to first well center
+   private final boolean wellsCircular;
+
+   /**
+    * Full constructor — use for multi-well plates.
+    * Set wellCols/wellRows to 0 for simple rectangle vessels.
+    */
+   public VesselType(String name, double widthUm, double heightUm,
+                     int wellCols, int wellRows,
+                     double wellWidthUm, double wellHeightUm,
+                     double wellSpacingXUm, double wellSpacingYUm,
+                     double firstWellXUm, double firstWellYUm,
+                     boolean wellsCircular) {
+      this.name = name;
+      this.widthUm = widthUm;
+      this.heightUm = heightUm;
+      this.wellCols = wellCols;
+      this.wellRows = wellRows;
+      this.wellWidthUm = wellWidthUm;
+      this.wellHeightUm = wellHeightUm;
+      this.wellSpacingXUm = wellSpacingXUm;
+      this.wellSpacingYUm = wellSpacingYUm;
+      this.firstWellXUm = firstWellXUm;
+      this.firstWellYUm = firstWellYUm;
+      this.wellsCircular = wellsCircular;
+   }
+
+   /** Convenience constructor for a simple rectangular vessel (no individual wells). */
+   public VesselType(String name, double widthUm, double heightUm) {
+      this(name, widthUm, heightUm, 0, 0, 0, 0, 0, 0, 0, 0, false);
+   }
+
+   // ── Built-in types ──────────────────────────────────────────────────────────
+
+   public static final VesselType NONE =
+         new VesselType("None", 0, 0);
+   public static final VesselType CS_18X18 =
+         new VesselType("Coverslip 18x18mm", 18000, 18000);
+   public static final VesselType CS_22X22 =
+         new VesselType("Coverslip 22x22mm", 22000, 22000);
+   public static final VesselType CS_22X60 =
+         new VesselType("Coverslip 22x60mm", 60000, 22000);
+   // Multi-well plate dimensions from SBS/ANSI standard (sourced from HCS SBSPlate.java).
+   public static final VesselType WELL_6 =
+         new VesselType("6-Well Plate", 127760, 85470,
+               3, 2, 34800, 34800, 39120, 39120, 24760, 23160, true);
+   public static final VesselType WELL_24 =
+         new VesselType("24-Well Plate", 127500, 85250,
+               6, 4, 15540, 15540, 19300, 19300, 17050, 13670, true);
+   public static final VesselType WELL_96 =
+         new VesselType("96-Well Plate", 127760, 85480,
+               12, 8, 8000, 8000, 9000, 9000, 14380, 11240, true);
+   public static final VesselType WELL_384 =
+         new VesselType("384-Well Plate", 127760, 85480,
+               24, 16, 4000, 4000, 4500, 4500, 12130, 8990, false);
+
+   /** Returns all built-in vessel types in display order. */
+   public static List<VesselType> builtIn() {
+      return Arrays.asList(
+            NONE, CS_18X18, CS_22X22, CS_22X60,
+            WELL_6, WELL_24, WELL_96, WELL_384);
+   }
+
+   // ── Static well-label utilities ──────────────────────────────────────────────
+
+   /** Returns the row label for the given 0-based row index: 0 → "A", 1 → "B", … */
+   public static String getRowLabel(int row) {
+      return String.valueOf((char) ('A' + row));
+   }
+
+   /** Returns the well label for 0-based row/col: (0,0) → "A1", (1,11) → "B12", … */
+   public static String getWellLabel(int row, int col) {
+      return getRowLabel(row) + (col + 1);
+   }
+
+   // ── Accessors ────────────────────────────────────────────────────────────────
+
+   public String getName() {
+      return name;
+   }
+
+   public double getWidthUm() {
+      return widthUm;
+   }
+
+   public double getHeightUm() {
+      return heightUm;
+   }
+
+   public boolean isNone() {
+      return widthUm <= 0;
+   }
+
+   public boolean isMultiWell() {
+      return wellCols > 0 && wellRows > 0;
+   }
+
+   public int getWellCols() {
+      return wellCols;
+   }
+
+   public int getWellRows() {
+      return wellRows;
+   }
+
+   public double getWellWidthUm() {
+      return wellWidthUm;
+   }
+
+   public double getWellHeightUm() {
+      return wellHeightUm;
+   }
+
+   public double getWellSpacingXUm() {
+      return wellSpacingXUm;
+   }
+
+   public double getWellSpacingYUm() {
+      return wellSpacingYUm;
+   }
+
+   public double getFirstWellXUm() {
+      return firstWellXUm;
+   }
+
+   public double getFirstWellYUm() {
+      return firstWellYUm;
+   }
+
+   public boolean isWellsCircular() {
+      return wellsCircular;
+   }
+
+   @Override
+   public String toString() {
+      return name;
+   }
+}


### PR DESCRIPTION
- Adds multiple vessels (coverslips and plates) that appear as overlays.  Multiwell plates use calibration from the HCS plugin (obtained through the user profile), coverslips need an anchor point set by the operator.
- Add ROIs taht can be used to define the area of interest where Stage positions should be created.
- All stages checked in the PositionList are recorded
- Adds RefineZ, which uses the same strategy as the Tile Creator to make a Z surface from the few points where Z position was measured.