### PR TITLE
Studio:  load all Micro-Manager plugins on one shared classloader so they see each other and the ZMQ bridge

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/PluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/PluginManager.java
@@ -108,16 +108,5 @@ public interface PluginManager {
     */
    HashMap<String, DisplayGearMenuPlugin> getDisplayGearMenuPlugins();
 
-   /**
-    * Return the class loader through which all plugins are loaded.
-    *
-    * <p>All plugins share this single class loader, whose parent is
-    * Micro-Manager's own class loader. It can therefore resolve both plugin
-    * classes and Micro-Manager / core classes. This is useful for code that
-    * needs to see plugin classes, such as scripting engines (so that BeanShell
-    * scripts can import plugin classes) and the Pycro-Manager / ZMQ bridge.
-    *
-    * @return the shared class loader used to load all plugins
-    */
-   ClassLoader getPluginClassLoader();
+
 }

--- a/mmstudio/src/main/java/org/micromanager/PluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/PluginManager.java
@@ -107,4 +107,17 @@ public interface PluginManager {
     *     instances
     */
    HashMap<String, DisplayGearMenuPlugin> getDisplayGearMenuPlugins();
+
+   /**
+    * Return the class loader through which all plugins are loaded.
+    *
+    * <p>All plugins share this single class loader, whose parent is
+    * Micro-Manager's own class loader. It can therefore resolve both plugin
+    * classes and Micro-Manager / core classes. This is useful for code that
+    * needs to see plugin classes, such as scripting engines (so that BeanShell
+    * scripts can import plugin classes) and the Pycro-Manager / ZMQ bridge.
+    *
+    * @return the shared class loader used to load all plugins
+    */
+   ClassLoader getPluginClassLoader();
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -624,28 +624,12 @@ public final class MMStudio implements Studio {
             }
          };
          try {
-            // It appears that every plugin has its own ClassLoader.
-            // We need to extract all of these and pass to ZMQServer, so that it knows
-            // where to search for classes to load. If we don't do this, and just create
-            // new ClassLoaders to instantiate objects, static variables will not be shared
-            // across instances created by the two objects, leading to confusing behavior.
+            // All plugins are loaded through a single shared class loader (whose parent is
+            // Micro-Manager's own class loader). Passing that one loader to ZMQServer lets it
+            // resolve both plugin classes and Micro-Manager / core classes, and avoids the
+            // problem of static variables not being shared across multiple class loaders.
             Collection<ClassLoader> classLoaders = new HashSet<>();
-            for (Object plugin : plugins().getMenuPlugins().values()) {
-               classLoaders.add(plugin.getClass().getClassLoader());
-            }
-            for (Object plugin : plugins().getAutofocusPlugins().values()) {
-               classLoaders.add(plugin.getClass().getClassLoader());
-            }
-            for (Object plugin : plugins().getDisplayGearMenuPlugins().values()) {
-               classLoaders.add(plugin.getClass().getClassLoader());
-            }
-            for (Object plugin : plugins().getProcessorPlugins().values()) {
-               classLoaders.add(plugin.getClass().getClassLoader());
-            }
-            for (Object plugin : plugins().getOverlayPlugins().values()) {
-               classLoaders.add(plugin.getClass().getClassLoader());
-            }
-
+            classLoaders.add(pluginManager_.getPluginClassLoader());
 
             zmqServer_ = new ZMQServer(classLoaders,
                   instanceGrabberFunction,

--- a/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMUIManager.java
@@ -187,6 +187,9 @@ public class MMUIManager {
    }
 
    public void showScriptPanel() {
+      // Clear BeanShell's negative class cache so that plugin classes loaded after the REPL
+      // interpreter was created (plugins load on a background thread) become visible to scripts.
+      scriptPanel_.resetReplClassCache();
       scriptPanel_.setVisible(true);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
@@ -129,22 +129,31 @@ public final class DefaultPluginManager implements PluginManager {
     */
    private void loadPlugins() {
       final long startTime = System.currentTimeMillis();
+
+      // Discover all plugin classes from every directory first, adding every directory's JARs to
+      // the shared class loader, and only then instantiate any plugin. This way all plugin JARs
+      // are on the shared loader before any plugin constructor runs, so plugins can reference each
+      // other regardless of which directory they live in or the order in which they are found.
+      List<Class<?>> pluginClasses = new ArrayList<>();
+
       String dir = System.getProperty("org.micromanager.plugin.path",
             System.getProperty("user.dir") + "/mmplugins");
       ReportingUtils.logMessage("Searching for plugins in " + dir);
-      loadPlugins(PluginFinder.findPlugins(pluginClassLoader_, dir));
+      pluginClasses.addAll(PluginFinder.findPlugins(pluginClassLoader_, dir));
 
       dir = System.getProperty("org.micromanager.autofocus.path",
             System.getProperty("user.dir") + "/mmautofocus");
       ReportingUtils.logMessage("Searching for plugins in " + dir);
-      loadPlugins(PluginFinder.findPlugins(pluginClassLoader_, dir));
+      pluginClasses.addAll(PluginFinder.findPlugins(pluginClassLoader_, dir));
 
       ReportingUtils.logMessage("Searching for plugins in MMStudio's class loader");
       // We need to use our normal class loader to load stuff from the MMJ_.jar
       // file, since otherwise we won't be able to cast the new plugin to
       // MMPlugin in loadPlugins(), below.
-      loadPlugins(PluginFinder.findPluginsWithLoader(
+      pluginClasses.addAll(PluginFinder.findPluginsWithLoader(
             studio_.getClass().getClassLoader()));
+
+      loadPlugins(pluginClasses);
 
       ReportingUtils.logMessage("Plugin loading took "
             + (System.currentTimeMillis() - startTime) + "ms");

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
@@ -97,6 +97,7 @@ public final class DefaultPluginManager implements PluginManager {
     *
     * @return the shared plugin class loader
     */
+   @Override
    public SharedPluginClassLoader getPluginClassLoader() {
       return pluginClassLoader_;
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
@@ -80,7 +80,7 @@ public final class DefaultPluginManager implements PluginManager {
       // its parent) so that plugins are visible to each other and to Micro-Manager's own code,
       // including the Pycro-Manager / ZMQ bridge.
       pluginClassLoader_ = new SharedPluginClassLoader(
-            ((MMStudio) studio_).getClass().getClassLoader());
+            studio_.getClass().getClassLoader());
 
       for (Class<?> classType : VALID_CLASSES) {
          pluginTypeToPlugins_.put(classType, new ArrayList<>());
@@ -143,7 +143,7 @@ public final class DefaultPluginManager implements PluginManager {
       // file, since otherwise we won't be able to cast the new plugin to
       // MMPlugin in loadPlugins(), below.
       loadPlugins(PluginFinder.findPluginsWithLoader(
-            ((MMStudio) studio_).getClass().getClassLoader()));
+            studio_.getClass().getClassLoader()));
 
       ReportingUtils.logMessage("Plugin loading took "
             + (System.currentTimeMillis() - startTime) + "ms");

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
@@ -90,15 +90,17 @@ public final class DefaultPluginManager implements PluginManager {
    }
 
    /**
-    * The single class loader through which all plugins are loaded.
+    * Return the class loader through which all plugins are loaded.
     *
-    * <p>Its parent is Micro-Manager's own class loader, so it can resolve both plugin classes and
-    * Micro-Manager / core classes. The Pycro-Manager / ZMQ bridge uses this to access plugins.
+    * <p>All plugins share this single class loader, whose parent is
+    * Micro-Manager's own class loader. It can therefore resolve both plugin
+    * classes and Micro-Manager / core classes. This is useful for code that
+    * needs to see plugin classes, such as scripting engines (so that BeanShell
+    * scripts can import plugin classes) and the Pycro-Manager / ZMQ bridge.
     *
-    * @return the shared plugin class loader
+    * @return the shared class loader used to load all plugins
     */
-   @Override
-   public SharedPluginClassLoader getPluginClassLoader() {
+   public ClassLoader getPluginClassLoader() {
       return pluginClassLoader_;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/DefaultPluginManager.java
@@ -69,17 +69,36 @@ public final class DefaultPluginManager implements PluginManager {
 
    private final Studio studio_;
    private final Thread loadingThread_;
+   private final SharedPluginClassLoader pluginClassLoader_;
    private final Map<Class<?>, List<MMGenericPlugin>> pluginTypeToPlugins_ =
          new HashMap<>();
 
    public DefaultPluginManager(Studio studio) {
       studio_ = studio;
 
+      // All plugins are loaded through a single class loader (with Micro-Manager's class loader as
+      // its parent) so that plugins are visible to each other and to Micro-Manager's own code,
+      // including the Pycro-Manager / ZMQ bridge.
+      pluginClassLoader_ = new SharedPluginClassLoader(
+            ((MMStudio) studio_).getClass().getClassLoader());
+
       for (Class<?> classType : VALID_CLASSES) {
          pluginTypeToPlugins_.put(classType, new ArrayList<>());
       }
       loadingThread_ = new Thread(this::loadPlugins, "Plugin loading thread");
       loadingThread_.start();
+   }
+
+   /**
+    * The single class loader through which all plugins are loaded.
+    *
+    * <p>Its parent is Micro-Manager's own class loader, so it can resolve both plugin classes and
+    * Micro-Manager / core classes. The Pycro-Manager / ZMQ bridge uses this to access plugins.
+    *
+    * @return the shared plugin class loader
+    */
+   public SharedPluginClassLoader getPluginClassLoader() {
+      return pluginClassLoader_;
    }
 
    /**
@@ -112,12 +131,12 @@ public final class DefaultPluginManager implements PluginManager {
       String dir = System.getProperty("org.micromanager.plugin.path",
             System.getProperty("user.dir") + "/mmplugins");
       ReportingUtils.logMessage("Searching for plugins in " + dir);
-      loadPlugins(PluginFinder.findPlugins(dir));
+      loadPlugins(PluginFinder.findPlugins(pluginClassLoader_, dir));
 
       dir = System.getProperty("org.micromanager.autofocus.path",
             System.getProperty("user.dir") + "/mmautofocus");
       ReportingUtils.logMessage("Searching for plugins in " + dir);
-      loadPlugins(PluginFinder.findPlugins(dir));
+      loadPlugins(PluginFinder.findPlugins(pluginClassLoader_, dir));
 
       ReportingUtils.logMessage("Searching for plugins in MMStudio's class loader");
       // We need to use our normal class loader to load stuff from the MMJ_.jar

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/PluginFinder.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/PluginFinder.java
@@ -70,9 +70,11 @@ public final class PluginFinder {
     * list of the corresponding annotated classes.
     *
     * <p>All plugins are loaded through the single {@code loader} so that they are visible to each
-    * other and to Micro-Manager's own code (the loader's parent). The JARs added by previous
-    * calls remain on the loader, so a plugin in one directory can reference classes from a plugin
-    * in another directory.
+    * other and to Micro-Manager's own code (the loader's parent). The JARs added by previous and
+    * subsequent calls remain on the loader. Note that this method only discovers and loads the
+    * plugin classes; the caller is expected to add the JARs from every directory (by calling this
+    * method for each) before instantiating any plugin, so that a plugin in one directory can
+    * reference classes from a plugin in another directory regardless of discovery order.
     *
     * @param loader the shared plugin class loader to add the discovered JARs to
     * @param root   the directory (or jar file) to search for plugin JARs

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/PluginFinder.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/PluginFinder.java
@@ -27,7 +27,6 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
-import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.scijava.InstantiableException;
 import org.scijava.plugin.DefaultPluginFinder;
@@ -66,12 +65,20 @@ public final class PluginFinder {
    }
 
    /**
-    * Find all jars under the given root, check them for the META-INF file that
-    * indicates that they're annotated with the @Plugin annotation, and return
-    * a list of the corresponding annotated classes.
+    * Add all jars under the given root to the shared plugin class loader, then check them for the
+    * META-INF file that indicates they are annotated with the @Plugin annotation, and return a
+    * list of the corresponding annotated classes.
+    *
+    * <p>All plugins are loaded through the single {@code loader} so that they are visible to each
+    * other and to Micro-Manager's own code (the loader's parent). The JARs added by previous
+    * calls remain on the loader, so a plugin in one directory can reference classes from a plugin
+    * in another directory.
+    *
+    * @param loader the shared plugin class loader to add the discovered JARs to
+    * @param root   the directory (or jar file) to search for plugin JARs
+    * @return the @Plugin-annotated classes found under {@code root}, loaded by {@code loader}
     */
-   public static List<Class<?>> findPlugins(String root) {
-      ArrayList<Class<?>> result = new ArrayList<>();
+   public static List<Class<?>> findPlugins(SharedPluginClassLoader loader, String root) {
       List<URL> jarURLs = new ArrayList<>();
       for (String jarPath : findPaths(root, ".jar")) {
          try {
@@ -82,21 +89,62 @@ public final class PluginFinder {
          }
       }
 
-      // The class loader used by the plugin should find classes and
-      // resources within the plugin JAR first, then fall back to the
-      // default class loader.
-      // However, when SciJava is discovering plugin classes, we do NOT
-      // want to search all JARs on the class path.
-      // So we temporarily set the class loader to look only at the given
-      // URL for resources.
+      // Add the plugin JARs to the shared loader so the classes we discover (and any classes
+      // they reference in sibling plugins) resolve through it. SciJava discovery itself runs on a
+      // throwaway loader scoped to just these JARs (see findPluginsInUrls), so it does not pick up
+      // @Plugin index files from every JAR on the parent class path.
       try {
-         PluginClassLoader loader = new PluginClassLoader(jarURLs.toArray(new URL[0]),
-               MMStudio.getInstance().getClass().getClassLoader());
-         loader.setBlockInheritedResources(true);
-         result.addAll(findPluginsWithLoader(loader));
-         loader.setBlockInheritedResources(false);
+         for (URL jarURL : jarURLs) {
+            loader.addURL(jarURL);
+         }
+         return findPluginsInUrls(loader, jarURLs);
       } catch (Throwable e) {
          ReportingUtils.logError(e, "Unable to load JARs at " + root);
+         return new ArrayList<>();
+      }
+   }
+
+   /**
+    * Discover @Plugin-annotated classes contained in the given JARs, loading them through the
+    * shared loader.
+    *
+    * <p>Discovery is scoped to {@code jarURLs} (the JARs just added) by running SciJava's index
+    * scan on a throwaway loader over only those URLs, then loading the resulting classes by name
+    * from the shared loader so they end up on the shared loader, visible to all other plugins.
+    */
+   private static List<Class<?>> findPluginsInUrls(SharedPluginClassLoader sharedLoader,
+                                                    List<URL> jarURLs) {
+      ArrayList<Class<?>> result = new ArrayList<>();
+      URLClassLoader discoveryLoader = new URLClassLoader(jarURLs.toArray(new URL[0]),
+            sharedLoader.getParent()) {
+         @Override
+         public URL getResource(String name) {
+            // Do not defer to the parent during discovery, so SciJava only sees the index files
+            // of the JARs we are scanning, not every JAR on the parent class path.
+            return findResource(name);
+         }
+
+         @Override
+         public Enumeration<URL> getResources(String name) throws IOException {
+            return findResources(name);
+         }
+      };
+      DefaultPluginFinder finder = new DefaultPluginFinder(discoveryLoader);
+      PluginIndex index = new PluginIndex(finder);
+      index.discover();
+      for (PluginInfo<?> info : index.getAll()) {
+         String className = info.getClassName();
+         try {
+            // Load the real class through the shared loader so it is visible to other plugins.
+            result.add(Class.forName(className, false, sharedLoader));
+         } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            ReportingUtils.logError(e, "Unable to load plugin class " + className);
+         }
+      }
+      try {
+         discoveryLoader.close();
+      } catch (IOException e) {
+         ReportingUtils.logError(e, "Failed to close plugin discovery class loader");
       }
       return result;
    }
@@ -114,44 +162,5 @@ public final class PluginFinder {
          }
       }
       return result;
-   }
-
-   /**
-    * Custom class loader for loading plugin classes and resources.
-    *
-    * <p>The only difference from URLClassLoader is that it allows temporary
-    * blockage of resource enumeration and loading from the parent loader.
-    */
-   private static class PluginClassLoader extends URLClassLoader {
-      private boolean blockInheritedResources_ = false;
-
-      public PluginClassLoader(URL[] jarURLs, ClassLoader parent) {
-         super(jarURLs, parent);
-      }
-
-      public void setBlockInheritedResources(boolean flag) {
-         blockInheritedResources_ = flag;
-      }
-
-      @Override
-      public URL getResource(String name) {
-         if (blockInheritedResources_) {
-            // findResource does not defer to the parent ClassLoader, and thus
-            // will return null if the resource is not found in our specific
-            // jar.
-            return findResource(name);
-         } else {
-            return super.getResource(name);
-         }
-      }
-
-      @Override
-      public Enumeration<URL> getResources(String name) throws IOException {
-         if (blockInheritedResources_) {
-            return findResources(name);
-         } else {
-            return super.getResources(name);
-         }
-      }
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/PluginFinder.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/PluginFinder.java
@@ -129,22 +129,25 @@ public final class PluginFinder {
             return findResources(name);
          }
       };
-      DefaultPluginFinder finder = new DefaultPluginFinder(discoveryLoader);
-      PluginIndex index = new PluginIndex(finder);
-      index.discover();
-      for (PluginInfo<?> info : index.getAll()) {
-         String className = info.getClassName();
-         try {
-            // Load the real class through the shared loader so it is visible to other plugins.
-            result.add(Class.forName(className, false, sharedLoader));
-         } catch (ClassNotFoundException | NoClassDefFoundError e) {
-            ReportingUtils.logError(e, "Unable to load plugin class " + className);
-         }
-      }
       try {
-         discoveryLoader.close();
-      } catch (IOException e) {
-         ReportingUtils.logError(e, "Failed to close plugin discovery class loader");
+         DefaultPluginFinder finder = new DefaultPluginFinder(discoveryLoader);
+         PluginIndex index = new PluginIndex(finder);
+         index.discover();
+         for (PluginInfo<?> info : index.getAll()) {
+            String className = info.getClassName();
+            try {
+               // Load the real class through the shared loader so it is visible to other plugins.
+               result.add(Class.forName(className, false, sharedLoader));
+            } catch (ClassNotFoundException | NoClassDefFoundError e) {
+               ReportingUtils.logError(e, "Unable to load plugin class " + className);
+            }
+         }
+      } finally {
+         try {
+            discoveryLoader.close();
+         } catch (IOException e) {
+            ReportingUtils.logError(e, "Failed to close plugin discovery class loader");
+         }
       }
       return result;
    }

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/SharedPluginClassLoader.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/SharedPluginClassLoader.java
@@ -21,8 +21,8 @@ import java.net.URLClassLoader;
 /**
  * A single class loader shared by all Micro-Manager plugins.
  *
- * <p>Historically each plugin directory got its own {@link URLClassLoader}, which meant plugins
- * in different directories could not see each other's classes, and code on Micro-Manager's class
+ * <p>Historically each plugin  got its own {@link URLClassLoader}, which meant plugins
+ *  could not see each other's classes, and code on Micro-Manager's class
  * loader could not see plugin classes at all (a parent class loader never sees its children).
  *
  * <p>This loader instead holds the JARs from <em>all</em> plugin directories, with

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/SharedPluginClassLoader.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/SharedPluginClassLoader.java
@@ -21,7 +21,7 @@ import java.net.URLClassLoader;
 /**
  * A single class loader shared by all Micro-Manager plugins.
  *
- * <p>Historically each plugin  got its own {@link URLClassLoader}, which meant plugins
+ * <p>Historically each plugin got its own {@link URLClassLoader}, which meant plugins
  *  could not see each other's classes, and code on Micro-Manager's class
  * loader could not see plugin classes at all (a parent class loader never sees its children).
  *

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/SharedPluginClassLoader.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/SharedPluginClassLoader.java
@@ -1,0 +1,62 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//COPYRIGHT:     University of California, San Francisco, 2006-2013
+//LICENSE:       This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+
+package org.micromanager.internal.pluginmanagement;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * A single class loader shared by all Micro-Manager plugins.
+ *
+ * <p>Historically each plugin directory got its own {@link URLClassLoader}, which meant plugins
+ * in different directories could not see each other's classes, and code on Micro-Manager's class
+ * loader could not see plugin classes at all (a parent class loader never sees its children).
+ *
+ * <p>This loader instead holds the JARs from <em>all</em> plugin directories, with
+ * Micro-Manager's own class loader as its parent. Because every plugin is loaded through this one
+ * loader, plugins can see each other, and a single class loader is enough to give the
+ * Pycro-Manager / ZMQ bridge visibility of every plugin class.
+ *
+ * <p>We deliberately create our own {@link URLClassLoader} rather than reflectively adding URLs
+ * to Micro-Manager's existing loader: the latter relies on the application class loader being a
+ * {@code URLClassLoader} and on bypassing access checks, both of which break on Java 9+. A
+ * {@code URLClassLoader} we instantiate ourselves remains valid on all Java versions, and being a
+ * {@code URLClassLoader} keeps it compatible with the ZMQ bridge's package enumeration.
+ *
+ * <p>Plugin discovery (scanning for SciJava {@code @Plugin} index resources) is <em>not</em> done
+ * on this loader; {@link PluginFinder} runs discovery on a throwaway loader scoped to the JARs
+ * being scanned so it does not pick up index files from every JAR on the parent class path. This
+ * loader only needs to expose {@link #addURL} so that the discovered JARs accumulate on it.
+ */
+public final class SharedPluginClassLoader extends URLClassLoader {
+
+   public SharedPluginClassLoader(ClassLoader parent) {
+      super(new URL[0], parent);
+   }
+
+   /**
+    * Add a plugin JAR (or other URL) to this loader's search path.
+    *
+    * <p>{@link URLClassLoader#addURL} is protected; this method exposes it within the package so
+    * that {@link PluginFinder} can accumulate JARs from every scanned directory.
+    *
+    * @param url the URL to add
+    */
+   @Override
+   public void addURL(URL url) {
+      super.addURL(url);
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/SharedPluginClassLoader.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pluginmanagement/SharedPluginClassLoader.java
@@ -50,8 +50,9 @@ public final class SharedPluginClassLoader extends URLClassLoader {
    /**
     * Add a plugin JAR (or other URL) to this loader's search path.
     *
-    * <p>{@link URLClassLoader#addURL} is protected; this method exposes it within the package so
-    * that {@link PluginFinder} can accumulate JARs from every scanned directory.
+    *  <p>{@link URLClassLoader#addURL} is protected; this override makes it public (the class
+    *  itself lives in an internal package) so that {@link PluginFinder} can accumulate JARs from
+    *  every scanned directory.
     *
     * @param url the URL to add
     */

--- a/mmstudio/src/main/java/org/micromanager/internal/script/BeanshellEngine.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/BeanshellEngine.java
@@ -32,6 +32,9 @@ public final class BeanshellEngine implements ScriptingEngine {
       public void run() {
          stop_ = false;
          running_ = true;
+         // Resolve classes (including those referenced by library code via the thread context
+         // class loader) through the shared plugin class loader, so scripts can see plugins.
+         setContextClassLoader(panel_.getPluginClassLoader());
          try {
             interp_.eval(script_);
          } catch (TargetError e) {

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -306,7 +306,16 @@ public final class ScriptPanel extends JFrame implements MouseListener, ScriptCo
 
       beanshellREPLint_ = new Interpreter(cons_);
 
-      new Thread(beanshellREPLint_, "BeanShell interpreter").start();
+      // Load classes (e.g. in import statements) through the shared plugin class loader, so that
+      // scripts can see plugin classes in addition to Micro-Manager / core classes (its parent).
+      ClassLoader pluginClassLoader = studio_.plugins().getPluginClassLoader();
+      beanshellREPLint_.setClassLoader(pluginClassLoader);
+
+      Thread interpreterThread = new Thread(beanshellREPLint_, "BeanShell interpreter");
+      // Also set the thread context class loader so that library code which resolves classes via
+      // the context loader (rather than BeanShell's class manager) sees plugins too.
+      interpreterThread.setContextClassLoader(pluginClassLoader);
+      interpreterThread.start();
    }
 
    // Add methods and variables to the interpreter
@@ -352,6 +361,33 @@ public final class ScriptPanel extends JFrame implements MouseListener, ScriptCo
 
    public JConsole getREPLCons() {
       return cons_;
+   }
+
+   /**
+    * The class loader through which plugins are loaded, so that scripts can see plugin classes.
+    *
+    * @return the shared plugin class loader
+    */
+   ClassLoader getPluginClassLoader() {
+      return studio_.plugins().getPluginClassLoader();
+   }
+
+   /**
+    * Clear BeanShell's class cache for the REPL interpreter.
+    *
+    * <p>Plugins are loaded onto the shared plugin class loader on a background thread, which may
+    * not have finished when the REPL interpreter is created. BeanShell caches failed class lookups
+    * ("class not found") permanently, so if a script references a plugin class before that plugin's
+    * JAR has been added to the shared class loader, the class would stay unresolvable for the life
+    * of the interpreter even after the plugin finished loading. Resetting the class manager clears
+    * that negative cache (it does not change the class loader set via setClassLoader), so newly
+    * loaded plugin classes become visible. Call this when the panel is shown, by which time plugin
+    * loading has normally completed.
+    */
+   public void resetReplClassCache() {
+      if (beanshellREPLint_ != null) {
+         beanshellREPLint_.getClassManager().reset();
+      }
    }
 
    private void readFileToTextArea(File file, RSyntaxTextArea rsa)
@@ -1006,6 +1042,9 @@ public final class ScriptPanel extends JFrame implements MouseListener, ScriptCo
          stopButton_.setText("Interrupt");
          stopButton_.setEnabled(true);
 
+         // Clear BeanShell's negative class cache so plugin classes that finished loading after
+         // the interpreter was created are visible to the script.
+         resetReplClassCache();
          interp_.evaluateAsync(scriptArea_.getText());
 
          // Spawn a thread that waits for the execution thread to exit and then

--- a/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/script/ScriptPanel.java
@@ -82,6 +82,7 @@ import org.fife.ui.rtextarea.SearchResult;
 import org.micromanager.ScriptController;
 import org.micromanager.Studio;
 import org.micromanager.internal.MMStudio;
+import org.micromanager.internal.pluginmanagement.DefaultPluginManager;
 import org.micromanager.internal.utils.DaytimeNighttime;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.FileDialogs.FileType;
@@ -308,7 +309,8 @@ public final class ScriptPanel extends JFrame implements MouseListener, ScriptCo
 
       // Load classes (e.g. in import statements) through the shared plugin class loader, so that
       // scripts can see plugin classes in addition to Micro-Manager / core classes (its parent).
-      ClassLoader pluginClassLoader = studio_.plugins().getPluginClassLoader();
+      ClassLoader pluginClassLoader = ((DefaultPluginManager) studio_.plugins())
+               .getPluginClassLoader();
       beanshellREPLint_.setClassLoader(pluginClassLoader);
 
       Thread interpreterThread = new Thread(beanshellREPLint_, "BeanShell interpreter");
@@ -369,7 +371,7 @@ public final class ScriptPanel extends JFrame implements MouseListener, ScriptCo
     * @return the shared plugin class loader
     */
    ClassLoader getPluginClassLoader() {
-      return studio_.plugins().getPluginClassLoader();
+      return ((DefaultPluginManager) studio_.plugins()).getPluginClassLoader();
    }
 
    /**


### PR DESCRIPTION
The classloader division has been a source of confusion, and led to the wild-growth of the "Libraries".  I am now kind of used to the situation, so do not feel very strongly about this, but it turned out to be not super difficult to change to using one classloader.  Also see #1773, which may have addressed the same issue (partially).  This fix makes it possible to call plugins from Beanshell, so likely is more solid than what we had in #1773.


 New file: SharedPluginClassLoader.java
  A URLClassLoader we own, with MM's classloader as parent. Exposes addURL
  (package-visible) so plugin JARs accumulate on it. Deliberately our own
  URLClassLoader (not reflective addURL on the app loader) so it survives the
  Java 9+ migration and stays compatible with the ZMQ bridge's
  getPackagesFromJars cast.

  PluginFinder.java
  - findPlugins(String) → findPlugins(SharedPluginClassLoader loader, String root): adds the directory's JARs to the shared loader, then discovers.
  - New findPluginsInUrls(...): runs SciJava discovery on a throwaway URLClassLoader scoped to just the new JARs (with parent resources blocked, preserving the original - don't rescan the whole classpath - behavior), then loads the real classes by name through the shared loader via Class.forName(name, false, sharedLoader) — so every plugin lands on the one shared loader.
  - Removed the dead per-directory PluginClassLoader inner class and the now-unused MMStudio import.

  DefaultPluginManager.java
  - Owns a single SharedPluginClassLoader (parent = MM's loader), built in the constructor.