### PR TITLE
Fixes some bugs in Stitch plugin

### DIFF
--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchDataProviderAdapter.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchDataProviderAdapter.java
@@ -560,15 +560,8 @@ public class StitchDataProviderAdapter extends MMDataProviderAdapter {
       if (xyByPos.isEmpty()) {
          return null;
       }
-      // Map every position to canvas-pixel space, then quantize each axis to integer
-      // grid indices using the ACTUAL measured tile pitch (not imageWidth).
-      //
-      // The tile pitch in canvas pixels is imageWidth - overlap, which is strictly
-      // smaller than imageWidth whenever tiles overlap (the normal case). Quantizing
-      // with imageWidth therefore drifts: over many columns, adjacent positions can
-      // round to the same index (collisions that drop tiles AND poison the overlap
-      // estimate, collapsing the stitch into a single column). Measuring the pitch
-      // from the data makes the indices exact regardless of overlap.
+      // Map every position to canvas-pixel space so placement is derived from the SAME
+      // affine that drives the per-tile pixel transform.
       List<Integer> posList = new ArrayList<>(xyByPos.keySet());
       double[] canvasX = new double[posList.size()];
       double[] canvasY = new double[posList.size()];
@@ -578,6 +571,30 @@ public class StitchDataProviderAdapter extends MMDataProviderAdapter {
          canvasX[i] = canvas[0];
          canvasY[i] = canvas[1];
       }
+
+      // Prefer the AUTHORITATIVE grid indices stored on the MultiStagePositions (set by
+      // the Explorer/TileCreator when the positions were created). These give exact,
+      // collision-free row/col even for irregular grids (rows with different column
+      // counts), where the pitch-estimation fallback below can collapse many positions
+      // onto a handful of cells. The stored indices live in stage/lattice space; mapping
+      // them onto canvas axes (which the affine may rotate) is done by correlating each
+      // stored axis with the canvas coordinates, so the result stays consistent with the
+      // affine-driven pixel transform.
+      Map<Integer, GridCell> fromStored = tryGridFromStoredCoordsInCanvas(
+            source, posList, canvasX, canvasY);
+      if (fromStored != null) {
+         return shiftToZero(fromStored);
+      }
+
+      // Fallback: quantize each canvas axis to integer grid indices using the ACTUAL
+      // measured tile pitch (not imageWidth).
+      //
+      // The tile pitch in canvas pixels is imageWidth - overlap, which is strictly
+      // smaller than imageWidth whenever tiles overlap (the normal case). Quantizing
+      // with imageWidth therefore drifts: over many columns, adjacent positions can
+      // round to the same index (collisions that drop tiles AND poison the overlap
+      // estimate, collapsing the stitch into a single column). Measuring the pitch
+      // from the data makes the indices exact regardless of overlap.
       double pitchX = estimateAxisPitch(canvasX, imageWidth);
       double pitchY = estimateAxisPitch(canvasY, imageHeight);
       Map<Integer, GridCell> grid = new HashMap<>();
@@ -587,6 +604,89 @@ public class StitchDataProviderAdapter extends MMDataProviderAdapter {
          grid.put(posList.get(i), new GridCell(row, col));
       }
       return shiftToZero(grid);
+   }
+
+   /**
+    * Build the grid from the authoritative grid indices stored on the
+    * MultiStagePositions, mapped onto the CANVAS axes.
+    *
+    * <p>The stored {@code gridColumn}/{@code gridRow} are exact integer lattice indices,
+    * so this avoids the pitch-estimation heuristic entirely -- the source of the
+    * irregular-grid collapse (many positions rounding onto the same cell). Because the
+    * orientation affine may rotate stage axes relative to canvas axes, this determines
+    * which stored axis maps to the canvas column (X) and which to the canvas row (Y) by
+    * correlating each stored index with the canvas coordinates, and flips the sign of an
+    * axis when it runs opposite to the canvas coordinate. The output row/col therefore
+    * increase with canvas Y/X respectively, matching how the rest of the adapter places
+    * tiles.</p>
+    *
+    * @return the position-index -> (row, col) map (NOT yet shifted to zero-origin), or
+    *         {@code null} when no usable stored grid coordinates are available
+    */
+   private static Map<Integer, GridCell> tryGridFromStoredCoordsInCanvas(
+         DataProvider source, List<Integer> posList, double[] canvasX, double[] canvasY) {
+      SummaryMetadata summary = source.getSummaryMetadata();
+      if (summary == null) {
+         return null;
+      }
+      List<MultiStagePosition> positions = summary.getStagePositionList();
+      if (positions == null || positions.isEmpty()) {
+         return null;
+      }
+      int n = posList.size();
+      double[] gCol = new double[n];
+      double[] gRow = new double[n];
+      boolean anyNonZero = false;
+      for (int i = 0; i < n; i++) {
+         int posIdx = posList.get(i);
+         if (posIdx < 0 || posIdx >= positions.size()) {
+            return null;  // position index has no matching stored position; bail out
+         }
+         MultiStagePosition msp = positions.get(posIdx);
+         int c = msp.getGridColumn();
+         int r = msp.getGridRow();
+         gCol[i] = c;
+         gRow[i] = r;
+         if (c != 0 || r != 0) {
+            anyNonZero = true;
+         }
+      }
+      // All (0,0) is the unset default -- no authoritative grid to use (unless there is a
+      // single position, where (0,0) is genuinely correct).
+      if (!anyNonZero && n != 1) {
+         return null;
+      }
+
+      // Decide the mapping of stored axes onto canvas axes via absolute correlation.
+      // Canvas column tracks canvas X; canvas row tracks canvas Y. Pick, for each canvas
+      // axis, the stored axis it correlates with most strongly.
+      double colX = Math.abs(pearson(gCol, canvasX));
+      double colY = Math.abs(pearson(gCol, canvasY));
+      double rowX = Math.abs(pearson(gRow, canvasX));
+      double rowY = Math.abs(pearson(gRow, canvasY));
+      // gridColumn maps to canvas X (and gridRow to canvas Y) unless gridRow tracks X
+      // more strongly (a 90/270-degree rotation swaps them).
+      boolean swap = (rowX > colX) && (colY > rowY);
+      double[] canvasColSource = swap ? gRow : gCol;
+      double[] canvasRowSource = swap ? gCol : gRow;
+
+      // Orient each axis so the index increases with the canvas coordinate.
+      boolean flipCol = pearson(canvasColSource, canvasX) < 0;
+      boolean flipRow = pearson(canvasRowSource, canvasY) < 0;
+
+      Map<Integer, GridCell> grid = new HashMap<>();
+      for (int i = 0; i < n; i++) {
+         int col = (int) Math.round(canvasColSource[i]);
+         int row = (int) Math.round(canvasRowSource[i]);
+         if (flipCol) {
+            col = -col;
+         }
+         if (flipRow) {
+            row = -row;
+         }
+         grid.put(posList.get(i), new GridCell(row, col));
+      }
+      return grid;
    }
 
    /**

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchDataProviderAdapter.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchDataProviderAdapter.java
@@ -664,9 +664,13 @@ public class StitchDataProviderAdapter extends MMDataProviderAdapter {
       double colY = Math.abs(pearson(gCol, canvasY));
       double rowX = Math.abs(pearson(gRow, canvasX));
       double rowY = Math.abs(pearson(gRow, canvasY));
-      // gridColumn maps to canvas X (and gridRow to canvas Y) unless gridRow tracks X
-      // more strongly (a 90/270-degree rotation swaps them).
-      boolean swap = (rowX > colX) && (colY > rowY);
+      // Choose between the two possible axis assignments by TOTAL correlation, not by
+      // requiring both pairwise inequalities: this is a 2x2 assignment problem, and the
+      // best overall mapping can win on the sum even when one pairwise comparison goes the
+      // other way (real data has noise). No-swap maps gCol->X, gRow->Y (score colX + rowY);
+      // swap maps gRow->X, gCol->Y (score rowX + colY), as happens for a 90/270-degree
+      // rotation. Ties keep the no-swap (identity) assignment.
+      boolean swap = (rowX + colY) > (colX + rowY);
       double[] canvasColSource = swap ? gRow : gCol;
       double[] canvasRowSource = swap ? gCol : gRow;
 

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
@@ -459,13 +459,11 @@ public class StitchFrame extends JDialog {
          int[] correction = null;
          StitchDataProviderAdapter.OrientationModel orientationModel = null;
          if (doCorrectOrientation) {
+            // resolveOrientation shows its own user-facing message (and returns null) when it
+            // cannot proceed -- either no affine at all, or a miscalibrated one -- so no
+            // generic message is needed here.
             ResolvedOrientation resolved = resolveOrientation(dataProvider_);
-            if (resolved == null) {
-               SwingUtilities.invokeLater(() ->
-                     studio_.logs().showMessage(
-                           "No pixel size affine transform found in image metadata. "
-                           + "Orientation correction will be skipped.", null));
-            } else {
+            if (resolved != null) {
                correction = resolved.pixelOp;
                orientationModel = resolved.model;
                int rot = correction != null ? correction[0] : 0;
@@ -2247,6 +2245,9 @@ public class StitchFrame extends JDialog {
       AffineTransform affine = probeAffineTransform(dataProvider);
       int[] o = ImageTransformUtils.correctionFromAffine(affine);
       if (o == null) {
+         SwingUtilities.invokeLater(() -> studio_.logs().showMessage(
+               "No pixel size affine transform found in image metadata. "
+               + "Orientation correction will be skipped.", StitchFrame.this));
          return null;
       }
 
@@ -2263,6 +2264,33 @@ public class StitchFrame extends JDialog {
          int[] flipInv = ImageTransformUtils.invertCorrection(flipperOp[0], flipperOp[1]);
          pixelOp = ImageTransformUtils.composeCorrection(
                o[0], o[1], flipInv[0], flipInv[1]);
+      }
+
+      // The pixelSizeAffine is the sole authority for tile placement magnitude on this path:
+      // M = O * A^-1 maps stage microns to canvas pixels with scale 1/affineScale. If the
+      // affine is miscalibrated so its scale disagrees with the true pixel size
+      // (getPixelSizeUm()), placement is wrong by that ratio -- e.g. the demo camera's
+      // uncalibrated identity affine [1,0,0,1] claims 1 um/px while the real size is
+      // ~0.25 um/px, so tiles pile up 4x too close ("Picasso"). We do NOT silently rescale
+      // around bad calibration (that would mask a real setup error and discard genuine
+      // anisotropy/rotation in a correct affine). Instead, refuse orientation correction and
+      // tell the user to recalibrate. Tolerance is generous (25%) so ordinary rounding or
+      // mild anisotropy does not trip it.
+      double realPixelSizeUm = probePixelSizeUm(dataProvider);
+      double affineScaleUm = affineScale(affine);
+      if (realPixelSizeUm > 0 && affineScaleUm > 0) {
+         double ratio = affineScaleUm / realPixelSizeUm;
+         if (ratio < 0.75 || ratio > 1.25) {
+            SwingUtilities.invokeLater(() -> studio_.logs().showMessage(String.format(
+                  "Orientation correction was skipped: the pixel-size affine transform%n"
+                  + "is not calibrated for this optical path.%n%n"
+                  + "Its scale (%.4f um/pixel) disagrees with the image pixel size%n"
+                  + "(%.4f um/pixel).%n%n"
+                  + "Recalibrate the pixel-size affine (Devices > Pixel Size Calibration),%n"
+                  + "or stitch without \"Correct camera orientation\".",
+                  affineScaleUm, realPixelSizeUm), StitchFrame.this));
+            return null;
+         }
       }
 
       double[] m = ImageTransformUtils.stageToCanvasMatrix(
@@ -2327,6 +2355,22 @@ public class StitchFrame extends JDialog {
          // Ignore - fall through to origin.
       }
       return new double[]{0.0, 0.0};
+   }
+
+   /**
+    * Returns the scale (microns per pixel) encoded in the affine's 2x2 linear part,
+    * as the average of its two column norms. Matches the fallback used by
+    * {@link #probePixelSizeUm}. Returns 0 for a null or degenerate affine.
+    */
+   private static double affineScale(AffineTransform affine) {
+      if (affine == null) {
+         return 0;
+      }
+      double colX = Math.sqrt(affine.getScaleX() * affine.getScaleX()
+            + affine.getShearY() * affine.getShearY());
+      double colY = Math.sqrt(affine.getShearX() * affine.getShearX()
+            + affine.getScaleY() * affine.getScaleY());
+      return (colX + colY) / 2.0;
    }
 
    private static AffineTransform probeAffineTransform(DataProvider dataProvider) {


### PR DESCRIPTION
Bug #1: On the affine-driven placement path (tryGridFromOrientation), row/column indices were being re-derived from stage XY via a fragile pitch estimate. On an irregular grid (rows with different column counts) the pitch came out too large, so many positions rounded onto the same (row, col) cell and got deduped away. 

- Added tryGridFromStoredCoordsInCanvas(): prefers the authoritative grid indices already stored on each MultiStagePosition (getGridColumn()/getGridRow(), set by the Explorer). These are exact integers → no collisions.
- It maps stored axes onto canvas axes by absolute-Pearson correlation (handles 90°/270° affine rotations) and sign-flips so indices increase with canvas X/Y.
- Falls back to the old pitch-estimate quantizer only when no stored grid coords exist, so datasets without them behave as before.


Bug #2: With "Correct camera orientation" on and an uncalibrated affine ([1,0,0,1] on the demo camera, real pixel size 0.25 µm/px), M = O·A⁻¹ placed tiles ~4× too close → center pile-up.

- In resolveOrientation(): compare the affine's scale (new helper affineScale(), avg column norm) against getPixelSizeUm(). If they disagree by more than ±25%, refuse orientation correction (return null) and show a message telling the user to recalibrate the pixel-size affine. Per your call, it does not silently rescale around bad input.
- Consolidated skip messaging: the "no affine found" and "miscalibrated affine" messages now both live in resolveOrientation; removed the caller's generic message so only one dialog shows.
 