### PR TITLE
Fix NPE on window centering

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -25,6 +25,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
 import java.awt.Insets;
 import java.awt.LayoutManager;
 import java.awt.Point;
@@ -321,8 +322,12 @@ public final class DisplayUIController implements Closeable, WindowListener,
          frame = new JFrame();
          frame.setUndecorated(true);
          frame.setResizable(false);
-         frame.setBounds(
-               GUIUtils.getFullScreenBounds(frame_.getGraphicsConfiguration()));
+         GraphicsConfiguration gc = frame_.getGraphicsConfiguration();
+         if (gc == null) {
+            gc = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                  .getDefaultScreenDevice().getDefaultConfiguration();
+         }
+         frame.setBounds(GUIUtils.getFullScreenBounds(gc));
          frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
       }
       setTitle(frame);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/IJVersionCheckDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/IJVersionCheckDlg.java
@@ -24,8 +24,6 @@
 package org.micromanager.internal.dialogs;
 
 import ij.ImageJ;
-import java.awt.Dimension;
-import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
@@ -38,7 +36,6 @@ import javax.swing.JPanel;
 import javax.swing.UIManager;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
-import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 
 /**
@@ -142,12 +139,7 @@ public final class IJVersionCheckDlg extends JDialog {
       contents.add(okay, "align right");
       getContentPane().add(contents);
       pack();
-      // Center us in the middle of the screen.
-      Dimension size = getSize();
-      Rectangle bounds = GUIUtils.getFullScreenBounds(
-            GUIUtils.getGraphicsConfigurationContaining(1, 1));
-      setLocation((int) (bounds.getX() + size.getWidth() / 2),
-            (int) (bounds.getY() + size.getHeight() / 2));
+      setLocationRelativeTo(null);
       setVisible(true);
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/IntroDlg.java
@@ -25,11 +25,8 @@ package org.micromanager.internal.dialogs;
 
 import ij.IJ;
 import java.awt.Color;
-import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.GraphicsConfiguration;
 import java.awt.Insets;
-import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.io.IOException;
@@ -55,7 +52,6 @@ import org.micromanager.internal.StartupSettings;
 import org.micromanager.internal.dialogs.introdialogparts.ConfigSelectionUIController;
 import org.micromanager.internal.dialogs.introdialogparts.FastInitializationUIController;
 import org.micromanager.internal.dialogs.introdialogparts.ProfileSelectionUIController;
-import org.micromanager.internal.utils.GUIUtils;
 import org.micromanager.internal.utils.ReportingUtils;
 import org.micromanager.profile.internal.UserProfileAdmin;
 
@@ -222,11 +218,7 @@ public final class IntroDlg extends JDialog {
       super.getContentPane().add(contentsPanel, new CC().grow().push());
       super.pack();
 
-      Dimension winSize = contentsPanel.getPreferredSize();
-      GraphicsConfiguration config = GUIUtils.getGraphicsConfigurationContaining(0, 0);
-      Rectangle bounds = config.getBounds();
-      super.setLocation(bounds.x + bounds.width / 2 - winSize.width / 2,
-            bounds.y + bounds.height / 2 - winSize.height / 2);
+      super.setLocationRelativeTo(null);
 
       super.toFront();
       super.setVisible(true);


### PR DESCRIPTION
Closes #1427.

On Ubuntu (24.04), `GUIUtils.getGraphicsConfigurationContaining(0, 0)` returns null if the point (0, 0), which is the top-left of the bounding box around all monitors, is not within any of the monitors (for example in a horizontal dual-monitor setup where the left monitor is at a lower position than the right monitor).

For the 2 places where this is used to center the frame, just use the more idiomatic `setLocationRelativeTo(null)`.

For the third place (`DisplayUIController` full-screen bounds), fall back to the default graphics configuration when the frame's GC is not available (because the frame is not displayed).

- [x] Behaves correctly on Ubuntu 24.04
- [x] Behaves correctly on Windows
- [x] Behaves correctly on macOS