### PR TITLE
Improve behavior of dropdown menus in the User Interface

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1509,8 +1509,19 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
          for (ActionListener cgsal : cgsals) {
             channelGroupCombo_.addActionListener(cgsal);
          }
+         // Editing a cell (e.g. picking a Configuration) ends up here too, via
+         // ChannelTableModel.setValueAt() -> storeChannels() -> setSequenceSettings()
+         // -> this AcquisitionSettingsChangedEvent handler. fireTableStructureChanged()
+         // below is a full rebuild that clears row selection with nothing to restore
+         // it, unlike the New/Remove/Up/Down button handlers, which explicitly
+         // restore selection after their own structural changes. Do the same here so
+         // committing a dropdown edit doesn't lose the row selection.
+         int selectedRow = channelTable_.getSelectedRow();
          model_.setChannels(sequenceSettings.channels());
          model_.fireTableStructureChanged();
+         if (selectedRow > -1 && selectedRow < channelTable_.getRowCount()) {
+            channelTable_.setRowSelectionInterval(selectedRow, selectedRow);
+         }
          chanKeepShutterOpenCheckBox_.setSelected(sequenceSettings.keepShutterOpenChannels());
          channelTable_.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
          boolean selected = channelsPanel_.isSelected();

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
@@ -11,6 +11,7 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.PopupMenuEvent;
@@ -28,7 +29,35 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
 
    private static final long serialVersionUID = -8374637422965302637L;
    private final JTextField text_ = new JTextField();
-   private final JComboBox<String> channelSelect_ = new JComboBox<>();
+   // Set for the remainder of the current AWT event right after we close the
+   // popup via setPopupVisible(false), then cleared on the next EDT cycle.
+   // See setPopupVisible() below for why this exists.
+   private boolean justClosedPopup_ = false;
+
+   private final JComboBox<String> channelSelect_ = new JComboBox<String>() {
+      @Override
+      public void setPopupVisible(boolean visible) {
+         if (visible) {
+            // Clicking the combo box's own arrow/button while its popup is
+            // already open can trigger a same-click close-then-reopen race:
+            // MenuSelectionManager sees that click as landing outside the
+            // popup and closes it, then the arrow button's own toggle
+            // handler (processing the same click right after) sees the
+            // now-closed state and calls setPopupVisible(true) again,
+            // reopening it. The popup ends up glitched/stuck instead of
+            // cleanly closed. Ignore "become visible" requests while
+            // already visible, or immediately after we just closed it
+            // ourselves within this same event, to break that race.
+            if (isPopupVisible() || justClosedPopup_) {
+               return;
+            }
+         } else if (isPopupVisible()) {
+            justClosedPopup_ = true;
+            SwingUtilities.invokeLater(() -> justClosedPopup_ = false);
+         }
+         super.setPopupVisible(visible);
+      }
+   };
    private final JCheckBox checkBox_ = new JCheckBox();
    boolean checkBoxValue_ = false;
    private final JLabel colorLabel_ = new JLabel();
@@ -44,6 +73,12 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
 
    public ChannelCellEditor() {
       checkBoxChangeListener_ = new CheckBoxChangeListener(this);
+
+      // Tells the combo box's UI delegate it is being used as a table cell
+      // editor, so its built-in Enter/Escape key handling (e.g. confirming
+      // the highlighted item and handing off to the table) behaves as
+      // javax.swing.DefaultCellEditor's JComboBox constructor sets it up.
+      channelSelect_.putClientProperty("JComboBox.isTableCellEditor", Boolean.TRUE);
 
       channelSelect_.addPopupMenuListener(new PopupMenuListener() {
          @Override
@@ -62,23 +97,90 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
             // Treat that case as an implicit re-confirmation.
             if (wasOpen && !selectionMade_) {
                selectionMade_ = true;
-               fireEditingStopped();
+               // This listener fires *during* the popup's own hide()
+               // teardown (unlike the ActionListener above, which fires
+               // before hide() begins). Committing synchronously here runs
+               // our table-mutating code interleaved with that teardown,
+               // which can leave the popup visually stuck mid-collapse.
+               // Defer to the next EDT cycle so hide() finishes first, and
+               // go through stopCellEditing() (not fireEditingStopped()
+               // directly) so a popup that got spuriously reopened by the
+               // race above is forced closed before the editor is removed.
+               SwingUtilities.invokeLater(() -> stopCellEditing());
             }
          }
 
          @Override
          public void popupMenuCanceled(PopupMenuEvent e) {
             channelSelect_.putClientProperty("popupOpen", null);
-            fireEditingCanceled();
+            cancelCellEditing();
          }
       });
 
       channelSelect_.addActionListener(e -> {
-         if (Boolean.TRUE.equals(channelSelect_.getClientProperty("popupOpen"))) {
+         // Remember any real value change (mouse or arrow keys) so a later
+         // commit reflects it, but only commit *now* when the popup is open:
+         // clicking an item there is itself the confirm gesture. Arrow-key
+         // browsing with the popup closed should not commit on every
+         // keystroke; JTable's own Enter/Tab/focus-loss handling will call
+         // stopCellEditing() when the user actually confirms.
+         if (!Objects.equals(channelSelect_.getSelectedItem(), channel_.config())) {
             selectionMade_ = true;
-            fireEditingStopped();
+         }
+         if (Boolean.TRUE.equals(channelSelect_.getClientProperty("popupOpen"))) {
+            stopCellEditing();
          }
       });
+   }
+
+   /**
+    * Closes the Configuration dropdown's popup, if open, before actually
+    * stopping or canceling the edit.
+    *
+    * <p>Callers such as {@code applySettingsFromGUI()} may call
+    * {@code stopCellEditing()} on the active editor programmatically (e.g.
+    * right before the Up/Down/Remove buttons reorder the underlying rows).
+    * If the combo box's popup is still open at that point, removing the
+    * editor out from under it leaves the popup as a visual orphan, and the
+    * table can end up attaching a leftover editing state to the wrong row
+    * after the reorder — the same symptom as the original stuck-dropdown
+    * bug. Hiding the popup first ensures it closes through the normal
+    * PopupMenuListener path before the row data underneath it changes.
+    */
+   @Override
+   public boolean stopCellEditing() {
+      if (channelSelect_.isPopupVisible()) {
+         channelSelect_.hidePopup();
+      }
+      return super.stopCellEditing();
+   }
+
+   @Override
+   public void cancelCellEditing() {
+      if (channelSelect_.isPopupVisible()) {
+         channelSelect_.hidePopup();
+      }
+      super.cancelCellEditing();
+   }
+
+   /**
+    * Selects {@code value} in {@code combo} if it is actually present among
+    * the combo's items, otherwise clears the selection.
+    *
+    * <p>{@code JComboBox.setSelectedItem()}/{@code getSelectedItem()} is not
+    * a reliable presence check: {@code DefaultComboBoxModel} stores whatever
+    * object is passed in as the selected item regardless of whether it is
+    * one of the combo's actual items, so a value absent from the list would
+    * otherwise appear to "stick" instead of falling back to no selection.
+    */
+   private static void selectItemOrClear(JComboBox<String> combo, String value) {
+      for (int i = 0; i < combo.getItemCount(); i++) {
+         if (Objects.equals(combo.getItemAt(i), value)) {
+            combo.setSelectedItem(value);
+            return;
+         }
+      }
+      combo.setSelectedIndex(-1);
    }
 
    // This method is called when a cell value is edited by the user.
@@ -114,7 +216,6 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
          text_.setText(NumberUtils.intToDisplayString((Integer) value));
          return text_;
       } else if (colIndex == 1) {
-         selectionMade_ = false;
          channelSelect_.putClientProperty("popupOpen", null);
          channelSelect_.removeAllItems();
 
@@ -132,10 +233,16 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
                channelSelect_.addItem(config);
             }
          }
-         channelSelect_.setSelectedItem(channel_.config());
-         if (!Objects.equals(channel_.config(), channelSelect_.getSelectedItem())) {
-            channelSelect_.setSelectedIndex(-1);
-         }
+         selectItemOrClear(channelSelect_, channel_.config());
+         // Reset only now, after the item-list rebuild above has settled:
+         // removeAllItems() drops the selection to null and can fire a
+         // spurious ActionEvent (selectedItem=null) that our own
+         // ActionListener would otherwise misread as a real user change,
+         // incorrectly marking selectionMade_ true before any real
+         // interaction happens. That poisoned flag then silently defeats
+         // the popupMenuWillBecomeInvisible reselect-same-item commit further
+         // down, leaving the cell editor stuck open indefinitely.
+         selectionMade_ = false;
 
          // Return the configured component
          return channelSelect_;

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
@@ -1,7 +1,6 @@
 package org.micromanager.internal.dialogs;
 
 import java.awt.Component;
-import java.awt.event.ActionListener;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -14,6 +13,8 @@ import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import javax.swing.table.TableCellEditor;
 import org.micromanager.acquisition.ChannelSpec;
 import org.micromanager.internal.utils.NumberUtils;
@@ -36,8 +37,48 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
 
    private final CheckBoxChangeListener checkBoxChangeListener_;
 
+   // True only after the user picks an item from the open dropdown.
+   // getCellEditorValue() returns the original value when false, making any
+   // external stopCellEditing() call a no-op.
+   private boolean selectionMade_ = false;
+
    public ChannelCellEditor() {
       checkBoxChangeListener_ = new CheckBoxChangeListener(this);
+
+      channelSelect_.addPopupMenuListener(new PopupMenuListener() {
+         @Override
+         public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+            channelSelect_.putClientProperty("popupOpen", Boolean.TRUE);
+         }
+
+         @Override
+         public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+            boolean wasOpen = Boolean.TRUE.equals(channelSelect_.getClientProperty("popupOpen"));
+            channelSelect_.putClientProperty("popupOpen", null);
+            // JComboBox only fires an ActionEvent when the selection actually
+            // changes. If the user reopens the popup and clicks the item that
+            // was already selected, the popup closes normally here but no
+            // ActionEvent ever fires, leaving the cell editor stuck open.
+            // Treat that case as an implicit re-confirmation.
+            if (wasOpen && !selectionMade_) {
+               selectionMade_ = true;
+               fireEditingStopped();
+            }
+         }
+
+         @Override
+         public void popupMenuCanceled(PopupMenuEvent e) {
+            channelSelect_.putClientProperty("popupOpen", null);
+            fireEditingCanceled();
+         }
+      });
+
+      channelSelect_.addActionListener(e -> {
+         if (Boolean.TRUE.equals(channelSelect_.getClientProperty("popupOpen"))) {
+            selectionMade_ = true;
+            fireEditingStopped();
+         }
+      });
    }
 
    // This method is called when a cell value is edited by the user.
@@ -73,11 +114,8 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
          text_.setText(NumberUtils.intToDisplayString((Integer) value));
          return text_;
       } else if (colIndex == 1) {
-         // remove old listeners
-         ActionListener[] listeners = channelSelect_.getActionListeners();
-         for (ActionListener listener : listeners) {
-            channelSelect_.removeActionListener(listener);
-         }
+         selectionMade_ = false;
+         channelSelect_.putClientProperty("popupOpen", null);
          channelSelect_.removeAllItems();
 
          // Only allow channels that aren't already selected in a different
@@ -95,13 +133,9 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
             }
          }
          channelSelect_.setSelectedItem(channel_.config());
-
-         // end editing on selection change
-         channelSelect_.addPropertyChangeListener(e -> {
-            if (!Objects.equals(channelSelect_.getSelectedItem(), channel_.config())) {
-               fireEditingStopped();
-            }
-         });
+         if (!Objects.equals(channel_.config(), channelSelect_.getSelectedItem())) {
+            channelSelect_.setSelectedIndex(-1);
+         }
 
          // Return the configured component
          return channelSelect_;
@@ -122,7 +156,7 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
          if (editCol_ == 0) {
             return checkBox_.isSelected();
          } else if (editCol_ == 1) {
-            return channelSelect_.getSelectedItem();
+            return selectionMade_ ? channelSelect_.getSelectedItem() : channel_.config();
          } else if (editCol_ == 2 || editCol_ == 3) {
             return NumberUtils.displayStringToDouble(text_.getText());
          } else if (editCol_ == 4) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelCellEditor.java
@@ -192,6 +192,15 @@ public final class ChannelCellEditor extends AbstractCellEditor implements Table
       ArrayList<ChannelSpec> channels = model.getChannels();
       channel_ = channels.get(rowIndex);
 
+      // Once an editor component is showing in a cell, further clicks in
+      // that area (the combo box, then its popup) land on those components
+      // directly rather than on the JTable, so JTable's own mouse handling
+      // (which normally updates row selection on click) never sees them.
+      // Select the row explicitly here so it doesn't depend on that.
+      if (!table.isRowSelected(rowIndex)) {
+         table.setRowSelectionInterval(rowIndex, rowIndex);
+      }
+
       colIndex = table.convertColumnIndexToModel(colIndex);
 
       // Configure the component with the specified value

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ChannelTableModel.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import javax.swing.event.TableModelEvent;
 import javax.swing.table.AbstractTableModel;
 import org.micromanager.acquisition.ChannelSpec;
 import org.micromanager.acquisition.internal.AcquisitionEngine;
@@ -176,7 +175,15 @@ public final class ChannelTableModel extends AbstractTableModel {
       channels_.set(row, channel);
       storeChannels();
 
-      this.fireTableChanged(new TableModelEvent(this));
+      // A row-scoped update, not fireTableChanged(new TableModelEvent(this))
+      // (which claims the whole table changed): storeChannels() -> ...
+      // -> AcquisitionSettingsChangedEvent already triggers a full
+      // fireTableStructureChanged() rebuild via
+      // AcqControlDlg.updateGUIFromSequenceSettings() when applicable, so a
+      // second "everything changed" event here is redundant - and empirically
+      // (unlike this narrower one) it clears the table's row selection with
+      // nothing to restore it afterward.
+      this.fireTableRowsUpdated(row, row);
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -521,7 +521,18 @@ public final class AutofocusPropertyEditor extends JDialog {
 
             @Override
             public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+               boolean wasOpen = Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"));
                combo_.putClientProperty("popupOpen", null);
+               // JComboBox only fires an ActionEvent when the selection actually
+               // changes. If the user reopens the popup and clicks the item that
+               // was already selected, the popup closes normally here but no
+               // ActionEvent ever fires, leaving the cell editor stuck open
+               // (shown with the "editing" look) until something else forces a
+               // table event. Treat that case as an implicit re-confirmation.
+               if (wasOpen && !selectionMade_) {
+                  selectionMade_ = true;
+                  fireEditingStopped();
+               }
             }
 
             @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/AutofocusPropertyEditor.java
@@ -46,6 +46,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.SpringLayout;
+import javax.swing.SwingUtilities;
 import javax.swing.border.BevelBorder;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
@@ -490,7 +491,36 @@ public final class AutofocusPropertyEditor extends JDialog {
       private static final long serialVersionUID = 1L;
       // This is the component that will handle the editing of the cell value
       JTextField text_ = new JTextField();
-      JComboBox<String> combo_ = new JComboBox<>();
+      // Set for the remainder of the current AWT event right after we close
+      // the popup via setPopupVisible(false), then cleared on the next EDT
+      // cycle. See setPopupVisible() below for why this exists.
+      private boolean justClosedPopup_ = false;
+
+      JComboBox<String> combo_ = new JComboBox<String>() {
+         @Override
+         public void setPopupVisible(boolean visible) {
+            if (visible) {
+               // Clicking the combo box's own arrow/button while its popup
+               // is already open can trigger a same-click close-then-reopen
+               // race: MenuSelectionManager sees that click as landing
+               // outside the popup and closes it, then the arrow button's
+               // own toggle handler (processing the same click right after)
+               // sees the now-closed state and calls setPopupVisible(true)
+               // again, reopening it. The popup ends up glitched/stuck
+               // instead of cleanly closed. Ignore "become visible"
+               // requests while already visible, or immediately after we
+               // just closed it ourselves within this same event, to break
+               // that race.
+               if (isPopupVisible() || justClosedPopup_) {
+                  return;
+               }
+            } else if (isPopupVisible()) {
+               justClosedPopup_ = true;
+               SwingUtilities.invokeLater(() -> justClosedPopup_ = false);
+            }
+            super.setPopupVisible(visible);
+         }
+      };
       JCheckBox check_ = new JCheckBox();
       SliderPanel slider_ = new SliderPanel();
       int editingCol_;
@@ -507,12 +537,13 @@ public final class AutofocusPropertyEditor extends JDialog {
          super();
          check_.addActionListener(e -> fireEditingStopped());
 
-         // Commit when the user picks a value from the dropdown while it is open.
-         // A bare ActionListener fires spuriously on focus loss; gating it on the
-         // popup-open flag suppresses those false fires while still catching every
-         // genuine selection (including selecting the first item when an empty
-         // entry was previously chosen — a case where PopupMenuListener comparison
-         // logic breaks on the Windows L&F).
+         // Tells the combo box's UI delegate it is being used as a table
+         // cell editor, so its built-in Enter/Escape key handling (e.g.
+         // confirming the highlighted item and handing off to the table)
+         // behaves as javax.swing.DefaultCellEditor's JComboBox constructor
+         // sets it up.
+         combo_.putClientProperty("JComboBox.isTableCellEditor", Boolean.TRUE);
+
          combo_.addPopupMenuListener(new PopupMenuListener() {
             @Override
             public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
@@ -531,23 +562,42 @@ public final class AutofocusPropertyEditor extends JDialog {
                // table event. Treat that case as an implicit re-confirmation.
                if (wasOpen && !selectionMade_) {
                   selectionMade_ = true;
-                  fireEditingStopped();
+                  // This listener fires *during* the popup's own hide()
+                  // teardown (unlike the ActionListener below, which fires
+                  // before hide() begins). Committing synchronously here
+                  // runs our table-mutating code interleaved with that
+                  // teardown, which can leave the popup visually stuck
+                  // mid-collapse. Defer to the next EDT cycle so hide()
+                  // finishes first, and go through stopCellEditing() (not
+                  // fireEditingStopped() directly) so a popup that got
+                  // spuriously reopened by the race above is forced closed
+                  // before the editor is removed.
+                  SwingUtilities.invokeLater(() -> stopCellEditing());
                }
             }
 
             @Override
             public void popupMenuCanceled(PopupMenuEvent e) {
                combo_.putClientProperty("popupOpen", null);
-               fireEditingCanceled();
+               cancelCellEditing();
             }
          });
 
          combo_.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-               if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+               // Remember any real value change (mouse or arrow keys) so a
+               // later commit reflects it, but only commit *now* when the
+               // popup is open: clicking an item there is itself the confirm
+               // gesture. Arrow-key browsing with the popup closed should
+               // not commit on every keystroke; JTable's own Enter/Tab/
+               // focus-loss handling will call stopCellEditing() when the
+               // user actually confirms.
+               if (!Objects.equals(combo_.getSelectedItem(), item_.value)) {
                   selectionMade_ = true;
-                  fireEditingStopped();
+               }
+               if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+                  stopCellEditing();
                }
             }
          });
@@ -563,7 +613,36 @@ public final class AutofocusPropertyEditor extends JDialog {
       }
 
       public void stopEditing() {
-         fireEditingStopped();
+         stopCellEditing();
+      }
+
+      /**
+       * Closes the dropdown's popup, if open, before actually stopping or
+       * canceling the edit.
+       *
+       * <p>External callers (e.g. {@link #stopEditing()}, invoked when the
+       * autofocus method changes) may call {@code stopCellEditing()} on the
+       * active editor programmatically. If the combo box's popup is still
+       * open at that point, removing the editor out from under it leaves
+       * the popup as a visual orphan, and the table can end up attaching a
+       * leftover editing state to the wrong row if its structure changes
+       * shortly after. Hiding the popup first ensures it closes through the
+       * normal PopupMenuListener path before that happens.
+       */
+      @Override
+      public boolean stopCellEditing() {
+         if (combo_.isPopupVisible()) {
+            combo_.hidePopup();
+         }
+         return super.stopCellEditing();
+      }
+
+      @Override
+      public void cancelCellEditing() {
+         if (combo_.isPopupVisible()) {
+            combo_.hidePopup();
+         }
+         super.cancelCellEditing();
       }
 
       // This method is called when a cell value is edited by the user.
@@ -597,21 +676,47 @@ public final class AutofocusPropertyEditor extends JDialog {
                }
             }
 
-            selectionMade_ = false;
             combo_.putClientProperty("popupOpen", null);
             combo_.removeAllItems();
             for (String allowed : item_.allowed) {
                combo_.addItem(allowed);
             }
-            combo_.setSelectedItem(item_.value);
-            if (!Objects.equals(item_.value, combo_.getSelectedItem())) {
-               combo_.setSelectedIndex(-1);
-            }
+            selectItemOrClear(combo_, item_.value);
+            // Reset only now, after the item-list rebuild above has settled:
+            // removeAllItems() drops the selection to null and can fire a
+            // spurious ActionEvent (selectedItem=null) that our own
+            // ActionListener would otherwise misread as a real user change,
+            // incorrectly marking selectionMade_ true before any real
+            // interaction happens. That poisoned flag then silently defeats
+            // the popupMenuWillBecomeInvisible reselect-same-item commit
+            // further down, leaving the cell editor stuck open indefinitely.
+            selectionMade_ = false;
             return combo_;
          } else if (colIndex == 2) {
             return check_;
          }
          return null;
+      }
+
+      /**
+       * Selects {@code value} in {@code combo} if it is actually present
+       * among the combo's items, otherwise clears the selection.
+       *
+       * <p>{@code JComboBox.setSelectedItem()}/{@code getSelectedItem()} is
+       * not a reliable presence check: {@code DefaultComboBoxModel} stores
+       * whatever object is passed in as the selected item regardless of
+       * whether it is one of the combo's actual items, so a value absent
+       * from the list would otherwise appear to "stick" instead of falling
+       * back to no selection.
+       */
+      private void selectItemOrClear(JComboBox<String> combo, String value) {
+         for (int i = 0; i < combo.getItemCount(); i++) {
+            if (Objects.equals(combo.getItemAt(i), value)) {
+               combo.setSelectedItem(value);
+               return;
+            }
+         }
+         combo.setSelectedIndex(-1);
       }
 
       // This method is called when editing is completed.

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
@@ -58,7 +58,18 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
 
          @Override
          public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+            boolean wasOpen = Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"));
             combo_.putClientProperty("popupOpen", null);
+            // JComboBox only fires an ActionEvent when the selection actually
+            // changes. If the user reopens the popup and clicks the item that
+            // was already selected, the popup closes normally here but no
+            // ActionEvent ever fires, leaving the cell editor stuck open
+            // (shown with the "editing" look) until something else forces a
+            // table event. Treat that case as an implicit re-confirmation.
+            if (wasOpen && !selectionMade_) {
+               selectionMade_ = true;
+               fireEditingStopped();
+            }
          }
 
          @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
@@ -15,6 +15,7 @@ import javax.swing.AbstractCellEditor;
 import javax.swing.JComboBox;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.table.TableCellEditor;
@@ -28,7 +29,35 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
    private static final long serialVersionUID = 1L;
    // This is the component that will handle the editing of the cell value
    JTextField text_ = new JTextField();
-   JComboBox<String> combo_ = new JComboBox<>();
+   // Set for the remainder of the current AWT event right after we close the
+   // popup via setPopupVisible(false), then cleared on the next EDT cycle.
+   // See setPopupVisible() below for why this exists.
+   private boolean justClosedPopup_ = false;
+
+   JComboBox<String> combo_ = new JComboBox<String>() {
+      @Override
+      public void setPopupVisible(boolean visible) {
+         if (visible) {
+            // Clicking the combo box's own arrow/button while its popup is
+            // already open can trigger a same-click close-then-reopen race:
+            // MenuSelectionManager sees that click as landing outside the
+            // popup and closes it, then the arrow button's own toggle
+            // handler (processing the same click right after) sees the
+            // now-closed state and calls setPopupVisible(true) again,
+            // reopening it. The popup ends up glitched/stuck instead of
+            // cleanly closed. Ignore "become visible" requests while
+            // already visible, or immediately after we just closed it
+            // ourselves within this same event, to break that race.
+            if (isPopupVisible() || justClosedPopup_) {
+               return;
+            }
+         } else if (isPopupVisible()) {
+            justClosedPopup_ = true;
+            SwingUtilities.invokeLater(() -> justClosedPopup_ = false);
+         }
+         super.setPopupVisible(visible);
+      }
+   };
    SliderPanel slider_ = new SliderPanel();
 
    PropertyItem item_;
@@ -50,6 +79,12 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
 
       disableExcluded_ = disableExcluded;
 
+      // Tells the combo box's UI delegate it is being used as a table cell
+      // editor, so its built-in Enter/Escape key handling (e.g. confirming
+      // the highlighted item and handing off to the table) behaves as
+      // javax.swing.DefaultCellEditor's JComboBox constructor sets it up.
+      combo_.putClientProperty("JComboBox.isTableCellEditor", Boolean.TRUE);
+
       combo_.addPopupMenuListener(new PopupMenuListener() {
          @Override
          public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
@@ -68,23 +103,40 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
             // table event. Treat that case as an implicit re-confirmation.
             if (wasOpen && !selectionMade_) {
                selectionMade_ = true;
-               fireEditingStopped();
+               // This listener fires *during* the popup's own hide()
+               // teardown (unlike the ActionListener below, which fires
+               // before hide() begins). Committing synchronously here runs
+               // our table-mutating code interleaved with that teardown,
+               // which can leave the popup visually stuck mid-collapse.
+               // Defer to the next EDT cycle so hide() finishes first, and
+               // go through stopCellEditing() (not fireEditingStopped()
+               // directly) so a popup that got spuriously reopened by the
+               // race above is forced closed before the editor is removed.
+               SwingUtilities.invokeLater(() -> stopCellEditing());
             }
          }
 
          @Override
          public void popupMenuCanceled(PopupMenuEvent e) {
             combo_.putClientProperty("popupOpen", null);
-            fireEditingCanceled();
+            cancelCellEditing();
          }
       });
 
       combo_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+            // Remember any real value change (mouse or arrow keys) so a later
+            // commit reflects it, but only commit *now* when the popup is
+            // open: clicking an item there is itself the confirm gesture.
+            // Arrow-key browsing with the popup closed should not commit on
+            // every keystroke; JTable's own Enter/Tab/focus-loss handling
+            // will call stopCellEditing() when the user actually confirms.
+            if (!Objects.equals(combo_.getSelectedItem(), item_.value)) {
                selectionMade_ = true;
-               fireEditingStopped();
+            }
+            if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+               stopCellEditing();
             }
          }
       });
@@ -116,6 +168,54 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
       });
    }
 
+   /**
+    * Closes the dropdown's popup, if open, before actually stopping or
+    * canceling the edit.
+    *
+    * <p>External callers (e.g. a dialog's OK button) may call
+    * {@code stopCellEditing()} on the active editor programmatically. If the
+    * combo box's popup is still open at that point, removing the editor out
+    * from under it leaves the popup as a visual orphan, and the table can
+    * end up attaching a leftover editing state to the wrong row if its
+    * structure changes shortly after. Hiding the popup first ensures it
+    * closes through the normal PopupMenuListener path before that happens.
+    */
+   @Override
+   public boolean stopCellEditing() {
+      if (combo_.isPopupVisible()) {
+         combo_.hidePopup();
+      }
+      return super.stopCellEditing();
+   }
+
+   @Override
+   public void cancelCellEditing() {
+      if (combo_.isPopupVisible()) {
+         combo_.hidePopup();
+      }
+      super.cancelCellEditing();
+   }
+
+   /**
+    * Selects {@code value} in {@code combo} if it is actually present among
+    * the combo's items, otherwise clears the selection.
+    *
+    * <p>{@code JComboBox.setSelectedItem()}/{@code getSelectedItem()} is not
+    * a reliable presence check: {@code DefaultComboBoxModel} stores whatever
+    * object is passed in as the selected item regardless of whether it is
+    * one of the combo's actual items, so a value absent from the list would
+    * otherwise appear to "stick" instead of falling back to no selection.
+    */
+   private static void selectItemOrClear(JComboBox<String> combo, String value) {
+      for (int i = 0; i < combo.getItemCount(); i++) {
+         if (Objects.equals(combo.getItemAt(i), value)) {
+            combo.setSelectedItem(value);
+            return;
+         }
+      }
+      combo.setSelectedIndex(-1);
+   }
+
    // This method is called when a cell value is edited by the user.
    @Override
    public Component getTableCellEditorComponent(JTable table, Object value,
@@ -144,16 +244,21 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
                return text_;
             }
          } else {
-            selectionMade_ = false;
             combo_.putClientProperty("popupOpen", null);
             combo_.removeAllItems();
             for (int i = 0; i < item_.allowed.length; i++) {
                combo_.addItem(item_.allowed[i]);
             }
-            combo_.setSelectedItem(item_.value);
-            if (!Objects.equals(item_.value, combo_.getSelectedItem())) {
-               combo_.setSelectedIndex(-1);
-            }
+            selectItemOrClear(combo_, item_.value);
+            // Reset only now, after the item-list rebuild above has settled:
+            // removeAllItems() drops the selection to null and can fire a
+            // spurious ActionEvent (selectedItem=null) that our own
+            // ActionListener would otherwise misread as a real user change,
+            // incorrectly marking selectionMade_ true before any real
+            // interaction happens. That poisoned flag then silently defeats
+            // the popupMenuWillBecomeInvisible reselect-same-item commit
+            // further down, leaving the cell editor stuck open indefinitely.
+            selectionMade_ = false;
             return combo_;
          }
       } else {

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/PropertyValueCellEditor.java
@@ -3,8 +3,6 @@ package org.micromanager.internal.utils;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -157,14 +155,6 @@ public final class PropertyValueCellEditor extends AbstractCellEditor implements
                fireEditingStopped();
             }
          }
-      });
-
-      text_.addFocusListener(new FocusAdapter() {
-         @Override
-         public void focusLost(FocusEvent e) {
-            // fireEditingStopped();
-         }
-
       });
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
@@ -48,7 +48,18 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
 
          @Override
          public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+            boolean wasOpen = Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"));
             combo_.putClientProperty("popupOpen", null);
+            // JComboBox only fires an ActionEvent when the selection actually
+            // changes. If the user reopens the popup and clicks the item that
+            // was already selected, the popup closes normally here but no
+            // ActionEvent ever fires, leaving the cell editor stuck open
+            // (shown with the "editing" look) until something else forces a
+            // table event. Treat that case as an implicit re-confirmation.
+            if (wasOpen && !selectionMade_) {
+               selectionMade_ = true;
+               fireEditingStopped();
+            }
          }
 
          @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
@@ -12,6 +12,7 @@ import javax.swing.AbstractCellEditor;
 import javax.swing.JComboBox;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.table.TableCellEditor;
@@ -28,7 +29,35 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
    private static final long serialVersionUID = 1L;
    // This is the component that will handle the editing of the cell value
    JTextField text_ = new JTextField();
-   JComboBox<String> combo_ = new JComboBox<>();
+   // Set for the remainder of the current AWT event right after we close the
+   // popup via setPopupVisible(false), then cleared on the next EDT cycle.
+   // See setPopupVisible() below for why this exists.
+   private boolean justClosedPopup_ = false;
+
+   JComboBox<String> combo_ = new JComboBox<String>() {
+      @Override
+      public void setPopupVisible(boolean visible) {
+         if (visible) {
+            // Clicking the combo box's own arrow/button while its popup is
+            // already open can trigger a same-click close-then-reopen race:
+            // MenuSelectionManager sees that click as landing outside the
+            // popup and closes it, then the arrow button's own toggle
+            // handler (processing the same click right after) sees the
+            // now-closed state and calls setPopupVisible(true) again,
+            // reopening it. The popup ends up glitched/stuck instead of
+            // cleanly closed. Ignore "become visible" requests while
+            // already visible, or immediately after we just closed it
+            // ourselves within this same event, to break that race.
+            if (isPopupVisible() || justClosedPopup_) {
+               return;
+            }
+         } else if (isPopupVisible()) {
+            justClosedPopup_ = true;
+            SwingUtilities.invokeLater(() -> justClosedPopup_ = false);
+         }
+         super.setPopupVisible(visible);
+      }
+   };
    StateItem item_;
    SliderPanel slider_ = new SliderPanel();
 
@@ -39,6 +68,12 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
 
    public StatePresetCellEditor() {
       super();
+
+      // Tells the combo box's UI delegate it is being used as a table cell
+      // editor, so its built-in Enter/Escape key handling (e.g. confirming
+      // the highlighted item and handing off to the table) behaves as
+      // javax.swing.DefaultCellEditor's JComboBox constructor sets it up.
+      combo_.putClientProperty("JComboBox.isTableCellEditor", Boolean.TRUE);
 
       combo_.addPopupMenuListener(new PopupMenuListener() {
          @Override
@@ -58,7 +93,16 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
             // table event. Treat that case as an implicit re-confirmation.
             if (wasOpen && !selectionMade_) {
                selectionMade_ = true;
-               fireEditingStopped();
+               // This listener fires *during* the popup's own hide()
+               // teardown (unlike the ActionListener below, which fires
+               // before hide() begins). Committing synchronously here runs
+               // our table-mutating code interleaved with that teardown,
+               // which can leave the popup visually stuck mid-collapse.
+               // Defer to the next EDT cycle so hide() finishes first, and
+               // go through stopCellEditing() (not fireEditingStopped()
+               // directly) so a popup that got spuriously reopened by the
+               // race above is forced closed before the editor is removed.
+               SwingUtilities.invokeLater(() -> stopCellEditing());
             }
          }
 
@@ -68,16 +112,24 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
             // Clear the flag and cancel the cell edit in one step so the user
             // does not need a second Escape/click to dismiss the editor too.
             combo_.putClientProperty("popupOpen", null);
-            fireEditingCanceled();
+            cancelCellEditing();
          }
       });
 
       combo_.addActionListener(new ActionListener() {
          @Override
          public void actionPerformed(ActionEvent e) {
-            if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+            // Remember any real value change (mouse or arrow keys) so a later
+            // commit reflects it, but only commit *now* when the popup is
+            // open: clicking an item there is itself the confirm gesture.
+            // Arrow-key browsing with the popup closed should not commit on
+            // every keystroke; JTable's own Enter/Tab/focus-loss handling
+            // will call stopCellEditing() when the user actually confirms.
+            if (!Objects.equals(combo_.getSelectedItem(), item_.config)) {
                selectionMade_ = true;
-               fireEditingStopped();
+            }
+            if (Boolean.TRUE.equals(combo_.getClientProperty("popupOpen"))) {
+               stopCellEditing();
             }
          }
       });
@@ -97,6 +149,34 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
             fireEditingStopped();
          }
       });
+   }
+
+   /**
+    * Closes the dropdown's popup, if open, before actually stopping or
+    * canceling the edit.
+    *
+    * <p>External callers (e.g. a dialog's OK button) may call
+    * {@code stopCellEditing()} on the active editor programmatically. If the
+    * combo box's popup is still open at that point, removing the editor out
+    * from under it leaves the popup as a visual orphan, and the table can
+    * end up attaching a leftover editing state to the wrong row if its
+    * structure changes shortly after. Hiding the popup first ensures it
+    * closes through the normal PopupMenuListener path before that happens.
+    */
+   @Override
+   public boolean stopCellEditing() {
+      if (combo_.isPopupVisible()) {
+         combo_.hidePopup();
+      }
+      return super.stopCellEditing();
+   }
+
+   @Override
+   public void cancelCellEditing() {
+      if (combo_.isPopupVisible()) {
+         combo_.hidePopup();
+      }
+      super.cancelCellEditing();
    }
 
    // This method is called when a cell value is edited by the user.
@@ -168,19 +248,44 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
    }
 
    private void setComboBox(String[] allowed) {
-      selectionMade_ = false;
       combo_.putClientProperty("popupOpen", null);
       combo_.removeAllItems();
       for (int i = 0; i < allowed.length; i++) {
          combo_.addItem(allowed[i]);
       }
-      // setSelectedItem silently fails when item_.config is not in the list
-      // (e.g. "" when no preset matches). Fall back to no selection (-1) so
-      // the combo shows blank rather than defaulting to item 0.
-      combo_.setSelectedItem(item_.config);
-      if (!Objects.equals(item_.config, combo_.getSelectedItem())) {
-         combo_.setSelectedIndex(-1);
+      // item_.config may not be in the list (e.g. "" when no preset matches).
+      // Fall back to no selection (-1) so the combo shows blank rather than
+      // defaulting to item 0.
+      selectItemOrClear(combo_, item_.config);
+      // Reset only now, after the item-list rebuild above has settled:
+      // removeAllItems() drops the selection to null and can fire a
+      // spurious ActionEvent (selectedItem=null) that our own ActionListener
+      // would otherwise misread as a real user change, incorrectly marking
+      // selectionMade_ true before any real interaction happens. That
+      // poisoned flag then silently defeats the popupMenuWillBecomeInvisible
+      // reselect-same-item commit further down, leaving the cell editor
+      // stuck open indefinitely.
+      selectionMade_ = false;
+   }
+
+   /**
+    * Selects {@code value} in {@code combo} if it is actually present among
+    * the combo's items, otherwise clears the selection.
+    *
+    * <p>{@code JComboBox.setSelectedItem()}/{@code getSelectedItem()} is not
+    * a reliable presence check: {@code DefaultComboBoxModel} stores whatever
+    * object is passed in as the selected item regardless of whether it is
+    * one of the combo's actual items, so a value absent from the list would
+    * otherwise appear to "stick" instead of falling back to no selection.
+    */
+   private static void selectItemOrClear(JComboBox<String> combo, String value) {
+      for (int i = 0; i < combo.getItemCount(); i++) {
+         if (Objects.equals(combo.getItemAt(i), value)) {
+            combo.setSelectedItem(value);
+            return;
+         }
       }
+      combo.setSelectedIndex(-1);
    }
 
    // This method is called when editing is completed.

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/StatePresetCellEditor.java
@@ -184,10 +184,6 @@ public final class StatePresetCellEditor extends AbstractCellEditor implements T
    public Component getTableCellEditorComponent(JTable table, Object value,
                                                 boolean isSelected, int rowIndex, int vColIndex) {
 
-      if (isSelected) {
-         // cell (and perhaps other cells) are selected
-      }
-
       StateTableData data = (StateTableData) table.getModel();
       item_ = data.getPropertyItem(rowIndex);
       // Configure the component with the specified value


### PR DESCRIPTION
Second attempt to close #2370.  Now also improve the behavior of the dropdown menus in the ChannelTable in the MDA window.  Only thing that I do not like is that - when clicking on a dropdown, then clicking somewhere else - the second click needs to be repeated to get the desired action.  That may be OK though, and the new behavior is a great improvement.