### PR TITLE
EMU refresh on property change

### DIFF
--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/controller/SystemController.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/controller/SystemController.java
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 import mmcorej.CMMCore;
 import org.micromanager.ApplicationSkin;
 import org.micromanager.Studio;
+import org.micromanager.events.ConfigGroupChangedEvent;
 import org.micromanager.events.GUIRefreshEvent;
 import org.micromanager.events.PropertiesChangedEvent;
 import org.micromanager.events.PropertyChangedEvent;
@@ -607,6 +608,18 @@ public class SystemController {
     */
    @Subscribe
    public void onPropertiesChanged(PropertiesChangedEvent event) {
+      forceUpdate();
+   }
+
+   /**
+    * Refreshes all UIProperties when a Micro-manager configuration group / preset changes (for
+    * instance {@code core.setConfig("Channel", ...)} from a script). The Core posts this instead
+    * of a per-property event, so the property handlers never fire for preset-driven changes.
+    *
+    * @param event Config-group changed event.
+    */
+   @Subscribe
+   public void onConfigGroupChanged(ConfigGroupChangedEvent event) {
       forceUpdate();
    }
 

--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/controller/SystemController.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/controller/SystemController.java
@@ -34,6 +34,7 @@ import mmcorej.CMMCore;
 import org.micromanager.ApplicationSkin;
 import org.micromanager.Studio;
 import org.micromanager.events.GUIRefreshEvent;
+import org.micromanager.events.PropertiesChangedEvent;
 import org.micromanager.events.PropertyChangedEvent;
 import org.micromanager.internal.utils.DaytimeNighttime;
 
@@ -590,6 +591,22 @@ public class SystemController {
     */
    @Subscribe
    public void onGuiRefresh(GUIRefreshEvent event) {
+      forceUpdate();
+   }
+
+   /**
+    * Refreshes all UIProperties when Micro-manager reports that one or more device properties
+    * have changed (the Core's bulk "properties changed" callback). This is the catch-all for
+    * device adapters that do not emit a per-property {@link PropertyChangedEvent} (e.g. some
+    * laser controllers), so the targeted {@link #onPropertyChanged(PropertyChangedEvent)} never
+    * fires for them. Performs the same full re-read as the "Refresh UI" / "Refresh GUI" actions.
+    *
+    * <p>Note: Micro-manager suppresses this callback while an acquisition is running.
+    *
+    * @param event Bulk properties-changed event.
+    */
+   @Subscribe
+   public void onPropertiesChanged(PropertiesChangedEvent event) {
       forceUpdate();
    }
 

--- a/plugins/Emu/src/main/java/de/embl/rieslab/emu/controller/SystemController.java
+++ b/plugins/Emu/src/main/java/de/embl/rieslab/emu/controller/SystemController.java
@@ -1,5 +1,6 @@
 package de.embl.rieslab.emu.controller;
 
+import com.google.common.eventbus.Subscribe;
 import de.embl.rieslab.emu.configuration.ConfigurationController;
 import de.embl.rieslab.emu.configuration.data.GlobalConfiguration;
 import de.embl.rieslab.emu.controller.log.Logger;
@@ -32,6 +33,8 @@ import java.util.TreeMap;
 import mmcorej.CMMCore;
 import org.micromanager.ApplicationSkin;
 import org.micromanager.Studio;
+import org.micromanager.events.GUIRefreshEvent;
+import org.micromanager.events.PropertyChangedEvent;
 import org.micromanager.internal.utils.DaytimeNighttime;
 
 
@@ -81,6 +84,10 @@ public class SystemController {
       // extracts MM properties, configuration groups and register configurations groups
       // as properties
       mmregistry_ = new MMRegistry(studio_, logger_);
+
+      // subscribes to Micro-manager events to refresh the UI when properties change
+      // outside of EMU (e.g. from the main MM GUI, a script or hardware)
+      studio_.events().registerForEvents(this);
 
       // loads plugin list
       pluginloader_ = new UIPluginLoader(this);
@@ -551,9 +558,46 @@ public class SystemController {
    }
 
    /**
+    * Updates the single UIProperty affected by a Micro-manager property change. This is
+    * triggered by the Micro-manager Core callback (relayed through the Studio event bus) when
+    * a device property changes outside of EMU. Only properties whose device adapter emits the
+    * change are covered; the broader {@link #onGuiRefresh(GUIRefreshEvent)} acts as a backstop.
+    *
+    * @param event Property change event holding the device label, property label and new value.
+    */
+   @SuppressWarnings("rawtypes")
+   @Subscribe
+   public void onPropertyChanged(PropertyChangedEvent event) {
+      if (mmregistry_ == null) {
+         return;
+      }
+
+      // the MMProperty hash is "{device label}-{property label}", matching the event
+      MMProperty mmprop = mmregistry_.getMMPropertiesRegistry()
+            .getProperty(event.getDevice() + "-" + event.getProperty());
+      if (mmprop != null) {
+         // re-reads the Core value and pushes it to all bound UIProperties (on the EDT)
+         mmprop.updateMMProperty();
+      }
+   }
+
+   /**
+    * Refreshes all UIProperties when the Micro-manager GUI refreshes from the Core, for instance
+    * when a script calls {@code refreshGUI()} / {@code refreshGUIFromCache()} or the user clicks
+    * the main window "Refresh" button. This is relayed through the Studio event bus.
+    *
+    * @param event GUI refresh event.
+    */
+   @Subscribe
+   public void onGuiRefresh(GUIRefreshEvent event) {
+      forceUpdate();
+   }
+
+   /**
     * Shutdowns the UI.
     */
    public void shutDown() {
+      studio_.events().unregisterForEvents(this);
       if (configurationController_ != null) {
          configurationController_.shutDown();
       }


### PR DESCRIPTION
This enables the EMU GUI to listen for property changes and update the GUI when they occur. It also addresses the GUI refresh issue described at https://forum.image.sc/t/a-way-to-refresh-gui-of-emu-simple-ui-by-a-script/119684.