### PR TITLE
RatioImaging plugin: Re-wrote to output only to a float image.

### DIFF
--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioAcqManager.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioAcqManager.java
@@ -23,6 +23,9 @@ package org.micromanager.ratioimaging;
 
 import java.awt.Color;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import org.micromanager.Studio;
 import org.micromanager.data.Coords;
 import org.micromanager.data.DataProvider;
@@ -49,7 +52,11 @@ public class RatioAcqManager {
    public static final String RATIO_DISPLAYSETTINGS = "Ratio_Display";
 
    private final Studio studio_;
-   private DisplayWindow window_;
+   // One entry per ratio datastore created by this plugin instance.  A single
+   // field would not do: createStoreAndDisplay is called once per acquisition,
+   // and the windows of earlier acquisitions may still be open.
+   private final Map<DataProvider, DisplayWindow> windows_ =
+            new HashMap<DataProvider, DisplayWindow>();
 
    public RatioAcqManager(Studio studio) {
       studio_ = studio;
@@ -114,23 +121,45 @@ public class RatioAcqManager {
                                  ? displaySettings.getChannelColor(0)
                                  : Color.WHITE));
 
-      window_ = studio_.displays().createDisplay(store, null, displaySettingsBuilder.build());
-      window_.setWindowPositionKey(RATIO_DISPLAYSETTINGS);
-      window_.setDisplaySettingsProfileKey(RATIO_DISPLAYSETTINGS);
-      window_.show();
+      DisplayWindow window =
+               studio_.displays().createDisplay(store, null, displaySettingsBuilder.build());
+      window.setWindowPositionKey(RATIO_DISPLAYSETTINGS);
+      window.setDisplaySettingsProfileKey(RATIO_DISPLAYSETTINGS);
+      forgetClosedWindows();
+      windows_.put(store, window);
+      window.show();
 
       return store;
    }
 
    /**
+    * Drops entries whose window the user has already closed.
+    *
+    * <p>closeViewerFor() only runs for datastores that ended up empty, so
+    * without this the map would retain an entry for every ratio window ever
+    * opened.
+    */
+   private void forgetClosedWindows() {
+      Iterator<Map.Entry<DataProvider, DisplayWindow>> it = windows_.entrySet().iterator();
+      while (it.hasNext()) {
+         if (it.next().getValue().isClosed()) {
+            it.remove();
+         }
+      }
+   }
+
+   /**
     * Closes the display window belonging to the given data provider, if any.
+    *
+    * <p>The entry is removed whether or not a window was found, so that this
+    * map does not keep growing as acquisitions come and go.
     *
     * @param provider DataProvider whose viewer should be closed.
     */
    public void closeViewerFor(DataProvider provider) {
-      if (window_ != null && window_.getDataProvider() == provider) {
-         window_.close();
-         window_ = null;
+      DisplayWindow window = windows_.remove(provider);
+      if (window != null) {
+         window.close();
       }
    }
 }

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioAcqManager.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioAcqManager.java
@@ -1,0 +1,136 @@
+///////////////////////////////////////////////////////////////////////////////
+//FILE:          RatioAcqManager.java
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// AUTHOR:       Nico Stuurman
+//
+// COPYRIGHT:    Regents of the University of California, 2018
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+
+package org.micromanager.ratioimaging;
+
+import java.awt.Color;
+import java.io.IOException;
+import org.micromanager.Studio;
+import org.micromanager.data.Coords;
+import org.micromanager.data.DataProvider;
+import org.micromanager.data.Datastore;
+import org.micromanager.data.SummaryMetadata;
+import org.micromanager.data.internal.PropertyKey;
+import org.micromanager.display.DisplaySettings;
+import org.micromanager.display.DisplayWindow;
+import org.micromanager.display.internal.RememberedDisplaySettings;
+
+/**
+ * Creates and tracks the datastore and display window that hold the float
+ * ratio images.
+ *
+ * <p>The ratio is 32-bit float, whereas the source channels are usually 8 or
+ * 16-bit integer.  Micro-Manager datastores can not hold images of differing
+ * pixel type (see ImageSizeChecker), so the ratio images go into their own
+ * datastore rather than being added as an extra channel to the acquisition.
+ *
+ * <p>This class is owned by the RatioImagingFactory, so that it outlives the
+ * individual Processors (which are created anew for each acquisition).
+ */
+public class RatioAcqManager {
+   public static final String RATIO_DISPLAYSETTINGS = "Ratio_Display";
+
+   private final Studio studio_;
+   private DisplayWindow window_;
+
+   public RatioAcqManager(Studio studio) {
+      studio_ = studio;
+   }
+
+   /**
+    * Creates a RAM datastore for the float ratio images, along with a display
+    * window showing it.
+    *
+    * @param summaryMetadata SummaryMetadata of the input data, used as the base
+    *                        for the ratio datastore's SummaryMetadata.
+    * @param channelName Name of the (single) ratio channel.
+    * @param prefix Name of the datastore, shown in the display window's title.
+    * @param width Width of the ratio images in pixels.
+    * @param height Height of the ratio images in pixels.
+    * @return The newly created Datastore, or null if creation failed.
+    * @throws IOException If setting the SummaryMetadata fails.
+    */
+   public Datastore createStoreAndDisplay(SummaryMetadata summaryMetadata,
+                                          String channelName,
+                                          String prefix,
+                                          int width,
+                                          int height) throws IOException {
+      Datastore store = studio_.data().createRAMDatastore();
+      if (store == null) {
+         studio_.logs().showError("Failed to create datastore for Ratio Imaging.");
+         return null;
+      }
+      store.setName(prefix);
+
+      // The ratio datastore holds a single channel.  Channel names reach the
+      // display through the SummaryMetadata, so this must be set before the
+      // display is created.
+      Coords.Builder cb = summaryMetadata.getIntendedDimensions().copyBuilder().c(1);
+      SummaryMetadata outputSummaryMetadata = summaryMetadata.copyBuilder()
+               .channelNames(new String[] {channelName})
+               .intendedDimensions(cb.build())
+               .imageWidth(width)
+               .imageHeight(height)
+               .prefix(prefix)
+               .build();
+      store.setSummaryMetadata(outputSummaryMetadata);
+
+      DisplaySettings displaySettings =
+               studio_.displays().displaySettingsFromProfile(RATIO_DISPLAYSETTINGS);
+      if (displaySettings == null) {
+         displaySettings = studio_.displays().displaySettingsFromProfile(
+                  PropertyKey.ACQUISITION_DISPLAY_SETTINGS.key());
+      }
+      DisplaySettings.Builder displaySettingsBuilder;
+      if (displaySettings == null) {
+         displaySettingsBuilder = studio_.displays().displaySettingsBuilder();
+      } else {
+         displaySettingsBuilder = displaySettings.copyBuilder();
+      }
+      displaySettingsBuilder.colorModeGrayscale();
+      displaySettingsBuilder.channel(0,
+               RememberedDisplaySettings.loadChannel(studio_,
+                        outputSummaryMetadata.getChannelGroup(),
+                        channelName,
+                        displaySettings != null
+                                 ? displaySettings.getChannelColor(0)
+                                 : Color.WHITE));
+
+      window_ = studio_.displays().createDisplay(store, null, displaySettingsBuilder.build());
+      window_.setWindowPositionKey(RATIO_DISPLAYSETTINGS);
+      window_.setDisplaySettingsProfileKey(RATIO_DISPLAYSETTINGS);
+      window_.show();
+
+      return store;
+   }
+
+   /**
+    * Closes the display window belonging to the given data provider, if any.
+    *
+    * @param provider DataProvider whose viewer should be closed.
+    */
+   public void closeViewerFor(DataProvider provider) {
+      if (window_ != null && window_.getDataProvider() == provider) {
+         window_.close();
+         window_ = null;
+      }
+   }
+}

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImaging.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImaging.java
@@ -70,7 +70,7 @@ public class RatioImaging implements ProcessorPlugin, SciJavaPlugin {
 
    @Override
    public String getVersion() {
-      return "0.2";
+      return "0.3";
    }
    
    @Override

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFactory.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFactory.java
@@ -33,14 +33,18 @@ import org.micromanager.data.ProcessorFactory;
 public class RatioImagingFactory implements ProcessorFactory {
    private final Studio studio_;
    private final PropertyMap settings_;
-   
+   private final RatioAcqManager ratioAcqManager_;
+
    public RatioImagingFactory(Studio studio, PropertyMap settings) {
       studio_ = studio;
       settings_ = settings;
+      // Owned by the Factory rather than the Processor, since a new Processor
+      // is created for each acquisition.
+      ratioAcqManager_ = new RatioAcqManager(studio);
    }
 
    @Override
    public Processor createProcessor() {
-      return new RatioImagingProcessor(studio_, settings_);
+      return new RatioImagingProcessor(studio_, settings_, ratioAcqManager_);
    }
 }

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
@@ -38,7 +38,6 @@ import javax.swing.JLabel;
 import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import mmcorej.CMMCore;
 import net.miginfocom.swing.MigLayout;
 import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
@@ -70,11 +69,9 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
    static final String BACKGROUND2 = "Background2";
    static final String BACKGROUND1CONSTANT = "Background1Constant";
    static final String BACKGROUND2CONSTANT = "Background2Constant";
-   static final String FACTOR = "Factor";
    private static final String[] IMAGESUFFIXES = {"tif", "tiff", "jpg", "png"};
 
    private final Studio studio_;
-   private final CMMCore core_;
    private final JComboBox<String> ch1Combo_;
    private final JComboBox<String> ch2Combo_;
    private final MutablePropertyMapView settings_;
@@ -92,7 +89,6 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
     */
    public RatioImagingFrame(PropertyMap configuratorSettings, Studio studio) {
       studio_ = studio;
-      core_ = studio_.getCMMCore();
       settings_ = studio_.profile().getSettings(this.getClass());
       copySettings(settings_, configuratorSettings);
       pluginUtilities_ = new PluginUtilities(studio_);
@@ -127,14 +123,6 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
               new TextFieldUpdater(bc2TextField, BACKGROUND2CONSTANT, settings_));
       settings_.putString(BACKGROUND2CONSTANT, bc2TextField.getText());
       
-      final int maxValue = 2 << core_.getImageBitDepth();
-      final JTextField factorTextField = new JTextField(5);
-      factorTextField.setText(settings_.getString(FACTOR, 
-              NumberUtils.intToDisplayString((maxValue))));
-      factorTextField.getDocument().addDocumentListener(
-              new TextFieldUpdater(factorTextField, FACTOR, settings_));
-      settings_.putString(FACTOR, factorTextField.getText());
-
       super.add(darkImageLabel, "skip 2, center");
       super.add(new JLabel("constant"), "skip 1, center, gap 20:push, wrap");
       
@@ -150,10 +138,12 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
       super.add(background2Button_);
       super.add(bc2TextField, "gap 20:push, wrap");
       
-      super.add(new JLabel("(Ch1 - (background + constant)) / (Ch2 - (background + constant) *"), 
-              "gapy 20:push, span 5, split 2");
-      super.add(factorTextField, "wrap");
-      
+      super.add(new JLabel(
+              "(Ch1 - background1 - constant1) / (Ch2 - background2 - constant2)"),
+              "gapy 20:push, span 5, wrap");
+      super.add(new JLabel("Output is 32-bit float, in a separate window."),
+              "span 5, wrap");
+
       super.pack();
 
       super.setIconImage(Toolkit.getDefaultToolkit().getImage(
@@ -188,9 +178,8 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
       settings.putString(BACKGROUND2, configuratorSettings.getString(BACKGROUND2, ""));
       settings.putString(BACKGROUND1CONSTANT, 
               configuratorSettings.getString(BACKGROUND1CONSTANT, ""));
-      settings.putString(BACKGROUND2CONSTANT, 
+      settings.putString(BACKGROUND2CONSTANT,
               configuratorSettings.getString(BACKGROUND2CONSTANT, ""));
-      settings.putString(FACTOR, configuratorSettings.getString(FACTOR, ""));
    }
 
 

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingFrame.java
@@ -32,6 +32,7 @@ import java.awt.event.FocusListener;
 import java.io.File;
 import java.text.ParseException;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -69,6 +70,7 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
    static final String BACKGROUND2 = "Background2";
    static final String BACKGROUND1CONSTANT = "Background1Constant";
    static final String BACKGROUND2CONSTANT = "Background2Constant";
+   static final String COPY_SOURCE_CHANNELS = "CopySourceChannels";
    private static final String[] IMAGESUFFIXES = {"tif", "tiff", "jpg", "png"};
 
    private final Studio studio_;
@@ -138,11 +140,28 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
       super.add(background2Button_);
       super.add(bc2TextField, "gap 20:push, wrap");
       
+      final JCheckBox copySourceChannelsCheckBox =
+              new JCheckBox("Copy source channels to output");
+      copySourceChannelsCheckBox.setSelected(
+              settings_.getBoolean(COPY_SOURCE_CHANNELS, true));
+      copySourceChannelsCheckBox.setToolTipText(
+              "<html>When checked, the source channels are passed on to the output "
+              + "datastore<br>in addition to the ratio image.<br><br>"
+              + "Uncheck when processing existing data, to avoid duplicating the "
+              + "source dataset.<br>Note that with this unchecked the ratio window "
+              + "is the only output, and the<br>pipeline's own output datastore will "
+              + "remain empty.</html>");
+      copySourceChannelsCheckBox.addActionListener(e ->
+              settings_.putBoolean(COPY_SOURCE_CHANNELS,
+                      copySourceChannelsCheckBox.isSelected()));
+      settings_.putBoolean(COPY_SOURCE_CHANNELS, copySourceChannelsCheckBox.isSelected());
+
       super.add(new JLabel(
               "(Ch1 - background1 - constant1) / (Ch2 - background2 - constant2)"),
               "gapy 20:push, span 5, wrap");
       super.add(new JLabel("Output is 32-bit float, in a separate window."),
               "span 5, wrap");
+      super.add(copySourceChannelsCheckBox, "span 5, wrap");
 
       super.pack();
 
@@ -180,6 +199,8 @@ public class RatioImagingFrame extends JFrame implements ProcessorConfigurator {
               configuratorSettings.getString(BACKGROUND1CONSTANT, ""));
       settings.putString(BACKGROUND2CONSTANT,
               configuratorSettings.getString(BACKGROUND2CONSTANT, ""));
+      settings.putBoolean(COPY_SOURCE_CHANNELS,
+              configuratorSettings.getBoolean(COPY_SOURCE_CHANNELS, true));
    }
 
 

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingProcessor.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingProcessor.java
@@ -26,16 +26,18 @@ package org.micromanager.ratioimaging;
 import ij.ImagePlus;
 import ij.process.Blitter;
 import ij.process.ByteProcessor;
-import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
 import ij.process.ShortProcessor;
 import java.awt.Rectangle;
+import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.SwingUtilities;
 import org.micromanager.PropertyMap;
 import org.micromanager.Studio;
 import org.micromanager.data.Coords;
+import org.micromanager.data.Datastore;
 import org.micromanager.data.Image;
 import org.micromanager.data.Processor;
 import org.micromanager.data.ProcessorContext;
@@ -48,7 +50,13 @@ import org.micromanager.data.SummaryMetadata;
 import org.micromanager.internal.utils.NumberUtils;
 
 /**
- * DataProcessor that creates a ration image as instructed in the UI.
+ * DataProcessor that creates a ratio image as instructed in the UI.
+ *
+ * <p>The ratio is computed and emitted as 32-bit float.  Since Micro-Manager
+ * datastores can not hold images of differing pixel type, the float ratio
+ * images can not be added as an extra channel to the (usually 8 or 16-bit
+ * integer) acquisition datastore.  They are therefore written to a datastore of
+ * their own, created and managed by the RatioAcqManager.
  *
  * @author nico
  */
@@ -56,7 +64,7 @@ public class RatioImagingProcessor implements Processor {
 
    private final Studio studio_;
    private final PropertyMap settings_;
-   private final int factor_;
+   private final RatioAcqManager ratioAcqManager_;
    private final int bc1Constant_;
    private final int bc2Constant_;
    private final String bc1Path_;
@@ -67,29 +75,25 @@ public class RatioImagingProcessor implements Processor {
    private boolean process_;
    private int ch1Index_;
    private int ch2Index_;
-   private int ratioIndex_;
+   private String ratioChannelName_;
+   private SummaryMetadata inputSummaryMetadata_;
+   private Datastore ratioStore_;
 
    /**
     * Constructor of the Processor doing the heavy lifting.
     *
     * @param studio Studio object gives access to all we need.
     * @param settings Plugin Settings
+    * @param ratioAcqManager Creates and tracks the ratio datastore and display.
     */
-   public RatioImagingProcessor(Studio studio, PropertyMap settings) {
+   public RatioImagingProcessor(Studio studio, PropertyMap settings,
+                                RatioAcqManager ratioAcqManager) {
       studio_ = studio;
       settings_ = settings;
+      ratioAcqManager_ = ratioAcqManager;
       images_ = new ArrayList<Image>();
-      int factor = 1;
       int bc1Constant = 0;
       int bc2Constant = 0;
-      try {
-         if (settings_.containsString(RatioImagingFrame.FACTOR)) {
-            factor = NumberUtils.displayStringToInt(
-                    settings_.getString(RatioImagingFrame.FACTOR, "1"));
-         }
-      } catch (ParseException pe) {
-         studio_.logs().logError(pe);
-      }
       try {
          if (settings_.containsString(RatioImagingFrame.BACKGROUND1CONSTANT)) {
             bc1Constant = NumberUtils.displayStringToInt(
@@ -108,15 +112,18 @@ public class RatioImagingProcessor implements Processor {
       }
       bc1Path_ = settings_.getString(RatioImagingFrame.BACKGROUND1, "");
       bc2Path_ = settings_.getString(RatioImagingFrame.BACKGROUND2, "");
-      factor_ = factor;
       bc1Constant_ = bc1Constant;
       bc2Constant_ = bc2Constant;
    }
 
    @Override
    public SummaryMetadata processSummaryMetadata(SummaryMetadata summary) {
-      
-      // Update channel names in summary metadata.
+
+      // The ratio images go into a datastore of their own, so the incoming
+      // SummaryMetadata is passed through unchanged.  Keep a copy of it as the
+      // basis for the ratio datastore's SummaryMetadata.
+      inputSummaryMetadata_ = summary;
+
       List<String> chNames = summary.getChannelNameList();
       if (chNames == null || chNames.isEmpty() || chNames.size() < 2) {
          // Can't do anything as we don't know how many names there'll be.
@@ -124,9 +131,9 @@ public class RatioImagingProcessor implements Processor {
       }
       final String ch1Name = settings_.getString(RatioImagingFrame.CHANNEL1, "");
       final String ch2Name = settings_.getString(RatioImagingFrame.CHANNEL2, "");
-      
+
       process_ = true;
-      
+
       ch1Index_ = -1;
       ch2Index_ = -1;
       for (int i = 0; i < chNames.size(); i++) {
@@ -141,18 +148,10 @@ public class RatioImagingProcessor implements Processor {
          process_ = false;
          return summary;
       }
-      
-      String[] newNames = new String[chNames.size() + 1];
-      for (int i = 0; i < chNames.size(); i++) {
-         newNames[i] = chNames.get(i);
-      }
-      newNames[chNames.size() ] = "ratio " + ch1Name + "-" + ch2Name;
-      ratioIndex_ = chNames.size();
-      Coords newDimensions = summary.getIntendedDimensions().copyBuilder()
-                  .c(newNames.length).build();
-      
-      return summary.copyBuilder().channelNames(newNames)
-                  .intendedDimensions(newDimensions).build();
+
+      ratioChannelName_ = "ratio " + ch1Name + "-" + ch2Name;
+
+      return summary;
    }
 
 
@@ -255,13 +254,13 @@ public class RatioImagingProcessor implements Processor {
          Coords oldCoords = oldImage.getCoords();
          if (newCoords.copyRemovingAxes(Coords.C).equals(oldCoords.copyRemovingAxes(Coords.C))) {
             if (newCoords.getC() == ch1Index_ && oldCoords.getC() == ch2Index_) {
-               process(newImage, oldImage, context);
+               process(newImage, oldImage);
                images_.remove(oldImage);
                return;
             }
-         
+
             if (oldCoords.getC() == ch1Index_ && newCoords.getC() == ch2Index_) {
-               process(oldImage, newImage, context);
+               process(oldImage, newImage);
                images_.remove(oldImage);
                return;
             }
@@ -273,10 +272,23 @@ public class RatioImagingProcessor implements Processor {
 
    }
       
-   private void process(Image ch1Image, Image ch2Image, ProcessorContext context) {
-      
-      final Coords ratioCoords = ch1Image.getCoords().copyBuilder().c(ratioIndex_).build();
-      
+   /**
+    * Computes the float ratio of the two images and writes it to the ratio
+    * datastore, creating that datastore (and its display) on first use.
+    *
+    * <p>The result is not handed to the ProcessorContext: it is 32-bit float
+    * and so can not be added to the acquisition datastore alongside the
+    * integer source channels.
+    *
+    * @param ch1Image Numerator image.
+    * @param ch2Image Denominator image.
+    */
+   private void process(Image ch1Image, Image ch2Image) {
+
+      // The ratio datastore holds a single channel, so the ratio image always
+      // lives at channel index 0 there.
+      final Coords ratioCoords = ch1Image.getCoords().copyBuilder().c(0).build();
+
       ImageProcessor ch1Proc = studio_.data().ij().createProcessor(ch1Image);
       ImageProcessor ch2Proc = studio_.data().ij().createProcessor(ch2Image);
       if (bc1_ != null) {
@@ -289,57 +301,73 @@ public class RatioImagingProcessor implements Processor {
       ch2Proc = ch2Proc.convertToFloat();
       ch1Proc.subtract(bc1Constant_);
       ch2Proc.subtract(bc2Constant_);
-      ImageProcessor ch3Proc = ch1Proc.createProcessor(ch1Proc.getWidth(), 
+      ImageProcessor ch3Proc = ch1Proc.createProcessor(ch1Proc.getWidth(),
               ch1Proc.getHeight());
       ch3Proc.insert(ch1Proc, 0, 0);
       ch3Proc.copyBits(ch2Proc, 0, 0, Blitter.DIVIDE);
-      ch3Proc.multiply(factor_);
-      
-      if (ch1Image.getBytesPerPixel() == 1) {
-         // check this actually works....
-         ch3Proc = ch3Proc.convertToByteProcessor();
-      } else if (ch1Image.getBytesPerPixel() == 2) {
-         // ImageJ method seems to be broken. Copied code from ImageJ1 here
-         ch3Proc = convertFloatToShort((FloatProcessor) ch3Proc);
-      }
-      int max = (int) ch3Proc.getMax();
-      int bitDepth = 1;
-      while ((1 << bitDepth) < max && bitDepth <= ch1Image.getBytesPerPixel() * 8) {
-         bitDepth += 1;
-      }
-      
-      Image ratioImage = studio_.data().ij().createImage(ch3Proc, ratioCoords, 
-              ch1Image.getMetadata().copyBuilderWithNewUUID().bitDepth(bitDepth)
+
+      // ch3Proc is a FloatProcessor, and is deliberately left as such: the
+      // ratio is output as 32-bit float rather than being scaled and rounded
+      // into an integer range.  Where ch2 is zero the division yields NaN or
+      // Infinity; these are left alone.  They mark "undefined" and are excluded
+      // from the histogram and statistics by ImageStatsProcessor.
+      Image ratioImage = studio_.data().ij().createImage(ch3Proc, ratioCoords,
+              ch1Image.getMetadata().copyBuilderWithNewUUID().bitDepth(32)
                           .build());
-      
-      context.outputImage(ratioImage);
-   }
-   
-   /**
-    * Copied from https://github.com/imagej/imagej1/blob/master/ij/process/TypeConverter.java.
-    *
-    * <p>The call to chrProc.convertToShortProcess results in pixel values of -1
-    * Not sure why (but in included ImageJ version?) 
-    * Copying the relevant code from the ImageJ1 source fixes it
-    *
-    * @param ip FloatProcessor to be converted
-    * @return Shortprocessor
-    */
-   ShortProcessor convertFloatToShort(FloatProcessor ip) {
-      float[] pixels32 = (float[]) ip.getPixels();
-      short[] pixels16 = new short[ip.getWidth() * ip.getHeight()];
-      double value;
-      for (int i = 0, j = 0; i < (ip.getWidth() * ip.getHeight()); i++) {
-         value = pixels32[i];
-         if (value < 0.0) {
-            value = 0.0;
+
+      if (ratioStore_ == null) {
+         String prefix = (inputSummaryMetadata_ == null
+                 || inputSummaryMetadata_.getPrefix() == null
+                 || inputSummaryMetadata_.getPrefix().isEmpty())
+                 ? "Untitled" : inputSummaryMetadata_.getPrefix();
+         try {
+            ratioStore_ = ratioAcqManager_.createStoreAndDisplay(inputSummaryMetadata_,
+                    ratioChannelName_, prefix + "-Ratio",
+                    ratioImage.getWidth(), ratioImage.getHeight());
+         } catch (IOException ioe) {
+            studio_.logs().logError(ioe);
+            process_ = false;
+            return;
          }
-         if (value > 65535.0) {
-            value = 65535.0;
+         if (ratioStore_ == null) {
+            process_ = false;
+            return;
          }
-         pixels16[i] = (short) (value + 0.5);
       }
-      return new ShortProcessor(ip.getWidth(), ip.getHeight(), pixels16, ip.getColorModel());
+
+      try {
+         ratioStore_.putImage(ratioImage);
+      } catch (IOException ioe) {
+         studio_.logs().logError(ioe);
+      }
+   }
+
+   @Override
+   public void cleanup(ProcessorContext context) {
+      images_.clear();
+      if (ratioStore_ != null) {
+         final Datastore store = ratioStore_;
+         try {
+            store.freeze();
+            if (store.getNumImages() == 0) {
+               // Nothing was produced; close the empty window rather than
+               // leaving it behind.  Window work is deferred to the EDT since
+               // cleanup() blocks Pipeline.halt() and may run on a Processor
+               // thread.
+               SwingUtilities.invokeLater(() -> {
+                  ratioAcqManager_.closeViewerFor(store);
+                  try {
+                     store.close();
+                  } catch (IOException ioe) {
+                     studio_.logs().logError(ioe);
+                  }
+               });
+            }
+         } catch (IOException ioe) {
+            studio_.logs().logError(ioe);
+         }
+         ratioStore_ = null;
+      }
    }
    
    private static ByteProcessor subtractByteProcessors(ByteProcessor proc1, ByteProcessor proc2) {

--- a/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingProcessor.java
+++ b/plugins/RatioImaging/src/main/java/org/micromanager/ratioimaging/RatioImagingProcessor.java
@@ -69,6 +69,7 @@ public class RatioImagingProcessor implements Processor {
    private final int bc2Constant_;
    private final String bc1Path_;
    private final String bc2Path_;
+   private final boolean copySourceChannels_;
    private ImagePlus bc1_;
    private ImagePlus bc2_;
    private final List<Image> images_;
@@ -112,6 +113,8 @@ public class RatioImagingProcessor implements Processor {
       }
       bc1Path_ = settings_.getString(RatioImagingFrame.BACKGROUND1, "");
       bc2Path_ = settings_.getString(RatioImagingFrame.BACKGROUND2, "");
+      copySourceChannels_ = settings_.getBoolean(
+              RatioImagingFrame.COPY_SOURCE_CHANNELS, true);
       bc1Constant_ = bc1Constant;
       bc2Constant_ = bc2Constant;
    }
@@ -220,9 +223,14 @@ public class RatioImagingProcessor implements Processor {
 
    @Override
    public void processImage(Image newImage, ProcessorContext context) {
-      
-      context.outputImage(newImage);
-      
+
+      // The ratio image goes to its own datastore, so passing the source
+      // channels on is optional.  When processing existing data it only
+      // duplicates the input dataset, so the user can switch it off.
+      if (copySourceChannels_) {
+         context.outputImage(newImage);
+      }
+
       if (newImage.getNumComponents() > 1) {
          return;
       }


### PR DESCRIPTION
This obviates the need to round numbers to integers, loosing resolution.

Also adds ability to suppress output, so as to not duplicate data for existing acquisitions.