### PR TITLE
Studio-MultiMDA: Fix bug(s) causing Z drive to be send to 0.0 inadvertently.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -99,7 +99,7 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
    private CMMCore core_;
    protected Studio studio_;
    private PositionList posList_;
-   private HashMap<String, MultiStagePosition> positionMap_;
+   protected HashMap<String, MultiStagePosition> positionMap_;
    private String zStage_;
    private SequenceSettings sequenceSettings_;
    protected JSONObject summaryMetadataJSON_;
@@ -916,40 +916,56 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
       return new AcquisitionHook() {
          @Override
          public AcquisitionEvent run(AcquisitionEvent event) {
-            // If we do not have previous positions, there is no point in running this code.
-            if (positionMap_.isEmpty()) {
-               return event;
-            }
             String posName = event.getTags().get(AcqEngMetadata.POS_NAME);
             String zDevice = core_.getFocusDevice();
-            if (posName != null) {
-               MultiStagePosition msp = positionMap_.get(posName);
-               if (msp != null) {
-                  for (int i = 0; i < msp.size(); i++) {
-                     StagePosition sp = msp.get(i);
-                     if (sp != null && sp.is1DStagePosition()
-                              && sp.getStageDeviceLabel().equals(zDevice)) {
-                        // here we adjust the Z position of the event
-                        // because at this point in code the event was already generated
-                        // and event.zPos has already been set using old (un-adjusted)
-                        // event's stage coordinate event.sp.get1DPosition()
-                        // hence, adjusting coordinate using setStageCoordinate
-                        // doesn't affect event's zPos
-                        studio_.core().logMessage("Adjusting Z position for event; current zPos = "
-                                + event.getZPosition() + ", current stage single axis position = "
-                                + event.getStageSingleAxisStagePosition(sp.getStageDeviceLabel())
-                                + ", new stage position = " + sp.get1DPosition());
-                        event.setZ(event.getZIndex(),
-                              event.getZPosition()
-                              - event.getStageSingleAxisStagePosition(sp.getStageDeviceLabel())
-                              + sp.get1DPosition()
-                           );
-                        event.setStageCoordinate(sp.getStageDeviceLabel(), sp.get1DPosition());
-                     }
+            MultiStagePosition msp = posName == null ? null : positionMap_.get(posName);
+            boolean adjusted = false;
+            if (msp != null) {
+               for (int i = 0; i < msp.size(); i++) {
+                  StagePosition sp = msp.get(i);
+                  if (sp != null && sp.is1DStagePosition()
+                           && sp.getStageDeviceLabel().equals(zDevice)) {
+                     // here we adjust the Z position of the event
+                     // because at this point in code the event was already generated
+                     // and event.zPos has already been set using old (un-adjusted)
+                     // event's stage coordinate event.sp.get1DPosition()
+                     // hence, adjusting coordinate using setStageCoordinate
+                     // doesn't affect event's zPos
+                     studio_.core().logMessage("Adjusting Z position for event; current zPos = "
+                             + event.getZPosition() + ", current stage single axis position = "
+                             + event.getStageSingleAxisStagePosition(sp.getStageDeviceLabel())
+                             + ", new stage position = " + sp.get1DPosition());
+                     event.setZ(event.getZIndex(),
+                           event.getZPosition()
+                           - event.getStageSingleAxisStagePosition(sp.getStageDeviceLabel())
+                           + sp.get1DPosition()
+                        );
+                     event.setStageCoordinate(sp.getStageDeviceLabel(), sp.get1DPosition());
+                     adjusted = true;
                   }
                }
-            } else { // we dont have positions, AF just moved stage but didn't update poslist
-                  
+            }
+            // No recorded (autofocused) Z for this location - e.g. autofocus failed/timed
+            // out, or this is the first visit before any autofocus recorded a position. In
+            // that case the event may carry a raw absolute Z origin (0) that would drive the
+            // focus drive to 0 and ruin the experiment. Instead, leave Z where it is: pin the
+            // event's Z to the current focus position so no absolute Z move is issued.
+            if (!adjusted && zDevice != null && !zDevice.isEmpty()
+                     && event.getZPosition() != null) {
+               try {
+                  double currentZ = core_.getPosition(zDevice);
+                  Double eventStageZ = event.getStageSingleAxisStagePosition(zDevice);
+                  double newZPos = eventStageZ == null
+                        ? currentZ
+                        : event.getZPosition() - eventStageZ + currentZ;
+                  studio_.core().logMessage("No recorded autofocus position for event; "
+                        + "pinning Z to current position " + currentZ
+                        + " (was zPos = " + event.getZPosition() + ")");
+                  event.setZ(event.getZIndex(), newZPos);
+                  event.setStageCoordinate(zDevice, currentZ);
+               } catch (Exception ex) {
+                  studio_.logs().logError(ex, "Failed to pin Z to current position");
+               }
             }
             return event;
          }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
@@ -104,6 +104,7 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
    private boolean autofocusOn_;
 
    private long nextWakeTime_ = -1;
+   private long lastFrameIndex_ = -1;
 
    private ArrayList<RunnablePlusIndices> runnables_ = new ArrayList<>();
 
@@ -287,6 +288,15 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
                   AcquisitionAPI.BEFORE_Z_DRIVE_HOOK);
          }
 
+         // Hook to update the time of the next wake-up call, so that the "Next frame in
+         // xxx sec" alert shows a sensible countdown. Without this, getNextWakeTime()
+         // returns its initial -1 and the alert shows a large negative number.
+         if (timeLapseSettings_.useFrames()) {
+            lastFrameIndex_ = -1;
+            currentMultiMDA_.addHook(updateNextWakeHook(timeLapseSettings_),
+                  AcquisitionAPI.AFTER_HARDWARE_HOOK);
+         }
+
          for (int i = 0; i < sequenceSettings.size(); i++) {
             // Hook to move back the ZStage to its original position after a Z stack
             if (sequenceSettings.get(i).useSlices()) {
@@ -460,6 +470,23 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
       Function<AcquisitionEvent, Iterator<AcquisitionEvent>> positions = null;
       if (acquisitionSettings.usePositionList()) {
          positions = MDAAcqEventModules.positions(positionList, tag, core_);
+      } else if (timeLapseSettings_.useAutofocus()) {
+         // No position list, but autofocus is on. Mirror the single-MDA path
+         // (AcqEngJAdapter.createAcqEventIterator): synthesize a single dummy position so
+         // every event carries a POS_NAME tag. Without POS_NAME, autofocusHook() cannot
+         // record the autofocused Z into positionMap_, so adjustZDrivesHook() would fall
+         // back to re-reading the live Z on every BEFORE_Z_DRIVE_HOOK call - re-anchoring
+         // each slice to the current Z instead of a stable autofocus reference.
+         PositionList dummyPosList = new PositionList();
+         MultiStagePosition msp = new MultiStagePosition();
+         String zDevice = core_.getFocusDevice();
+         if (zDevice != null && !zDevice.isEmpty()) {
+            msp.add(StagePosition.create1D(zDevice, core_.getPosition(zDevice)));
+         }
+         dummyPosList.addPosition(msp);
+         positions = MDAAcqEventModules.positions(dummyPosList, tag, core_);
+         // update acquisition settings to include the (synthetic) position
+         acquisitionSettings = acquisitionSettings.copyBuilder().usePositionList(true).build();
       }
 
       ArrayList<Function<AcquisitionEvent, Iterator<AcquisitionEvent>>> acqFunctions =
@@ -842,6 +869,40 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
    public long getNextWakeTime() {
       // TODO What to do if next wake time undefined?
       return nextWakeTime_;
+   }
+
+   /**
+    * Hook that updates nextWakeTime_ at the start of each new time point, so the
+    * "Next frame in xxx sec" alert (MMAcquisition.setNextImageAlert) can show a sensible
+    * countdown. Mirrors AcqEngJAdapter.updateNextWakeHook.
+    *
+    * @param sequenceSettings Settings providing the time-lapse interval.
+    * @return The Hook.
+    */
+   private AcquisitionHook updateNextWakeHook(SequenceSettings sequenceSettings) {
+      return new AcquisitionHook() {
+         @Override
+         public AcquisitionEvent run(AcquisitionEvent event) {
+            if (event.getMinimumStartTimeAbsolute() != null) {
+               int frameIndex = event.getTIndex() == null ? 0 : event.getTIndex();
+               if (event.getSequence() != null && event.getSequence().get(0) != null) {
+                  frameIndex = event.getSequence().get(0).getTIndex();
+               }
+               if (frameIndex > lastFrameIndex_) {
+                  lastFrameIndex_ = frameIndex;
+                  // Note that nanoTime() and currentTimeMillis() are not guaranteed to have
+                  // the same offset (0).
+                  nextWakeTime_ = System.nanoTime() / 1000000L
+                           + (long) (sequenceSettings.intervalMs());
+               }
+            }
+            return event;
+         }
+
+         @Override
+         public void close() {
+         }
+      };
    }
 
 

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/acqengj/MultiAcqEngJAdapter.java
@@ -259,6 +259,10 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
 
          zStage_ = core_.getFocusDevice();
          zStart_ = core_.getPosition(zStage_);
+         // Initialize positionMap_ (declared in the base AcqEngJAdapter). The inherited
+         // autofocusHook() writes into it and would NPE if it were left null (the base
+         // runAcquisition() that normally initializes it is overridden here).
+         positionMap_ = new HashMap<>();
          autofocusMethod_ = studio_.getAutofocusManager().getAutofocusMethod();
          autofocusOn_ = false;
          if (autofocusMethod_ != null) {
@@ -271,10 +275,16 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
                   sequenceSettings.get(i)));
          }
 
-         // These hooks implement Autofocus
+         // These hooks implement Autofocus.  Mirror the single-MDA path
+         // (AcqEngJAdapter.runAcquisition): autofocus must run at BEFORE_Z_DRIVE_HOOK
+         // (after XY/other stages are set, but before the Z drive moves for the stack),
+         // and adjustZDrivesHook rewrites the event's Z to the autofocused position so
+         // the Z drive is not sent to the raw (absolute) zStack origin.
          if (basicSettings.useAutofocus()) {
             currentMultiMDA_.addHook(autofocusHook(basicSettings.skipAutofocusCount()),
-                  AcquisitionAPI.BEFORE_HARDWARE_HOOK);
+                  AcquisitionAPI.BEFORE_Z_DRIVE_HOOK);
+            currentMultiMDA_.addHook(adjustZDrivesHook(),
+                  AcquisitionAPI.BEFORE_Z_DRIVE_HOOK);
          }
 
          for (int i = 0; i < sequenceSettings.size(); i++) {
@@ -404,6 +414,35 @@ public class MultiAcqEngJAdapter extends AcqEngJAdapter {
          zStack = MDAAcqEventModules.zStack(
                acquisitionSettings,
                origin,
+               posList,
+               chSpecs,
+               tag);
+      } else if (((acquisitionSettings.useChannels() && !chSpecs.isEmpty())
+               || timeLapseSettings_.useAutofocus())
+               && !studio_.core().getFocusDevice().isEmpty()) {
+         // Mirror the single-MDA path (AcqEngJAdapter.createAcqEventIterator): when there
+         // is no Z stack but channels and/or autofocus are used, add a "fake" single-slice
+         // Z stack anchored at the CURRENT focus position (relative slice at 0.0). Without
+         // this, MDAAcqEventModules.channels sets the event's Z coordinate to the absolute
+         // zOffset (0.0 when there are no offsets), which drives the focus drive to 0.
+         PositionList posList = null;
+         if (acquisitionSettings.usePositionList()
+                  && AcqEngJUtils.posListHasZDrive(studio_, positionList)) {
+            posList = positionList;
+         }
+         ArrayList<Double> slices = new ArrayList<>();
+         slices.add(0.0);
+         acquisitionSettings = acquisitionSettings.copyBuilder()
+                                                  .useSlices(true)
+                                                  .slices(slices)
+                                                  .relativeZSlice(true)
+                                                  .sliceZBottomUm(0.0)
+                                                  .sliceZTopUm(0.0)
+                                                  .sliceZStepUm(0.0)
+                                                  .zReference(0.0).build();
+         zStack = MDAAcqEventModules.zStack(
+               acquisitionSettings,
+               studio_.core().getPosition(),
                posList,
                chSpecs,
                tag);


### PR DESCRIPTION
adjustZDrivesHook now will use the current live z position upon autofocus failure instead of sending it to 0.0. Use the same protection for the positionMap_.isEmpty() path. The hook only runs when autofocus is enables, so ordinary acquisitions are untouched.

Also fixes a bug in the count down time shown through messages.