### PR TITLE
Test acquisition: ensure that current MDA settings are actually used

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionSettingsChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/AcquisitionSettingsChangedEvent.java
@@ -16,4 +16,26 @@ public interface AcquisitionSettingsChangedEvent extends MMEvent {
     */
    SequenceSettings getNewSettings();
 
+   /**
+    * Indicates whether these settings belong to the application's primary
+    * acquisition engine, i.e. the one driving the MDA window, as opposed to a
+    * secondary engine such as a Test Acquisition.
+    *
+    * <p>Secondary engines derive their settings from the MDA window and then
+    * modify them for their own purposes (a Test Acquisition, for instance,
+    * switches off saving, time-lapse, and the position list).  Those modified
+    * settings are not the user's MDA settings, so subscribers that mirror the
+    * state of the MDA window should ignore events for which this returns false.
+    * Subscribers that simply want to observe whatever acquisition is being set
+    * up can ignore this method.
+    *
+    * <p>Defaults to true, which is the behavior of this event before this
+    * method was introduced.
+    *
+    * @return true if these settings came from the primary acquisition engine.
+    */
+   default boolean isPrimaryEngine() {
+      return true;
+   }
+
 }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionSettingsChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/DefaultAcquisitionSettingsChangedEvent.java
@@ -29,13 +29,39 @@ import org.micromanager.acquisition.SequenceSettings;
  */
 public class DefaultAcquisitionSettingsChangedEvent implements AcquisitionSettingsChangedEvent {
    private final SequenceSettings newSettings_;
+   private final boolean isPrimaryEngine_;
 
+   /**
+    * Constructs the event for the primary acquisition engine.
+    *
+    * @param newSettings The settings that were just applied.
+    */
    public DefaultAcquisitionSettingsChangedEvent(SequenceSettings newSettings) {
+      this(newSettings, true);
+   }
+
+   /**
+    * Constructs the event, specifying which kind of engine it came from.
+    *
+    * @param newSettings     The settings that were just applied.
+    * @param isPrimaryEngine False when posted by a secondary engine, such as a
+    *                        Test Acquisition, whose settings are derived from
+    *                        the MDA window rather than being the MDA window's
+    *                        own settings.
+    */
+   public DefaultAcquisitionSettingsChangedEvent(SequenceSettings newSettings,
+                                                 boolean isPrimaryEngine) {
       newSettings_ = newSettings;
+      isPrimaryEngine_ = isPrimaryEngine;
    }
 
    @Override
    public SequenceSettings getNewSettings() {
       return newSettings_;
+   }
+
+   @Override
+   public boolean isPrimaryEngine() {
+      return isPrimaryEngine_;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/testacquisition/TestAcqAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/testacquisition/TestAcqAdapter.java
@@ -1066,9 +1066,14 @@ public class TestAcqAdapter extends DataViewerListener implements
 
    /**
     * Will notify registered AcqSettingsListeners that the settings have changed.
+    *
+    * <p>These are the settings of a Test Acquisition, which are derived from the
+    * MDA window but not identical to it, so the event is marked as not coming
+    * from the primary engine.  That keeps the MDA window (and anything else
+    * mirroring it) from redrawing itself with our modified settings.
     */
    private void settingsChanged(SequenceSettings sequenceSettings) {
-      studio_.events().post(new DefaultAcquisitionSettingsChangedEvent(sequenceSettings));
+      studio_.events().post(new DefaultAcquisitionSettingsChangedEvent(sequenceSettings, false));
    }
 
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -2080,6 +2080,12 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
     */
    @Subscribe
    public void onSettingsChanged(AcquisitionSettingsChangedEvent event) {
+      if (!event.isPrimaryEngine()) {
+         // A secondary engine (e.g. a Test Acquisition) derived its own settings
+         // from this window.  Redrawing this window from those settings would
+         // show the user something they did not ask for.
+         return;
+      }
       if (this.isDisplayable()) {
          updateGUIFromSequenceSettings(event.getNewSettings());
       }

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -364,6 +364,12 @@ public final class ChannelTableModel extends AbstractTableModel {
    /**
     * Updates the exposure time in the given preset.
     *
+    * <p>The new exposure time is also written through to the profile and to the
+    * acquisition engine's SequenceSettings (by storeChannels()).  Without that,
+    * the table would show the new exposure while the engine still held the old
+    * one, and the next refresh of this dialog from the engine's settings would
+    * silently revert the displayed value.
+    *
     * @param channelGroup - if it does not match current channelGroup,
     *                     no action will be taken
     * @param channel      - preset for which to change exposure time
@@ -378,8 +384,15 @@ public final class ChannelTableModel extends AbstractTableModel {
       for (int row = 0; row < channels_.size(); row++) {
          ChannelSpec cs = channels_.get(row);
          if (cs.config().equals(channel)) {
+            if (Double.compare(cs.exposure(), exposure) == 0) {
+               // Nothing changed.  Returning early avoids a needless profile
+               // write, and avoids feeding the same value back to the Core
+               // through onGUIRefresh().
+               return;
+            }
             channels_.set(row, cs.copyBuilder().exposure(exposure).build());
             this.fireTableCellUpdated(row, 2);
+            storeChannels();
             return;
          }
       }

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewFrame.java
@@ -513,6 +513,12 @@ public class DeskewFrame extends JFrame implements ProcessorConfigurator {
     */
    @Subscribe
    public void onAcquisitionSettingsChanged(AcquisitionSettingsChangedEvent event) {
+      if (!event.isPrimaryEngine()) {
+         // Settings from a secondary engine such as a Test Acquisition, which
+         // switches off saving.  Applying those here would clobber the user's
+         // output settings.
+         return;
+      }
       updateUIBasedOnAcquisitionSettings(event.getNewSettings());
    }
 


### PR DESCRIPTION
Users described various confusing scenarios where the Test Acquisition was not carrying out the MDA as specified in the MDA window, or even changed the values in the MDA dialog.  This could be seen after changing the exposure in the main window (with "sync exposure between Main and MDA" checked), as TestAcquisition would revert the exposure back to what it was before.  

There seemed to be more instances of unexpected reversal of settings.  I will do some testing on this code.