### PR TITLE
Float Display improvements

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -566,6 +566,12 @@ public enum PropertyKey {
       }
    },
 
+   FLOAT_HISTO_RANGE_MIN("FloatHistoRangeMin", ChannelDisplaySettings.class),
+
+   FLOAT_HISTO_RANGE_MAX("FloatHistoRangeMax", ChannelDisplaySettings.class),
+
+   FLOAT_HISTO_RANGE_PINNED("FloatHistoRangePinned", ChannelDisplaySettings.class),
+
    HISTOGRAM_BIT_DEPTH("HistogramBitDepth", ChannelDisplaySettings.class),
 
    HISTOGRAM_IS_LOGARITHMIC("HistogramIsLogarithmic", DisplaySettings.class),

--- a/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/PropertyKey.java
@@ -1281,6 +1281,10 @@ public enum PropertyKey {
 
    SCALING_MAX("ScalingMax", ComponentDisplaySettings.class),
 
+   SCALING_MIN_FLOAT("ScalingMinFloat", ComponentDisplaySettings.class),
+
+   SCALING_MAX_FLOAT("ScalingMaxFloat", ComponentDisplaySettings.class),
+
    SCOPE_DATA("ScopeData", "scopeData", Metadata.class) {
       @Override
       public String getDescription() {

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffWriter.java
@@ -922,9 +922,11 @@ public final class MultipageTiffWriter {
             ChannelDisplaySettings cs = ds.getChannelSettings(ch);
             // Display Ranges: For each channel, write min then max
             // TODO: doesn't handle multi-component images.
-            mdBuffer.putDouble(bufferPosition, cs.getComponentSettings(0).getScalingMinimum());
+            mdBuffer.putDouble(bufferPosition,
+                  cs.getComponentSettings(0).getEffectiveScalingMinimum());
             bufferPosition += 8;
-            mdBuffer.putDouble(bufferPosition, cs.getComponentSettings(0).getScalingMaximum());
+            mdBuffer.putDouble(bufferPosition,
+                  cs.getComponentSettings(0).getEffectiveScalingMaximum());
             bufferPosition += 8;
          }
       } else if (studio != null) {
@@ -934,11 +936,11 @@ public final class MultipageTiffWriter {
                   studio, channelGroup, name, null);
             // Display Ranges: For each channel, write min then max
             // TODO: doesn't handle multi-component images.
-            mdBuffer.putDouble(bufferPosition, (double)
-                  cds.getComponentSettings(0).getScalingMinimum());
+            mdBuffer.putDouble(bufferPosition,
+                  cds.getComponentSettings(0).getEffectiveScalingMinimum());
             bufferPosition += 8;
-            mdBuffer.putDouble(bufferPosition, (double)
-                  cds.getComponentSettings(0).getScalingMaximum());
+            mdBuffer.putDouble(bufferPosition,
+                  cds.getComponentSettings(0).getEffectiveScalingMaximum());
             bufferPosition += 8;
          }
       } else {

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
@@ -46,11 +46,16 @@ public interface ChannelDisplaySettings {
        * <p>Only meaningful for float images, whose axis is a real value range rather than
        * a bit depth. Pass {@code Double.NaN} for both to clear it.
        *
+       * <p>The default implementation ignores the values, so that builders written before
+       * the float axis existed keep compiling; they simply carry no axis range.
+       *
        * @param min low end of the axis
        * @param max high end of the axis
        * @return this builder
        */
-      Builder floatHistoRange(double min, double max);
+      default Builder floatHistoRange(double min, double max) {
+         return this;
+      }
 
       /**
        * Marks the float histogram axis as chosen by the user.
@@ -61,7 +66,9 @@ public interface ChannelDisplaySettings {
        * @param pinned true to stop the axis adapting to the data
        * @return this builder
        */
-      Builder floatHistoRangePinned(boolean pinned);
+      default Builder floatHistoRangePinned(boolean pinned) {
+         return this;
+      }
 
       Builder name(String name);
 
@@ -126,10 +133,15 @@ public interface ChannelDisplaySettings {
    /**
     * Low end of the histogram axis for floating point images.
     *
+    * <p>The default implementation reports no axis range, so that implementations written
+    * before the float axis existed keep compiling.
+    *
     * @return pixel value, or {@code Double.NaN} if not set
     * @see #hasFloatHistoRange()
     */
-   double getFloatHistoRangeMinimum();
+   default double getFloatHistoRangeMinimum() {
+      return Double.NaN;
+   }
 
    /**
     * High end of the histogram axis for floating point images.
@@ -137,7 +149,9 @@ public interface ChannelDisplaySettings {
     * @return pixel value, or {@code Double.NaN} if not set
     * @see #hasFloatHistoRange()
     */
-   double getFloatHistoRangeMaximum();
+   default double getFloatHistoRangeMaximum() {
+      return Double.NaN;
+   }
 
    /**
     * Returns whether a float histogram axis range has been recorded.
@@ -145,7 +159,11 @@ public interface ChannelDisplaySettings {
     * @return true if both ends are set and the high end is strictly above the low end;
     *     an empty or inverted range counts as unset, since it cannot be drawn
     */
-   boolean hasFloatHistoRange();
+   default boolean hasFloatHistoRange() {
+      double min = getFloatHistoRangeMinimum();
+      double max = getFloatHistoRangeMaximum();
+      return !Double.isNaN(min) && !Double.isNaN(max) && max > min;
+   }
 
    /**
     * Returns whether the float histogram axis was chosen by the user.
@@ -154,7 +172,9 @@ public interface ChannelDisplaySettings {
     *
     * @return true if the axis should be left as-is
     */
-   boolean isFloatHistoRangePinned();
+   default boolean isFloatHistoRangePinned() {
+      return false;
+   }
 
    /**
     * Indicates whether this is visible.

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
@@ -129,7 +129,7 @@ public interface ChannelDisplaySettings {
     * @return pixel value, or {@code Double.NaN} if not set
     * @see #hasFloatHistoRange()
     */
-   double getFloatHistoRangeMin();
+   double getFloatHistoRangeMinimum();
 
    /**
     * High end of the histogram axis for floating point images.
@@ -137,12 +137,13 @@ public interface ChannelDisplaySettings {
     * @return pixel value, or {@code Double.NaN} if not set
     * @see #hasFloatHistoRange()
     */
-   double getFloatHistoRangeMax();
+   double getFloatHistoRangeMaximum();
 
    /**
     * Returns whether a float histogram axis range has been recorded.
     *
-    * @return true if both ends are set
+    * @return true if both ends are set and the high end is strictly above the low end;
+    *     an empty or inverted range counts as unset, since it cannot be drawn
     */
    boolean hasFloatHistoRange();
 

--- a/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ChannelDisplaySettings.java
@@ -40,6 +40,29 @@ public interface ChannelDisplaySettings {
 
       Builder useCameraHistoRange(boolean use);
 
+      /**
+       * Sets the histogram axis range for floating point images, as pixel values.
+       *
+       * <p>Only meaningful for float images, whose axis is a real value range rather than
+       * a bit depth. Pass {@code Double.NaN} for both to clear it.
+       *
+       * @param min low end of the axis
+       * @param max high end of the axis
+       * @return this builder
+       */
+      Builder floatHistoRange(double min, double max);
+
+      /**
+       * Marks the float histogram axis as chosen by the user.
+       *
+       * <p>When set, the axis is left exactly as given instead of being widened to take in
+       * each newly displayed image.
+       *
+       * @param pinned true to stop the axis adapting to the data
+       * @return this builder
+       */
+      Builder floatHistoRangePinned(boolean pinned);
+
       Builder name(String name);
 
       Builder groupName(String groupName);
@@ -99,6 +122,38 @@ public interface ChannelDisplaySettings {
     * @return True when historangebits is equal to the maximum intensity coming from the camera
     */
    boolean useCameraRange();
+
+   /**
+    * Low end of the histogram axis for floating point images.
+    *
+    * @return pixel value, or {@code Double.NaN} if not set
+    * @see #hasFloatHistoRange()
+    */
+   double getFloatHistoRangeMin();
+
+   /**
+    * High end of the histogram axis for floating point images.
+    *
+    * @return pixel value, or {@code Double.NaN} if not set
+    * @see #hasFloatHistoRange()
+    */
+   double getFloatHistoRangeMax();
+
+   /**
+    * Returns whether a float histogram axis range has been recorded.
+    *
+    * @return true if both ends are set
+    */
+   boolean hasFloatHistoRange();
+
+   /**
+    * Returns whether the float histogram axis was chosen by the user.
+    *
+    * <p>A pinned axis is not widened to include newly displayed images.
+    *
+    * @return true if the axis should be left as-is
+    */
+   boolean isFloatHistoRangePinned();
 
    /**
     * Indicates whether this is visible.

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
@@ -39,10 +39,15 @@ public interface ComponentDisplaySettings {
        * since the interesting range is rarely integral. Pass {@code Double.NaN} to clear
        * the float scaling and fall back to the long-valued setting.
        *
+       * <p>The default implementation ignores the value, so that builders written before
+       * float scaling existed keep compiling; they simply carry no float range.
+       *
        * @param minIntensity pixel value, or NaN to unset
        * @return this builder
        */
-      Builder floatScalingMinimum(double minIntensity);
+      default Builder floatScalingMinimum(double minIntensity) {
+         return this;
+      }
 
       /**
        * Sets the scaling maximum as an actual pixel value, for floating point images.
@@ -51,7 +56,9 @@ public interface ComponentDisplaySettings {
        * @return this builder
        * @see #floatScalingMinimum(double)
        */
-      Builder floatScalingMaximum(double maxIntensity);
+      default Builder floatScalingMaximum(double maxIntensity) {
+         return this;
+      }
 
       /**
        * Sets both float scaling bounds as actual pixel values.
@@ -61,7 +68,9 @@ public interface ComponentDisplaySettings {
        * @return this builder
        * @see #floatScalingMinimum(double)
        */
-      Builder floatScalingRange(double minIntensity, double maxIntensity);
+      default Builder floatScalingRange(double minIntensity, double maxIntensity) {
+         return floatScalingMinimum(minIntensity).floatScalingMaximum(maxIntensity);
+      }
 
       ComponentDisplaySettings build();
    }
@@ -73,10 +82,15 @@ public interface ComponentDisplaySettings {
    /**
     * Returns the scaling minimum as an actual pixel value, for floating point images.
     *
+    * <p>The default implementation reports no float scaling, so that implementations
+    * written before float scaling existed keep compiling.
+    *
     * @return pixel value, or {@code Double.NaN} if no float scaling has been set
     * @see #hasFloatScaling()
     */
-   double getFloatScalingMinimum();
+   default double getFloatScalingMinimum() {
+      return Double.NaN;
+   }
 
    /**
     * Returns the scaling maximum as an actual pixel value, for floating point images.
@@ -84,7 +98,9 @@ public interface ComponentDisplaySettings {
     * @return pixel value, or {@code Double.NaN} if no float scaling has been set
     * @see #hasFloatScaling()
     */
-   double getFloatScalingMaximum();
+   default double getFloatScalingMaximum() {
+      return Double.NaN;
+   }
 
    /**
     * Returns whether a floating point scaling range has been set.
@@ -95,7 +111,11 @@ public interface ComponentDisplaySettings {
     * @return true if both bounds are set and the maximum is strictly above the minimum;
     *     an empty or inverted range counts as unset, since it cannot be displayed
     */
-   boolean hasFloatScaling();
+   default boolean hasFloatScaling() {
+      double min = getFloatScalingMinimum();
+      double max = getFloatScalingMaximum();
+      return !Double.isNaN(min) && !Double.isNaN(max) && max > min;
+   }
 
    /**
     * Scaling minimum as a pixel value, whichever range is in effect.

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
@@ -32,12 +32,69 @@ public interface ComponentDisplaySettings {
 
       Builder scalingGamma(double gamma);
 
+      /**
+       * Sets the scaling minimum as an actual pixel value, for floating point images.
+       *
+       * <p>For float images the long-valued {@link #scalingMinimum(long)} is not usable,
+       * since the interesting range is rarely integral. Pass {@code Double.NaN} to clear
+       * the float scaling and fall back to the long-valued setting.
+       *
+       * @param minIntensity pixel value, or NaN to unset
+       * @return this builder
+       */
+      Builder scalingMinimumDouble(double minIntensity);
+
+      /**
+       * Sets the scaling maximum as an actual pixel value, for floating point images.
+       *
+       * @param maxIntensity pixel value, or NaN to unset
+       * @return this builder
+       * @see #scalingMinimumDouble(double)
+       */
+      Builder scalingMaximumDouble(double maxIntensity);
+
+      /**
+       * Sets both float scaling bounds as actual pixel values.
+       *
+       * @param minIntensity pixel value, or NaN to unset
+       * @param maxIntensity pixel value, or NaN to unset
+       * @return this builder
+       * @see #scalingMinimumDouble(double)
+       */
+      Builder scalingRangeDouble(double minIntensity, double maxIntensity);
+
       ComponentDisplaySettings build();
    }
 
    long getScalingMinimum();
 
    long getScalingMaximum();
+
+   /**
+    * Returns the scaling minimum as an actual pixel value, for floating point images.
+    *
+    * @return pixel value, or {@code Double.NaN} if no float scaling has been set
+    * @see #hasFloatScaling()
+    */
+   double getScalingMinimumDouble();
+
+   /**
+    * Returns the scaling maximum as an actual pixel value, for floating point images.
+    *
+    * @return pixel value, or {@code Double.NaN} if no float scaling has been set
+    * @see #hasFloatScaling()
+    */
+   double getScalingMaximumDouble();
+
+   /**
+    * Returns whether a floating point scaling range has been set.
+    *
+    * <p>When false, callers displaying float images should fall back to deriving a range
+    * from the image statistics.
+    *
+    * @return true if both float scaling bounds are set
+    */
+   boolean hasFloatScaling();
 
    double getScalingGamma();
 

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentDisplaySettings.java
@@ -42,16 +42,16 @@ public interface ComponentDisplaySettings {
        * @param minIntensity pixel value, or NaN to unset
        * @return this builder
        */
-      Builder scalingMinimumDouble(double minIntensity);
+      Builder floatScalingMinimum(double minIntensity);
 
       /**
        * Sets the scaling maximum as an actual pixel value, for floating point images.
        *
        * @param maxIntensity pixel value, or NaN to unset
        * @return this builder
-       * @see #scalingMinimumDouble(double)
+       * @see #floatScalingMinimum(double)
        */
-      Builder scalingMaximumDouble(double maxIntensity);
+      Builder floatScalingMaximum(double maxIntensity);
 
       /**
        * Sets both float scaling bounds as actual pixel values.
@@ -59,9 +59,9 @@ public interface ComponentDisplaySettings {
        * @param minIntensity pixel value, or NaN to unset
        * @param maxIntensity pixel value, or NaN to unset
        * @return this builder
-       * @see #scalingMinimumDouble(double)
+       * @see #floatScalingMinimum(double)
        */
-      Builder scalingRangeDouble(double minIntensity, double maxIntensity);
+      Builder floatScalingRange(double minIntensity, double maxIntensity);
 
       ComponentDisplaySettings build();
    }
@@ -76,7 +76,7 @@ public interface ComponentDisplaySettings {
     * @return pixel value, or {@code Double.NaN} if no float scaling has been set
     * @see #hasFloatScaling()
     */
-   double getScalingMinimumDouble();
+   double getFloatScalingMinimum();
 
    /**
     * Returns the scaling maximum as an actual pixel value, for floating point images.
@@ -84,7 +84,7 @@ public interface ComponentDisplaySettings {
     * @return pixel value, or {@code Double.NaN} if no float scaling has been set
     * @see #hasFloatScaling()
     */
-   double getScalingMaximumDouble();
+   double getFloatScalingMaximum();
 
    /**
     * Returns whether a floating point scaling range has been set.
@@ -92,9 +92,34 @@ public interface ComponentDisplaySettings {
     * <p>When false, callers displaying float images should fall back to deriving a range
     * from the image statistics.
     *
-    * @return true if both float scaling bounds are set
+    * @return true if both bounds are set and the maximum is strictly above the minimum;
+    *     an empty or inverted range counts as unset, since it cannot be displayed
     */
    boolean hasFloatScaling();
+
+   /**
+    * Scaling minimum as a pixel value, whichever range is in effect.
+    *
+    * <p>Returns the float range when one is set, and otherwise the long-valued range
+    * widened to a double. Use this rather than {@link #getScalingMinimum()} anywhere the
+    * value feeds a renderer or a file, so that float images are handled correctly without
+    * every caller having to branch on {@link #hasFloatScaling()}.
+    *
+    * @return the scaling minimum
+    */
+   default double getEffectiveScalingMinimum() {
+      return hasFloatScaling() ? getFloatScalingMinimum() : (double) getScalingMinimum();
+   }
+
+   /**
+    * Scaling maximum as a pixel value, whichever range is in effect.
+    *
+    * @return the scaling maximum
+    * @see #getEffectiveScalingMinimum()
+    */
+   default double getEffectiveScalingMaximum() {
+      return hasFloatScaling() ? getFloatScalingMaximum() : (double) getScalingMaximum();
+   }
 
    double getScalingGamma();
 

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentIntensityRange.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentIntensityRange.java
@@ -69,10 +69,15 @@ public interface ComponentIntensityRange {
        * the interesting range is rarely integral. Pass {@code Double.NaN} to clear the
        * float range and fall back to the long-valued setting.
        *
+       * <p>The default implementation ignores the value, so that builders written before
+       * the float range existed keep compiling; they simply carry no float range.
+       *
        * @param min pixel value, or NaN to unset
        * @return this builder
        */
-      Builder floatMinimum(double min);
+      default Builder floatMinimum(double min) {
+         return this;
+      }
 
       /**
        * Sets the maximum as an actual pixel value, for floating point images.
@@ -81,7 +86,9 @@ public interface ComponentIntensityRange {
        * @return this builder
        * @see #floatMinimum(double)
        */
-      Builder floatMaximum(double max);
+      default Builder floatMaximum(double max) {
+         return this;
+      }
 
       /**
        * Sets both float bounds as actual pixel values.
@@ -91,7 +98,9 @@ public interface ComponentIntensityRange {
        * @return this builder
        * @see #floatMinimum(double)
        */
-      Builder floatRange(double min, double max);
+      default Builder floatRange(double min, double max) {
+         return floatMinimum(min).floatMaximum(max);
+      }
 
       /**
        * Builds and returns the {@link ComponentIntensityRange}.
@@ -135,10 +144,15 @@ public interface ComponentIntensityRange {
    /**
     * Returns the minimum as an actual pixel value, for floating point images.
     *
+    * <p>The default implementation reports no float range, so that implementations written
+    * before the float range existed keep compiling.
+    *
     * @return pixel value, or {@code Double.NaN} if no float range has been set
     * @see #hasFloatRange()
     */
-   double getFloatMinimum();
+   default double getFloatMinimum() {
+      return Double.NaN;
+   }
 
    /**
     * Returns the maximum as an actual pixel value, for floating point images.
@@ -146,7 +160,9 @@ public interface ComponentIntensityRange {
     * @return pixel value, or {@code Double.NaN} if no float range has been set
     * @see #hasFloatRange()
     */
-   double getFloatMaximum();
+   default double getFloatMaximum() {
+      return Double.NaN;
+   }
 
    /**
     * Returns whether a floating point range has been set.
@@ -154,5 +170,9 @@ public interface ComponentIntensityRange {
     * @return true if both bounds are set and the maximum is strictly above the minimum;
     *     an empty or inverted range counts as unset, since it cannot be displayed
     */
-   boolean hasFloatRange();
+   default boolean hasFloatRange() {
+      double min = getFloatMinimum();
+      double max = getFloatMaximum();
+      return !Double.isNaN(min) && !Double.isNaN(max) && max > min;
+   }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/ComponentIntensityRange.java
+++ b/mmstudio/src/main/java/org/micromanager/display/ComponentIntensityRange.java
@@ -63,6 +63,37 @@ public interface ComponentIntensityRange {
       Builder range(long min, long max);
 
       /**
+       * Sets the minimum as an actual pixel value, for floating point images.
+       *
+       * <p>For float images the long-valued {@link #minimum(long)} is not usable, since
+       * the interesting range is rarely integral. Pass {@code Double.NaN} to clear the
+       * float range and fall back to the long-valued setting.
+       *
+       * @param min pixel value, or NaN to unset
+       * @return this builder
+       */
+      Builder floatMinimum(double min);
+
+      /**
+       * Sets the maximum as an actual pixel value, for floating point images.
+       *
+       * @param max pixel value, or NaN to unset
+       * @return this builder
+       * @see #floatMinimum(double)
+       */
+      Builder floatMaximum(double max);
+
+      /**
+       * Sets both float bounds as actual pixel values.
+       *
+       * @param min pixel value, or NaN to unset
+       * @param max pixel value, or NaN to unset
+       * @return this builder
+       * @see #floatMinimum(double)
+       */
+      Builder floatRange(double min, double max);
+
+      /**
        * Builds and returns the {@link ComponentIntensityRange}.
        *
        * @return immutable {@link ComponentIntensityRange}
@@ -100,4 +131,28 @@ public interface ComponentIntensityRange {
     *     which means "use the full camera bit-depth range"
     */
    long getMaximum();
+
+   /**
+    * Returns the minimum as an actual pixel value, for floating point images.
+    *
+    * @return pixel value, or {@code Double.NaN} if no float range has been set
+    * @see #hasFloatRange()
+    */
+   double getFloatMinimum();
+
+   /**
+    * Returns the maximum as an actual pixel value, for floating point images.
+    *
+    * @return pixel value, or {@code Double.NaN} if no float range has been set
+    * @see #hasFloatRange()
+    */
+   double getFloatMaximum();
+
+   /**
+    * Returns whether a floating point range has been set.
+    *
+    * @return true if both bounds are set and the maximum is strictly above the minimum;
+    *     an empty or inverted range counts as unset, since it cannot be displayed
+    */
+   boolean hasFloatRange();
 }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -552,20 +552,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                }
                floatMappers_[c] = mapper;
                long binCount = Math.max(1L, mapper.getBinCount());
-               // This image's bins cover only the part of the axis between its own min and
-               // max, so tell the view where the graph starts and how much it spans.
-               long graphSpan = binCount;
-               long graphOffset = 0L;
-               double axisSpan = floatRangeMax_ - floatRangeMin_;
-               if (axisSpan > 0.0) {
-                  double imageSpan = cStats.getBinWidthDouble() * cStats.getHistogramBinCount();
-                  double imageMin = cStats.getHistogramRangeMinDouble();
-                  graphSpan = Math.max(1L, Math.round(binCount * (imageSpan / axisSpan)));
-                  graphOffset = Math.max(0L,
-                        Math.round(binCount * ((imageMin - floatRangeMin_) / axisSpan)));
-               }
-               histogram_.setComponentGraph(c, data, data.length, 0L, binCount,
-                     graphSpan, graphOffset);
+               // The image's bins span its own min..max, which need not coincide with the
+               // axis; resample them onto the axis so every bin lands at its true pixel
+               // value and anything outside the axis is dropped rather than displaced.
+               long[] axisData = resampleOntoAxis(cStats, mapper, (int) binCount);
+               histogram_.setComponentGraph(c, axisData, axisData.length, 0L, binCount);
                histogram_.setComponentFloatMapper(c, mapper);
                histogram_.setComponentRangeMaxLabel(c, mapper.formatBinIndex(binCount));
                histogram_.setComponentRangeMinLabel(c, mapper.formatBinIndex(0L));
@@ -998,6 +989,77 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
                .build();
       } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+   }
+
+   /**
+    * Rebins a float image's histogram from the image's own value range onto the axis.
+    *
+    * <p>The statistics are computed with bins spanning the image's own min..max, which is
+    * generally not the range the axis shows. Each source bin is distributed over the axis
+    * bins it overlaps, so that a count always appears at the pixel value it came from.
+    * Counts falling outside the axis are dropped, which is what makes data beyond the
+    * chosen range read as clipped rather than piling up at an end.
+    *
+    * @param cStats statistics of the image
+    * @param mapper mapper describing the axis
+    * @param axisBins number of bins on the axis
+    * @return counts per axis bin
+    */
+   private static long[] resampleOntoAxis(ComponentStats cStats,
+                                          FloatCoordinateMapper mapper, int axisBins) {
+      long[] src = cStats.getInRangeHistogram();
+      long[] out = new long[Math.max(1, axisBins)];
+      if (src == null || src.length == 0) {
+         return out;
+      }
+      double srcBinWidth = cStats.getBinWidthDouble();
+      double srcMin = cStats.getHistogramRangeMinDouble();
+      double axisMin = mapper.getRangeMin();
+      double axisBinWidth = mapper.getBinWidth();
+      if (axisBinWidth <= 0.0) {
+         return out;
+      }
+      if (srcBinWidth <= 0.0) {
+         // Degenerate source (all pixels identical): put every count in one axis bin.
+         int idx = (int) Math.floor((srcMin - axisMin) / axisBinWidth);
+         if (idx >= 0 && idx < out.length) {
+            long total = 0;
+            for (int i = 0; i < src.length; ++i) {
+               total += src[i];
+            }
+            out[idx] += total;
+         }
+         return out;
+      }
+      for (int i = 0; i < src.length; ++i) {
+         if (src[i] == 0) {
+            continue;
+         }
+         // Value range covered by this source bin, in axis-bin coordinates.
+         double lo = ((srcMin + i * srcBinWidth) - axisMin) / axisBinWidth;
+         double hi = lo + srcBinWidth / axisBinWidth;
+         if (hi <= 0.0 || lo >= out.length) {
+            continue; // Entirely outside the axis
+         }
+         int firstBin = (int) Math.floor(Math.max(0.0, lo));
+         int lastBin = (int) Math.ceil(Math.min((double) out.length, hi)) - 1;
+         if (lastBin < firstBin) {
+            lastBin = firstBin;
+         }
+         double width = hi - lo;
+         for (int b = firstBin; b <= lastBin && b < out.length; ++b) {
+            if (b < 0) {
+               continue;
+            }
+            // Fraction of this source bin that falls inside axis bin b.
+            double overlap = Math.min(hi, b + 1.0) - Math.max(lo, (double) b);
+            if (overlap <= 0.0) {
+               continue;
+            }
+            out[b] += Math.round(src[i] * (overlap / width));
+         }
+      }
+      return out;
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -167,8 +167,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          super.setOpaque(true);
          FontMetrics keyFontMetrics = super.getFontMetrics(keyFont_);
 
-         maxMinMaxWidth_ = valueFontMetrics_.stringWidth("99999") + 2;
-         maxAvgStdWidth_ = valueFontMetrics_.stringWidth("9.99e+99") + 2;
+         // Wide enough for a signed float in scientific notation: float images show real
+         // values such as "-2.238" or "-1.62e-01", which do not fit an integer-sized slot
+         // and would otherwise be replaced by "..." in formatString().
+         maxMinMaxWidth_ = valueFontMetrics_.stringWidth("-9.999e+99") + 2;
+         maxAvgStdWidth_ = valueFontMetrics_.stringWidth("-9.999e+99") + 2;
 
          valueX1 = keyX1 + Math.max(keyFontMetrics.stringWidth("MAX"),
                keyFontMetrics.stringWidth("MIN"))
@@ -484,6 +487,26 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       return histoPanel_;
    }
 
+   /**
+    * Formats a floating point intensity for the stats readout.
+    *
+    * <p>Switches to scientific notation for magnitudes that would otherwise be shown as
+    * mostly zeros or as an unreadably long integer.
+    *
+    * @param v value to format
+    * @return the formatted value, or null if it is not a number
+    */
+   static String formatStatValue(double v) {
+      if (Double.isNaN(v)) {
+         return null;
+      }
+      double m = Math.abs(v);
+      if (m != 0.0 && (m < 1e-3 || m >= 1e5)) {
+         return String.format("%.2e", v);
+      }
+      return String.format("%.4g", v);
+   }
+
    @MustCallOnEDT
    private void statsOrRangeChanged() {
       if (stats_ == null) {
@@ -501,18 +524,34 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       final DisplaySettings displaySettings = viewer_.getDisplaySettings();
       boolean ignoreZeros = displaySettings.isAutoscaleIgnoringZeros();
 
-      long min = ignoreZeros ? selectedStats.getMinIntensityExcludingZeros()
-                             : selectedStats.getMinIntensity();
-      intensityStatsPanel_.setMin(min >= 0 ? Long.toString(min) : null);
-      long max = selectedStats.getMaxIntensity();
-      intensityStatsPanel_.setMax(max >= 0 ? Long.toString(max) : null);
-      long mean = ignoreZeros ? selectedStats.getMeanIntensityExcludingZeros()
-                              : selectedStats.getMeanIntensity();
-      intensityStatsPanel_.setMean(mean >= 0 ? Long.toString(mean) : null);
-      double stdev = ignoreZeros ? selectedStats.getStandardDeviationExcludingZeros()
-                                 : selectedStats.getStandardDeviation();
-      intensityStatsPanel_.setStdev(Double.isNaN(stdev) ? null :
-            String.format("%1.2e", stdev));
+      if (selectedStats.isFloat()) {
+         // Float values are genuinely fractional and often negative, so show them as such
+         // rather than rounding (which collapses a mean of -0.16 to 0) or hiding them.
+         double min = ignoreZeros ? selectedStats.getMinIntensityExcludingZerosDouble()
+                                  : selectedStats.getMinIntensityDouble();
+         intensityStatsPanel_.setMin(formatStatValue(min));
+         intensityStatsPanel_.setMax(formatStatValue(selectedStats.getMaxIntensityDouble()));
+         double mean = ignoreZeros ? selectedStats.getMeanIntensityExcludingZerosDouble()
+                                   : selectedStats.getMeanIntensityDouble();
+         intensityStatsPanel_.setMean(formatStatValue(mean));
+         double stdev = ignoreZeros ? selectedStats.getStandardDeviationExcludingZerosDouble()
+                                    : selectedStats.getStandardDeviationDouble();
+         intensityStatsPanel_.setStdev(Double.isNaN(stdev) ? null :
+               String.format("%1.2e", stdev));
+      } else {
+         long min = ignoreZeros ? selectedStats.getMinIntensityExcludingZeros()
+                                : selectedStats.getMinIntensity();
+         intensityStatsPanel_.setMin(min >= 0 ? Long.toString(min) : null);
+         long max = selectedStats.getMaxIntensity();
+         intensityStatsPanel_.setMax(max >= 0 ? Long.toString(max) : null);
+         long mean = ignoreZeros ? selectedStats.getMeanIntensityExcludingZeros()
+                                 : selectedStats.getMeanIntensity();
+         intensityStatsPanel_.setMean(mean >= 0 ? Long.toString(mean) : null);
+         double stdev = ignoreZeros ? selectedStats.getStandardDeviationExcludingZeros()
+                                    : selectedStats.getStandardDeviation();
+         intensityStatsPanel_.setStdev(Double.isNaN(stdev) ? null :
+               String.format("%1.2e", stdev));
+      }
 
       cameraBits_ = stats_.getComponentStats(0).getBitDepth();
       updateHistoRangeControlsEnabled();

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -73,6 +73,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    // Set once the user edits an axis end by hand: the axis then stays exactly where they
    // put it and no longer widens to take in new images.
    private boolean floatRangePinned_ = false;
+   // Guards the one-time adoption of a range recorded in the display settings.
+   private boolean floatRangeRestored_ = false;
    private boolean pickingWhiteBalancePoint_ = false;
    private long[] lastPickedValues_ = null; // pixel values tracked while in pick mode
 
@@ -527,6 +529,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       int numComponents = stats_.getNumberOfComponents();
       setRGBMode(numComponents > 1);
 
+      restoreFloatRangeFromSettings(displaySettings);
       accumulateFloatRange();
       seedFloatScalingIfUnset(displaySettings);
 
@@ -867,6 +870,63 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
    void setRgbAutostretchEnabled(boolean enabled) {
       rgbAutostretchEnabled_ = enabled;
+   }
+
+   /**
+    * Adopts a float histogram axis range recorded in the display settings.
+    *
+    * <p>Called before accumulating, so that a range restored from a saved dataset (or set
+    * in an earlier session) takes precedence over one derived from the images.
+    *
+    * @param settings current display settings
+    */
+   @MustCallOnEDT
+   private void restoreFloatRangeFromSettings(DisplaySettings settings) {
+      if (floatRangeRestored_) {
+         return;
+      }
+      ChannelDisplaySettings channelSettings = settings.getChannelSettings(channelIndex_);
+      if (!channelSettings.hasFloatHistoRange()) {
+         return;
+      }
+      floatRangeRestored_ = true;
+      floatRangeMin_ = channelSettings.getFloatHistoRangeMin();
+      floatRangeMax_ = channelSettings.getFloatHistoRangeMax();
+      floatRangePinned_ = channelSettings.isFloatHistoRangePinned();
+   }
+
+   /**
+    * Records the current float histogram axis in the display settings so that it survives
+    * closing and reopening the dataset.
+    *
+    * @param pinned whether the axis was chosen by the user
+    */
+   @MustCallOnEDT
+   private void storeFloatRangeInSettings(boolean pinned) {
+      if (Double.isNaN(floatRangeMin_) || Double.isNaN(floatRangeMax_)
+            || floatRangeMax_ <= floatRangeMin_) {
+         return;
+      }
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      do {
+         oldDisplaySettings = viewer_.getDisplaySettings();
+         ChannelDisplaySettings channelSettings =
+               oldDisplaySettings.getChannelSettings(channelIndex_);
+         if (channelSettings.hasFloatHistoRange()
+               && channelSettings.getFloatHistoRangeMin() == floatRangeMin_
+               && channelSettings.getFloatHistoRangeMax() == floatRangeMax_
+               && channelSettings.isFloatHistoRangePinned() == pinned) {
+            return;
+         }
+         newDisplaySettings = oldDisplaySettings
+               .copyBuilderWithChannelSettings(channelIndex_,
+                     channelSettings.copyBuilder()
+                           .floatHistoRange(floatRangeMin_, floatRangeMax_)
+                           .floatHistoRangePinned(pinned)
+                           .build())
+               .build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
    }
 
    /**
@@ -1512,8 +1572,11 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       }
       // The user has chosen the axis explicitly: stop widening it to fit new images.
       floatRangePinned_ = true;
+      floatRangeRestored_ = true;
       floatRangeMin_ = newRangeMin;
       floatRangeMax_ = newRangeMax;
+      // Record it so the choice survives closing and reopening the dataset.
+      storeFloatRangeInSettings(true);
       // Keep the scaling range inside the new axis, otherwise the handles would sit off
       // the end and the image would be scaled to something the user cannot see or reach.
       DisplaySettings oldDisplaySettings;

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -527,15 +527,15 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       if (selectedStats.isFloat()) {
          // Float values are genuinely fractional and often negative, so show them as such
          // rather than rounding (which collapses a mean of -0.16 to 0) or hiding them.
-         double min = ignoreZeros ? selectedStats.getMinIntensityExcludingZerosDouble()
-                                  : selectedStats.getMinIntensityDouble();
+         double min = ignoreZeros ? selectedStats.getFloatMinIntensityExcludingZeros()
+                                  : selectedStats.getFloatMinIntensity();
          intensityStatsPanel_.setMin(formatStatValue(min));
-         intensityStatsPanel_.setMax(formatStatValue(selectedStats.getMaxIntensityDouble()));
-         double mean = ignoreZeros ? selectedStats.getMeanIntensityExcludingZerosDouble()
-                                   : selectedStats.getMeanIntensityDouble();
+         intensityStatsPanel_.setMax(formatStatValue(selectedStats.getFloatMaxIntensity()));
+         double mean = ignoreZeros ? selectedStats.getFloatMeanIntensityExcludingZeros()
+                                   : selectedStats.getFloatMeanIntensity();
          intensityStatsPanel_.setMean(formatStatValue(mean));
-         double stdev = ignoreZeros ? selectedStats.getStandardDeviationExcludingZerosDouble()
-                                    : selectedStats.getStandardDeviationDouble();
+         double stdev = ignoreZeros ? selectedStats.getFloatStandardDeviationExcludingZeros()
+                                    : selectedStats.getFloatStandardDeviation();
          intensityStatsPanel_.setStdev(Double.isNaN(stdev) ? null :
                String.format("%1.2e", stdev));
       } else {
@@ -639,6 +639,31 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       long max;
       if (settings.isAutostretchEnabled()) {
          double q = settings.getAutoscaleIgnoredQuantile();
+         FloatCoordinateMapper mapper = getFloatMapper(component);
+         if (mapper != null) {
+            // Stay in pixel values and convert to bin positions only for drawing. Going
+            // through the long autoscale would round the bounds to whole units first,
+            // which for a range such as 2.7..22.7 pins the handles at 3 and 22 no matter
+            // what the ignore fraction is.
+            double fMin;
+            double fMax;
+            if (settings.isAutoscaleIgnoringZeros()) {
+               fMin = 0.0;
+               fMax = componentStats.getFloatAutoscaleMaxForQuantileIgnoringZeros(q);
+            } else {
+               double[] fMinMax = new double[2];
+               componentStats.getFloatAutoscaleMinMaxForQuantile(q, fMinMax);
+               fMin = fMinMax[0];
+               fMax = fMinMax[1];
+            }
+            int binCount = mapper.getBinCount();
+            long binMax = Math.max(1, Math.min(binCount,
+                  mapper.pixelValueToBinIndex(fMax)));
+            long binMin = Math.max(0, Math.min(binMax - 1,
+                  mapper.pixelValueToBinIndex(fMin)));
+            histogram_.setComponentScaling(component, binMin, binMax);
+            return;
+         }
          if (settings.isAutoscaleIgnoringZeros()) {
             min = 0L;
             max = componentStats.getAutoscaleMaxForQuantileIgnoringZeros(q);
@@ -648,9 +673,6 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             min = minMax[0];
             max = minMax[1];
          }
-         // For float images the histogram X-axis is in bin-index space; convert.
-         min = toStoredScalingValue(component, min);
-         max = toStoredScalingValue(component, max);
       } else {
          ComponentDisplaySettings componentSettings =
                settings.getChannelSettings(channelIndex_)
@@ -664,9 +686,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             if (componentSettings.hasFloatScaling()) {
                // Stored as pixel values; convert to bin positions for drawing only.
                clampedMax = mapper.pixelValueToBinIndex(
-                     componentSettings.getScalingMaximumDouble());
+                     componentSettings.getFloatScalingMaximum());
                clampedMin = mapper.pixelValueToBinIndex(
-                     componentSettings.getScalingMinimumDouble());
+                     componentSettings.getFloatScalingMinimum());
                clampedMax = Math.max(1, Math.min(binCount, clampedMax));
                clampedMin = Math.max(0, Math.min(clampedMax - 1, clampedMin));
             } else {
@@ -929,8 +951,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          return;
       }
       floatRangeRestored_ = true;
-      floatRangeMin_ = channelSettings.getFloatHistoRangeMin();
-      floatRangeMax_ = channelSettings.getFloatHistoRangeMax();
+      floatRangeMin_ = channelSettings.getFloatHistoRangeMinimum();
+      floatRangeMax_ = channelSettings.getFloatHistoRangeMaximum();
       floatRangePinned_ = channelSettings.isFloatHistoRangePinned();
    }
 
@@ -953,8 +975,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          ChannelDisplaySettings channelSettings =
                oldDisplaySettings.getChannelSettings(channelIndex_);
          if (channelSettings.hasFloatHistoRange()
-               && channelSettings.getFloatHistoRangeMin() == floatRangeMin_
-               && channelSettings.getFloatHistoRangeMax() == floatRangeMax_
+               && channelSettings.getFloatHistoRangeMinimum() == floatRangeMin_
+               && channelSettings.getFloatHistoRangeMaximum() == floatRangeMax_
                && channelSettings.isFloatHistoRangePinned() == pinned) {
             return;
          }
@@ -1055,19 +1077,20 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                continue;
             }
             ComponentStats cStats = stats_.getComponentStats(c);
-            long seedMin;
-            long seedMax;
+            // Use the float autoscale, which keeps the quantiles as pixel values. The
+            // long-valued one rounds them, so data spanning less than a unit would seed
+            // a range of 0..1 or wider than the data itself.
+            double seedMinValue;
+            double seedMaxValue;
             if (ignoreZeros) {
-               seedMin = 0L;
-               seedMax = cStats.getAutoscaleMaxForQuantileIgnoringZeros(q);
+               seedMinValue = 0.0;
+               seedMaxValue = cStats.getFloatAutoscaleMaxForQuantileIgnoringZeros(q);
             } else {
-               long[] minMax = new long[2];
-               cStats.getAutoscaleMinMaxForQuantile(q, minMax);
-               seedMin = minMax[0];
-               seedMax = minMax[1];
+               double[] minMax = new double[2];
+               cStats.getFloatAutoscaleMinMaxForQuantile(q, minMax);
+               seedMinValue = minMax[0];
+               seedMaxValue = minMax[1];
             }
-            double seedMinValue = (double) seedMin;
-            double seedMaxValue = (double) seedMax;
             if (seedMaxValue <= seedMinValue) {
                // Degenerate (e.g. constant image); fall back to the accumulated axis.
                seedMinValue = floatRangeMin_;
@@ -1078,7 +1101,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                continue;
             }
             builder.component(c, chSettings.getComponentSettings(c).copyBuilder()
-                  .scalingRangeDouble(seedMinValue, seedMaxValue).build());
+                  .floatScalingRange(seedMinValue, seedMaxValue).build());
             changed = true;
          }
          if (!changed) {
@@ -1098,6 +1121,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
     * bins it overlaps, so that a count always appears at the pixel value it came from.
     * Counts falling outside the axis are dropped, which is what makes data beyond the
     * chosen range read as clipped rather than piling up at an end.
+    *
+    * <p>Each output bin is rounded independently, so the total count is not exactly
+    * conserved. That is fine for a display histogram, which is only ever drawn.
     *
     * @param cStats statistics of the image
     * @param mapper mapper describing the axis
@@ -1184,7 +1210,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private double currentFloatMin(ComponentDisplaySettings settings,
                                   FloatCoordinateMapper mapper) {
       if (settings.hasFloatScaling()) {
-         return settings.getScalingMinimumDouble();
+         return settings.getFloatScalingMinimum();
       }
       return mapper.binIndexToPixelValue(settings.getScalingMinimum());
    }
@@ -1199,7 +1225,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private double currentFloatMax(ComponentDisplaySettings settings,
                                   FloatCoordinateMapper mapper) {
       if (settings.hasFloatScaling()) {
-         return settings.getScalingMaximumDouble();
+         return settings.getFloatScalingMaximum();
       }
       long storedMax = settings.getScalingMaximum();
       long binIndex = (storedMax == Long.MAX_VALUE) ? mapper.getBinCount() : storedMax;
@@ -1306,28 +1332,47 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
       } else {
          // Single component: only autoscale the selected component, leave others unchanged.
-         long newMin;
-         long newMax;
-         if (ignoreZeros) {
-            newMin = 0L;
-            newMax = stats_.getComponentStats(selectedComponent)
-                  .getAutoscaleMaxForQuantileIgnoringZeros(q);
+         ComponentStats selStats = stats_.getComponentStats(selectedComponent);
+         FloatCoordinateMapper selMapper = getFloatMapper(selectedComponent);
+         double newFloatMin = 0.0;
+         double newFloatMax = 0.0;
+         long newMin = 0L;
+         long newMax = 0L;
+         if (selMapper != null) {
+            // Keep pixel values: rounding them here would pin the range to whole units.
+            if (ignoreZeros) {
+               newFloatMax = selStats.getFloatAutoscaleMaxForQuantileIgnoringZeros(q);
+            } else {
+               double[] fMinMax = new double[2];
+               selStats.getFloatAutoscaleMinMaxForQuantile(q, fMinMax);
+               newFloatMin = fMinMax[0];
+               newFloatMax = fMinMax[1];
+            }
          } else {
-            long[] minMax = new long[2];
-            stats_.getComponentStats(selectedComponent).getAutoscaleMinMaxForQuantile(q, minMax);
-            newMin = minMax[0];
-            newMax = minMax[1];
+            if (ignoreZeros) {
+               newMin = 0L;
+               newMax = selStats.getAutoscaleMaxForQuantileIgnoringZeros(q);
+            } else {
+               long[] minMax = new long[2];
+               selStats.getAutoscaleMinMaxForQuantile(q, minMax);
+               newMin = minMax[0];
+               newMax = minMax[1];
+            }
          }
-         newMin = toStoredScalingValue(selectedComponent, newMin);
-         newMax = toStoredScalingValue(selectedComponent, newMax);
          do {
             oldDisplaySettings = viewer_.getDisplaySettings();
             ChannelDisplaySettings channelSettings =
                   oldDisplaySettings.getChannelSettings(channelIndex_);
+            ComponentDisplaySettings.Builder cb =
+                  channelSettings.getComponentSettings(selectedComponent).copyBuilder();
+            if (selMapper != null) {
+               cb.floatScalingRange(newFloatMin, newFloatMax);
+            } else {
+               cb.scalingRange(newMin, newMax);
+            }
             newDisplaySettings = oldDisplaySettings
                   .copyBuilderWithComponentSettings(channelIndex_, selectedComponent,
-                        channelSettings.getComponentSettings(selectedComponent).copyBuilder()
-                              .scalingRange(newMin, newMax).build())
+                        cb.build())
                   .autostretch(false)
                   .build();
          } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
@@ -1377,7 +1422,7 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             FloatCoordinateMapper mapper = getFloatMapper(sel);
             builder.component(sel,
                   channelSettings.getComponentSettings(sel).copyBuilder()
-                        .scalingRangeDouble(mapper.getRangeMin(),
+                        .floatScalingRange(mapper.getRangeMin(),
                               mapper.binIndexToPixelValue(mapper.getBinCount()))
                         .build());
          } else {
@@ -1426,24 +1471,36 @@ public final class ChannelIntensityController implements HistogramView.Listener 
 
          } else {
             ComponentStats stats = stats_.getComponentStats(sel);
-            long min;
-            long max;
-            if (ignoreZeros) {
-               min = 0L;
-               max = stats.getAutoscaleMaxForQuantileIgnoringZeros(q);
-            } else {
-               long[] minMax = new long[2];
-               stats.getAutoscaleMinMaxForQuantile(q, minMax);
-               min = minMax[0];
-               max = minMax[1];
-            }
             if (getFloatMapper(sel) != null) {
-               // min/max are already pixel values; store them as such rather than as bin
-               // indices, which would be reinterpreted against the next image's binning.
+               // Stay in pixel values throughout: the long-valued autoscale would round
+               // the quantiles first, and the range is stored as pixel values so that it
+               // is not reinterpreted against the next image's binning.
+               double min;
+               double max;
+               if (ignoreZeros) {
+                  min = 0.0;
+                  max = stats.getFloatAutoscaleMaxForQuantileIgnoringZeros(q);
+               } else {
+                  double[] minMax = new double[2];
+                  stats.getFloatAutoscaleMinMaxForQuantile(q, minMax);
+                  min = minMax[0];
+                  max = minMax[1];
+               }
                builder.component(sel,
                      channelSettings.getComponentSettings(sel).copyBuilder()
-                           .scalingRangeDouble((double) min, (double) max).build());
+                           .floatScalingRange(min, max).build());
             } else {
+               long min;
+               long max;
+               if (ignoreZeros) {
+                  min = 0L;
+                  max = stats.getAutoscaleMaxForQuantileIgnoringZeros(q);
+               } else {
+                  long[] minMax = new long[2];
+                  stats.getAutoscaleMinMaxForQuantile(q, minMax);
+                  min = minMax[0];
+                  max = minMax[1];
+               }
                builder.component(sel,
                      channelSettings.getComponentSettings(sel).copyBuilder()
                            .scalingRange(min, max).build());
@@ -1476,13 +1533,13 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             // range keeps its meaning when the next image has a different distribution.
             double newMinValue = mapper.binIndexToPixelValue(newMin);
             if (componentSettings.hasFloatScaling()
-                  && componentSettings.getScalingMinimumDouble() == newMinValue) {
+                  && componentSettings.getFloatScalingMinimum() == newMinValue) {
                return;
             }
             componentSettings = componentSettings
                   .copyBuilder()
-                  .scalingMinimumDouble(newMinValue)
-                  .scalingMaximumDouble(currentFloatMax(componentSettings, mapper))
+                  .floatScalingMinimum(newMinValue)
+                  .floatScalingMaximum(currentFloatMax(componentSettings, mapper))
                   .build();
          } else {
             if (componentSettings.getScalingMinimum() == newMin) {
@@ -1519,12 +1576,12 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          if (mapper != null) {
             double newMaxValue = mapper.binIndexToPixelValue(newMax);
             if (componentSettings.hasFloatScaling()
-                  && componentSettings.getScalingMaximumDouble() == newMaxValue) {
+                  && componentSettings.getFloatScalingMaximum() == newMaxValue) {
                return;
             }
             componentSettings = componentSettings.copyBuilder()
-                  .scalingMinimumDouble(currentFloatMin(componentSettings, mapper))
-                  .scalingMaximumDouble(newMaxValue)
+                  .floatScalingMinimum(currentFloatMin(componentSettings, mapper))
+                  .floatScalingMaximum(newMaxValue)
                   .build();
          } else {
             if (componentSettings.getScalingMaximum() == newMax) {
@@ -1630,24 +1687,51 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             break;
          }
          double clampedMin = Math.max(newRangeMin,
-               Math.min(componentSettings.getScalingMinimumDouble(), newRangeMax));
+               Math.min(componentSettings.getFloatScalingMinimum(), newRangeMax));
          double clampedMax = Math.max(clampedMin,
-               Math.min(componentSettings.getScalingMaximumDouble(), newRangeMax));
+               Math.min(componentSettings.getFloatScalingMaximum(), newRangeMax));
          if (clampedMax <= clampedMin) {
             clampedMin = newRangeMin;
             clampedMax = newRangeMax;
          }
-         if (clampedMin == componentSettings.getScalingMinimumDouble()
-               && clampedMax == componentSettings.getScalingMaximumDouble()) {
+         if (clampedMin == componentSettings.getFloatScalingMinimum()
+               && clampedMax == componentSettings.getFloatScalingMaximum()) {
             break;
          }
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithComponentSettings(channelIndex_, component,
                      componentSettings.copyBuilder()
-                           .scalingRangeDouble(clampedMin, clampedMax).build())
+                           .floatScalingRange(clampedMin, clampedMax).build())
                .build();
       } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
       statsOrRangeChanged();
+   }
+
+   @Override
+   public void histogramFloatScalingChanged(int component, double newMin, double newMax) {
+      if (newMax <= newMin || Double.isNaN(newMin) || Double.isNaN(newMax)) {
+         return;
+      }
+      rgbAutostretchEnabled_ = false;
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      do {
+         oldDisplaySettings = viewer_.getDisplaySettings();
+         ComponentDisplaySettings componentSettings =
+               oldDisplaySettings.getChannelSettings(channelIndex_)
+                     .getComponentSettings(component);
+         if (componentSettings.hasFloatScaling()
+               && componentSettings.getFloatScalingMinimum() == newMin
+               && componentSettings.getFloatScalingMaximum() == newMax) {
+            return;
+         }
+         newDisplaySettings = oldDisplaySettings
+               .copyBuilderWithComponentSettings(channelIndex_, component,
+                     componentSettings.copyBuilder()
+                           .floatScalingRange(newMin, newMax).build())
+               .autostretch(false)
+               .build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
    }
 
    @Override
@@ -1776,14 +1860,18 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          return;
       }
 
+      // Read the untruncated values for float images: a pixel of 0.37 arrives as 0
+      // through the long-valued accessor, so the highlight lands in the wrong bin.
+      double[] floatValues = getPixelValuesDoubleForChannel(e);
       long[] values = getPixelValuesForChannel(e);
       if (values != null) {
          for (int component = 0; component < values.length; ++component) {
             long highlightValue = values[component];
             if (floatMappers_ != null && component < floatMappers_.length
                   && floatMappers_[component] != null) {
-               highlightValue = floatMappers_[component].pixelValueToBinIndex(
-                     (double) highlightValue);
+               double pixelValue = floatValues != null && component < floatValues.length
+                     ? floatValues[component] : (double) highlightValue;
+               highlightValue = floatMappers_[component].pixelValueToBinIndex(pixelValue);
             }
             histogram_.setComponentHighlight(component, highlightValue);
          }
@@ -1807,16 +1895,33 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    }
 
    private long[] getPixelValuesForChannel(DataViewerMousePixelInfoChangedEvent e) {
+      Coords coords = getCoordsForChannel(e);
+      return coords == null ? null : e.getComponentValuesForCoords(coords);
+   }
+
+   /**
+    * Pixel values for this channel without float truncation.
+    *
+    * @param e the event to read
+    * @return the values, or null when unavailable
+    */
+   private double[] getPixelValuesDoubleForChannel(
+         DataViewerMousePixelInfoChangedEvent e) {
+      Coords coords = getCoordsForChannel(e);
+      return coords == null ? null : e.getComponentValuesDoubleForCoords(coords);
+   }
+
+   private Coords getCoordsForChannel(DataViewerMousePixelInfoChangedEvent e) {
       // Channel-less case
       if (channelIndex_ == 0 && e.getNumberOfCoords() == 1) {
          Coords coords = e.getAllCoords().get(0);
          if (!coords.hasAxis(Coords.CHANNEL)) {
-            return e.getComponentValuesForCoords(coords);
+            return coords;
          }
       }
       for (Coords coords : e.getAllCoords()) {
          if (coords.getChannel() == channelIndex_) {
-            return e.getComponentValuesForCoords(coords);
+            return coords;
          }
       }
       return null;

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -75,6 +75,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private boolean floatRangePinned_ = false;
    // Guards the one-time adoption of a range recorded in the display settings.
    private boolean floatRangeRestored_ = false;
+   // Whether the stats the accumulated range was built from were ROI stats. Entering or
+   // leaving an ROI changes which pixels are measured, so the accumulation restarts;
+   // otherwise a range widened by a bright ROI would outlive the ROI itself.
+   private boolean floatRangeFromROI_ = false;
    private boolean pickingWhiteBalancePoint_ = false;
    private long[] lastPickedValues_ = null; // pixel values tracked while in pick mode
 
@@ -88,6 +92,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
          new HistoRangeComboBoxModel();
    private final JComboBox<String> histoRangeComboBox_ =
          new JComboBox<>(histoRangeComboBoxModel_);
+   // Shown in place of the bit-depth combo for float images, whose histogram range comes
+   // from the data rather than from a bit depth.
+   private final JButton floatRangeResetButton_ = new JButton();
    private final StatsPanel intensityStatsPanel_ = new StatsPanel();
 
    private static final class HistoRangeComboBoxModel extends DefaultComboBoxModel<String> {
@@ -394,9 +401,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       histoPanel_.setOpaque(true);
       histoPanel_.add(histogram_, new CC().grow().push().wrap("rel"));
 
-      histoPanel_.add(histoRangeDownButton_, new CC().split(5).gapBefore("12").gapAfter("0"));
+      histoPanel_.add(histoRangeDownButton_, new CC().split(6).gapBefore("12").gapAfter("0"));
       histoPanel_.add(histoRangeComboBox_, new CC().gapAfter("0").pad(0, -4, 0, 4));
-      histoPanel_.add(histoRangeUpButton_, new CC().gapAfter("push"));
+      histoPanel_.add(histoRangeUpButton_, new CC().gapAfter("0"));
+      histoPanel_.add(floatRangeResetButton_, new CC().gapAfter("push"));
 
       histoPanel_.add(intensityStatsPanel_, new CC().gapAfter("push"));
       JToggleButton intensityLinkButton = new JToggleButton();
@@ -449,6 +457,20 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             histoRangeComboBox_.setSelectedIndex(index + 1);
          }
       });
+
+      floatRangeResetButton_.setText("Reset Range");
+      floatRangeResetButton_.setToolTipText("<html>Rebuild the histogram range from the "
+            + "image being displayed.<br>Use after editing an axis end, which pins the "
+            + "range, or after<br>an unusual image has widened it.</html>");
+      floatRangeResetButton_.setMaximumSize(new Dimension(90, 20));
+      floatRangeResetButton_.setMinimumSize(new Dimension(90, 20));
+      floatRangeResetButton_.setPreferredSize(new Dimension(90, 20));
+      floatRangeResetButton_.setFocusable(false);
+      floatRangeResetButton_.setMargin(new Insets(0, 0, 0, 0));
+      floatRangeResetButton_.setFont(
+            floatRangeResetButton_.getFont().deriveFont(10.0f));
+      floatRangeResetButton_.setVisible(false);
+      floatRangeResetButton_.addActionListener((ActionEvent e) -> resetFloatHistoRange());
 
       histoRangeComboBox_.setMaximumSize(new Dimension(128, 20));
       histoRangeComboBox_.setFocusable(false);
@@ -741,6 +763,45 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       histoRangeDownButton_.setEnabled(!isFloat && histoRangeComboBox_.getSelectedIndex() > 0);
       histoRangeUpButton_.setEnabled(!isFloat
             && histoRangeComboBox_.getSelectedIndex() < histoRangeComboBoxModel_.getSize() - 2);
+      // A float histogram has no bit depth to choose, so the bit-depth controls give way
+      // to the one range control that does apply to it.
+      histoRangeComboBox_.setVisible(!isFloat);
+      histoRangeDownButton_.setVisible(!isFloat);
+      histoRangeUpButton_.setVisible(!isFloat);
+      floatRangeResetButton_.setVisible(isFloat);
+      // Only worth pressing once the range has been pinned or widened past this image.
+      floatRangeResetButton_.setEnabled(isFloat
+            && (floatRangePinned_ || floatRangeExceedsCurrentImage()));
+   }
+
+   /**
+    * Whether the accumulated axis is wider than the image now displayed needs.
+    *
+    * <p>Used to tell whether resetting the range would actually change anything.
+    *
+    * @return true if the axis extends beyond the current image's own range
+    */
+   @MustCallOnEDT
+   private boolean floatRangeExceedsCurrentImage() {
+      if (stats_ == null || Double.isNaN(floatRangeMin_) || Double.isNaN(floatRangeMax_)) {
+         return false;
+      }
+      for (int c = 0; c < stats_.getNumberOfComponents(); ++c) {
+         ComponentStats cStats = stats_.getComponentStats(c);
+         if (!cStats.isFloat()) {
+            continue;
+         }
+         double frameMin = cStats.getHistogramRangeMinDouble();
+         double frameMax = frameMin
+               + cStats.getBinWidthDouble() * cStats.getHistogramBinCount();
+         if (Double.isNaN(frameMin) || Double.isNaN(frameMax)) {
+            continue;
+         }
+         if (floatRangeMin_ < frameMin || floatRangeMax_ > frameMax) {
+            return true;
+         }
+      }
+      return false;
    }
 
    @MustCallOnEDT
@@ -999,13 +1060,27 @@ public final class ChannelIntensityController implements HistogramView.Listener 
     */
    @MustCallOnEDT
    private void accumulateFloatRange() {
-      if (stats_ == null || floatRangePinned_) {
+      if (stats_ == null || stats_.getNumberOfComponents() < 1
+            || !stats_.getComponentStats(0).isFloat()) {
+         return; // Integer image: nothing to accumulate.
+      }
+      // Switching an ROI on or off changes which pixels are measured, so a range
+      // accumulated under the old selection no longer describes what is being shown.
+      boolean isROI = stats_.getComponentStats(0).isROIStats();
+      if (isROI != floatRangeFromROI_) {
+         floatRangeFromROI_ = isROI;
+         if (!floatRangePinned_) {
+            floatRangeMin_ = Double.NaN;
+            floatRangeMax_ = Double.NaN;
+         }
+      }
+      if (floatRangePinned_) {
          return;
       }
       for (int c = 0; c < stats_.getNumberOfComponents(); ++c) {
          ComponentStats cStats = stats_.getComponentStats(c);
          if (!cStats.isFloat()) {
-            return; // Integer image: nothing to accumulate.
+            continue;
          }
          double frameMin = cStats.getHistogramRangeMinDouble();
          double frameMax = frameMin
@@ -1122,18 +1197,21 @@ public final class ChannelIntensityController implements HistogramView.Listener 
     * Counts falling outside the axis are dropped, which is what makes data beyond the
     * chosen range read as clipped rather than piling up at an end.
     *
-    * <p>Each output bin is rounded independently, so the total count is not exactly
-    * conserved. That is fine for a display histogram, which is only ever drawn.
+    * <p>Contributions are accumulated as doubles and rounded once at the end. Rounding
+    * each contribution as it lands loses whole bins whenever a source bin spreads over
+    * three or more axis bins -- every fraction is then below a half and rounds to zero --
+    * which empties the histogram for an axis pinned much narrower than the image.
     *
     * @param cStats statistics of the image
     * @param mapper mapper describing the axis
     * @param axisBins number of bins on the axis
     * @return counts per axis bin
     */
-   private static long[] resampleOntoAxis(ComponentStats cStats,
-                                          FloatCoordinateMapper mapper, int axisBins) {
+   static long[] resampleOntoAxis(ComponentStats cStats,
+                                  FloatCoordinateMapper mapper, int axisBins) {
       long[] src = cStats.getInRangeHistogram();
-      long[] out = new long[Math.max(1, axisBins)];
+      double[] acc = new double[Math.max(1, axisBins)];
+      long[] out = new long[acc.length];
       if (src == null || src.length == 0) {
          return out;
       }
@@ -1181,8 +1259,14 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             if (overlap <= 0.0) {
                continue;
             }
-            out[b] += Math.round(src[i] * (overlap / width));
+            acc[b] += src[i] * (overlap / width);
          }
+      }
+      for (int b = 0; b < acc.length; ++b) {
+         // Round up anything that received a contribution at all, so that a bin holding a
+         // sliver of a count still draws; the log-scaled graph makes such bins visible and
+         // dropping them would misreport the data as absent.
+         out[b] = acc[b] > 0.0 ? Math.max(1L, Math.round(acc[b])) : 0L;
       }
       return out;
    }
@@ -1705,6 +1789,53 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                .build();
       } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
       statsOrRangeChanged();
+   }
+
+   /**
+    * Makes the float histogram range follow the displayed data again.
+    *
+    * <p>Undoes both a range the user pinned by editing an axis end and one widened by
+    * images seen earlier in the session.
+    */
+   @MustCallOnEDT
+   private void resetFloatHistoRange() {
+      // Forget both the pin and the accumulated range, so the axis is rebuilt from the
+      // image currently displayed rather than from everything seen so far. Without the
+      // second part a single outlier frame would keep the axis wide forever.
+      floatRangePinned_ = false;
+      floatRangeMin_ = Double.NaN;
+      floatRangeMax_ = Double.NaN;
+      // Drop the stored axis too, otherwise restoreFloatRangeFromSettings() would put the
+      // old one straight back on the next viewer or session.
+      clearFloatRangeInSettings();
+      floatRangeRestored_ = true;
+      accumulateFloatRange();
+      statsOrRangeChanged();
+   }
+
+   /**
+    * Removes any float histogram axis recorded in the display settings.
+    */
+   @MustCallOnEDT
+   private void clearFloatRangeInSettings() {
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      do {
+         oldDisplaySettings = viewer_.getDisplaySettings();
+         ChannelDisplaySettings channelSettings =
+               oldDisplaySettings.getChannelSettings(channelIndex_);
+         if (!channelSettings.hasFloatHistoRange()
+               && !channelSettings.isFloatHistoRangePinned()) {
+            return;
+         }
+         newDisplaySettings = oldDisplaySettings
+               .copyBuilderWithChannelSettings(channelIndex_,
+                     channelSettings.copyBuilder()
+                           .floatHistoRange(Double.NaN, Double.NaN)
+                           .floatHistoRangePinned(false)
+                           .build())
+               .build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/ChannelIntensityController.java
@@ -51,6 +51,8 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private final JLabel channelNameLabel_ = new JLabel();
    private final JToggleButton channelVisibleButton_ = new JToggleButton();
    private static final int COMPONENT_WHITE = 3;
+   // Number of bins the accumulated float axis is divided into for display.
+   private static final int FLOAT_AXIS_BINS = 256;
    private double[] whiteRatios_ = null; // non-null when white mode is active
    private long whiteMainMax_ = 0;  // main max shown by white handle; = max(R,G,B)
    private long whiteMainMin_ = -1; // min shown by black handle; = min(R,G,B); -1 = not set
@@ -62,6 +64,15 @@ public final class ChannelIntensityController implements HistogramView.Listener 
    private boolean suppressAutostretchDetection_ = false;
    // Non-null for float images: one mapper per component, rebuilt on each statsOrRangeChanged().
    private FloatCoordinateMapper[] floatMappers_ = null;
+   // For float images: the pixel-value range of the histogram axis, accumulated over the
+   // images seen so far. Each image only tells us its own min/max, so using that directly
+   // would rescale the display on every frame. Widening a remembered range instead lets it
+   // settle as the user browses. NaN until the first float image arrives.
+   private double floatRangeMin_ = Double.NaN;
+   private double floatRangeMax_ = Double.NaN;
+   // Set once the user edits an axis end by hand: the axis then stays exactly where they
+   // put it and no longer widens to take in new images.
+   private boolean floatRangePinned_ = false;
    private boolean pickingWhiteBalancePoint_ = false;
    private long[] lastPickedValues_ = null; // pixel values tracked while in pick mode
 
@@ -516,6 +527,9 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       int numComponents = stats_.getNumberOfComponents();
       setRGBMode(numComponents > 1);
 
+      accumulateFloatRange();
+      seedFloatScalingIfUnset(displaySettings);
+
       boolean whiteMode = getSelectedComponent() == COMPONENT_WHITE;
       for (int c = 0; c < numComponents; c++) {
          ComponentStats cStats = stats_.getComponentStats(c);
@@ -528,22 +542,40 @@ public final class ChannelIntensityController implements HistogramView.Listener 
             if (cStats.isFloat()) {
                // Use bin-index coordinate space: rangeMin=0, rangeMax=binCount (~256).
                // The X axis shows bin indices; labels are formatted as pixel values via
-               // the FloatCoordinateMapper wired into HistogramView.
-               FloatCoordinateMapper mapper = new FloatCoordinateMapper(cStats);
+               // the FloatCoordinateMapper wired into HistogramView. The mapper spans the
+               // accumulated range rather than this image's own range, so the axis stays
+               // put as one steps through images.
+               FloatCoordinateMapper mapper = new FloatCoordinateMapper(
+                     floatRangeMin_, floatRangeMax_, FLOAT_AXIS_BINS);
                if (floatMappers_ == null || floatMappers_.length != numComponents) {
                   floatMappers_ = new FloatCoordinateMapper[numComponents];
                }
                floatMappers_[c] = mapper;
                long binCount = Math.max(1L, mapper.getBinCount());
-               histogram_.setComponentGraph(c, data, data.length, 0L, binCount);
+               // This image's bins cover only the part of the axis between its own min and
+               // max, so tell the view where the graph starts and how much it spans.
+               long graphSpan = binCount;
+               long graphOffset = 0L;
+               double axisSpan = floatRangeMax_ - floatRangeMin_;
+               if (axisSpan > 0.0) {
+                  double imageSpan = cStats.getBinWidthDouble() * cStats.getHistogramBinCount();
+                  double imageMin = cStats.getHistogramRangeMinDouble();
+                  graphSpan = Math.max(1L, Math.round(binCount * (imageSpan / axisSpan)));
+                  graphOffset = Math.max(0L,
+                        Math.round(binCount * ((imageMin - floatRangeMin_) / axisSpan)));
+               }
+               histogram_.setComponentGraph(c, data, data.length, 0L, binCount,
+                     graphSpan, graphOffset);
                histogram_.setComponentFloatMapper(c, mapper);
                histogram_.setComponentRangeMaxLabel(c, mapper.formatBinIndex(binCount));
+               histogram_.setComponentRangeMinLabel(c, mapper.formatBinIndex(0L));
             } else {
                if (c == 0) {
                   floatMappers_ = null; // integer image: clear all mappers
                }
                histogram_.setComponentFloatMapper(c, null);
                histogram_.setComponentRangeMaxLabel(c, null);
+               histogram_.setComponentRangeMinLabel(c, null);
                int clampedRangeBits = Math.min(rangeBits, 30);
                int lengthToUse = Math.min(data.length, (1 << clampedRangeBits) - 1);
                if (lengthToUse <= 0) {
@@ -558,6 +590,10 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       if (whiteMode) {
          updateWhiteScalingIndicator(displaySettings, stats_.getComponentStats(0));
       }
+      // Only float images have a meaningful, user-choosable axis range; for integer data
+      // the axis is determined by the bit depth.
+      histogram_.setAxisRangeEditable(
+            numComponents > 0 && stats_.getComponentStats(0).isFloat());
    }
 
    @MustCallOnEDT
@@ -590,11 +626,23 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                && component < floatMappers_.length && floatMappers_[component] != null) {
             FloatCoordinateMapper mapper = floatMappers_[component];
             int binCount = mapper.getBinCount();
-            long storedMax = componentSettings.getScalingMaximum();
-            long storedMin = componentSettings.getScalingMinimum();
-            long clampedMax = (storedMax == Long.MAX_VALUE) ? binCount
-                              : Math.min(binCount, storedMax);
-            long clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
+            long clampedMin;
+            long clampedMax;
+            if (componentSettings.hasFloatScaling()) {
+               // Stored as pixel values; convert to bin positions for drawing only.
+               clampedMax = mapper.pixelValueToBinIndex(
+                     componentSettings.getScalingMaximumDouble());
+               clampedMin = mapper.pixelValueToBinIndex(
+                     componentSettings.getScalingMinimumDouble());
+               clampedMax = Math.max(1, Math.min(binCount, clampedMax));
+               clampedMin = Math.max(0, Math.min(clampedMax - 1, clampedMin));
+            } else {
+               long storedMax = componentSettings.getScalingMaximum();
+               long storedMin = componentSettings.getScalingMinimum();
+               clampedMax = (storedMax == Long.MAX_VALUE) ? binCount
+                                 : Math.min(binCount, storedMax);
+               clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
+            }
             histogram_.setComponentScaling(component, clampedMin, clampedMax);
             return;
          }
@@ -830,6 +878,173 @@ public final class ChannelIntensityController implements HistogramView.Listener 
       rgbAutostretchEnabled_ = enabled;
    }
 
+   /**
+    * Widens the remembered float axis range to include the current image.
+    *
+    * <p>Only ever widens: a range that tracked each image exactly would rescale the display
+    * on every frame, which is what this exists to avoid. Browsing therefore makes the axis
+    * settle rather than oscillate.
+    */
+   @MustCallOnEDT
+   private void accumulateFloatRange() {
+      if (stats_ == null || floatRangePinned_) {
+         return;
+      }
+      for (int c = 0; c < stats_.getNumberOfComponents(); ++c) {
+         ComponentStats cStats = stats_.getComponentStats(c);
+         if (!cStats.isFloat()) {
+            return; // Integer image: nothing to accumulate.
+         }
+         double frameMin = cStats.getHistogramRangeMinDouble();
+         double frameMax = frameMin
+               + cStats.getBinWidthDouble() * cStats.getHistogramBinCount();
+         if (Double.isNaN(frameMin) || Double.isNaN(frameMax)) {
+            continue;
+         }
+         if (Double.isNaN(floatRangeMin_) || frameMin < floatRangeMin_) {
+            floatRangeMin_ = frameMin;
+         }
+         if (Double.isNaN(floatRangeMax_) || frameMax > floatRangeMax_) {
+            floatRangeMax_ = frameMax;
+         }
+      }
+      // A single-valued image gives a zero-width range; widen it so the axis is drawable.
+      if (!Double.isNaN(floatRangeMin_) && floatRangeMax_ <= floatRangeMin_) {
+         floatRangeMax_ = floatRangeMin_ + 1.0;
+      }
+   }
+
+   /**
+    * Gives a float channel an explicit scaling range the first time it is displayed.
+    *
+    * <p>Without this, the settings still hold the integer defaults (0 and Long.MAX_VALUE).
+    * Those are bin indices in the legacy interpretation, so they get resolved against
+    * whichever image happens to be on screen -- the display keeps rescaling itself, and the
+    * numbers shown next to the handles do not match what the image is actually scaled to.
+    * Seeding from this image's autoscale range makes the two agree from the start and gives
+    * a sensible first view.
+    *
+    * <p>Only ever fills in a missing range; a range the user or a saved settings file
+    * provided is left alone.
+    *
+    * @param settings current display settings
+    */
+   @MustCallOnEDT
+   private void seedFloatScalingIfUnset(DisplaySettings settings) {
+      if (stats_ == null || settings.isAutostretchEnabled()) {
+         return;
+      }
+      int numComponents = stats_.getNumberOfComponents();
+      if (numComponents < 1 || !stats_.getComponentStats(0).isFloat()) {
+         return;
+      }
+      ChannelDisplaySettings channelSettings = settings.getChannelSettings(channelIndex_);
+      boolean anyUnset = false;
+      for (int c = 0; c < numComponents; ++c) {
+         if (!channelSettings.getComponentSettings(c).hasFloatScaling()) {
+            anyUnset = true;
+            break;
+         }
+      }
+      if (!anyUnset) {
+         return;
+      }
+
+      double q = settings.getAutoscaleIgnoredQuantile();
+      boolean ignoreZeros = settings.isAutoscaleIgnoringZeros();
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      do {
+         oldDisplaySettings = viewer_.getDisplaySettings();
+         ChannelDisplaySettings chSettings =
+               oldDisplaySettings.getChannelSettings(channelIndex_);
+         ChannelDisplaySettings.Builder builder = chSettings.copyBuilder();
+         boolean changed = false;
+         for (int c = 0; c < numComponents; ++c) {
+            if (chSettings.getComponentSettings(c).hasFloatScaling()) {
+               continue;
+            }
+            ComponentStats cStats = stats_.getComponentStats(c);
+            long seedMin;
+            long seedMax;
+            if (ignoreZeros) {
+               seedMin = 0L;
+               seedMax = cStats.getAutoscaleMaxForQuantileIgnoringZeros(q);
+            } else {
+               long[] minMax = new long[2];
+               cStats.getAutoscaleMinMaxForQuantile(q, minMax);
+               seedMin = minMax[0];
+               seedMax = minMax[1];
+            }
+            double seedMinValue = (double) seedMin;
+            double seedMaxValue = (double) seedMax;
+            if (seedMaxValue <= seedMinValue) {
+               // Degenerate (e.g. constant image); fall back to the accumulated axis.
+               seedMinValue = floatRangeMin_;
+               seedMaxValue = floatRangeMax_;
+            }
+            if (Double.isNaN(seedMinValue) || Double.isNaN(seedMaxValue)
+                  || seedMaxValue <= seedMinValue) {
+               continue;
+            }
+            builder.component(c, chSettings.getComponentSettings(c).copyBuilder()
+                  .scalingRangeDouble(seedMinValue, seedMaxValue).build());
+            changed = true;
+         }
+         if (!changed) {
+            return;
+         }
+         newDisplaySettings = oldDisplaySettings
+               .copyBuilderWithChannelSettings(channelIndex_, builder.build())
+               .build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+   }
+
+   /**
+    * Returns the float mapper for a component, or null if this is not a float image.
+    *
+    * @param component component index
+    * @return the mapper, or null
+    */
+   private FloatCoordinateMapper getFloatMapper(int component) {
+      if (floatMappers_ == null || component < 0 || component >= floatMappers_.length) {
+         return null;
+      }
+      return floatMappers_[component];
+   }
+
+   /**
+    * Returns the float scaling minimum to preserve when only the maximum is being changed.
+    *
+    * @param settings current component settings
+    * @param mapper mapper for converting a legacy bin index
+    * @return pixel value
+    */
+   private double currentFloatMin(ComponentDisplaySettings settings,
+                                  FloatCoordinateMapper mapper) {
+      if (settings.hasFloatScaling()) {
+         return settings.getScalingMinimumDouble();
+      }
+      return mapper.binIndexToPixelValue(settings.getScalingMinimum());
+   }
+
+   /**
+    * Returns the float scaling maximum to preserve when only the minimum is being changed.
+    *
+    * @param settings current component settings
+    * @param mapper mapper for converting a legacy bin index
+    * @return pixel value
+    */
+   private double currentFloatMax(ComponentDisplaySettings settings,
+                                  FloatCoordinateMapper mapper) {
+      if (settings.hasFloatScaling()) {
+         return settings.getScalingMaximumDouble();
+      }
+      long storedMax = settings.getScalingMaximum();
+      long binIndex = (storedMax == Long.MAX_VALUE) ? mapper.getBinCount() : storedMax;
+      return mapper.binIndexToPixelValue(binIndex);
+   }
+
    private long toStoredScalingValue(int component, long pixelValue) {
       if (floatMappers_ != null && component < floatMappers_.length
             && floatMappers_[component] != null) {
@@ -996,6 +1211,14 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                            .scalingRange(0L, scaledMax).build());
             }
 
+         } else if (getFloatMapper(sel) != null) {
+            // Float: full scale is the whole accumulated axis, as pixel values.
+            FloatCoordinateMapper mapper = getFloatMapper(sel);
+            builder.component(sel,
+                  channelSettings.getComponentSettings(sel).copyBuilder()
+                        .scalingRangeDouble(mapper.getRangeMin(),
+                              mapper.binIndexToPixelValue(mapper.getBinCount()))
+                        .build());
          } else {
             builder.component(sel,
                   channelSettings.getComponentSettings(sel).copyBuilder()
@@ -1053,11 +1276,17 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                min = minMax[0];
                max = minMax[1];
             }
-            min = toStoredScalingValue(sel, min);
-            max = toStoredScalingValue(sel, max);
-            builder.component(sel,
-                  channelSettings.getComponentSettings(sel).copyBuilder()
-                        .scalingRange(min, max).build());
+            if (getFloatMapper(sel) != null) {
+               // min/max are already pixel values; store them as such rather than as bin
+               // indices, which would be reinterpreted against the next image's binning.
+               builder.component(sel,
+                     channelSettings.getComponentSettings(sel).copyBuilder()
+                           .scalingRangeDouble((double) min, (double) max).build());
+            } else {
+               builder.component(sel,
+                     channelSettings.getComponentSettings(sel).copyBuilder()
+                           .scalingRange(min, max).build());
+            }
          }
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithChannelSettings(channelIndex_, builder.build())
@@ -1080,13 +1309,29 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ComponentDisplaySettings componentSettings =
                channelSettings.getComponentSettings(component);
-         if (componentSettings.getScalingMinimum() == newMin) {
-            return;
+         FloatCoordinateMapper mapper = getFloatMapper(component);
+         if (mapper != null) {
+            // The handle position is a bin index; store the pixel value it denotes so the
+            // range keeps its meaning when the next image has a different distribution.
+            double newMinValue = mapper.binIndexToPixelValue(newMin);
+            if (componentSettings.hasFloatScaling()
+                  && componentSettings.getScalingMinimumDouble() == newMinValue) {
+               return;
+            }
+            componentSettings = componentSettings
+                  .copyBuilder()
+                  .scalingMinimumDouble(newMinValue)
+                  .scalingMaximumDouble(currentFloatMax(componentSettings, mapper))
+                  .build();
+         } else {
+            if (componentSettings.getScalingMinimum() == newMin) {
+               return;
+            }
+            componentSettings = componentSettings
+                  .copyBuilder()
+                  .scalingMinimum(newMin)
+                  .build();
          }
-         componentSettings = componentSettings
-               .copyBuilder()
-               .scalingMinimum(newMin)
-               .build();
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithComponentSettings(channelIndex_, component, componentSettings)
                .autostretch(false)
@@ -1109,12 +1354,25 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                oldDisplaySettings.getChannelSettings(channelIndex_);
          ComponentDisplaySettings componentSettings =
                channelSettings.getComponentSettings(component);
-         if (componentSettings.getScalingMaximum() == newMax) {
-            return;
+         FloatCoordinateMapper mapper = getFloatMapper(component);
+         if (mapper != null) {
+            double newMaxValue = mapper.binIndexToPixelValue(newMax);
+            if (componentSettings.hasFloatScaling()
+                  && componentSettings.getScalingMaximumDouble() == newMaxValue) {
+               return;
+            }
+            componentSettings = componentSettings.copyBuilder()
+                  .scalingMinimumDouble(currentFloatMin(componentSettings, mapper))
+                  .scalingMaximumDouble(newMaxValue)
+                  .build();
+         } else {
+            if (componentSettings.getScalingMaximum() == newMax) {
+               return;
+            }
+            componentSettings = componentSettings.copyBuilder()
+                  .scalingMaximum(newMax)
+                  .build();
          }
-         componentSettings = componentSettings.copyBuilder()
-               .scalingMaximum(newMax)
-               .build();
          newDisplaySettings = oldDisplaySettings
                .copyBuilderWithComponentSettings(channelIndex_, component, componentSettings)
                .autostretch(false)
@@ -1182,6 +1440,50 @@ public final class ChannelIntensityController implements HistogramView.Listener 
                .autostretch(false)
                .build();
       } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+   }
+
+   @Override
+   public void histogramAxisRangeChanged(int component, double newRangeMin,
+                                         double newRangeMax) {
+      if (newRangeMax <= newRangeMin) {
+         return;
+      }
+      // The user has chosen the axis explicitly: stop widening it to fit new images.
+      floatRangePinned_ = true;
+      floatRangeMin_ = newRangeMin;
+      floatRangeMax_ = newRangeMax;
+      // Keep the scaling range inside the new axis, otherwise the handles would sit off
+      // the end and the image would be scaled to something the user cannot see or reach.
+      DisplaySettings oldDisplaySettings;
+      DisplaySettings newDisplaySettings;
+      do {
+         oldDisplaySettings = viewer_.getDisplaySettings();
+         ChannelDisplaySettings channelSettings =
+               oldDisplaySettings.getChannelSettings(channelIndex_);
+         ComponentDisplaySettings componentSettings =
+               channelSettings.getComponentSettings(component);
+         if (!componentSettings.hasFloatScaling()) {
+            break;
+         }
+         double clampedMin = Math.max(newRangeMin,
+               Math.min(componentSettings.getScalingMinimumDouble(), newRangeMax));
+         double clampedMax = Math.max(clampedMin,
+               Math.min(componentSettings.getScalingMaximumDouble(), newRangeMax));
+         if (clampedMax <= clampedMin) {
+            clampedMin = newRangeMin;
+            clampedMax = newRangeMax;
+         }
+         if (clampedMin == componentSettings.getScalingMinimumDouble()
+               && clampedMax == componentSettings.getScalingMaximumDouble()) {
+            break;
+         }
+         newDisplaySettings = oldDisplaySettings
+               .copyBuilderWithComponentSettings(channelIndex_, component,
+                     componentSettings.copyBuilder()
+                           .scalingRangeDouble(clampedMin, clampedMax).build())
+               .build();
+      } while (!viewer_.compareAndSetDisplaySettings(oldDisplaySettings, newDisplaySettings));
+      statsOrRangeChanged();
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/FloatCoordinateMapper.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/FloatCoordinateMapper.java
@@ -21,6 +21,23 @@ final class FloatCoordinateMapper {
       binCount_ = stats.getHistogramBinCount();
    }
 
+   /**
+    * Creates a mapper spanning an explicit pixel-value range.
+    *
+    * <p>Used to map the histogram onto a range accumulated over several images, rather than
+    * the range of the single image the statistics came from.
+    *
+    * @param rangeMin lowest pixel value on the axis
+    * @param rangeMax highest pixel value on the axis
+    * @param binCount number of bins to divide the range into
+    */
+   FloatCoordinateMapper(double rangeMin, double rangeMax, int binCount) {
+      rangeMin_ = rangeMin;
+      binCount_ = Math.max(1, binCount);
+      double span = rangeMax - rangeMin;
+      binWidth_ = span > 0.0 ? span / binCount_ : 0.0;
+   }
+
    long pixelValueToBinIndex(double pixelValue) {
       if (binWidth_ == 0.0) {
          return 0;

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -671,7 +671,9 @@ public final class HistogramView extends JPanel {
 
       Graphics2D g2d = (Graphics2D) g.create();
       g2d.setFont(g.getFont().deriveFont(INTENSITY_FONT_SIZE));
-      FontMetrics metrics = g.getFontMetrics();
+      // Measure with the derived font actually used to draw, so that the
+      // position and the hit rectangle match what is on screen.
+      FontMetrics metrics = g2d.getFontMetrics();
       int x = graphBottomRight.x - metrics.stringWidth(text);
       if (x <= getScalingHandlePos(selectedComponent_, false)) {
          return; // Hide when scaling lower limit handle overlaps
@@ -704,7 +706,9 @@ public final class HistogramView extends JPanel {
 
       Graphics2D g2d = (Graphics2D) g.create();
       g2d.setFont(g.getFont().deriveFont(INTENSITY_FONT_SIZE));
-      FontMetrics metrics = g.getFontMetrics();
+      // Measure with the derived font actually used to draw, so that the
+      // overlap checks and the hit rectangle match what is on screen.
+      FontMetrics metrics = g2d.getFontMetrics();
       int x = rect.x;
       // Keep clear of the low scaling handle and of the range-max label.
       if (x + metrics.stringWidth(text) >= getScalingHandlePos(selectedComponent_, false)) {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -59,6 +59,15 @@ public final class HistogramView extends JPanel {
 
       void histogramScalingMaxChanged(int component, long newMax);
 
+      /**
+       * Called when the user edits one end of the histogram axis.
+       *
+       * @param component component index
+       * @param newRangeMin low end of the axis, as a pixel value
+       * @param newRangeMax high end of the axis, as a pixel value
+       */
+      void histogramAxisRangeChanged(int component, double newRangeMin, double newRangeMax);
+
       void histogramGammaChanged(double newGamma);
    }
 
@@ -70,6 +79,14 @@ public final class HistogramView extends JPanel {
       long[] graph_ = new long[0];
       long rangeMin_ = 0;
       long rangeMax_ = 0;
+      // Extent of the axis actually covered by graph_, in the same units as
+      // rangeMin_/rangeMax_. Equal to (rangeMax_ - rangeMin_) unless the bins span only
+      // part of the axis, as happens when the axis covers a range accumulated over several
+      // images while the bins come from just one of them.
+      long graphSpan_ = 0;
+      // Where on the axis the first bin starts, in the same units. Non-zero when the bins
+      // cover only an interior part of the axis.
+      long graphOffset_ = 0;
       Color color_ = Color.GRAY;
       Color highlightColor_ = Color.YELLOW;
       long highlightIntensity_ = -1; // Negative = off
@@ -79,6 +96,8 @@ public final class HistogramView extends JPanel {
       FloatCoordinateMapper floatMapper_ = null;
       // Optional label override for the range-max tick (e.g. "1.000" for bin-index 256).
       String rangeMaxLabel_ = null;
+      // Optional label override for the range-min tick, drawn at the left of the axis.
+      String rangeMinLabel_ = null;
 
       float[] cachedInterpolatedLogScaledGraph_;
       Path2D.Float cachedPath_;
@@ -117,6 +136,10 @@ public final class HistogramView extends JPanel {
    private Handle handleBeingDragged_ = Handle.NONE;
    private long scalingHandleDragOriginalValue_;
    private double gammaHandleDragOriginalValue_;
+   // Hit rectangles for the two axis end labels; null until laid out during painting.
+   private Rectangle rangeMinLabelRect_;
+   private Rectangle rangeMaxLabelRect_;
+   private boolean axisRangeEditable_ = false;
 
 
    private static final int HORIZONTAL_MARGIN = 12;
@@ -130,6 +153,8 @@ public final class HistogramView extends JPanel {
    private static final float OVERLAY_FONT_SIZE = 12.0f;
    private static final int OVERLAY_FONT_STYLE = Font.BOLD;
    private static final Color OVERLAY_COLOR = Color.GRAY;
+   // Axis end labels are tinted when they can be double-clicked to edit the range.
+   private static final Color EDITABLE_AXIS_LABEL_COLOR = new Color(0, 90, 180);
    private static final double GAMMA_MIN = 1e-1;
    private static final double GAMMA_MAX = 1e+1;
 
@@ -201,15 +226,36 @@ public final class HistogramView extends JPanel {
 
    public void setComponentGraph(int component, long[] graph, int graphLen,
                                   long rangeMin, long rangeMax) {
+      setComponentGraph(component, graph, graphLen, rangeMin, rangeMax,
+            rangeMax - rangeMin, 0L);
+   }
+
+   /**
+    * Sets the graph for one component, with the bins covering only part of the axis.
+    *
+    * @param component component index
+    * @param graph bin counts
+    * @param graphLen number of bins to use from {@code graph}
+    * @param rangeMin lowest value on the axis
+    * @param rangeMax highest value on the axis
+    * @param graphSpan extent of the axis covered by the bins, in axis units
+    * @param graphOffset where on the axis the first bin starts, in axis units
+    */
+   public void setComponentGraph(int component, long[] graph, int graphLen,
+                                  long rangeMin, long rangeMax, long graphSpan,
+                                  long graphOffset) {
       Preconditions.checkArgument(component >= 0);
       Preconditions.checkArgument(graphLen <= graph.length);
       Preconditions.checkArgument(rangeMax > rangeMin);
       addComponentIfNecessary(component);
       ComponentState state = componentStates_.get(component);
-      final boolean rangeChanged = (rangeMin != state.rangeMin_ || rangeMax != state.rangeMax_);
+      final boolean rangeChanged = (rangeMin != state.rangeMin_ || rangeMax != state.rangeMax_
+            || graphSpan != state.graphSpan_ || graphOffset != state.graphOffset_);
       state.graph_ = Arrays.copyOf(graph, graphLen);
       state.rangeMin_ = rangeMin;
       state.rangeMax_ = rangeMax;
+      state.graphSpan_ = graphSpan;
+      state.graphOffset_ = graphOffset;
 
       if (component == selectedComponent_ && rangeChanged) {
          nullRectsAndMappingPath();
@@ -242,10 +288,13 @@ public final class HistogramView extends JPanel {
       state.graph_ = null;
       state.rangeMin_ = 0;
       state.rangeMax_ = 0;
+      state.graphSpan_ = 0;
+      state.graphOffset_ = 0;
       state.scalingMin_ = 0;
       state.scalingMax_ = 0;
       state.floatMapper_ = null;
       state.rangeMaxLabel_ = null;
+      state.rangeMinLabel_ = null;
       state.cachedInterpolatedLogScaledGraph_ = null;
       state.cachedPath_ = null;
    }
@@ -319,6 +368,36 @@ public final class HistogramView extends JPanel {
       Preconditions.checkArgument(component >= 0);
       addComponentIfNecessary(component);
       componentStates_.get(component).rangeMaxLabel_ = label;
+      rangeMinLabelRect_ = null;
+      rangeMaxLabelRect_ = null;
+      repaint();
+   }
+
+   /**
+    * Sets the text drawn at the low end of the axis.
+    *
+    * @param component component index
+    * @param label text to draw, or null to draw nothing
+    */
+   public void setComponentRangeMinLabel(int component, String label) {
+      Preconditions.checkArgument(component >= 0);
+      addComponentIfNecessary(component);
+      componentStates_.get(component).rangeMinLabel_ = label;
+      rangeMinLabelRect_ = null;
+      rangeMaxLabelRect_ = null;
+      repaint();
+   }
+
+   /**
+    * Enables double-click editing of the two axis end labels.
+    *
+    * <p>Only meaningful for float images, where the axis is a real pixel-value range that
+    * the user may want to choose; for integer images the axis is fixed by the bit depth.
+    *
+    * @param editable whether the axis ends can be edited
+    */
+   public void setAxisRangeEditable(boolean editable) {
+      axisRangeEditable_ = editable;
       repaint();
    }
 
@@ -556,6 +635,7 @@ public final class HistogramView extends JPanel {
       drawGraphBackground(g);
       if (numComponents > 0) {
          drawRangeMaxLabel(g);
+         drawRangeMinLabel(g);
       }
 
       for (int i = 0; i < componentStates_.size(); ++i) {
@@ -603,6 +683,7 @@ public final class HistogramView extends JPanel {
    }
 
    private void drawRangeMaxLabel(Graphics2D g) {
+      rangeMaxLabelRect_ = null;
       if (componentStates_.isEmpty()) {
          return;
       }
@@ -626,7 +707,50 @@ public final class HistogramView extends JPanel {
       if (x <= getScalingHandlePos(selectedComponent_, false)) {
          return; // Hide when scaling lower limit handle overlaps
       }
+      if (axisRangeEditable_) {
+         g2d.setColor(EDITABLE_AXIS_LABEL_COLOR);
+      }
       g2d.drawString(text, x, graphBottomRight.y + metrics.getAscent());
+      rangeMaxLabelRect_ = new Rectangle(x, graphBottomRight.y,
+            metrics.stringWidth(text), VERTICAL_MARGIN);
+   }
+
+   private void drawRangeMinLabel(Graphics2D g) {
+      rangeMinLabelRect_ = null;
+      if (componentStates_.isEmpty()) {
+         return;
+      }
+      ComponentState first = componentStates_.get(0);
+      if (first.rangeMinLabel_ == null) {
+         return; // Only float images label the low end of the axis
+      }
+      final long rangeMin = first.rangeMin_;
+      for (ComponentState state : componentStates_) {
+         if (state.rangeMin_ != rangeMin) {
+            return; // Only draw if all components have the same min
+         }
+      }
+      String text = first.rangeMinLabel_;
+      Rectangle rect = getGraphRect();
+
+      Graphics2D g2d = (Graphics2D) g.create();
+      g2d.setFont(g.getFont().deriveFont(INTENSITY_FONT_SIZE));
+      FontMetrics metrics = g.getFontMetrics();
+      int x = rect.x;
+      // Keep clear of the low scaling handle and of the range-max label.
+      if (x + metrics.stringWidth(text) >= getScalingHandlePos(selectedComponent_, false)) {
+         return;
+      }
+      if (rangeMaxLabelRect_ != null
+            && x + metrics.stringWidth(text) >= rangeMaxLabelRect_.x) {
+         return;
+      }
+      if (axisRangeEditable_) {
+         g2d.setColor(EDITABLE_AXIS_LABEL_COLOR);
+      }
+      g2d.drawString(text, x, rect.y + rect.height + metrics.getAscent());
+      rangeMinLabelRect_ = new Rectangle(x, rect.y + rect.height,
+            metrics.stringWidth(text), VERTICAL_MARGIN);
    }
 
    private void drawComponentGraph(int component, Graphics2D g) {
@@ -867,7 +991,18 @@ public final class HistogramView extends JPanel {
          float[] data = getComponentInterpolatedLogScaledData(component);
          float dataMax = getComponentInterpolatedLogScaledDataMax(component);
          final float dataScaling = (float) rect.height / dataMax;
-         final float pixelsPerBin = (float) rect.width / data.length;
+         // The bins cover graphSpan_ of the rangeMin_..rangeMax_ axis. Usually that is the
+         // whole axis and this reduces to rect.width / data.length; when the axis is wider
+         // than the bins, the graph occupies only the corresponding fraction of it, keeping
+         // bars aligned with the value-positioned scaling handles.
+         final long axisSpan = state.rangeMax_ - state.rangeMin_;
+         float pixelsPerBin = (float) rect.width / data.length;
+         float graphStartX = 0.0f;
+         if (axisSpan > 0 && state.graphSpan_ > 0 && state.graphSpan_ != axisSpan) {
+            pixelsPerBin = (float) (rect.width * ((double) state.graphSpan_ / axisSpan)
+                  / data.length);
+            graphStartX = (float) (rect.width * ((double) state.graphOffset_ / axisSpan));
+         }
 
          if (dataMax == 0.0) {
             // A zero-area path can cause rendering artifacts (seen with Apple
@@ -888,15 +1023,16 @@ public final class HistogramView extends JPanel {
 
          state.cachedPath_ =
                new Path2D.Float(Path2D.WIND_EVEN_ODD, 2 * data.length + 2);
-         float startX = firstNonZero * pixelsPerBin;
+         float startX = graphStartX + firstNonZero * pixelsPerBin;
          state.cachedPath_.moveTo(startX, (float) rect.height);
          for (int i = firstNonZero; i <= lastNonZero; ++i) {
-            float x = i * pixelsPerBin;
+            float x = graphStartX + i * pixelsPerBin;
             float y = rect.height - dataScaling * data[i];
             state.cachedPath_.lineTo(x, y);                // Vertical
             state.cachedPath_.lineTo(x + pixelsPerBin, y); // Horizontal
          }
-         state.cachedPath_.lineTo((lastNonZero + 1) * pixelsPerBin, (float) rect.height);
+         state.cachedPath_.lineTo(graphStartX + (lastNonZero + 1) * pixelsPerBin,
+               (float) rect.height);
          if (fillHistograms_) {
             state.cachedPath_.closePath();
          }
@@ -1012,7 +1148,11 @@ public final class HistogramView extends JPanel {
 
    private void mouseClicked(MouseEvent e) {
       if (e.getClickCount() == 2) {
-         if (isPointInScalingLabel(e.getPoint(), true)) {
+         if (axisRangeEditable_ && isPointInAxisRangeLabel(e.getPoint(), false)) {
+            startAxisRangeEdit(false);
+         } else if (axisRangeEditable_ && isPointInAxisRangeLabel(e.getPoint(), true)) {
+            startAxisRangeEdit(true);
+         } else if (isPointInScalingLabel(e.getPoint(), true)) {
             startScalingEdit(true);
          } else if (isPointInScalingLabel(e.getPoint(), false)) {
             startScalingEdit(false);
@@ -1097,6 +1237,61 @@ public final class HistogramView extends JPanel {
          return false;
       }
       return getGammaHandleRect().contains(p);
+   }
+
+   private boolean isPointInAxisRangeLabel(Point p, boolean top) {
+      Rectangle rect = top ? rangeMaxLabelRect_ : rangeMinLabelRect_;
+      return rect != null && rect.contains(p);
+   }
+
+   /**
+    * Opens a spinner for editing one end of the axis.
+    *
+    * <p>Both ends are reported together, since the listener stores them as a pair.
+    *
+    * @param top true to edit the high end, false for the low end
+    */
+   private void startAxisRangeEdit(final boolean top) {
+      final ComponentState state = componentStates_.get(selectedComponent_);
+      final FloatCoordinateMapper mapper = state.floatMapper_;
+      if (mapper == null) {
+         return;
+      }
+      final double axisMin = mapper.getRangeMin();
+      final double axisMax = mapper.binIndexToPixelValue(mapper.getBinCount());
+      final double current = top ? axisMax : axisMin;
+      final double span = Math.abs(axisMax - axisMin);
+      // Allow a generous range around the current axis, and a step that is fine enough to
+      // be useful but not so fine that reaching a nearby value takes many clicks.
+      final double limit = Math.max(1.0, span) * 1000.0;
+      double step = span > 0.0 ? span / 100.0 : 1.0;
+      final JSpinner spinner = new JSpinner(
+            new SpinnerNumberModel(current, current - limit, current + limit, step));
+      spinner.setPreferredSize(new Dimension(110, spinner.getPreferredSize().height));
+      spinner.addChangeListener((ChangeEvent e) -> {
+         double val = ((Number) spinner.getValue()).doubleValue();
+         // Re-read the opposite end each time: it may have been updated by an earlier
+         // change from this same spinner.
+         FloatCoordinateMapper cur = componentStates_.get(selectedComponent_).floatMapper_;
+         if (cur == null) {
+            return;
+         }
+         double otherMin = cur.getRangeMin();
+         double otherMax = cur.binIndexToPixelValue(cur.getBinCount());
+         double newMin = top ? otherMin : val;
+         double newMax = top ? val : otherMax;
+         if (newMax <= newMin) {
+            return; // Ignore inverted ranges rather than fighting the user mid-edit
+         }
+         listeners_.fire().histogramAxisRangeChanged(selectedComponent_, newMin, newMax);
+      });
+      JPopupMenu popup = new JPopupMenu();
+      popup.add(spinner);
+      popup.validate();
+      Rectangle labelRect = top ? rangeMaxLabelRect_ : rangeMinLabelRect_;
+      int x = (labelRect != null ? labelRect.x : getGraphRect().x)
+            - popup.getPreferredSize().width / 2;
+      popup.show(this, x, getBounds().height);
    }
 
    private void startScalingEdit(final boolean top) {

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -79,14 +79,6 @@ public final class HistogramView extends JPanel {
       long[] graph_ = new long[0];
       long rangeMin_ = 0;
       long rangeMax_ = 0;
-      // Extent of the axis actually covered by graph_, in the same units as
-      // rangeMin_/rangeMax_. Equal to (rangeMax_ - rangeMin_) unless the bins span only
-      // part of the axis, as happens when the axis covers a range accumulated over several
-      // images while the bins come from just one of them.
-      long graphSpan_ = 0;
-      // Where on the axis the first bin starts, in the same units. Non-zero when the bins
-      // cover only an interior part of the axis.
-      long graphOffset_ = 0;
       Color color_ = Color.GRAY;
       Color highlightColor_ = Color.YELLOW;
       long highlightIntensity_ = -1; // Negative = off
@@ -226,36 +218,15 @@ public final class HistogramView extends JPanel {
 
    public void setComponentGraph(int component, long[] graph, int graphLen,
                                   long rangeMin, long rangeMax) {
-      setComponentGraph(component, graph, graphLen, rangeMin, rangeMax,
-            rangeMax - rangeMin, 0L);
-   }
-
-   /**
-    * Sets the graph for one component, with the bins covering only part of the axis.
-    *
-    * @param component component index
-    * @param graph bin counts
-    * @param graphLen number of bins to use from {@code graph}
-    * @param rangeMin lowest value on the axis
-    * @param rangeMax highest value on the axis
-    * @param graphSpan extent of the axis covered by the bins, in axis units
-    * @param graphOffset where on the axis the first bin starts, in axis units
-    */
-   public void setComponentGraph(int component, long[] graph, int graphLen,
-                                  long rangeMin, long rangeMax, long graphSpan,
-                                  long graphOffset) {
       Preconditions.checkArgument(component >= 0);
       Preconditions.checkArgument(graphLen <= graph.length);
       Preconditions.checkArgument(rangeMax > rangeMin);
       addComponentIfNecessary(component);
       ComponentState state = componentStates_.get(component);
-      final boolean rangeChanged = (rangeMin != state.rangeMin_ || rangeMax != state.rangeMax_
-            || graphSpan != state.graphSpan_ || graphOffset != state.graphOffset_);
+      final boolean rangeChanged = (rangeMin != state.rangeMin_ || rangeMax != state.rangeMax_);
       state.graph_ = Arrays.copyOf(graph, graphLen);
       state.rangeMin_ = rangeMin;
       state.rangeMax_ = rangeMax;
-      state.graphSpan_ = graphSpan;
-      state.graphOffset_ = graphOffset;
 
       if (component == selectedComponent_ && rangeChanged) {
          nullRectsAndMappingPath();
@@ -288,8 +259,6 @@ public final class HistogramView extends JPanel {
       state.graph_ = null;
       state.rangeMin_ = 0;
       state.rangeMax_ = 0;
-      state.graphSpan_ = 0;
-      state.graphOffset_ = 0;
       state.scalingMin_ = 0;
       state.scalingMax_ = 0;
       state.floatMapper_ = null;
@@ -991,18 +960,9 @@ public final class HistogramView extends JPanel {
          float[] data = getComponentInterpolatedLogScaledData(component);
          float dataMax = getComponentInterpolatedLogScaledDataMax(component);
          final float dataScaling = (float) rect.height / dataMax;
-         // The bins cover graphSpan_ of the rangeMin_..rangeMax_ axis. Usually that is the
-         // whole axis and this reduces to rect.width / data.length; when the axis is wider
-         // than the bins, the graph occupies only the corresponding fraction of it, keeping
-         // bars aligned with the value-positioned scaling handles.
-         final long axisSpan = state.rangeMax_ - state.rangeMin_;
-         float pixelsPerBin = (float) rect.width / data.length;
-         float graphStartX = 0.0f;
-         if (axisSpan > 0 && state.graphSpan_ > 0 && state.graphSpan_ != axisSpan) {
-            pixelsPerBin = (float) (rect.width * ((double) state.graphSpan_ / axisSpan)
-                  / data.length);
-            graphStartX = (float) (rect.width * ((double) state.graphOffset_ / axisSpan));
-         }
+         // The bins always span the full axis: callers rebin their data onto the axis
+         // before handing it over.
+         final float pixelsPerBin = (float) rect.width / data.length;
 
          if (dataMax == 0.0) {
             // A zero-area path can cause rendering artifacts (seen with Apple
@@ -1023,16 +983,15 @@ public final class HistogramView extends JPanel {
 
          state.cachedPath_ =
                new Path2D.Float(Path2D.WIND_EVEN_ODD, 2 * data.length + 2);
-         float startX = graphStartX + firstNonZero * pixelsPerBin;
+         float startX = firstNonZero * pixelsPerBin;
          state.cachedPath_.moveTo(startX, (float) rect.height);
          for (int i = firstNonZero; i <= lastNonZero; ++i) {
-            float x = graphStartX + i * pixelsPerBin;
+            float x = i * pixelsPerBin;
             float y = rect.height - dataScaling * data[i];
             state.cachedPath_.lineTo(x, y);                // Vertical
             state.cachedPath_.lineTo(x + pixelsPerBin, y); // Horizontal
          }
-         state.cachedPath_.lineTo(graphStartX + (lastNonZero + 1) * pixelsPerBin,
-               (float) rect.height);
+         state.cachedPath_.lineTo((lastNonZero + 1) * pixelsPerBin, (float) rect.height);
          if (fillHistograms_) {
             state.cachedPath_.closePath();
          }
@@ -1111,7 +1070,9 @@ public final class HistogramView extends JPanel {
          for (int k = startFloor + 1; k < endFloor; ++k) {
             result[i] += data[k];
          }
-         if (endFloor < width - 1) {
+         // Bound against the source length, not the output length: the two differ
+         // whenever the histogram is being resampled.
+         if (endFloor + 1 < data.length) {
             result[i] += data[endFloor + 1] * (endFloor + 1 - endBin);
          }
       }

--- a/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
+++ b/mmstudio/src/main/java/org/micromanager/display/inspector/internal/panels/intensity/HistogramView.java
@@ -68,6 +68,20 @@ public final class HistogramView extends JPanel {
        */
       void histogramAxisRangeChanged(int component, double newRangeMin, double newRangeMax);
 
+      /**
+       * Called when the user sets a float scaling bound to an exact pixel value.
+       *
+       * <p>The long-valued callbacks above carry a histogram bin index, which quantizes a
+       * float bound to one of ~256 positions. This one carries the value as typed.
+       *
+       * @param component component index
+       * @param newMin low end of the scaling range, as a pixel value
+       * @param newMax high end of the scaling range, as a pixel value
+       */
+      default void histogramFloatScalingChanged(int component, double newMin,
+                                                double newMax) {
+      }
+
       void histogramGammaChanged(double newGamma);
    }
 
@@ -1310,14 +1324,18 @@ public final class HistogramView extends JPanel {
       spinner.addChangeListener((ChangeEvent e) -> {
          double val = ((Number) spinner.getValue()).doubleValue();
          long binIdx = mapper.pixelValueToBinIndex(val);
+         // The handle is drawn at a bin index, but the stored range keeps the exact value
+         // the user typed: rounding it to a bin here would be visible on the image.
          if (top) {
             binIdx = Math.max(state.scalingMin_ + 1, binIdx);
             setComponentScaling(selectedComponent_, state.scalingMin_, binIdx);
-            listeners_.fire().histogramScalingMaxChanged(selectedComponent_, binIdx);
+            listeners_.fire().histogramFloatScalingChanged(selectedComponent_,
+                  mapper.binIndexToPixelValue(state.scalingMin_), val);
          } else {
             binIdx = Math.min(state.scalingMax_ - 1, binIdx);
             setComponentScaling(selectedComponent_, binIdx, state.scalingMax_);
-            listeners_.fire().histogramScalingMinChanged(selectedComponent_, binIdx);
+            listeners_.fire().histogramFloatScalingChanged(selectedComponent_,
+                  val, mapper.binIndexToPixelValue(state.scalingMax_));
          }
       });
       JPopupMenu popup = new JPopupMenu();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
@@ -259,12 +259,12 @@ public final class DefaultChannelDisplaySettings
    }
 
    @Override
-   public double getFloatHistoRangeMin() {
+   public double getFloatHistoRangeMinimum() {
       return floatHistoRangeMin_;
    }
 
    @Override
-   public double getFloatHistoRangeMax() {
+   public double getFloatHistoRangeMaximum() {
       return floatHistoRangeMax_;
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultChannelDisplaySettings.java
@@ -24,6 +24,12 @@ public final class DefaultChannelDisplaySettings
    private final boolean visible_;
    private final int histoRangeBits_;
    private final boolean useCameraRange_;
+   // Histogram axis range for float images, as pixel values; NaN when unset. Float images
+   // have no bit depth to derive an axis from, so the range is recorded here instead.
+   private final double floatHistoRangeMin_;
+   private final double floatHistoRangeMax_;
+   // True once the user has chosen the axis; it then stops adapting to the data.
+   private final boolean floatHistoRangePinned_;
    private final List<ComponentDisplaySettings> componentSettings_;
 
    private static final class Builder
@@ -35,6 +41,9 @@ public final class DefaultChannelDisplaySettings
       private boolean visible_ = true;
       private int histoRangeBits_ = 8;
       private boolean useCameraRange_ = true;
+      private double floatHistoRangeMin_ = Double.NaN;
+      private double floatHistoRangeMax_ = Double.NaN;
+      private boolean floatHistoRangePinned_ = false;
       private final List<ComponentDisplaySettings> componentSettings_ =
             new ArrayList<>();
 
@@ -120,6 +129,19 @@ public final class DefaultChannelDisplaySettings
       }
 
       @Override
+      public Builder floatHistoRange(double min, double max) {
+         floatHistoRangeMin_ = min;
+         floatHistoRangeMax_ = max;
+         return this;
+      }
+
+      @Override
+      public Builder floatHistoRangePinned(boolean pinned) {
+         floatHistoRangePinned_ = pinned;
+         return this;
+      }
+
+      @Override
       public Builder visible(boolean visible) {
          visible_ = visible;
          return this;
@@ -200,6 +222,9 @@ public final class DefaultChannelDisplaySettings
       visible_ = builder.visible_;
       histoRangeBits_ = builder.histoRangeBits_;
       useCameraRange_ = builder.useCameraRange_;
+      floatHistoRangeMin_ = builder.floatHistoRangeMin_;
+      floatHistoRangeMax_ = builder.floatHistoRangeMax_;
+      floatHistoRangePinned_ = builder.floatHistoRangePinned_;
       componentSettings_ = new ArrayList<>(builder.componentSettings_);
    }
 
@@ -231,6 +256,27 @@ public final class DefaultChannelDisplaySettings
    @Override
    public boolean useCameraRange() {
       return useCameraRange_;
+   }
+
+   @Override
+   public double getFloatHistoRangeMin() {
+      return floatHistoRangeMin_;
+   }
+
+   @Override
+   public double getFloatHistoRangeMax() {
+      return floatHistoRangeMax_;
+   }
+
+   @Override
+   public boolean hasFloatHistoRange() {
+      return !Double.isNaN(floatHistoRangeMin_) && !Double.isNaN(floatHistoRangeMax_)
+            && floatHistoRangeMax_ > floatHistoRangeMin_;
+   }
+
+   @Override
+   public boolean isFloatHistoRangePinned() {
+      return floatHistoRangePinned_;
    }
 
    @Override
@@ -266,6 +312,9 @@ public final class DefaultChannelDisplaySettings
       builder.groupName_ = groupName_;
       builder.histoRangeBits_ = histoRangeBits_;
       builder.useCameraRange_ = useCameraRange_;
+      builder.floatHistoRangeMin_ = floatHistoRangeMin_;
+      builder.floatHistoRangeMax_ = floatHistoRangeMax_;
+      builder.floatHistoRangePinned_ = floatHistoRangePinned_;
       builder.componentSettings_.clear();
       builder.componentSettings_.addAll(componentSettings_);
       return builder;
@@ -286,10 +335,15 @@ public final class DefaultChannelDisplaySettings
          return false;
       }
       DefaultChannelDisplaySettings o = (DefaultChannelDisplaySettings) obj;
+      // Double.compare (not ==) so the NaN "unset" sentinel compares equal to itself;
+      // compareAndSetDisplaySettings relies on equals() and would spin otherwise.
       return visible_ == o.visible_
             && useUniformComponentScaling_ == o.useUniformComponentScaling_
             && histoRangeBits_ == o.histoRangeBits_
             && useCameraRange_ == o.useCameraRange_
+            && Double.compare(floatHistoRangeMin_, o.floatHistoRangeMin_) == 0
+            && Double.compare(floatHistoRangeMax_, o.floatHistoRangeMax_) == 0
+            && floatHistoRangePinned_ == o.floatHistoRangePinned_
             && color_.equals(o.color_)
             && name_.equals(o.name_)
             && groupName_.equals(o.groupName_)
@@ -302,6 +356,9 @@ public final class DefaultChannelDisplaySettings
       result = 31 * result + name_.hashCode();
       result = 31 * result + groupName_.hashCode();
       result = 31 * result + Boolean.hashCode(visible_);
+      result = 31 * result + Double.hashCode(floatHistoRangeMin_);
+      result = 31 * result + Double.hashCode(floatHistoRangeMax_);
+      result = 31 * result + Boolean.hashCode(floatHistoRangePinned_);
       result = 31 * result + componentSettings_.hashCode();
       return result;
    }
@@ -326,6 +383,14 @@ public final class DefaultChannelDisplaySettings
             .putInteger(PropertyKey.HISTOGRAM_BIT_DEPTH.key(), histoRangeBits_)
             .putBoolean(PropertyKey.USE_CAMERA_BIT_DEPTH.key(), useCameraRange_)
             .putPropertyMapList(PropertyKey.COMPONENT_SETTINGS.key(), componentSettings);
+      // Only written for float images, so files for integer data are unchanged and
+      // readers can tell "unset" by the keys being absent.
+      if (hasFloatHistoRange()) {
+         pmBuilder.putDouble(PropertyKey.FLOAT_HISTO_RANGE_MIN.key(), floatHistoRangeMin_);
+         pmBuilder.putDouble(PropertyKey.FLOAT_HISTO_RANGE_MAX.key(), floatHistoRangeMax_);
+         pmBuilder.putBoolean(PropertyKey.FLOAT_HISTO_RANGE_PINNED.key(),
+               floatHistoRangePinned_);
+      }
       return pmBuilder.build();
    }
 
@@ -368,6 +433,18 @@ public final class DefaultChannelDisplaySettings
       if (pMap.containsBoolean(PropertyKey.USE_CAMERA_BIT_DEPTH.key())) {
          b.useCameraHistoRange(pMap.getBoolean(PropertyKey.USE_CAMERA_BIT_DEPTH.key(),
                b.useCameraRange_));
+      }
+      // Absent in files written before the float histogram range was recorded; the NaN
+      // defaults then leave hasFloatHistoRange() false and the axis is derived from data.
+      if (pMap.containsDouble(PropertyKey.FLOAT_HISTO_RANGE_MIN.key())
+            && pMap.containsDouble(PropertyKey.FLOAT_HISTO_RANGE_MAX.key())) {
+         b.floatHistoRange(
+               pMap.getDouble(PropertyKey.FLOAT_HISTO_RANGE_MIN.key(), b.floatHistoRangeMin_),
+               pMap.getDouble(PropertyKey.FLOAT_HISTO_RANGE_MAX.key(), b.floatHistoRangeMax_));
+      }
+      if (pMap.containsBoolean(PropertyKey.FLOAT_HISTO_RANGE_PINNED.key())) {
+         b.floatHistoRangePinned(pMap.getBoolean(
+               PropertyKey.FLOAT_HISTO_RANGE_PINNED.key(), b.floatHistoRangePinned_));
       }
       return b;
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
@@ -14,12 +14,20 @@ public final class DefaultComponentDisplaySettings
       implements ComponentDisplaySettings {
    private long scalingMin_;
    private long scalingMax_;
+   // For float images: the scaling range as actual pixel values. NaN when unset, in which
+   // case the long-valued scalingMin_/scalingMax_ apply. Storing real pixel values (rather
+   // than histogram bin indices) is what allows a float range to stay fixed across frames
+   // and to be persisted meaningfully.
+   private double scalingMinDouble_;
+   private double scalingMaxDouble_;
    private final double gamma_;
 
    private static final class Builder
          implements ComponentDisplaySettings.Builder {
       private long scalingMin_ = 0;
       private long scalingMax_ = Long.MAX_VALUE;
+      private double scalingMinDouble_ = Double.NaN;
+      private double scalingMaxDouble_ = Double.NaN;
       private double gamma_ = 1.0;
 
       @Override
@@ -54,6 +62,25 @@ public final class DefaultComponentDisplaySettings
       }
 
       @Override
+      public Builder scalingMinimumDouble(double minIntensity) {
+         scalingMinDouble_ = minIntensity;
+         return this;
+      }
+
+      @Override
+      public Builder scalingMaximumDouble(double maxIntensity) {
+         scalingMaxDouble_ = maxIntensity;
+         return this;
+      }
+
+      @Override
+      public Builder scalingRangeDouble(double minIntensity, double maxIntensity) {
+         scalingMinDouble_ = minIntensity;
+         scalingMaxDouble_ = maxIntensity;
+         return this;
+      }
+
+      @Override
       public ComponentDisplaySettings build() {
          return new DefaultComponentDisplaySettings(this);
       }
@@ -66,6 +93,8 @@ public final class DefaultComponentDisplaySettings
    private DefaultComponentDisplaySettings(Builder builder) {
       scalingMin_ = builder.scalingMin_;
       scalingMax_ = builder.scalingMax_;
+      scalingMinDouble_ = builder.scalingMinDouble_;
+      scalingMaxDouble_ = builder.scalingMaxDouble_;
       gamma_ = builder.gamma_;
    }
 
@@ -77,6 +106,29 @@ public final class DefaultComponentDisplaySettings
    @Override
    public long getScalingMaximum() {
       return scalingMax_;
+   }
+
+   @Override
+   public double getScalingMinimumDouble() {
+      return scalingMinDouble_;
+   }
+
+   @Override
+   public double getScalingMaximumDouble() {
+      return scalingMaxDouble_;
+   }
+
+   @Override
+   public boolean hasFloatScaling() {
+      return !Double.isNaN(scalingMinDouble_) && !Double.isNaN(scalingMaxDouble_);
+   }
+
+   public void hackScalingMinimumDouble(double min) {
+      scalingMinDouble_ = min;
+   }
+
+   public void hackScalingMaximumDouble(double max) {
+      scalingMaxDouble_ = max;
    }
 
    public void hackScalingMinimum(long min) {
@@ -97,6 +149,8 @@ public final class DefaultComponentDisplaySettings
       Builder builder = new Builder();
       builder.scalingMin_ = scalingMin_;
       builder.scalingMax_ = scalingMax_;
+      builder.scalingMinDouble_ = scalingMinDouble_;
+      builder.scalingMaxDouble_ = scalingMaxDouble_;
       builder.gamma_ = gamma_;
       return builder;
    }
@@ -110,8 +164,12 @@ public final class DefaultComponentDisplaySettings
          return false;
       }
       DefaultComponentDisplaySettings o = (DefaultComponentDisplaySettings) obj;
+      // Double.compare (not ==) so that the NaN "unset" sentinel compares equal to itself;
+      // compareAndSetDisplaySettings relies on equals() and would spin otherwise.
       return scalingMin_ == o.scalingMin_
             && scalingMax_ == o.scalingMax_
+            && Double.compare(scalingMinDouble_, o.scalingMinDouble_) == 0
+            && Double.compare(scalingMaxDouble_, o.scalingMaxDouble_) == 0
             && Double.compare(gamma_, o.gamma_) == 0;
    }
 
@@ -119,6 +177,8 @@ public final class DefaultComponentDisplaySettings
    public int hashCode() {
       int result = Long.hashCode(scalingMin_);
       result = 31 * result + Long.hashCode(scalingMax_);
+      result = 31 * result + Double.hashCode(scalingMinDouble_);
+      result = 31 * result + Double.hashCode(scalingMaxDouble_);
       result = 31 * result + Double.hashCode(gamma_);
       return result;
    }
@@ -129,11 +189,17 @@ public final class DefaultComponentDisplaySettings
     * @return Immutable PropertyMap
     */
    public PropertyMap toPropertyMap() {
-      return PropertyMaps.builder()
+      PropertyMap.Builder b = PropertyMaps.builder()
             .putLong(PropertyKey.SCALING_MIN.key(), scalingMin_)
             .putLong(PropertyKey.SCALING_MAX.key(), scalingMax_)
-            .putDouble(PropertyKey.GAMMA.key(), gamma_)
-            .build();
+            .putDouble(PropertyKey.GAMMA.key(), gamma_);
+      // Only write the float range when actually set, so that files for integer data are
+      // unchanged and readers can distinguish "unset" by key absence rather than by NaN.
+      if (hasFloatScaling()) {
+         b.putDouble(PropertyKey.SCALING_MIN_FLOAT.key(), scalingMinDouble_);
+         b.putDouble(PropertyKey.SCALING_MAX_FLOAT.key(), scalingMaxDouble_);
+      }
+      return b.build();
    }
 
    /**
@@ -153,6 +219,16 @@ public final class DefaultComponentDisplaySettings
       }
       if (pMap.containsDouble(PropertyKey.GAMMA.key())) {
          b.scalingGamma(pMap.getDouble(PropertyKey.GAMMA.key(), b.gamma_));
+      }
+      // Absent in files written before float scaling was stored as pixel values; the NaN
+      // default then leaves hasFloatScaling() false and the old behavior applies.
+      if (pMap.containsDouble(PropertyKey.SCALING_MIN_FLOAT.key())) {
+         b.scalingMinimumDouble(
+               pMap.getDouble(PropertyKey.SCALING_MIN_FLOAT.key(), b.scalingMinDouble_));
+      }
+      if (pMap.containsDouble(PropertyKey.SCALING_MAX_FLOAT.key())) {
+         b.scalingMaximumDouble(
+               pMap.getDouble(PropertyKey.SCALING_MAX_FLOAT.key(), b.scalingMaxDouble_));
       }
 
       return b.build();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
@@ -18,16 +18,17 @@ public final class DefaultComponentDisplaySettings
    // case the long-valued scalingMin_/scalingMax_ apply. Storing real pixel values (rather
    // than histogram bin indices) is what allows a float range to stay fixed across frames
    // and to be persisted meaningfully.
-   private double scalingMinDouble_;
-   private double scalingMaxDouble_;
+   // Not final only because of the hackFloatScaling* setters below; treat as immutable.
+   private double floatScalingMin_;
+   private double floatScalingMax_;
    private final double gamma_;
 
    private static final class Builder
          implements ComponentDisplaySettings.Builder {
       private long scalingMin_ = 0;
       private long scalingMax_ = Long.MAX_VALUE;
-      private double scalingMinDouble_ = Double.NaN;
-      private double scalingMaxDouble_ = Double.NaN;
+      private double floatScalingMin_ = Double.NaN;
+      private double floatScalingMax_ = Double.NaN;
       private double gamma_ = 1.0;
 
       @Override
@@ -51,6 +52,9 @@ public final class DefaultComponentDisplaySettings
 
       @Override
       public Builder scalingRange(ComponentIntensityRange range) {
+         if (range.hasFloatRange()) {
+            floatScalingRange(range.getFloatMinimum(), range.getFloatMaximum());
+         }
          return scalingRange(range.getMinimum(), range.getMaximum());
       }
 
@@ -62,21 +66,21 @@ public final class DefaultComponentDisplaySettings
       }
 
       @Override
-      public Builder scalingMinimumDouble(double minIntensity) {
-         scalingMinDouble_ = minIntensity;
+      public Builder floatScalingMinimum(double minIntensity) {
+         floatScalingMin_ = minIntensity;
          return this;
       }
 
       @Override
-      public Builder scalingMaximumDouble(double maxIntensity) {
-         scalingMaxDouble_ = maxIntensity;
+      public Builder floatScalingMaximum(double maxIntensity) {
+         floatScalingMax_ = maxIntensity;
          return this;
       }
 
       @Override
-      public Builder scalingRangeDouble(double minIntensity, double maxIntensity) {
-         scalingMinDouble_ = minIntensity;
-         scalingMaxDouble_ = maxIntensity;
+      public Builder floatScalingRange(double minIntensity, double maxIntensity) {
+         floatScalingMin_ = minIntensity;
+         floatScalingMax_ = maxIntensity;
          return this;
       }
 
@@ -93,8 +97,8 @@ public final class DefaultComponentDisplaySettings
    private DefaultComponentDisplaySettings(Builder builder) {
       scalingMin_ = builder.scalingMin_;
       scalingMax_ = builder.scalingMax_;
-      scalingMinDouble_ = builder.scalingMinDouble_;
-      scalingMaxDouble_ = builder.scalingMaxDouble_;
+      floatScalingMin_ = builder.floatScalingMin_;
+      floatScalingMax_ = builder.floatScalingMax_;
       gamma_ = builder.gamma_;
    }
 
@@ -109,13 +113,13 @@ public final class DefaultComponentDisplaySettings
    }
 
    @Override
-   public double getScalingMinimumDouble() {
-      return scalingMinDouble_;
+   public double getFloatScalingMinimum() {
+      return floatScalingMin_;
    }
 
    @Override
-   public double getScalingMaximumDouble() {
-      return scalingMaxDouble_;
+   public double getFloatScalingMaximum() {
+      return floatScalingMax_;
    }
 
    @Override
@@ -123,16 +127,16 @@ public final class DefaultComponentDisplaySettings
       // An inverted range is treated as unset: callers use this as the
       // authority on whether the stored bounds are usable, and applying
       // max < min would produce a nonsensical display range.
-      return !Double.isNaN(scalingMinDouble_) && !Double.isNaN(scalingMaxDouble_)
-            && scalingMaxDouble_ > scalingMinDouble_;
+      return !Double.isNaN(floatScalingMin_) && !Double.isNaN(floatScalingMax_)
+            && floatScalingMax_ > floatScalingMin_;
    }
 
-   public void hackScalingMinimumDouble(double min) {
-      scalingMinDouble_ = min;
+   public void hackFloatScalingMinimum(double min) {
+      floatScalingMin_ = min;
    }
 
-   public void hackScalingMaximumDouble(double max) {
-      scalingMaxDouble_ = max;
+   public void hackFloatScalingMaximum(double max) {
+      floatScalingMax_ = max;
    }
 
    public void hackScalingMinimum(long min) {
@@ -153,8 +157,8 @@ public final class DefaultComponentDisplaySettings
       Builder builder = new Builder();
       builder.scalingMin_ = scalingMin_;
       builder.scalingMax_ = scalingMax_;
-      builder.scalingMinDouble_ = scalingMinDouble_;
-      builder.scalingMaxDouble_ = scalingMaxDouble_;
+      builder.floatScalingMin_ = floatScalingMin_;
+      builder.floatScalingMax_ = floatScalingMax_;
       builder.gamma_ = gamma_;
       return builder;
    }
@@ -172,8 +176,8 @@ public final class DefaultComponentDisplaySettings
       // compareAndSetDisplaySettings relies on equals() and would spin otherwise.
       return scalingMin_ == o.scalingMin_
             && scalingMax_ == o.scalingMax_
-            && Double.compare(scalingMinDouble_, o.scalingMinDouble_) == 0
-            && Double.compare(scalingMaxDouble_, o.scalingMaxDouble_) == 0
+            && Double.compare(floatScalingMin_, o.floatScalingMin_) == 0
+            && Double.compare(floatScalingMax_, o.floatScalingMax_) == 0
             && Double.compare(gamma_, o.gamma_) == 0;
    }
 
@@ -181,8 +185,8 @@ public final class DefaultComponentDisplaySettings
    public int hashCode() {
       int result = Long.hashCode(scalingMin_);
       result = 31 * result + Long.hashCode(scalingMax_);
-      result = 31 * result + Double.hashCode(scalingMinDouble_);
-      result = 31 * result + Double.hashCode(scalingMaxDouble_);
+      result = 31 * result + Double.hashCode(floatScalingMin_);
+      result = 31 * result + Double.hashCode(floatScalingMax_);
       result = 31 * result + Double.hashCode(gamma_);
       return result;
    }
@@ -200,8 +204,8 @@ public final class DefaultComponentDisplaySettings
       // Only write the float range when actually set, so that files for integer data are
       // unchanged and readers can distinguish "unset" by key absence rather than by NaN.
       if (hasFloatScaling()) {
-         b.putDouble(PropertyKey.SCALING_MIN_FLOAT.key(), scalingMinDouble_);
-         b.putDouble(PropertyKey.SCALING_MAX_FLOAT.key(), scalingMaxDouble_);
+         b.putDouble(PropertyKey.SCALING_MIN_FLOAT.key(), floatScalingMin_);
+         b.putDouble(PropertyKey.SCALING_MAX_FLOAT.key(), floatScalingMax_);
       }
       return b.build();
    }
@@ -227,12 +231,12 @@ public final class DefaultComponentDisplaySettings
       // Absent in files written before float scaling was stored as pixel values; the NaN
       // default then leaves hasFloatScaling() false and the old behavior applies.
       if (pMap.containsDouble(PropertyKey.SCALING_MIN_FLOAT.key())) {
-         b.scalingMinimumDouble(
-               pMap.getDouble(PropertyKey.SCALING_MIN_FLOAT.key(), b.scalingMinDouble_));
+         b.floatScalingMinimum(
+               pMap.getDouble(PropertyKey.SCALING_MIN_FLOAT.key(), b.floatScalingMin_));
       }
       if (pMap.containsDouble(PropertyKey.SCALING_MAX_FLOAT.key())) {
-         b.scalingMaximumDouble(
-               pMap.getDouble(PropertyKey.SCALING_MAX_FLOAT.key(), b.scalingMaxDouble_));
+         b.floatScalingMaximum(
+               pMap.getDouble(PropertyKey.SCALING_MAX_FLOAT.key(), b.floatScalingMax_));
       }
 
       return b.build();

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentDisplaySettings.java
@@ -120,7 +120,11 @@ public final class DefaultComponentDisplaySettings
 
    @Override
    public boolean hasFloatScaling() {
-      return !Double.isNaN(scalingMinDouble_) && !Double.isNaN(scalingMaxDouble_);
+      // An inverted range is treated as unset: callers use this as the
+      // authority on whether the stored bounds are usable, and applying
+      // max < min would produce a nonsensical display range.
+      return !Double.isNaN(scalingMinDouble_) && !Double.isNaN(scalingMaxDouble_)
+            && scalingMaxDouble_ > scalingMinDouble_;
    }
 
    public void hackScalingMinimumDouble(double min) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentIntensityRange.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/DefaultComponentIntensityRange.java
@@ -5,10 +5,15 @@ import org.micromanager.display.ComponentIntensityRange;
 public class DefaultComponentIntensityRange implements ComponentIntensityRange {
    private final long min_;
    private final long max_;
+   // Pixel-value range for float images; NaN when unset, in which case min_/max_ apply.
+   private final double floatMin_;
+   private final double floatMax_;
 
    public static class Builder implements ComponentIntensityRange.Builder {
       private long min_ = 0;
       private long max_ = Long.MAX_VALUE;
+      private double floatMin_ = Double.NaN;
+      private double floatMax_ = Double.NaN;
 
       @Override
       public Builder minimum(long min) {
@@ -30,6 +35,25 @@ public class DefaultComponentIntensityRange implements ComponentIntensityRange {
       }
 
       @Override
+      public Builder floatMinimum(double min) {
+         floatMin_ = min;
+         return this;
+      }
+
+      @Override
+      public Builder floatMaximum(double max) {
+         floatMax_ = max;
+         return this;
+      }
+
+      @Override
+      public Builder floatRange(double min, double max) {
+         floatMin_ = min;
+         floatMax_ = max;
+         return this;
+      }
+
+      @Override
       public DefaultComponentIntensityRange build() {
          return new DefaultComponentIntensityRange(this);
       }
@@ -38,11 +62,13 @@ public class DefaultComponentIntensityRange implements ComponentIntensityRange {
    private DefaultComponentIntensityRange(Builder builder) {
       min_ = builder.min_;
       max_ = builder.max_;
+      floatMin_ = builder.floatMin_;
+      floatMax_ = builder.floatMax_;
    }
 
    @Override
    public Builder copyBuilder() {
-      return new Builder().range(min_, max_);
+      return new Builder().range(min_, max_).floatRange(floatMin_, floatMax_);
    }
 
    @Override
@@ -53,5 +79,20 @@ public class DefaultComponentIntensityRange implements ComponentIntensityRange {
    @Override
    public long getMaximum() {
       return max_;
+   }
+
+   @Override
+   public double getFloatMinimum() {
+      return floatMin_;
+   }
+
+   @Override
+   public double getFloatMaximum() {
+      return floatMax_;
+   }
+
+   @Override
+   public boolean hasFloatRange() {
+      return !Double.isNaN(floatMin_) && !Double.isNaN(floatMax_) && floatMax_ > floatMin_;
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1215,6 +1215,9 @@ public final class DisplayUIController implements Closeable, WindowListener,
       double fMin;
       double fMax;
       if (componentSettings.hasFloatScaling()) {
+         // Already guaranteed non-empty by hasFloatScaling(), and used exactly as stored:
+         // widening it by the current image's bin width would make the range the user set
+         // depend on which image happens to be on screen.
          fMin = componentSettings.getFloatScalingMinimum();
          fMax = componentSettings.getFloatScalingMaximum();
       } else {
@@ -1227,10 +1230,10 @@ public final class DisplayUIController implements Closeable, WindowListener,
          long clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
          fMin = rangeMin + clampedMin * binWidth;
          fMax = rangeMin + clampedMax * binWidth;
+         // The bin arithmetic can collapse the range; ImageJ misbehaves when min == max.
+         double minSpan = binWidth > 0.0 ? binWidth : Math.ulp(fMin);
+         fMax = Math.max(fMin + minSpan, fMax);
       }
-      // Guarantee a non-empty range; ImageJ misbehaves when min == max.
-      double minSpan = binWidth > 0.0 ? binWidth : Math.ulp(fMin);
-      fMax = Math.max(fMin + minSpan, fMax);
       ijBridge_.mm2ijSetFloatIntensityScaling(ijIndex, fMin, fMax, defer);
    }
 

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1215,8 +1215,8 @@ public final class DisplayUIController implements Closeable, WindowListener,
       double fMin;
       double fMax;
       if (componentSettings.hasFloatScaling()) {
-         fMin = componentSettings.getScalingMinimumDouble();
-         fMax = componentSettings.getScalingMaximumDouble();
+         fMin = componentSettings.getFloatScalingMinimum();
+         fMax = componentSettings.getFloatScalingMaximum();
       } else {
          long storedMin = componentSettings.getScalingMinimum();
          long storedMax = componentSettings.getScalingMaximum();
@@ -1311,12 +1311,25 @@ public final class DisplayUIController implements Closeable, WindowListener,
             DefaultComponentDisplaySettings dcds = (DefaultComponentDisplaySettings)
                   settings.getChannelSettings(ch).getComponentSettings(compo);
             if (cStats.isFloat()) {
-               // min/max are actual pixel values from the quantile computation. Store them
-               // as such, so that switching autostretch off leaves behind a range that is
-               // meaningful on its own rather than a bin index tied to this one image.
-               dcds.hackScalingMinimumDouble((double) min);
-               dcds.hackScalingMaximumDouble((double) max);
-               ijBridge_.mm2ijSetFloatIntensityScaling(ijIndex, (double) min, (double) max, defer);
+               // Recompute the quantiles in pixel values: the long-valued autoscale above
+               // rounds them, which for data spanning less than a unit collapses the range
+               // to 0..1 and then widens it past the data. Storing pixel values also means
+               // switching autostretch off leaves behind a range that is meaningful on its
+               // own rather than a bin index tied to this one image.
+               double fMin;
+               double fMax;
+               if (ignoreZeros) {
+                  fMin = 0.0;
+                  fMax = cStats.getFloatAutoscaleMaxForQuantileIgnoringZeros(q);
+               } else {
+                  double[] fMinMax = new double[2];
+                  cStats.getFloatAutoscaleMinMaxForQuantile(q, fMinMax);
+                  fMin = fMinMax[0];
+                  fMax = fMinMax[1];
+               }
+               dcds.hackFloatScalingMinimum(fMin);
+               dcds.hackFloatScalingMaximum(fMax);
+               ijBridge_.mm2ijSetFloatIntensityScaling(ijIndex, fMin, fMax, defer);
             } else {
                dcds.hackScalingMinimum(min);
                dcds.hackScalingMaximum(max);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/DisplayUIController.java
@@ -1140,18 +1140,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
             if (!autostretch) {
                ComponentStats cStats = getDisplayedComponentStats(i, 0);
                if (cStats != null && cStats.isFloat()) {
-                  long storedMin = componentSettings.getScalingMinimum();
-                  long storedMax = componentSettings.getScalingMaximum();
-                  int binCount = cStats.getHistogramBinCount();
-                  double binWidth = cStats.getBinWidthDouble();
-                  double rangeMin = cStats.getHistogramRangeMinDouble();
-                  long clampedMax = (storedMax == Long.MAX_VALUE) ? binCount
-                        : Math.min(binCount, storedMax);
-                  long clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
-                  double fMin = rangeMin + clampedMin * binWidth;
-                  double fMax = rangeMin + clampedMax * binWidth;
-                  fMax = Math.max(fMin + binWidth, fMax);
-                  ijBridge_.mm2ijSetFloatIntensityScaling(i, fMin, fMax, false);
+                  applyFloatIntensityScaling(i, componentSettings, cStats, false);
                } else {
                   int max = (int) Math.min(Integer.MAX_VALUE,
                         componentSettings.getScalingMaximum());
@@ -1181,18 +1170,7 @@ public final class DisplayUIController implements Closeable, WindowListener,
                boolean defer = i < nComponents - 1;
                ComponentStats cStats = getDisplayedComponentStats(chNr, i);
                if (cStats != null && cStats.isFloat()) {
-                  long storedMin = componentSettings.getScalingMinimum();
-                  long storedMax = componentSettings.getScalingMaximum();
-                  int binCount = cStats.getHistogramBinCount();
-                  double binWidth = cStats.getBinWidthDouble();
-                  double rangeMin = cStats.getHistogramRangeMinDouble();
-                  long clampedMax = (storedMax == Long.MAX_VALUE) ? binCount
-                        : Math.min(binCount, storedMax);
-                  long clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
-                  double fMin = rangeMin + clampedMin * binWidth;
-                  double fMax = rangeMin + clampedMax * binWidth;
-                  fMax = Math.max(fMin + binWidth, fMax);
-                  ijBridge_.mm2ijSetFloatIntensityScaling(i, fMin, fMax, defer);
+                  applyFloatIntensityScaling(i, componentSettings, cStats, defer);
                } else {
                   int max = Math.min(Integer.MAX_VALUE,
                         (int) componentSettings.getScalingMaximum());
@@ -1209,6 +1187,51 @@ public final class DisplayUIController implements Closeable, WindowListener,
 
       displayController_.setPlaybackSpeedFps(settings.getPlaybackFPS());
 
+   }
+
+   /**
+    * Pushes the scaling range for one component of a float image to ImageJ.
+    *
+    * <p>When the settings carry a real float range (pixel values), it is used directly.
+    * That range is independent of the current image, so the display no longer rescales
+    * itself as one steps through a time lapse.
+    *
+    * <p>Otherwise we fall back to the legacy interpretation, in which the stored longs are
+    * histogram bin indices resolved against the current image's binning. That fallback is
+    * inherently image-dependent, and is kept only for settings saved before the float range
+    * existed.
+    *
+    * @param ijIndex ImageJ channel/component index to apply to
+    * @param componentSettings settings holding the range
+    * @param cStats statistics of the currently displayed image, for the legacy fallback
+    * @param defer whether to defer the ImageJ repaint
+    */
+   @MustCallOnEDT
+   private void applyFloatIntensityScaling(int ijIndex,
+                                           ComponentDisplaySettings componentSettings,
+                                           ComponentStats cStats,
+                                           boolean defer) {
+      double binWidth = cStats.getBinWidthDouble();
+      double fMin;
+      double fMax;
+      if (componentSettings.hasFloatScaling()) {
+         fMin = componentSettings.getScalingMinimumDouble();
+         fMax = componentSettings.getScalingMaximumDouble();
+      } else {
+         long storedMin = componentSettings.getScalingMinimum();
+         long storedMax = componentSettings.getScalingMaximum();
+         int binCount = cStats.getHistogramBinCount();
+         double rangeMin = cStats.getHistogramRangeMinDouble();
+         long clampedMax = (storedMax == Long.MAX_VALUE) ? binCount
+               : Math.min(binCount, storedMax);
+         long clampedMin = Math.max(0, Math.min(clampedMax - 1, storedMin));
+         fMin = rangeMin + clampedMin * binWidth;
+         fMax = rangeMin + clampedMax * binWidth;
+      }
+      // Guarantee a non-empty range; ImageJ misbehaves when min == max.
+      double minSpan = binWidth > 0.0 ? binWidth : Math.ulp(fMin);
+      fMax = Math.max(fMin + minSpan, fMax);
+      ijBridge_.mm2ijSetFloatIntensityScaling(ijIndex, fMin, fMax, defer);
    }
 
    @MustCallOnEDT
@@ -1288,16 +1311,11 @@ public final class DisplayUIController implements Closeable, WindowListener,
             DefaultComponentDisplaySettings dcds = (DefaultComponentDisplaySettings)
                   settings.getChannelSettings(ch).getComponentSettings(compo);
             if (cStats.isFloat()) {
-               // min/max are actual pixel values from quantile computation.
-               // Pass pixel values directly to ImageJ; store bin indices in dcds for the inspector.
-               double binWidth = cStats.getBinWidthDouble();
-               double rangeMin = cStats.getHistogramRangeMinDouble();
-               long storedMin = binWidth != 0.0
-                     ? Math.max(0L, Math.round((min - rangeMin) / binWidth)) : 0L;
-               long storedMax = binWidth != 0.0
-                     ? Math.max(0L, Math.round((max - rangeMin) / binWidth)) : 0L;
-               dcds.hackScalingMinimum(storedMin);
-               dcds.hackScalingMaximum(storedMax);
+               // min/max are actual pixel values from the quantile computation. Store them
+               // as such, so that switching autostretch off leaves behind a range that is
+               // meaningful on its own rather than a bin index tied to this one image.
+               dcds.hackScalingMinimumDouble((double) min);
+               dcds.hackScalingMaximumDouble((double) max);
                ijBridge_.mm2ijSetFloatIntensityScaling(ijIndex, (double) min, (double) max, defer);
             } else {
                dcds.hackScalingMinimum(min);

--- a/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/displaywindow/imagej/AbstractColorModeStrategy.java
@@ -135,7 +135,31 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
       LUT lut = getCachedLUT(0);
       lut.min = getMinDouble(0);
       lut.max = getMaxDouble(0);
-      imagePlus_.getProcessor().setLut(lut);
+      ImageProcessor proc = imagePlus_.getProcessor();
+      proc.setLut(lut);
+      applyDisplayRangeToFloatProcessor(proc, getMinDouble(0), getMaxDouble(0));
+   }
+
+   /**
+    * Pushes the display range onto a FloatProcessor.
+    *
+    * <p>A FloatProcessor renders from its own min/max rather than from the LUT, and it
+    * recomputes those from the pixel data whenever the pixels are replaced -- which happens
+    * on every frame change. Without this, a float image silently reverts to autoscaling
+    * itself per frame no matter what range was requested.
+    *
+    * @param proc processor to update; ignored unless it is a FloatProcessor
+    * @param min low end of the display range
+    * @param max high end of the display range
+    */
+   private static void applyDisplayRangeToFloatProcessor(ImageProcessor proc,
+                                                         double min, double max) {
+      if (!(proc instanceof FloatProcessor)) {
+         return;
+      }
+      if (max > min) {
+         proc.setMinAndMax(min, max);
+      }
    }
 
    private void applyToCompositeImage() {
@@ -167,7 +191,11 @@ abstract class AbstractColorModeStrategy implements ColorModeStrategy {
       LUT lut = getCachedLUT(channel);
       lut.min = getMinDouble(channel);
       lut.max = getMaxDouble(channel);
-      compositeImage.getProcessor().setLut(lut);
+      ImageProcessor curProc = compositeImage.getProcessor();
+      curProc.setLut(lut);
+      // Also needed in GRAYSCALE mode, where the loop above does not reach this processor.
+      applyDisplayRangeToFloatProcessor(curProc,
+            getMinDouble(channel), getMaxDouble(channel));
    }
 
    protected final void apply() {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/event/DataViewerMousePixelInfoChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/event/DataViewerMousePixelInfoChangedEvent.java
@@ -8,7 +8,6 @@ package org.micromanager.display.internal.event;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import ij.ImagePlus;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -83,9 +82,8 @@ public class DataViewerMousePixelInfoChangedEvent {
     *     long-valued intensities are already exact
     */
    private static double[] floatComponentValues(Image image, int x, int y) {
-      if (image.getImageJPixelType() != ImagePlus.GRAY32) {
-         return null;
-      }
+      // The pixel array type is the authority, and checking it keeps ImageJ out of this
+      // package; a float[] is a 32-bit float image whatever the metadata claims.
       Object raw = image.getRawPixels();
       if (!(raw instanceof float[])) {
          return null;

--- a/mmstudio/src/main/java/org/micromanager/display/internal/event/DataViewerMousePixelInfoChangedEvent.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/event/DataViewerMousePixelInfoChangedEvent.java
@@ -8,6 +8,7 @@ package org.micromanager.display.internal.event;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import ij.ImagePlus;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -28,6 +29,8 @@ public class DataViewerMousePixelInfoChangedEvent {
    private final List<long[]> values_ = new ArrayList<long[]>();
    // Preformatted intensity strings; null entries mean fall back to formatting values_[i] as longs.
    private final List<String> valueStrings_ = new ArrayList<String>();
+   // Untruncated counterparts of values_; null entries for images that are not float.
+   private final List<double[]> doubleValues_ = new ArrayList<double[]>();
 
    public static DataViewerMousePixelInfoChangedEvent fromImage(int x, int y,
                                                                 Image image) {
@@ -46,6 +49,7 @@ public class DataViewerMousePixelInfoChangedEvent {
       List<Coords> coords = new ArrayList<Coords>();
       List<long[]> componentValues = new ArrayList<long[]>();
       List<String> valueStrings = new ArrayList<String>();
+      List<double[]> doubleValues = new ArrayList<double[]>();
       for (Image image : images) {
          Preconditions.checkNotNull(image);
          Coords c = image.getCoords();
@@ -55,12 +59,45 @@ public class DataViewerMousePixelInfoChangedEvent {
          }
          coords.add(cb.build());
          componentValues.add(image.getComponentIntensitiesAt(x, y));
+         doubleValues.add(floatComponentValues(image, x, y));
          valueStrings.add(image.getIntensityStringAt(x, y));
       }
       DataViewerMousePixelInfoChangedEvent event =
             create(x, y, indexingAxes, coords, componentValues);
       event.valueStrings_.addAll(valueStrings);
+      event.doubleValues_.addAll(doubleValues);
       return event;
+   }
+
+   /**
+    * Component values without the truncation of {@code getComponentIntensitiesAt}.
+    *
+    * <p>That accessor returns {@code long}, so a float pixel of 0.37 reads as 0 and the
+    * histogram highlight would land in the wrong bin. Read from the raw pixels instead,
+    * using only what {@link Image} already exposes.
+    *
+    * @param image image to read
+    * @param x X coordinate
+    * @param y Y coordinate
+    * @return the values, or null for anything that is not a 32-bit float image, whose
+    *     long-valued intensities are already exact
+    */
+   private static double[] floatComponentValues(Image image, int x, int y) {
+      if (image.getImageJPixelType() != ImagePlus.GRAY32) {
+         return null;
+      }
+      Object raw = image.getRawPixels();
+      if (!(raw instanceof float[])) {
+         return null;
+      }
+      float[] pixels = (float[]) raw;
+      int n = image.getNumComponents();
+      int index = (y * image.getWidth() + x) * n;
+      double[] result = new double[n];
+      for (int i = 0; i < n; ++i) {
+         result[i] = pixels[index + i];
+      }
+      return result;
    }
 
    public static DataViewerMousePixelInfoChangedEvent create(int x, int y,
@@ -158,6 +195,22 @@ public class DataViewerMousePixelInfoChangedEvent {
          throw new IllegalArgumentException();
       }
       return values_.get(i).clone();
+   }
+
+   /**
+    * Component values for these coords without float truncation.
+    *
+    * @param coords coords to look up
+    * @return the values, or null for an integer image, whose
+    *     {@link #getComponentValuesForCoords} values are already exact
+    */
+   public double[] getComponentValuesDoubleForCoords(Coords coords) {
+      int i = coords_.indexOf(coords);
+      if (i < 0 || i >= doubleValues_.size()) {
+         return null;
+      }
+      double[] values = doubleValues_.get(i);
+      return values == null ? null : values.clone();
    }
 
    public String getComponentValuesStringForCoords(Coords coords) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ComponentStats.java
@@ -43,11 +43,11 @@ public final class ComponentStats {
    // which case the long values apply. The longs cannot represent float statistics (a mean
    // of -0.16 rounds to 0), so the real values are carried alongside rather than replacing
    // them, leaving the integer bin/quantile machinery untouched.
-   private final double minimumDouble_;
-   private final double minimumExcludingZerosDouble_;
-   private final double maximumDouble_;
-   private final double sumDouble_;
-   private final double sumOfSquaresDouble_;
+   private final double floatMinimum_;
+   private final double floatMinimumExcludingZeros_;
+   private final double floatMaximum_;
+   private final double floatSum_;
+   private final double floatSumOfSquares_;
    private final transient long[] cumulativeDistrib_;
 
    public static class Builder {
@@ -65,11 +65,11 @@ public final class ComponentStats {
       private long maximum_;
       private long sum_;
       private long sumOfSquares_;
-      private double minimumDouble_ = Double.NaN;
-      private double minimumExcludingZerosDouble_ = Double.NaN;
-      private double maximumDouble_ = Double.NaN;
-      private double sumDouble_ = Double.NaN;
-      private double sumOfSquaresDouble_ = Double.NaN;
+      private double floatMinimum_ = Double.NaN;
+      private double floatMinimumExcludingZeros_ = Double.NaN;
+      private double floatMaximum_ = Double.NaN;
+      private double floatSum_ = Double.NaN;
+      private double floatSumOfSquares_ = Double.NaN;
 
       private Builder() {
       }
@@ -152,8 +152,8 @@ public final class ComponentStats {
        * @param min minimum pixel value, or NaN to leave unset
        * @return this builder
        */
-      public Builder minimumDouble(double min) {
-         minimumDouble_ = min;
+      public Builder floatMinimum(double min) {
+         floatMinimum_ = min;
          return this;
       }
 
@@ -163,8 +163,8 @@ public final class ComponentStats {
        * @param min minimum non-zero pixel value, or NaN to leave unset
        * @return this builder
        */
-      public Builder minimumExcludingZerosDouble(double min) {
-         minimumExcludingZerosDouble_ = min;
+      public Builder floatMinimumExcludingZeros(double min) {
+         floatMinimumExcludingZeros_ = min;
          return this;
       }
 
@@ -174,8 +174,8 @@ public final class ComponentStats {
        * @param max maximum pixel value, or NaN to leave unset
        * @return this builder
        */
-      public Builder maximumDouble(double max) {
-         maximumDouble_ = max;
+      public Builder floatMaximum(double max) {
+         floatMaximum_ = max;
          return this;
       }
 
@@ -185,8 +185,8 @@ public final class ComponentStats {
        * @param sum sum of pixel values, or NaN to leave unset
        * @return this builder
        */
-      public Builder sumDouble(double sum) {
-         sumDouble_ = sum;
+      public Builder floatSum(double sum) {
+         floatSum_ = sum;
          return this;
       }
 
@@ -196,8 +196,8 @@ public final class ComponentStats {
        * @param ssq sum of squares, or NaN to leave unset
        * @return this builder
        */
-      public Builder sumOfSquaresDouble(double ssq) {
-         sumOfSquaresDouble_ = ssq;
+      public Builder floatSumOfSquares(double ssq) {
+         floatSumOfSquares_ = ssq;
          return this;
       }
 
@@ -227,9 +227,10 @@ public final class ComponentStats {
          merged[i] = histA[i] + histB[i];
       }
       int binWidthPow2 = Integer.numberOfTrailingZeros(a.getHistogramBinWidth());
-      return builder()
+      boolean isFloat = a.isFloat() || b.isFloat();
+      Builder builder = builder()
             .histogram(merged, binWidthPow2)
-            .isFloat(a.isFloat() || b.isFloat())
+            .isFloat(isFloat)
             .pixelCount(a.getPixelCount() + b.getPixelCount())
             .pixelCountExcludingZeros(
                   a.getPixelCountExcludingZeros()
@@ -241,8 +242,40 @@ public final class ComponentStats {
             .maximum(Math.max(a.getMaxIntensity(), b.getMaxIntensity()))
             .sum(a.getSum() + b.getSum())
             .sumOfSquares(a.getSumOfSquares() + b.getSumOfSquares())
-            .usedROI(a.isROIStats() || b.isROIStats())
-            .build();
+            .usedROI(a.isROIStats() || b.isROIStats());
+      if (isFloat) {
+         // Without these the merged stats would claim to be float while every float field
+         // was NaN, so the accessors would silently fall back to the rounded longs. The
+         // axis must be carried too: it is not recoverable from binWidthPow2, which is
+         // always 0 for float stats.
+         builder.rangeMin(Math.min(a.getHistogramRangeMinDouble(),
+                     b.getHistogramRangeMinDouble()))
+               .binWidthFloat(Math.max(a.getBinWidthDouble(), b.getBinWidthDouble()))
+               .floatMinimum(minIgnoringNaN(
+                     a.getFloatMinIntensity(), b.getFloatMinIntensity()))
+               .floatMinimumExcludingZeros(minIgnoringNaN(
+                     a.getFloatMinIntensityExcludingZeros(),
+                     b.getFloatMinIntensityExcludingZeros()))
+               .floatMaximum(maxIgnoringNaN(
+                     a.getFloatMaxIntensity(), b.getFloatMaxIntensity()))
+               .floatSum(a.getFloatSum() + b.getFloatSum())
+               .floatSumOfSquares(a.getFloatSumOfSquares() + b.getFloatSumOfSquares());
+      }
+      return builder.build();
+   }
+
+   private static double minIgnoringNaN(double x, double y) {
+      if (Double.isNaN(x)) {
+         return y;
+      }
+      return Double.isNaN(y) ? x : Math.min(x, y);
+   }
+
+   private static double maxIgnoringNaN(double x, double y) {
+      if (Double.isNaN(x)) {
+         return y;
+      }
+      return Double.isNaN(y) ? x : Math.max(x, y);
    }
 
    private static long[] getFullHistogram(ComponentStats s) {
@@ -271,11 +304,11 @@ public final class ComponentStats {
       maximum_ = b.maximum_;
       sum_ = b.sum_;
       sumOfSquares_ = b.sumOfSquares_;
-      minimumDouble_ = b.minimumDouble_;
-      minimumExcludingZerosDouble_ = b.minimumExcludingZerosDouble_;
-      maximumDouble_ = b.maximumDouble_;
-      sumDouble_ = b.sumDouble_;
-      sumOfSquaresDouble_ = b.sumOfSquaresDouble_;
+      floatMinimum_ = b.floatMinimum_;
+      floatMinimumExcludingZeros_ = b.floatMinimumExcludingZeros_;
+      floatMaximum_ = b.floatMaximum_;
+      floatSum_ = b.floatSum_;
+      floatSumOfSquares_ = b.floatSumOfSquares_;
       cumulativeDistrib_ = computeCumulativeDistribution();
    }
 
@@ -402,8 +435,8 @@ public final class ComponentStats {
     *
     * @return the minimum; equal to the long value for integer images
     */
-   public double getMinIntensityDouble() {
-      return Double.isNaN(minimumDouble_) ? (double) minimum_ : minimumDouble_;
+   public double getFloatMinIntensity() {
+      return Double.isNaN(floatMinimum_) ? (double) minimum_ : floatMinimum_;
    }
 
    /**
@@ -411,9 +444,9 @@ public final class ComponentStats {
     *
     * @return the minimum excluding zeros; equal to the long value for integer images
     */
-   public double getMinIntensityExcludingZerosDouble() {
-      return Double.isNaN(minimumExcludingZerosDouble_)
-            ? (double) minimumExcludingZeros_ : minimumExcludingZerosDouble_;
+   public double getFloatMinIntensityExcludingZeros() {
+      return Double.isNaN(floatMinimumExcludingZeros_)
+            ? (double) minimumExcludingZeros_ : floatMinimumExcludingZeros_;
    }
 
    /**
@@ -421,8 +454,8 @@ public final class ComponentStats {
     *
     * @return the maximum; equal to the long value for integer images
     */
-   public double getMaxIntensityDouble() {
-      return Double.isNaN(maximumDouble_) ? (double) maximum_ : maximumDouble_;
+   public double getFloatMaxIntensity() {
+      return Double.isNaN(floatMaximum_) ? (double) maximum_ : floatMaximum_;
    }
 
    /**
@@ -433,25 +466,27 @@ public final class ComponentStats {
     *
     * @return the mean, or 0 when there are no pixels
     */
-   public double getMeanIntensityDouble() {
+   public double getFloatMeanIntensity() {
       if (pixelCount_ == 0) {
          return 0.0;
       }
-      double sum = Double.isNaN(sumDouble_) ? (double) sum_ : sumDouble_;
-      return sum / pixelCount_;
+      return getFloatSum() / pixelCount_;
    }
 
    /**
     * Mean of the non-zero pixel values, computed without truncation.
     *
+    * <p>The full sum is divided by the non-zero count, matching
+    * {@link #getMeanIntensityExcludingZeros()}. That is correct because zero pixels
+    * contribute nothing to the sum.
+    *
     * @return the mean excluding zeros, or 0 when there are no such pixels
     */
-   public double getMeanIntensityExcludingZerosDouble() {
+   public double getFloatMeanIntensityExcludingZeros() {
       if (pixelCountExcludingZeros_ == 0) {
          return 0.0;
       }
-      double sum = Double.isNaN(sumDouble_) ? (double) sum_ : sumDouble_;
-      return sum / pixelCountExcludingZeros_;
+      return getFloatSum() / pixelCountExcludingZeros_;
    }
 
    /**
@@ -464,14 +499,12 @@ public final class ComponentStats {
     *
     * @return the standard deviation, or NaN when there are no pixels
     */
-   public double getStandardDeviationDouble() {
+   public double getFloatStandardDeviation() {
       if (pixelCount_ == 0) {
          return Double.NaN;
       }
-      double ssq = Double.isNaN(sumOfSquaresDouble_)
-            ? (double) sumOfSquares_ : sumOfSquaresDouble_;
-      double meanSq = ssq / pixelCount_;
-      double mean = getMeanIntensityDouble();
+      double meanSq = getFloatSumOfSquares() / pixelCount_;
+      double mean = getFloatMeanIntensity();
       return Math.sqrt(Math.max(0.0, meanSq - (mean * mean)));
    }
 
@@ -480,14 +513,12 @@ public final class ComponentStats {
     *
     * @return the standard deviation excluding zeros, or NaN when there are no such pixels
     */
-   public double getStandardDeviationExcludingZerosDouble() {
+   public double getFloatStandardDeviationExcludingZeros() {
       if (pixelCountExcludingZeros_ == 0) {
          return Double.NaN;
       }
-      double ssq = Double.isNaN(sumOfSquaresDouble_)
-            ? (double) sumOfSquares_ : sumOfSquaresDouble_;
-      double meanSq = ssq / pixelCountExcludingZeros_;
-      double mean = getMeanIntensityExcludingZerosDouble();
+      double meanSq = getFloatSumOfSquares() / pixelCountExcludingZeros_;
+      double mean = getFloatMeanIntensityExcludingZeros();
       return Math.sqrt(Math.max(0.0, meanSq - (mean * mean)));
    }
 
@@ -552,6 +583,97 @@ public final class ComponentStats {
    }
 
    /**
+    * Autoscale bounds as real pixel values, for float images.
+    *
+    * <p>The long-valued {@link #getAutoscaleMinMaxForQuantile(double, long[])} rounds the
+    * quantiles to whole numbers, which destroys the range of float data: values spanning
+    * -0.65 to 1.04 collapse to 0 and 1, and the integer widening below then stretches the
+    * range wider than the data. Here the quantiles are used as they come, and a degenerate
+    * range is widened by a fraction of the data rather than by whole units.
+    *
+    * @param q fraction (0-1) of pixels to leave out at each end
+    * @param minMax two-element array receiving the minimum and maximum
+    */
+   public void getFloatAutoscaleMinMaxForQuantile(double q, double[] minMax) {
+      Preconditions.checkNotNull(minMax);
+      Preconditions.checkArgument(minMax.length == 2);
+
+      double min = getQuantile(q);
+      double max = getQuantile(1.0 - q);
+      // Keep the range at least one bin wide. When one bin holds most of the pixels, both
+      // quantiles land inside it and the range collapses to near-nothing, which would
+      // render the image pure black and white.
+      double floor = binWidthFloat_ > 0.0 ? binWidthFloat_ : padFor(min);
+      if (max - min < floor) {
+         double mid = 0.5 * (min + max);
+         min = mid - 0.5 * floor;
+         max = mid + 0.5 * floor;
+      }
+      minMax[0] = min;
+      minMax[1] = max;
+   }
+
+   /**
+    * Autoscale maximum as a real pixel value, ignoring zero pixels, for float images.
+    *
+    * @param q fraction (0-1) of pixels to leave out at the top
+    * @return the maximum
+    */
+   public double getFloatAutoscaleMaxForQuantileIgnoringZeros(double q) {
+      double max = getQuantileIgnoringZeros(q >= 0.5 ? 0.5 : 1.0 - q);
+      double min = getFloatMinIntensity();
+      if (max <= min) {
+         return min + padFor(min);
+      }
+      return max;
+   }
+
+   /**
+    * Amount by which to widen a range that came out empty.
+    *
+    * @param value the value the range collapsed to
+    * @return a positive, non-zero padding
+    */
+   private static double padFor(double value) {
+      double pad = Math.abs(value) * 1e-6;
+      return pad > 0.0 ? pad : Math.max(Math.ulp(value), Double.MIN_NORMAL);
+   }
+
+   /**
+    * Lowest pixel value, as the quantile machinery should report it.
+    *
+    * <p>For float stats this is the real minimum; {@code minimum_} is floored, so a
+    * minimum of -0.65 would otherwise be reported as -1.
+    *
+    * @return the low edge of the data
+    */
+   private double quantileLowEdge() {
+      return isFloat_ ? getFloatMinIntensity() : (double) minimum_;
+   }
+
+   /**
+    * Highest pixel value, as the quantile machinery should report it.
+    *
+    * <p>The integer convention is "one past the maximum", since integer bins are unit
+    * wide. Float bins are not, so the real maximum is the correct upper edge.
+    *
+    * @return the high edge of the data
+    */
+   private double quantileHighEdge() {
+      return isFloat_ ? getFloatMaxIntensity() : (double) (maximum_ + 1);
+   }
+
+   /**
+    * Upper edge of the histogram range, without the integer ceiling.
+    *
+    * @return the top of the axis
+    */
+   private double quantileRangeMax() {
+      return isFloat_ ? rangeMin_ + binWidthFloat_ * getHistogramBinCount()
+            : getHistogramRangeMax() + 1.0;
+   }
+
+   /**
     * Calculates the quantile, i.e. the bin value (ore more precise, the left bin edge)
     * for the bin where q * 100% of the pixel values are in lower bins.
     * Note: return value is in range 0 to (1 + range max), because it is in the
@@ -576,7 +698,7 @@ public final class ComponentStats {
       }
       if (countBelowQuantile > cumDistrib[cumDistrib.length - 2]) {
          // Quantile is above histogram range
-         return getHistogramRangeMax() + 1.0;
+         return quantileRangeMax();
       }
 
       int binIndex;
@@ -586,9 +708,9 @@ public final class ComponentStats {
       // the quantile for limiting scaling range), but when q = 0 or q = 1, we
       // need to find the exact edge of the non-zero part of the histogram.
       if (countBelowQuantile == 0) {
-         return minimum_;
+         return quantileLowEdge();
       } else if (countBelowQuantile == pixelCount_) {
-         return maximum_ + 1;
+         return quantileHighEdge();
       }
 
       binIndex = binarySearch(cumDistrib, 1, cumDistrib.length - 1,
@@ -630,7 +752,7 @@ public final class ComponentStats {
       }
       if (countBelowQuantile > cumDistrib[cumDistrib.length - 2]) {
          // Quantile is above histogram range
-         return getHistogramRangeMax() + 1.0;
+         return quantileRangeMax();
       }
 
       int binIndex;
@@ -640,9 +762,9 @@ public final class ComponentStats {
       // the quantile for limiting scaling range), but when q = 0 or q = 1, we
       // need to find the exact edge of the non-zero part of the histogram.
       if (countBelowQuantile == 0) {
-         return minimum_;
+         return quantileLowEdge();
       } else if (countBelowQuantile >= pixelCount_) {
-         return maximum_ + 1;
+         return quantileHighEdge();
       }
 
       binIndex = binarySearch(cumDistrib, 2, cumDistrib.length - 1,
@@ -690,6 +812,25 @@ public final class ComponentStats {
 
    public long getSumOfSquares() {
       return sumOfSquares_;
+   }
+
+   /**
+    * Sum of pixel values, without the rounding applied to {@link #getSum()}.
+    *
+    * @return the sum; equal to the long value for integer images
+    */
+   public double getFloatSum() {
+      return Double.isNaN(floatSum_) ? (double) sum_ : floatSum_;
+   }
+
+   /**
+    * Sum of squared pixel values, without the rounding applied to
+    * {@link #getSumOfSquares()}.
+    *
+    * @return the sum of squares; equal to the long value for integer images
+    */
+   public double getFloatSumOfSquares() {
+      return Double.isNaN(floatSumOfSquares_) ? (double) sumOfSquares_ : floatSumOfSquares_;
    }
 
    public double getStandardDeviation() {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ComponentStats.java
@@ -39,6 +39,15 @@ public final class ComponentStats {
    private final long maximum_;
    private final long sum_;
    private final long sumOfSquares_;
+   // Untruncated counterparts of the fields above, for float images. NaN when unset, in
+   // which case the long values apply. The longs cannot represent float statistics (a mean
+   // of -0.16 rounds to 0), so the real values are carried alongside rather than replacing
+   // them, leaving the integer bin/quantile machinery untouched.
+   private final double minimumDouble_;
+   private final double minimumExcludingZerosDouble_;
+   private final double maximumDouble_;
+   private final double sumDouble_;
+   private final double sumOfSquaresDouble_;
    private final transient long[] cumulativeDistrib_;
 
    public static class Builder {
@@ -56,6 +65,11 @@ public final class ComponentStats {
       private long maximum_;
       private long sum_;
       private long sumOfSquares_;
+      private double minimumDouble_ = Double.NaN;
+      private double minimumExcludingZerosDouble_ = Double.NaN;
+      private double maximumDouble_ = Double.NaN;
+      private double sumDouble_ = Double.NaN;
+      private double sumOfSquaresDouble_ = Double.NaN;
 
       private Builder() {
       }
@@ -132,6 +146,61 @@ public final class ComponentStats {
          return this;
       }
 
+      /**
+       * Sets the untruncated minimum, for float images.
+       *
+       * @param min minimum pixel value, or NaN to leave unset
+       * @return this builder
+       */
+      public Builder minimumDouble(double min) {
+         minimumDouble_ = min;
+         return this;
+      }
+
+      /**
+       * Sets the untruncated minimum of the non-zero pixels, for float images.
+       *
+       * @param min minimum non-zero pixel value, or NaN to leave unset
+       * @return this builder
+       */
+      public Builder minimumExcludingZerosDouble(double min) {
+         minimumExcludingZerosDouble_ = min;
+         return this;
+      }
+
+      /**
+       * Sets the untruncated maximum, for float images.
+       *
+       * @param max maximum pixel value, or NaN to leave unset
+       * @return this builder
+       */
+      public Builder maximumDouble(double max) {
+         maximumDouble_ = max;
+         return this;
+      }
+
+      /**
+       * Sets the untruncated sum of pixel values, for float images.
+       *
+       * @param sum sum of pixel values, or NaN to leave unset
+       * @return this builder
+       */
+      public Builder sumDouble(double sum) {
+         sumDouble_ = sum;
+         return this;
+      }
+
+      /**
+       * Sets the untruncated sum of squared pixel values, for float images.
+       *
+       * @param ssq sum of squares, or NaN to leave unset
+       * @return this builder
+       */
+      public Builder sumOfSquaresDouble(double ssq) {
+         sumOfSquaresDouble_ = ssq;
+         return this;
+      }
+
       public ComponentStats build() {
          return new ComponentStats(this);
       }
@@ -202,6 +271,11 @@ public final class ComponentStats {
       maximum_ = b.maximum_;
       sum_ = b.sum_;
       sumOfSquares_ = b.sumOfSquares_;
+      minimumDouble_ = b.minimumDouble_;
+      minimumExcludingZerosDouble_ = b.minimumExcludingZerosDouble_;
+      maximumDouble_ = b.maximumDouble_;
+      sumDouble_ = b.sumDouble_;
+      sumOfSquaresDouble_ = b.sumOfSquaresDouble_;
       cumulativeDistrib_ = computeCumulativeDistribution();
    }
 
@@ -321,6 +395,100 @@ public final class ComponentStats {
 
    public long getMaxIntensity() {
       return maximum_;
+   }
+
+   /**
+    * Minimum pixel value, without the truncation applied to {@link #getMinIntensity()}.
+    *
+    * @return the minimum; equal to the long value for integer images
+    */
+   public double getMinIntensityDouble() {
+      return Double.isNaN(minimumDouble_) ? (double) minimum_ : minimumDouble_;
+   }
+
+   /**
+    * Minimum non-zero pixel value, without truncation.
+    *
+    * @return the minimum excluding zeros; equal to the long value for integer images
+    */
+   public double getMinIntensityExcludingZerosDouble() {
+      return Double.isNaN(minimumExcludingZerosDouble_)
+            ? (double) minimumExcludingZeros_ : minimumExcludingZerosDouble_;
+   }
+
+   /**
+    * Maximum pixel value, without the truncation applied to {@link #getMaxIntensity()}.
+    *
+    * @return the maximum; equal to the long value for integer images
+    */
+   public double getMaxIntensityDouble() {
+      return Double.isNaN(maximumDouble_) ? (double) maximum_ : maximumDouble_;
+   }
+
+   /**
+    * Mean pixel value, computed without truncation.
+    *
+    * <p>{@link #getMeanIntensity()} rounds to a whole number, which discards the entire
+    * value for float data whose mean lies between -1 and 1.
+    *
+    * @return the mean, or 0 when there are no pixels
+    */
+   public double getMeanIntensityDouble() {
+      if (pixelCount_ == 0) {
+         return 0.0;
+      }
+      double sum = Double.isNaN(sumDouble_) ? (double) sum_ : sumDouble_;
+      return sum / pixelCount_;
+   }
+
+   /**
+    * Mean of the non-zero pixel values, computed without truncation.
+    *
+    * @return the mean excluding zeros, or 0 when there are no such pixels
+    */
+   public double getMeanIntensityExcludingZerosDouble() {
+      if (pixelCountExcludingZeros_ == 0) {
+         return 0.0;
+      }
+      double sum = Double.isNaN(sumDouble_) ? (double) sum_ : sumDouble_;
+      return sum / pixelCountExcludingZeros_;
+   }
+
+   /**
+    * Standard deviation, computed without truncation.
+    *
+    * <p>Unlike {@link #getStandardDeviation()}, this uses the unrounded sum and mean. That
+    * matters for float data: the rounded mean both inflates the result and can make the
+    * variance come out negative, yielding NaN. The variance is clamped at zero so rounding
+    * noise cannot produce NaN here.
+    *
+    * @return the standard deviation, or NaN when there are no pixels
+    */
+   public double getStandardDeviationDouble() {
+      if (pixelCount_ == 0) {
+         return Double.NaN;
+      }
+      double ssq = Double.isNaN(sumOfSquaresDouble_)
+            ? (double) sumOfSquares_ : sumOfSquaresDouble_;
+      double meanSq = ssq / pixelCount_;
+      double mean = getMeanIntensityDouble();
+      return Math.sqrt(Math.max(0.0, meanSq - (mean * mean)));
+   }
+
+   /**
+    * Standard deviation of the non-zero pixel values, computed without truncation.
+    *
+    * @return the standard deviation excluding zeros, or NaN when there are no such pixels
+    */
+   public double getStandardDeviationExcludingZerosDouble() {
+      if (pixelCountExcludingZeros_ == 0) {
+         return Double.NaN;
+      }
+      double ssq = Double.isNaN(sumOfSquaresDouble_)
+            ? (double) sumOfSquares_ : sumOfSquaresDouble_;
+      double meanSq = ssq / pixelCountExcludingZeros_;
+      double mean = getMeanIntensityExcludingZerosDouble();
+      return Math.sqrt(Math.max(0.0, meanSq - (mean * mean)));
    }
 
    public long getAutoscaleMinForQuantile(double q) {

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ComponentStats.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ComponentStats.java
@@ -616,27 +616,40 @@ public final class ComponentStats {
    /**
     * Autoscale maximum as a real pixel value, ignoring zero pixels, for float images.
     *
+    * <p>Callers pair this with a minimum of zero, which is what "ignoring zeros" means
+    * here, so the result is kept strictly above zero rather than above the data minimum.
+    * The data minimum is the wrong floor: for float data it is routinely negative, which
+    * would let this return a maximum below the zero the caller uses and yield an inverted
+    * range.
+    *
     * @param q fraction (0-1) of pixels to leave out at the top
-    * @return the maximum
+    * @return the maximum, always greater than zero
     */
    public double getFloatAutoscaleMaxForQuantileIgnoringZeros(double q) {
       double max = getQuantileIgnoringZeros(q >= 0.5 ? 0.5 : 1.0 - q);
-      double min = getFloatMinIntensity();
-      if (max <= min) {
-         return min + padFor(min);
+      if (max > 0.0) {
+         return max;
       }
-      return max;
+      // The quantile came out at or below zero, so it cannot be used against a floor of
+      // zero. Prefer the real maximum, which at least spans the positive data; fall back
+      // to a token width only when there is no positive data at all.
+      double dataMax = getFloatMaxIntensity();
+      return dataMax > 0.0 ? dataMax : padFor(dataMax);
    }
 
    /**
     * Amount by which to widen a range that came out empty.
+    *
+    * <p>Scaled to the value so that the widening stays negligible next to the data, with
+    * an absolute floor for a value of (or near) zero, where a relative pad would underflow
+    * to something too small to give a drawable range.
     *
     * @param value the value the range collapsed to
     * @return a positive, non-zero padding
     */
    private static double padFor(double value) {
       double pad = Math.abs(value) * 1e-6;
-      return pad > 0.0 ? pad : Math.max(Math.ulp(value), Double.MIN_NORMAL);
+      return pad > Double.MIN_NORMAL ? pad : 1e-6;
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -14,6 +14,7 @@
 package org.micromanager.display.internal.imagestats;
 
 import com.google.common.base.Preconditions;
+import ij.ImagePlus;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
@@ -203,7 +204,11 @@ public final class ImageStatsProcessor {
                mask,
                nComponents, boxedBitDepth, bitDepth, binCountPowerOf2,
                useROI, index);
-      } else if (bytesPerSample == 4 && nComponents == 1) {
+      } else if (bytesPerSample == 4 && nComponents == 1
+            && image.getImageJPixelType() == ImagePlus.GRAY32) {
+         // Ask the image what it is rather than inferring float from the sample size: the
+         // float path casts the pixels to float[], which a future 4-byte integer type
+         // would not satisfy.
          result = computeFloatStats(image, statsBounds, maskBytes, maskBounds, useROI, index);
       }
 
@@ -225,7 +230,6 @@ public final class ImageStatsProcessor {
       long count = 0;
       long countNonZero = 0;
       double sum = 0.0;
-      double sumNonZero = 0.0;
       double sumOfSquares = 0.0;
 
       // First pass: find min/max, accumulate sum/sumOfSquares/counts
@@ -253,7 +257,6 @@ public final class ImageStatsProcessor {
             }
             if (v != 0.0f) {
                countNonZero++;
-               sumNonZero += v;
                if (v < fMinNonZero) {
                   fMinNonZero = v;
                }
@@ -308,7 +311,7 @@ public final class ImageStatsProcessor {
       // The long-valued minimum/maximum/sum/sumOfSquares are kept because the bin and
       // quantile machinery is integer based. They cannot represent float statistics, so
       // the true values are also stored as doubles and are what the intensity readout
-      // uses; see ComponentStats.getMinIntensityDouble() and friends.
+      // uses; see ComponentStats.getFloatMinIntensity() and friends.
       ComponentStats stats = ComponentStats.builder()
             .histogram(hist, 0)
             .isFloat(true)
@@ -322,11 +325,11 @@ public final class ImageStatsProcessor {
             .maximum((long) Math.ceil(fMax))
             .sum(Math.round(sum))
             .sumOfSquares(Math.round(sumOfSquares))
-            .minimumDouble(fMin)
-            .minimumExcludingZerosDouble(fMinNonZero)
-            .maximumDouble(fMax)
-            .sumDouble(sum)
-            .sumOfSquaresDouble(sumOfSquares)
+            .floatMinimum(fMin)
+            .floatMinimumExcludingZeros(fMinNonZero)
+            .floatMaximum(fMax)
+            .floatSum(sum)
+            .floatSumOfSquares(sumOfSquares)
             .build();
       return ImageStats.create(index, stats);
    }

--- a/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
+++ b/mmstudio/src/main/java/org/micromanager/display/internal/imagestats/ImageStatsProcessor.java
@@ -305,10 +305,10 @@ public final class ImageStatsProcessor {
          }
       }
 
-      // sum and sumOfSquares are stored as long in IntegerComponentStats.
-      // Round to the nearest integer so that getMeanIntensity() and
-      // getStandardDeviation() return values that are correct to integer precision,
-      // matching the display which shows mean and stdev rounded to integers.
+      // The long-valued minimum/maximum/sum/sumOfSquares are kept because the bin and
+      // quantile machinery is integer based. They cannot represent float statistics, so
+      // the true values are also stored as doubles and are what the intensity readout
+      // uses; see ComponentStats.getMinIntensityDouble() and friends.
       ComponentStats stats = ComponentStats.builder()
             .histogram(hist, 0)
             .isFloat(true)
@@ -322,6 +322,11 @@ public final class ImageStatsProcessor {
             .maximum((long) Math.ceil(fMax))
             .sum(Math.round(sum))
             .sumOfSquares(Math.round(sumOfSquares))
+            .minimumDouble(fMin)
+            .minimumExcludingZerosDouble(fMinNonZero)
+            .maximumDouble(fMax)
+            .sumDouble(sum)
+            .sumOfSquaresDouble(sumOfSquares)
             .build();
       return ImageStats.create(index, stats);
    }

--- a/mmstudio/src/test/java/org/micromanager/display/inspector/internal/panels/intensity/ResampleOntoAxisTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/inspector/internal/panels/intensity/ResampleOntoAxisTest.java
@@ -1,0 +1,118 @@
+package org.micromanager.display.inspector.internal.panels.intensity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.micromanager.display.internal.imagestats.ComponentStats;
+
+/**
+ * Tests rebinning a float image's histogram onto the displayed axis.
+ *
+ * <p>The image's bins span its own min..max, which need not match the axis the user is
+ * looking at. Counts have to land at the pixel value they came from, without being lost
+ * or duplicated by rounding along the way.
+ */
+public class ResampleOntoAxisTest {
+
+   private static final int BINS = 256;
+
+   /** Float stats with the given per-bin counts spanning [min, max]. */
+   private static ComponentStats statsSpanning(double min, double max, long[] inRange) {
+      long[] hist = new long[inRange.length + 2];
+      System.arraycopy(inRange, 0, hist, 1, inRange.length);
+      long count = 0;
+      for (long v : inRange) {
+         count += v;
+      }
+      return ComponentStats.builder()
+            .histogram(hist, 0)
+            .isFloat(true)
+            .rangeMin(min)
+            .binWidthFloat((max - min) / inRange.length)
+            .pixelCount(count)
+            .pixelCountExcludingZeros(count)
+            .minimum((long) Math.floor(min))
+            .maximum((long) Math.ceil(max))
+            .floatMinimum(min)
+            .floatMaximum(max)
+            .build();
+   }
+
+   private static long[] flatCounts(long perBin) {
+      long[] counts = new long[BINS];
+      for (int i = 0; i < BINS; ++i) {
+         counts[i] = perBin;
+      }
+      return counts;
+   }
+
+   private static long total(long[] values) {
+      long sum = 0;
+      for (long v : values) {
+         sum += v;
+      }
+      return sum;
+   }
+
+   /**
+    * A source bin spread over three or more axis bins gives each of them less than half a
+    * count. Rounding those contributions individually floored every one of them to zero,
+    * leaving a completely empty histogram for an image displayed on a much narrower axis.
+    */
+   @Test
+   public void testNarrowAxisDoesNotEmptyTheHistogram() {
+      ComponentStats cs = statsSpanning(-2.0, 1.0, flatCounts(1L));
+      // Axis pinned far narrower than the image: each source bin covers many axis bins.
+      FloatCoordinateMapper mapper = new FloatCoordinateMapper(0.0, 0.1, BINS);
+
+      long[] out = ChannelIntensityController.resampleOntoAxis(cs, mapper, BINS);
+
+      assertTrue("histogram must not be empty", total(out) > 0);
+   }
+
+   /**
+    * A source bin straddling an axis boundary contributes half a count to each side.
+    * Rounding both halves up turned one count into two, doubling the histogram.
+    */
+   @Test
+   public void testStraddlingBinsDoNotDoubleCounts() {
+      ComponentStats cs = statsSpanning(0.5, 256.5, flatCounts(1L));
+      // Axis offset by exactly half a bin from the source binning.
+      FloatCoordinateMapper mapper = new FloatCoordinateMapper(0.0, 256.0, BINS);
+
+      long[] out = ChannelIntensityController.resampleOntoAxis(cs, mapper, BINS);
+
+      assertTrue("counts must not be inflated: " + total(out), total(out) <= BINS);
+   }
+
+   /** An axis matching the image exactly must pass the counts through untouched. */
+   @Test
+   public void testIdenticalAxisPreservesCounts() {
+      long[] counts = new long[BINS];
+      for (int i = 0; i < BINS; ++i) {
+         counts[i] = i * 3L;
+      }
+      ComponentStats cs = statsSpanning(-1.5, 2.5, counts);
+      FloatCoordinateMapper mapper = new FloatCoordinateMapper(-1.5, 2.5, BINS);
+
+      long[] out = ChannelIntensityController.resampleOntoAxis(cs, mapper, BINS);
+
+      assertEquals(total(counts), total(out));
+   }
+
+   /** Counts outside the axis are dropped, so clipped data reads as clipped. */
+   @Test
+   public void testCountsOutsideTheAxisAreDropped() {
+      ComponentStats cs = statsSpanning(0.0, 4.0, flatCounts(10L));
+      // Axis covers only the lower half of the image's range.
+      FloatCoordinateMapper mapper = new FloatCoordinateMapper(0.0, 2.0, BINS);
+
+      long[] out = ChannelIntensityController.resampleOntoAxis(cs, mapper, BINS);
+
+      long all = total(flatCounts(10L));
+      assertTrue("about half the counts should remain, got " + total(out),
+            total(out) < all);
+      assertTrue("counts inside the axis must survive", total(out) > 0);
+   }
+}

--- a/mmstudio/src/test/java/org/micromanager/display/inspector/internal/panels/intensity/StatValueFormatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/inspector/internal/panels/intensity/StatValueFormatTest.java
@@ -1,0 +1,64 @@
+package org.micromanager.display.inspector.internal.panels.intensity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests formatting of floating point intensities in the Inspector stats readout.
+ */
+public class StatValueFormatTest {
+
+   @Test
+   public void testTypicalValues() {
+      assertEquals("-2.238", ChannelIntensityController.formatStatValue(-2.238095283508301));
+      assertEquals("1.032", ChannelIntensityController.formatStatValue(1.0322580337524414));
+      assertEquals("-0.1622", ChannelIntensityController.formatStatValue(-0.16218741610646248));
+   }
+
+   @Test
+   public void testZero() {
+      assertEquals("0.000", ChannelIntensityController.formatStatValue(0.0));
+   }
+
+   @Test
+   public void testVerySmallUsesScientificNotation() {
+      String s = ChannelIntensityController.formatStatValue(1.23e-4);
+      assertTrue("expected scientific notation, got " + s, s.contains("e"));
+   }
+
+   @Test
+   public void testVeryLargeUsesScientificNotation() {
+      String s = ChannelIntensityController.formatStatValue(1.0e7);
+      assertTrue("expected scientific notation, got " + s, s.contains("e"));
+   }
+
+   @Test
+   public void testSmallBoundaryStaysDecimal() {
+      assertEquals("0.001000", ChannelIntensityController.formatStatValue(0.001));
+   }
+
+   /**
+    * Note %.4g itself switches to scientific notation beyond four significant digits, so
+    * values in the thousands are already exponential regardless of the explicit threshold.
+    */
+   @Test
+   public void testFourSignificantDigitsStayDecimal() {
+      assertEquals("9999", ChannelIntensityController.formatStatValue(9999.0));
+      assertEquals("1235", ChannelIntensityController.formatStatValue(1234.5));
+   }
+
+   @Test
+   public void testNaNIsNull() {
+      assertNull(ChannelIntensityController.formatStatValue(Double.NaN));
+   }
+
+   @Test
+   public void testNegativeValuesAreShown() {
+      // The readout used to hide negatives entirely; they must now render.
+      String s = ChannelIntensityController.formatStatValue(-0.5);
+      assertTrue(s.startsWith("-"));
+   }
+}

--- a/mmstudio/src/test/java/org/micromanager/display/internal/DefaultChannelDisplaySettingsFloatRangeTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/DefaultChannelDisplaySettingsFloatRangeTest.java
@@ -34,8 +34,8 @@ public class DefaultChannelDisplaySettingsFloatRangeTest {
             .floatHistoRangePinned(true)
             .build();
       assertTrue(s.hasFloatHistoRange());
-      assertEquals(-0.6484375, s.getFloatHistoRangeMin(), DELTA);
-      assertEquals(1.0390625, s.getFloatHistoRangeMax(), DELTA);
+      assertEquals(-0.6484375, s.getFloatHistoRangeMinimum(), DELTA);
+      assertEquals(1.0390625, s.getFloatHistoRangeMaximum(), DELTA);
       assertTrue(s.isFloatHistoRangePinned());
    }
 
@@ -56,8 +56,8 @@ public class DefaultChannelDisplaySettingsFloatRangeTest {
             .copyBuilder()
             .build();
       assertTrue(s.hasFloatHistoRange());
-      assertEquals(-2.0, s.getFloatHistoRangeMin(), DELTA);
-      assertEquals(3.0, s.getFloatHistoRangeMax(), DELTA);
+      assertEquals(-2.0, s.getFloatHistoRangeMinimum(), DELTA);
+      assertEquals(3.0, s.getFloatHistoRangeMaximum(), DELTA);
       assertTrue(s.isFloatHistoRangePinned());
    }
 
@@ -92,8 +92,8 @@ public class DefaultChannelDisplaySettingsFloatRangeTest {
       ChannelDisplaySettings read =
             DefaultChannelDisplaySettings.fromPropertyMap(pmap);
       assertTrue(read.hasFloatHistoRange());
-      assertEquals(-0.6484375, read.getFloatHistoRangeMin(), DELTA);
-      assertEquals(1.0390625, read.getFloatHistoRangeMax(), DELTA);
+      assertEquals(-0.6484375, read.getFloatHistoRangeMinimum(), DELTA);
+      assertEquals(1.0390625, read.getFloatHistoRangeMaximum(), DELTA);
       assertTrue(read.isFloatHistoRangePinned());
    }
 

--- a/mmstudio/src/test/java/org/micromanager/display/internal/DefaultChannelDisplaySettingsFloatRangeTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/DefaultChannelDisplaySettingsFloatRangeTest.java
@@ -1,0 +1,136 @@
+package org.micromanager.display.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
+import org.micromanager.data.internal.PropertyKey;
+import org.micromanager.display.ChannelDisplaySettings;
+
+/**
+ * Tests persistence of the float histogram axis range on ChannelDisplaySettings.
+ *
+ * <p>Float images have no bit depth to derive a histogram axis from, so the axis range is
+ * recorded per channel and must survive closing and reopening a dataset.
+ */
+public class DefaultChannelDisplaySettingsFloatRangeTest {
+
+   private static final double DELTA = 1e-9;
+
+   @Test
+   public void testDefaultHasNoFloatHistoRange() {
+      ChannelDisplaySettings s = ChannelDisplaySettings.builder().build();
+      assertFalse(s.hasFloatHistoRange());
+      assertFalse(s.isFloatHistoRangePinned());
+   }
+
+   @Test
+   public void testSetFloatHistoRange() {
+      ChannelDisplaySettings s = ChannelDisplaySettings.builder()
+            .floatHistoRange(-0.6484375, 1.0390625)
+            .floatHistoRangePinned(true)
+            .build();
+      assertTrue(s.hasFloatHistoRange());
+      assertEquals(-0.6484375, s.getFloatHistoRangeMin(), DELTA);
+      assertEquals(1.0390625, s.getFloatHistoRangeMax(), DELTA);
+      assertTrue(s.isFloatHistoRangePinned());
+   }
+
+   @Test
+   public void testInvertedRangeIsNotUsable() {
+      ChannelDisplaySettings s = ChannelDisplaySettings.builder()
+            .floatHistoRange(5.0, 1.0)
+            .build();
+      assertFalse(s.hasFloatHistoRange());
+   }
+
+   @Test
+   public void testCopyBuilderPreservesRange() {
+      ChannelDisplaySettings s = ChannelDisplaySettings.builder()
+            .floatHistoRange(-2.0, 3.0)
+            .floatHistoRangePinned(true)
+            .build()
+            .copyBuilder()
+            .build();
+      assertTrue(s.hasFloatHistoRange());
+      assertEquals(-2.0, s.getFloatHistoRangeMin(), DELTA);
+      assertEquals(3.0, s.getFloatHistoRangeMax(), DELTA);
+      assertTrue(s.isFloatHistoRangePinned());
+   }
+
+   /** The NaN sentinel must compare equal to itself or CAS loops never converge. */
+   @Test
+   public void testUnsetRangesAreEqual() {
+      ChannelDisplaySettings a = ChannelDisplaySettings.builder().build();
+      ChannelDisplaySettings b = ChannelDisplaySettings.builder().build();
+      assertTrue(a.equals(b));
+      assertEquals(a.hashCode(), b.hashCode());
+   }
+
+   @Test
+   public void testEqualsDistinguishesRangeAndPin() {
+      ChannelDisplaySettings a = ChannelDisplaySettings.builder()
+            .floatHistoRange(0.0, 1.0).build();
+      ChannelDisplaySettings b = ChannelDisplaySettings.builder()
+            .floatHistoRange(0.0, 2.0).build();
+      ChannelDisplaySettings c = ChannelDisplaySettings.builder()
+            .floatHistoRange(0.0, 1.0).floatHistoRangePinned(true).build();
+      assertFalse(a.equals(b));
+      assertFalse(a.equals(c));
+   }
+
+   @Test
+   public void testPropertyMapRoundTrip() {
+      ChannelDisplaySettings orig = ChannelDisplaySettings.builder()
+            .floatHistoRange(-0.6484375, 1.0390625)
+            .floatHistoRangePinned(true)
+            .build();
+      PropertyMap pmap = ((DefaultChannelDisplaySettings) orig).toPropertyMap();
+      ChannelDisplaySettings read =
+            DefaultChannelDisplaySettings.fromPropertyMap(pmap);
+      assertTrue(read.hasFloatHistoRange());
+      assertEquals(-0.6484375, read.getFloatHistoRangeMin(), DELTA);
+      assertEquals(1.0390625, read.getFloatHistoRangeMax(), DELTA);
+      assertTrue(read.isFloatHistoRangePinned());
+   }
+
+   @Test
+   public void testUnpinnedRangeRoundTrips() {
+      ChannelDisplaySettings orig = ChannelDisplaySettings.builder()
+            .floatHistoRange(-9.0, 25.0)
+            .floatHistoRangePinned(false)
+            .build();
+      PropertyMap pmap = ((DefaultChannelDisplaySettings) orig).toPropertyMap();
+      ChannelDisplaySettings read =
+            DefaultChannelDisplaySettings.fromPropertyMap(pmap);
+      assertTrue(read.hasFloatHistoRange());
+      assertFalse(read.isFloatHistoRangePinned());
+   }
+
+   /** Settings for integer data must not write the float keys at all. */
+   @Test
+   public void testUnsetRangeIsNotWritten() {
+      ChannelDisplaySettings orig = ChannelDisplaySettings.builder().build();
+      PropertyMap pmap = ((DefaultChannelDisplaySettings) orig).toPropertyMap();
+      assertFalse(pmap.containsKey(PropertyKey.FLOAT_HISTO_RANGE_MIN.key()));
+      assertFalse(pmap.containsKey(PropertyKey.FLOAT_HISTO_RANGE_MAX.key()));
+      assertFalse(pmap.containsKey(PropertyKey.FLOAT_HISTO_RANGE_PINNED.key()));
+   }
+
+   /** Files written before this existed must still load. */
+   @Test
+   public void testLegacyPropertyMapWithoutFloatKeys() {
+      PropertyMap legacy = PropertyMaps.builder()
+            .putInteger(PropertyKey.HISTOGRAM_BIT_DEPTH.key(), 12)
+            .putBoolean(PropertyKey.USE_CAMERA_BIT_DEPTH.key(), false)
+            .build();
+      ChannelDisplaySettings read =
+            DefaultChannelDisplaySettings.fromPropertyMap(legacy);
+      assertFalse(read.hasFloatHistoRange());
+      assertFalse(read.isFloatHistoRangePinned());
+      assertEquals(12, read.getHistoRangeBits());
+   }
+}

--- a/mmstudio/src/test/java/org/micromanager/display/internal/DefaultComponentDisplaySettingsFloatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/DefaultComponentDisplaySettingsFloatTest.java
@@ -1,0 +1,158 @@
+package org.micromanager.display.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.micromanager.PropertyMap;
+import org.micromanager.PropertyMaps;
+import org.micromanager.data.internal.PropertyKey;
+import org.micromanager.display.ComponentDisplaySettings;
+
+/**
+ * Tests the floating point scaling range of ComponentDisplaySettings.
+ *
+ * <p>Float images store their scaling range as actual pixel values rather than histogram
+ * bin indices, so that the range keeps its meaning across images with different intensity
+ * distributions.
+ */
+public class DefaultComponentDisplaySettingsFloatTest {
+
+   private static final double DELTA = 1e-9;
+
+   // --- Defaults ---
+
+   @Test
+   public void testDefaultHasNoFloatScaling() {
+      ComponentDisplaySettings s = ComponentDisplaySettings.builder().build();
+      assertFalse(s.hasFloatScaling());
+   }
+
+   @Test
+   public void testDefaultLongScalingUnaffected() {
+      ComponentDisplaySettings s = ComponentDisplaySettings.builder().build();
+      assertEquals(0L, s.getScalingMinimum());
+      assertEquals(Long.MAX_VALUE, s.getScalingMaximum());
+   }
+
+   // --- Setting the float range ---
+
+   @Test
+   public void testSetFloatRange() {
+      ComponentDisplaySettings s = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(-2.5, 17.25)
+            .build();
+      assertTrue(s.hasFloatScaling());
+      assertEquals(-2.5, s.getScalingMinimumDouble(), DELTA);
+      assertEquals(17.25, s.getScalingMaximumDouble(), DELTA);
+   }
+
+   @Test
+   public void testOnlyOneBoundSetIsNotFloatScaling() {
+      ComponentDisplaySettings s = ComponentDisplaySettings.builder()
+            .scalingMinimumDouble(1.0)
+            .build();
+      assertFalse(s.hasFloatScaling());
+   }
+
+   @Test
+   public void testNaNClearsFloatScaling() {
+      ComponentDisplaySettings s = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(1.0, 2.0)
+            .scalingMaximumDouble(Double.NaN)
+            .build();
+      assertFalse(s.hasFloatScaling());
+   }
+
+   @Test
+   public void testCopyBuilderPreservesFloatRange() {
+      ComponentDisplaySettings s = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(0.125, 4.5)
+            .build()
+            .copyBuilder()
+            .build();
+      assertTrue(s.hasFloatScaling());
+      assertEquals(0.125, s.getScalingMinimumDouble(), DELTA);
+      assertEquals(4.5, s.getScalingMaximumDouble(), DELTA);
+   }
+
+   // --- equals / hashCode ---
+
+   @Test
+   public void testEqualsDistinguishesFloatRange() {
+      ComponentDisplaySettings a = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(0.0, 1.0).build();
+      ComponentDisplaySettings b = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(0.0, 2.0).build();
+      assertFalse(a.equals(b));
+   }
+
+   /**
+    * The NaN sentinel must compare equal to itself, otherwise
+    * compareAndSetDisplaySettings would never converge for integer images.
+    */
+   @Test
+   public void testUnsetFloatRangesAreEqual() {
+      ComponentDisplaySettings a = ComponentDisplaySettings.builder().build();
+      ComponentDisplaySettings b = ComponentDisplaySettings.builder().build();
+      assertTrue(a.equals(b));
+      assertEquals(a.hashCode(), b.hashCode());
+   }
+
+   @Test
+   public void testEqualFloatRangesHaveEqualHashCodes() {
+      ComponentDisplaySettings a = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(-1.5, 3.5).build();
+      ComponentDisplaySettings b = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(-1.5, 3.5).build();
+      assertTrue(a.equals(b));
+      assertEquals(a.hashCode(), b.hashCode());
+   }
+
+   // --- Persistence ---
+
+   @Test
+   public void testPropertyMapRoundTrip() {
+      ComponentDisplaySettings orig = ComponentDisplaySettings.builder()
+            .scalingRange(3L, 900L)
+            .scalingRangeDouble(-0.75, 12.5)
+            .scalingGamma(1.5)
+            .build();
+      PropertyMap pmap = ((DefaultComponentDisplaySettings) orig).toPropertyMap();
+      ComponentDisplaySettings read =
+            DefaultComponentDisplaySettings.fromPropertyMap(pmap);
+      assertTrue(read.hasFloatScaling());
+      assertEquals(-0.75, read.getScalingMinimumDouble(), DELTA);
+      assertEquals(12.5, read.getScalingMaximumDouble(), DELTA);
+      assertEquals(3L, read.getScalingMinimum());
+      assertEquals(900L, read.getScalingMaximum());
+      assertEquals(1.5, read.getScalingGamma(), DELTA);
+   }
+
+   /** Settings for integer data must not write the float keys at all. */
+   @Test
+   public void testUnsetFloatRangeIsNotWritten() {
+      ComponentDisplaySettings orig = ComponentDisplaySettings.builder()
+            .scalingRange(0L, 255L)
+            .build();
+      PropertyMap pmap = ((DefaultComponentDisplaySettings) orig).toPropertyMap();
+      assertFalse(pmap.containsKey(PropertyKey.SCALING_MIN_FLOAT.key()));
+      assertFalse(pmap.containsKey(PropertyKey.SCALING_MAX_FLOAT.key()));
+   }
+
+   /** Files written before float scaling existed must still load. */
+   @Test
+   public void testLegacyPropertyMapWithoutFloatKeys() {
+      PropertyMap legacy = PropertyMaps.builder()
+            .putLong(PropertyKey.SCALING_MIN.key(), 10L)
+            .putLong(PropertyKey.SCALING_MAX.key(), 200L)
+            .putDouble(PropertyKey.GAMMA.key(), 1.0)
+            .build();
+      ComponentDisplaySettings read =
+            DefaultComponentDisplaySettings.fromPropertyMap(legacy);
+      assertFalse(read.hasFloatScaling());
+      assertEquals(10L, read.getScalingMinimum());
+      assertEquals(200L, read.getScalingMaximum());
+   }
+}

--- a/mmstudio/src/test/java/org/micromanager/display/internal/DefaultComponentDisplaySettingsFloatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/DefaultComponentDisplaySettingsFloatTest.java
@@ -65,6 +65,38 @@ public class DefaultComponentDisplaySettingsFloatTest {
       assertFalse(s.hasFloatScaling());
    }
 
+   /**
+    * Callers treat hasFloatScaling() as the authority on whether the stored bounds are
+    * usable, so an inverted range must read as unset rather than being applied.
+    */
+   @Test
+   public void testInvertedFloatRangeIsNotFloatScaling() {
+      ComponentDisplaySettings s = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(5.0, 1.0)
+            .build();
+      assertFalse(s.hasFloatScaling());
+   }
+
+   /** An empty range would give ImageJ a zero-width display range. */
+   @Test
+   public void testEmptyFloatRangeIsNotFloatScaling() {
+      ComponentDisplaySettings s = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(2.0, 2.0)
+            .build();
+      assertFalse(s.hasFloatScaling());
+   }
+
+   /** An inverted range must not be persisted either, so it cannot survive a reload. */
+   @Test
+   public void testInvertedFloatRangeIsNotWritten() {
+      ComponentDisplaySettings orig = ComponentDisplaySettings.builder()
+            .scalingRangeDouble(5.0, 1.0)
+            .build();
+      PropertyMap pmap = ((DefaultComponentDisplaySettings) orig).toPropertyMap();
+      assertFalse(pmap.containsKey(PropertyKey.SCALING_MIN_FLOAT.key()));
+      assertFalse(pmap.containsKey(PropertyKey.SCALING_MAX_FLOAT.key()));
+   }
+
    @Test
    public void testCopyBuilderPreservesFloatRange() {
       ComponentDisplaySettings s = ComponentDisplaySettings.builder()

--- a/mmstudio/src/test/java/org/micromanager/display/internal/DefaultComponentDisplaySettingsFloatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/DefaultComponentDisplaySettingsFloatTest.java
@@ -41,17 +41,17 @@ public class DefaultComponentDisplaySettingsFloatTest {
    @Test
    public void testSetFloatRange() {
       ComponentDisplaySettings s = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(-2.5, 17.25)
+            .floatScalingRange(-2.5, 17.25)
             .build();
       assertTrue(s.hasFloatScaling());
-      assertEquals(-2.5, s.getScalingMinimumDouble(), DELTA);
-      assertEquals(17.25, s.getScalingMaximumDouble(), DELTA);
+      assertEquals(-2.5, s.getFloatScalingMinimum(), DELTA);
+      assertEquals(17.25, s.getFloatScalingMaximum(), DELTA);
    }
 
    @Test
    public void testOnlyOneBoundSetIsNotFloatScaling() {
       ComponentDisplaySettings s = ComponentDisplaySettings.builder()
-            .scalingMinimumDouble(1.0)
+            .floatScalingMinimum(1.0)
             .build();
       assertFalse(s.hasFloatScaling());
    }
@@ -59,8 +59,8 @@ public class DefaultComponentDisplaySettingsFloatTest {
    @Test
    public void testNaNClearsFloatScaling() {
       ComponentDisplaySettings s = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(1.0, 2.0)
-            .scalingMaximumDouble(Double.NaN)
+            .floatScalingRange(1.0, 2.0)
+            .floatScalingMaximum(Double.NaN)
             .build();
       assertFalse(s.hasFloatScaling());
    }
@@ -72,7 +72,7 @@ public class DefaultComponentDisplaySettingsFloatTest {
    @Test
    public void testInvertedFloatRangeIsNotFloatScaling() {
       ComponentDisplaySettings s = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(5.0, 1.0)
+            .floatScalingRange(5.0, 1.0)
             .build();
       assertFalse(s.hasFloatScaling());
    }
@@ -81,7 +81,7 @@ public class DefaultComponentDisplaySettingsFloatTest {
    @Test
    public void testEmptyFloatRangeIsNotFloatScaling() {
       ComponentDisplaySettings s = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(2.0, 2.0)
+            .floatScalingRange(2.0, 2.0)
             .build();
       assertFalse(s.hasFloatScaling());
    }
@@ -90,7 +90,7 @@ public class DefaultComponentDisplaySettingsFloatTest {
    @Test
    public void testInvertedFloatRangeIsNotWritten() {
       ComponentDisplaySettings orig = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(5.0, 1.0)
+            .floatScalingRange(5.0, 1.0)
             .build();
       PropertyMap pmap = ((DefaultComponentDisplaySettings) orig).toPropertyMap();
       assertFalse(pmap.containsKey(PropertyKey.SCALING_MIN_FLOAT.key()));
@@ -100,13 +100,13 @@ public class DefaultComponentDisplaySettingsFloatTest {
    @Test
    public void testCopyBuilderPreservesFloatRange() {
       ComponentDisplaySettings s = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(0.125, 4.5)
+            .floatScalingRange(0.125, 4.5)
             .build()
             .copyBuilder()
             .build();
       assertTrue(s.hasFloatScaling());
-      assertEquals(0.125, s.getScalingMinimumDouble(), DELTA);
-      assertEquals(4.5, s.getScalingMaximumDouble(), DELTA);
+      assertEquals(0.125, s.getFloatScalingMinimum(), DELTA);
+      assertEquals(4.5, s.getFloatScalingMaximum(), DELTA);
    }
 
    // --- equals / hashCode ---
@@ -114,9 +114,9 @@ public class DefaultComponentDisplaySettingsFloatTest {
    @Test
    public void testEqualsDistinguishesFloatRange() {
       ComponentDisplaySettings a = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(0.0, 1.0).build();
+            .floatScalingRange(0.0, 1.0).build();
       ComponentDisplaySettings b = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(0.0, 2.0).build();
+            .floatScalingRange(0.0, 2.0).build();
       assertFalse(a.equals(b));
    }
 
@@ -135,9 +135,9 @@ public class DefaultComponentDisplaySettingsFloatTest {
    @Test
    public void testEqualFloatRangesHaveEqualHashCodes() {
       ComponentDisplaySettings a = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(-1.5, 3.5).build();
+            .floatScalingRange(-1.5, 3.5).build();
       ComponentDisplaySettings b = ComponentDisplaySettings.builder()
-            .scalingRangeDouble(-1.5, 3.5).build();
+            .floatScalingRange(-1.5, 3.5).build();
       assertTrue(a.equals(b));
       assertEquals(a.hashCode(), b.hashCode());
    }
@@ -148,15 +148,15 @@ public class DefaultComponentDisplaySettingsFloatTest {
    public void testPropertyMapRoundTrip() {
       ComponentDisplaySettings orig = ComponentDisplaySettings.builder()
             .scalingRange(3L, 900L)
-            .scalingRangeDouble(-0.75, 12.5)
+            .floatScalingRange(-0.75, 12.5)
             .scalingGamma(1.5)
             .build();
       PropertyMap pmap = ((DefaultComponentDisplaySettings) orig).toPropertyMap();
       ComponentDisplaySettings read =
             DefaultComponentDisplaySettings.fromPropertyMap(pmap);
       assertTrue(read.hasFloatScaling());
-      assertEquals(-0.75, read.getScalingMinimumDouble(), DELTA);
-      assertEquals(12.5, read.getScalingMaximumDouble(), DELTA);
+      assertEquals(-0.75, read.getFloatScalingMinimum(), DELTA);
+      assertEquals(12.5, read.getFloatScalingMaximum(), DELTA);
       assertEquals(3L, read.getScalingMinimum());
       assertEquals(900L, read.getScalingMaximum());
       assertEquals(1.5, read.getScalingGamma(), DELTA);

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsFloatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsFloatTest.java
@@ -219,6 +219,33 @@ public class ComponentStatsFloatTest {
       assertTrue("degenerate range must be widened", minMax[1] > minMax[0]);
    }
 
+   /**
+    * Callers of the ignoring-zeros autoscale pair it with a minimum of zero, so its result
+    * has to stay above zero. Data with a negative minimum used to clamp against that
+    * minimum instead, which could return a maximum below the caller's floor.
+    */
+   @Test
+   public void testAutoscaleIgnoringZerosStaysAboveZeroForNegativeData() {
+      ComponentStats cs = evenlySpreadFloatStats(-2.238, -0.5);
+      assertTrue("data minimum is negative", cs.getFloatMinIntensity() < 0.0);
+      double max = cs.getFloatAutoscaleMaxForQuantileIgnoringZeros(0.001);
+      assertTrue("max " + max + " must exceed the zero floor callers use", max > 0.0);
+   }
+
+   @Test
+   public void testAutoscaleIgnoringZerosIsPositiveForAllNegativeData() {
+      ComponentStats cs = evenlySpreadFloatStats(-5.0, -1.0);
+      double max = cs.getFloatAutoscaleMaxForQuantileIgnoringZeros(0.0);
+      assertTrue("max " + max + " must be greater than zero", max > 0.0);
+   }
+
+   @Test
+   public void testAutoscaleIgnoringZerosKeepsPositiveQuantile() {
+      ComponentStats cs = evenlySpreadFloatStats(0.0, 4.0);
+      double max = cs.getFloatAutoscaleMaxForQuantileIgnoringZeros(0.001);
+      assertTrue("a usable quantile must be kept as-is", max > 1.0 && max <= 4.0);
+   }
+
    // --- merge() must carry the float fields and the axis ---
 
    @Test

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsFloatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsFloatTest.java
@@ -35,11 +35,11 @@ public class ComponentStatsFloatTest {
             .maximum((long) Math.ceil(max))
             .sum(Math.round(mean * count))
             .sumOfSquares(Math.round(sumOfSquares))
-            .minimumDouble(min)
-            .minimumExcludingZerosDouble(min)
-            .maximumDouble(max)
-            .sumDouble(mean * count)
-            .sumOfSquaresDouble(sumOfSquares)
+            .floatMinimum(min)
+            .floatMinimumExcludingZeros(min)
+            .floatMaximum(max)
+            .floatSum(mean * count)
+            .floatSumOfSquares(sumOfSquares)
             .build();
    }
 
@@ -48,8 +48,8 @@ public class ComponentStatsFloatTest {
    @Test
    public void testMinMaxAreNotTruncated() {
       ComponentStats cs = floatStats(REAL_MIN, REAL_MAX, REAL_MEAN, 4194304L, 1000.0);
-      assertEquals(REAL_MIN, cs.getMinIntensityDouble(), DELTA);
-      assertEquals(REAL_MAX, cs.getMaxIntensityDouble(), DELTA);
+      assertEquals(REAL_MIN, cs.getFloatMinIntensity(), DELTA);
+      assertEquals(REAL_MAX, cs.getFloatMaxIntensity(), DELTA);
    }
 
    /** The long getters still floor/ceil; that is what the readout used to show. */
@@ -64,7 +64,7 @@ public class ComponentStatsFloatTest {
    public void testMeanIsNotRoundedToZero() {
       long count = 4194304L;
       ComponentStats cs = floatStats(REAL_MIN, REAL_MAX, REAL_MEAN, count, 1000.0);
-      assertEquals(REAL_MEAN, cs.getMeanIntensityDouble(), 1e-6);
+      assertEquals(REAL_MEAN, cs.getFloatMeanIntensity(), 1e-6);
       // The long mean collapses to zero, which is the bug being fixed.
       assertEquals(0L, cs.getMeanIntensity());
    }
@@ -73,7 +73,7 @@ public class ComponentStatsFloatTest {
    public void testMeanExcludingZeros() {
       long count = 1000L;
       ComponentStats cs = floatStats(-1.0, 1.0, 0.25, count, 100.0);
-      assertEquals(0.25, cs.getMeanIntensityExcludingZerosDouble(), 1e-9);
+      assertEquals(0.25, cs.getFloatMeanIntensityExcludingZeros(), 1e-9);
    }
 
    // --- Standard deviation ---
@@ -86,7 +86,7 @@ public class ComponentStatsFloatTest {
       // E[x^2] = sd^2 + mean^2
       double sumOfSquares = count * (sd * sd + mean * mean);
       ComponentStats cs = floatStats(0.0, 4.0, mean, count, sumOfSquares);
-      assertEquals(sd, cs.getStandardDeviationDouble(), 1e-9);
+      assertEquals(sd, cs.getFloatStandardDeviation(), 1e-9);
    }
 
    /**
@@ -99,7 +99,7 @@ public class ComponentStatsFloatTest {
       double sd = 0.05;
       double sumOfSquares = count * (sd * sd + REAL_MEAN * REAL_MEAN);
       ComponentStats cs = floatStats(REAL_MIN, REAL_MAX, REAL_MEAN, count, sumOfSquares);
-      double result = cs.getStandardDeviationDouble();
+      double result = cs.getFloatStandardDeviation();
       assertFalse("stdev should not be NaN", Double.isNaN(result));
       assertEquals(sd, result, 1e-6);
    }
@@ -111,7 +111,7 @@ public class ComponentStatsFloatTest {
       long count = 100L;
       double mean = 1.0;
       ComponentStats cs = floatStats(0.0, 2.0, mean, count, count * 0.999999);
-      double result = cs.getStandardDeviationDouble();
+      double result = cs.getFloatStandardDeviation();
       assertFalse(Double.isNaN(result));
       assertTrue(result >= 0.0);
    }
@@ -123,7 +123,7 @@ public class ComponentStatsFloatTest {
             .isFloat(true)
             .pixelCount(0)
             .build();
-      assertTrue(Double.isNaN(cs.getStandardDeviationDouble()));
+      assertTrue(Double.isNaN(cs.getFloatStandardDeviation()));
    }
 
    // --- Integer images fall back to the long values, unchanged ---
@@ -141,14 +141,14 @@ public class ComponentStatsFloatTest {
             .sumOfSquares(40000L)
             .build();
       assertFalse(cs.isFloat());
-      assertEquals(10.0, cs.getMinIntensityDouble(), DELTA);
-      assertEquals(12.0, cs.getMinIntensityExcludingZerosDouble(), DELTA);
-      assertEquals(200.0, cs.getMaxIntensityDouble(), DELTA);
-      assertEquals(100.0, cs.getMeanIntensityDouble(), DELTA);
+      assertEquals(10.0, cs.getFloatMinIntensity(), DELTA);
+      assertEquals(12.0, cs.getFloatMinIntensityExcludingZeros(), DELTA);
+      assertEquals(200.0, cs.getFloatMaxIntensity(), DELTA);
+      assertEquals(100.0, cs.getFloatMeanIntensity(), DELTA);
       // Matches the long getters exactly: no behavior change for integer images.
-      assertEquals((double) cs.getMinIntensity(), cs.getMinIntensityDouble(), DELTA);
-      assertEquals((double) cs.getMaxIntensity(), cs.getMaxIntensityDouble(), DELTA);
-      assertEquals((double) cs.getMeanIntensity(), cs.getMeanIntensityDouble(), DELTA);
+      assertEquals((double) cs.getMinIntensity(), cs.getFloatMinIntensity(), DELTA);
+      assertEquals((double) cs.getMaxIntensity(), cs.getFloatMaxIntensity(), DELTA);
+      assertEquals((double) cs.getMeanIntensity(), cs.getFloatMeanIntensity(), DELTA);
    }
 
    @Test
@@ -157,7 +157,193 @@ public class ComponentStatsFloatTest {
             .histogram(new long[] {0, 0, 0}, 0)
             .pixelCount(0)
             .build();
-      assertEquals(0.0, cs.getMeanIntensityDouble(), DELTA);
-      assertEquals(0.0, cs.getMeanIntensityExcludingZerosDouble(), DELTA);
+      assertEquals(0.0, cs.getFloatMeanIntensity(), DELTA);
+      assertEquals(0.0, cs.getFloatMeanIntensityExcludingZeros(), DELTA);
+   }
+
+   // --- Autoscale keeps pixel values (issue: long autoscale rounds them away) ---
+
+   /**
+    * Builds float stats whose histogram spreads pixels evenly over [min, max].
+    */
+   private static ComponentStats evenlySpreadFloatStats(double min, double max) {
+      int bins = 256;
+      long[] hist = new long[bins + 2];
+      for (int i = 1; i <= bins; ++i) {
+         hist[i] = 100L;
+      }
+      return ComponentStats.builder()
+            .histogram(hist, 0)
+            .isFloat(true)
+            .rangeMin(min)
+            .binWidthFloat((max - min) / bins)
+            .pixelCount(100L * bins)
+            .pixelCountExcludingZeros(100L * bins)
+            .minimum((long) Math.floor(min))
+            .maximum((long) Math.ceil(max))
+            .floatMinimum(min)
+            .floatMaximum(max)
+            .build();
+   }
+
+   @Test
+   public void testFloatAutoscaleStaysInsideTheDataRange() {
+      // A range narrower than one unit: the long-valued autoscale rounds this to 0/1 and
+      // then widens it to width >= 2, i.e. wider than the data itself.
+      ComponentStats cs = evenlySpreadFloatStats(-0.65, 1.04);
+      double[] minMax = new double[2];
+      cs.getFloatAutoscaleMinMaxForQuantile(0.001, minMax);
+
+      assertTrue("min " + minMax[0] + " below data", minMax[0] >= -0.65);
+      assertTrue("max " + minMax[1] + " above data", minMax[1] <= 1.04);
+      assertTrue("range must be non-empty", minMax[1] > minMax[0]);
+      // The whole point: the bounds are fractional, not rounded to whole numbers.
+      assertTrue("min should not be a whole number", minMax[0] != Math.rint(minMax[0]));
+   }
+
+   @Test
+   public void testLongAutoscaleStillRoundsForIntegerPath() {
+      // The long-valued method is unchanged; the float path exists precisely because
+      // this one cannot represent the range.
+      ComponentStats cs = evenlySpreadFloatStats(-0.65, 1.04);
+      long[] minMax = new long[2];
+      cs.getAutoscaleMinMaxForQuantile(0.001, minMax);
+      assertTrue("long autoscale rounds to whole units", minMax[1] - minMax[0] >= 2);
+   }
+
+   @Test
+   public void testFloatAutoscaleWidensDegenerateRange() {
+      ComponentStats cs = evenlySpreadFloatStats(2.5, 2.5);
+      double[] minMax = new double[2];
+      cs.getFloatAutoscaleMinMaxForQuantile(0.0, minMax);
+      assertTrue("degenerate range must be widened", minMax[1] > minMax[0]);
+   }
+
+   // --- merge() must carry the float fields and the axis ---
+
+   @Test
+   public void testMergeKeepsFloatStatistics() {
+      ComponentStats a = floatStats(-2.0, 1.0, -0.5, 100L, 50.0);
+      ComponentStats b = floatStats(-1.0, 3.0, 0.25, 100L, 40.0);
+      ComponentStats m = ComponentStats.merge(a, b);
+
+      assertTrue(m.isFloat());
+      // Without the fix these fall back to the floored/ceiled longs (-2.0 and 3.0 here
+      // by coincidence of the data, so assert the sums too, which cannot coincide).
+      assertEquals(-2.0, m.getFloatMinIntensity(), DELTA);
+      assertEquals(3.0, m.getFloatMaxIntensity(), DELTA);
+      assertEquals(-0.5 * 100 + 0.25 * 100, m.getFloatSum(), 1e-6);
+      assertEquals(90.0, m.getFloatSumOfSquares(), 1e-6);
+   }
+
+   @Test
+   public void testMergeKeepsFloatAxis() {
+      ComponentStats a = floatStats(-2.0, 1.0, -0.5, 100L, 50.0);
+      ComponentStats b = floatStats(-1.0, 3.0, 0.25, 100L, 40.0);
+      ComponentStats m = ComponentStats.merge(a, b);
+
+      // Without the fix the axis collapses to rangeMin=0.0, binWidth=1.0, which makes
+      // every bin edge and quantile wrong.
+      assertEquals(-2.0, m.getHistogramRangeMinDouble(), DELTA);
+      assertTrue("bin width must come from the float axis, not 1<<0",
+            m.getBinWidthDouble() != 1.0);
+   }
+
+   @Test
+   public void testMergeOfIntegerStatsIsUnaffected() {
+      ComponentStats a = ComponentStats.builder()
+            .histogram(new long[] {0, 5, 0}, 0)
+            .pixelCount(5L).pixelCountExcludingZeros(5L)
+            .minimum(2L).maximum(9L).sum(25L).sumOfSquares(150L)
+            .build();
+      ComponentStats m = ComponentStats.merge(a, a);
+      assertFalse(m.isFloat());
+      assertEquals(50L, m.getSum());
+      assertEquals(2L, m.getMinIntensity());
+      assertEquals(9L, m.getMaxIntensity());
+   }
+
+   // --- Quantile edges must not fall back to the floored/ceiled longs ---
+
+   @Test
+   public void testZeroIgnoreQuantileGivesTheRealDataRange() {
+      // q=0 hits the "exact edge of the non-zero histogram" branch, which used to return
+      // the long minimum_/maximum_+1: for [-0.65, 1.04] that gave [-1.0, 3.0], a range
+      // both wider than the data and outside it.
+      ComponentStats cs = evenlySpreadFloatStats(-0.65, 1.04);
+      double[] minMax = new double[2];
+      cs.getFloatAutoscaleMinMaxForQuantile(0.0, minMax);
+
+      assertEquals(-0.65, minMax[0], 1e-9);
+      assertEquals(1.04, minMax[1], 1e-9);
+   }
+
+   @Test
+   public void testQuantileEdgesStayIntegralForIntegerStats() {
+      // The integer convention ("one past the maximum") must be preserved.
+      ComponentStats cs = ComponentStats.builder()
+            .histogram(new long[] {0, 10, 20, 0}, 0)
+            .pixelCount(30L).pixelCountExcludingZeros(30L)
+            .minimum(5L).maximum(9L).sum(200L).sumOfSquares(2000L)
+            .build();
+      assertEquals(5.0, cs.getQuantile(0.0), 1e-9);
+      assertEquals(10.0, cs.getQuantile(1.0), 1e-9);
+   }
+
+   @Test
+   public void testRangeNeverCollapsesWhenOneBinDominates() {
+      // A background spike holding nearly every pixel puts both quantiles in the same
+      // bin, which would otherwise yield a range of width ~0 and a black/white image.
+      int bins = 256;
+      long[] hist = new long[bins + 2];
+      for (int i = 1; i <= bins; ++i) {
+         hist[i] = 1L;
+      }
+      hist[40] = 4_000_000L;
+      long total = 0;
+      for (long v : hist) {
+         total += v;
+      }
+      double min = -0.65;
+      double max = 1.04;
+      ComponentStats cs = ComponentStats.builder()
+            .histogram(hist, 0)
+            .isFloat(true)
+            .rangeMin(min)
+            .binWidthFloat((max - min) / bins)
+            .pixelCount(total)
+            .pixelCountExcludingZeros(total)
+            .minimum((long) Math.floor(min))
+            .maximum((long) Math.ceil(max))
+            .floatMinimum(min)
+            .floatMaximum(max)
+            .build();
+
+      double[] minMax = new double[2];
+      cs.getFloatAutoscaleMinMaxForQuantile(0.5, minMax);
+      assertTrue("range collapsed to " + (minMax[1] - minMax[0]),
+            minMax[1] - minMax[0] >= (max - min) / bins - 1e-12);
+   }
+
+   @Test
+   public void testAutoscaleRespondsToIgnoreFractionOnANonUnitRange() {
+      // Regression: a range such as 2.7..22.7 rounds to 3..22 under the long-valued
+      // autoscale, and stays pinned there for every ignore fraction up to ~1%. The float
+      // autoscale must move monotonically inward as the fraction rises.
+      ComponentStats cs = evenlySpreadFloatStats(2.7, 22.7);
+      double[] prev = new double[2];
+      cs.getFloatAutoscaleMinMaxForQuantile(0.0, prev);
+      assertEquals(2.7, prev[0], 1e-9);
+      assertEquals(22.7, prev[1], 1e-9);
+
+      for (double q : new double[] {0.005, 0.01, 0.05, 0.2}) {
+         double[] cur = new double[2];
+         cs.getFloatAutoscaleMinMaxForQuantile(q, cur);
+         assertTrue("min must rise at q=" + q + " (was " + prev[0] + ", got " + cur[0] + ")",
+               cur[0] > prev[0]);
+         assertTrue("max must fall at q=" + q + " (was " + prev[1] + ", got " + cur[1] + ")",
+               cur[1] < prev[1]);
+         prev = cur;
+      }
    }
 }

--- a/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsFloatTest.java
+++ b/mmstudio/src/test/java/org/micromanager/display/internal/imagestats/ComponentStatsFloatTest.java
@@ -1,0 +1,163 @@
+package org.micromanager.display.internal.imagestats;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests the untruncated (double) statistics used for float images.
+ *
+ * <p>The long-valued statistics cannot represent float data: a mean of -0.16 rounds to 0
+ * and a minimum of -2.24 floors to -3. The double counterparts carry the real values while
+ * the longs remain for the integer bin and quantile machinery.
+ */
+public class ComponentStatsFloatTest {
+
+   private static final double DELTA = 1e-9;
+
+   /** Values measured from a real 32-bit float dataset. */
+   private static final double REAL_MIN = -2.238095283508301;
+   private static final double REAL_MAX = 1.0322580337524414;
+   private static final double REAL_MEAN = -0.16218741610646248;
+
+   private static ComponentStats floatStats(double min, double max, double mean,
+                                            long count, double sumOfSquares) {
+      return ComponentStats.builder()
+            .histogram(new long[] {0, 1, 0}, 0)
+            .isFloat(true)
+            .rangeMin(min)
+            .binWidthFloat((max - min) / 256.0)
+            .pixelCount(count)
+            .pixelCountExcludingZeros(count)
+            .minimum((long) Math.floor(min))
+            .maximum((long) Math.ceil(max))
+            .sum(Math.round(mean * count))
+            .sumOfSquares(Math.round(sumOfSquares))
+            .minimumDouble(min)
+            .minimumExcludingZerosDouble(min)
+            .maximumDouble(max)
+            .sumDouble(mean * count)
+            .sumOfSquaresDouble(sumOfSquares)
+            .build();
+   }
+
+   // --- Float images keep their real values ---
+
+   @Test
+   public void testMinMaxAreNotTruncated() {
+      ComponentStats cs = floatStats(REAL_MIN, REAL_MAX, REAL_MEAN, 4194304L, 1000.0);
+      assertEquals(REAL_MIN, cs.getMinIntensityDouble(), DELTA);
+      assertEquals(REAL_MAX, cs.getMaxIntensityDouble(), DELTA);
+   }
+
+   /** The long getters still floor/ceil; that is what the readout used to show. */
+   @Test
+   public void testLongGettersStillTruncate() {
+      ComponentStats cs = floatStats(REAL_MIN, REAL_MAX, REAL_MEAN, 4194304L, 1000.0);
+      assertEquals(-3L, cs.getMinIntensity());
+      assertEquals(2L, cs.getMaxIntensity());
+   }
+
+   @Test
+   public void testMeanIsNotRoundedToZero() {
+      long count = 4194304L;
+      ComponentStats cs = floatStats(REAL_MIN, REAL_MAX, REAL_MEAN, count, 1000.0);
+      assertEquals(REAL_MEAN, cs.getMeanIntensityDouble(), 1e-6);
+      // The long mean collapses to zero, which is the bug being fixed.
+      assertEquals(0L, cs.getMeanIntensity());
+   }
+
+   @Test
+   public void testMeanExcludingZeros() {
+      long count = 1000L;
+      ComponentStats cs = floatStats(-1.0, 1.0, 0.25, count, 100.0);
+      assertEquals(0.25, cs.getMeanIntensityExcludingZerosDouble(), 1e-9);
+   }
+
+   // --- Standard deviation ---
+
+   @Test
+   public void testStandardDeviationIsCorrect() {
+      long count = 1000L;
+      double mean = 2.0;
+      double sd = 0.5;
+      // E[x^2] = sd^2 + mean^2
+      double sumOfSquares = count * (sd * sd + mean * mean);
+      ComponentStats cs = floatStats(0.0, 4.0, mean, count, sumOfSquares);
+      assertEquals(sd, cs.getStandardDeviationDouble(), 1e-9);
+   }
+
+   /**
+    * With a near-zero mean the integer version can compute a negative variance and return
+    * NaN. The double version must not.
+    */
+   @Test
+   public void testStandardDeviationNeverNaNForNearZeroMean() {
+      long count = 4194304L;
+      double sd = 0.05;
+      double sumOfSquares = count * (sd * sd + REAL_MEAN * REAL_MEAN);
+      ComponentStats cs = floatStats(REAL_MIN, REAL_MAX, REAL_MEAN, count, sumOfSquares);
+      double result = cs.getStandardDeviationDouble();
+      assertFalse("stdev should not be NaN", Double.isNaN(result));
+      assertEquals(sd, result, 1e-6);
+   }
+
+   @Test
+   public void testStandardDeviationClampsInsteadOfNaN() {
+      // sumOfSquares slightly below mean^2 * count (only possible via rounding) must give
+      // 0 rather than NaN.
+      long count = 100L;
+      double mean = 1.0;
+      ComponentStats cs = floatStats(0.0, 2.0, mean, count, count * 0.999999);
+      double result = cs.getStandardDeviationDouble();
+      assertFalse(Double.isNaN(result));
+      assertTrue(result >= 0.0);
+   }
+
+   @Test
+   public void testStandardDeviationNaNWithNoPixels() {
+      ComponentStats cs = ComponentStats.builder()
+            .histogram(new long[] {0, 0, 0}, 0)
+            .isFloat(true)
+            .pixelCount(0)
+            .build();
+      assertTrue(Double.isNaN(cs.getStandardDeviationDouble()));
+   }
+
+   // --- Integer images fall back to the long values, unchanged ---
+
+   @Test
+   public void testIntegerStatsFallBackToLongValues() {
+      ComponentStats cs = ComponentStats.builder()
+            .histogram(new long[] {0, 4, 0}, 0)
+            .pixelCount(4)
+            .pixelCountExcludingZeros(4)
+            .minimum(10L)
+            .minimumExcludingZeros(12L)
+            .maximum(200L)
+            .sum(400L)
+            .sumOfSquares(40000L)
+            .build();
+      assertFalse(cs.isFloat());
+      assertEquals(10.0, cs.getMinIntensityDouble(), DELTA);
+      assertEquals(12.0, cs.getMinIntensityExcludingZerosDouble(), DELTA);
+      assertEquals(200.0, cs.getMaxIntensityDouble(), DELTA);
+      assertEquals(100.0, cs.getMeanIntensityDouble(), DELTA);
+      // Matches the long getters exactly: no behavior change for integer images.
+      assertEquals((double) cs.getMinIntensity(), cs.getMinIntensityDouble(), DELTA);
+      assertEquals((double) cs.getMaxIntensity(), cs.getMaxIntensityDouble(), DELTA);
+      assertEquals((double) cs.getMeanIntensity(), cs.getMeanIntensityDouble(), DELTA);
+   }
+
+   @Test
+   public void testMeanIsZeroWithNoPixels() {
+      ComponentStats cs = ComponentStats.builder()
+            .histogram(new long[] {0, 0, 0}, 0)
+            .pixelCount(0)
+            .build();
+      assertEquals(0.0, cs.getMeanIntensityDouble(), DELTA);
+      assertEquals(0.0, cs.getMeanIntensityExcludingZerosDouble(), DELTA);
+   }
+}

--- a/plugins/OrthogonalViewer/src/main/java/org/micromanager/orthogonalviewer/OrthogonalViewerFrame.java
+++ b/plugins/OrthogonalViewer/src/main/java/org/micromanager/orthogonalviewer/OrthogonalViewerFrame.java
@@ -938,10 +938,10 @@ public class OrthogonalViewerFrame extends AbstractDataViewer
          double fMin;
          double fMax;
          if (settings.isAutoscaleIgnoringZeros()) {
-            // getAutoscale*IgnoringZeros return bin indices; convert to actual values
+            // The float autoscale returns actual pixel values, not bin indices; the
+            // long-valued getAutoscale* would round them first.
             fMin = 0.0;
-            fMax = cStats.getHistogramRangeMinDouble()
-                  + cStats.getAutoscaleMaxForQuantileIgnoringZeros(q) * cStats.getBinWidthDouble();
+            fMax = cStats.getFloatAutoscaleMaxForQuantileIgnoringZeros(q);
          } else {
             // getQuantile returns actual float pixel values for float images
             fMin = cStats.getQuantile(q);
@@ -951,6 +951,11 @@ public class OrthogonalViewerFrame extends AbstractDataViewer
             fMax = fMin + Math.max(cStats.getBinWidthDouble(), 1.0);
          }
          return new double[]{fMin, fMax};
+      }
+
+      if (comp.hasFloatScaling()) {
+         // A range stored as pixel values needs no conversion.
+         return new double[]{comp.getFloatScalingMinimum(), comp.getFloatScalingMaximum()};
       }
 
       if (cStats != null) {


### PR DESCRIPTION
No longer automatically adjusts histogram  range and brightness/contrast for each image (resulting in autoscaling), but expands the range based on what it has seen before.  Adds the ability to manually set a range.  These will be remembered in the display settings.

Fixes a bug in histogram calculation.

Calculate min, max, and avg now in floating point numbers, causing addition of methods to ComponentStats.