### PR TITLE
TiledDataViewer opening data: now actually opens a dataset when you selct the file rather than the encolsing directory.

### DIFF
--- a/libraries/TiledDataProvider/src/main/java/org/micromanager/tileddataprovider/DatasetPathUtils.java
+++ b/libraries/TiledDataProvider/src/main/java/org/micromanager/tileddataprovider/DatasetPathUtils.java
@@ -1,0 +1,85 @@
+package org.micromanager.tileddataprovider;
+
+import java.io.File;
+
+/**
+ * Helpers for turning a user's file-chooser selection into the root directory of a dataset.
+ *
+ * <p>Micro-Manager's "open dataset" choosers ({@code FileDialogs.openDir}) run in
+ * {@code FILES_AND_DIRECTORIES} mode with no suffix filter, so a user can just as easily pick a
+ * file <em>inside</em> a dataset as the dataset folder itself. Every storage backend, however,
+ * expects the dataset root. {@link #normalizeDatasetPath} bridges that gap.
+ *
+ * <p>A plain "if it is not a directory, take the parent" is not sufficient: it is right for
+ * OME-BigTIFF and OME-Zarr, whose planes sit directly in the dataset folder, but wrong for NDTiff,
+ * where a plane lives in a {@code Full resolution} (or {@code Downsampled_x<N>}) subdirectory one
+ * level below the root. This class therefore walks up until it recognizes a dataset, rather than
+ * assuming a fixed depth.
+ */
+public final class DatasetPathUtils {
+
+   /**
+    * How many levels above the selection to search. NDTiff needs two
+    * ({@code <root>/Full resolution/plane.tif}); one extra gives margin without letting a stray
+    * selection walk all the way to the drive root.
+    */
+   private static final int MAX_LEVELS_UP = 3;
+
+   private static final String NDTIFF_INDEX_FILE = "NDTiff.index";
+
+   private DatasetPathUtils() {
+   }
+
+   /**
+    * Returns true if {@code dir} is the root of a dataset one of the tiled-data backends can read
+    * (OME-Zarr, OME-BigTIFF, or NDTiff).
+    *
+    * @param dir directory to probe; may be null or a file, in which case false is returned
+    * @return true if a known dataset descriptor was found directly in {@code dir}
+    */
+   public static boolean isDatasetDir(String dir) {
+      if (dir == null || !new File(dir).isDirectory()) {
+         return false;
+      }
+      return OMEZarrMultiresStorage.isOMEZarrDataset(dir)
+            || OMEBigTiffMultiresStorage.isOMEBigTiffDataset(dir)
+            || isNDTiffDataset(dir);
+   }
+
+   /**
+    * Returns true if {@code dir} holds an NDTiff dataset. Mirrors
+    * {@code NDTiffAdapter.isNDTiffDataSet} in mmstudio; duplicated here so this library does not
+    * have to depend on mmstudio.
+    *
+    * @param dir directory to probe
+    * @return true if an NDTiff index file is present
+    */
+   public static boolean isNDTiffDataset(String dir) {
+      return new File(dir, NDTIFF_INDEX_FILE).exists();
+   }
+
+   /**
+    * Resolves a user's selection to the root directory of the dataset containing it.
+    *
+    * <p>Accepts the dataset folder itself, a file inside it (such as the {@code .ome.tif} plane
+    * inside a {@code .ome.tiff} folder), or a file in one of NDTiff's resolution-level
+    * subdirectories. Returns the selection unchanged when it is already a dataset root.
+    *
+    * @param selected path the user chose; may be null
+    * @return absolute path of the dataset root, or null if no dataset was found at or above
+    *         {@code selected}
+    */
+   public static String normalizeDatasetPath(String selected) {
+      if (selected == null) {
+         return null;
+      }
+      File candidate = new File(selected).getAbsoluteFile();
+      for (int level = 0; level <= MAX_LEVELS_UP && candidate != null; level++) {
+         if (isDatasetDir(candidate.getPath())) {
+            return candidate.getPath();
+         }
+         candidate = candidate.getParentFile();
+      }
+      return null;
+   }
+}

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreManager.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreManager.java
@@ -328,6 +328,13 @@ public class DeskewExploreManager {
          studio_.logs().showMessage("Not a recognized Micro-Manager dataset: " + selectedPath);
          return;
       }
+      // normalizeDatasetPath also accepts OME-Zarr and OME-BigTIFF, but Deskew Explore only
+      // reads NDTiff. Reject those here rather than letting NDTiffStorage fail obscurely.
+      if (!DatasetPathUtils.isNDTiffDataset(dir)) {
+         studio_.logs().showMessage(
+               "Deskew Explore can only open NDTiff datasets. Not an NDTiff dataset: " + dir);
+         return;
+      }
 
       try {
          exploring_ = true;

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreManager.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreManager.java
@@ -47,6 +47,7 @@ import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.lightsheet.StackResampler;
 import org.micromanager.ndtiffstorage.EssentialImageMetadata;
 import org.micromanager.ndtiffstorage.NDTiffStorage;
+import org.micromanager.tileddataprovider.DatasetPathUtils;
 import org.micromanager.tileddataprovider.NDTiffProviderAdapter;
 import org.micromanager.tileddataviewer.TiledDataViewerAPI;
 import org.micromanager.tileddataviewer.TiledDataViewerAcqInterface;
@@ -310,11 +311,21 @@ public class DeskewExploreManager {
     * The viewer shows the previously acquired tiles and allows acquiring new ones
     * (which requires the stage to be at the same position as the original acquisition).
     *
-    * @param dir Path to the NDTiff dataset directory
+    * @param selectedPath Path to the NDTiff dataset directory, or to any file inside it: the file
+    *                     chooser lets the user pick either, so the path is normalized first
     */
-   public void openExplore(String dir) {
+   public void openExplore(String selectedPath) {
       if (exploring_) {
          studio_.logs().showMessage("Explore session already running.");
+         return;
+      }
+
+      // The chooser (FileDialogs.openDir) allows picking a file inside the dataset, but
+      // NDTiffStorage expects the dataset root. Resolve before touching any state, so an
+      // unrecognized selection leaves the manager idle rather than half-started.
+      final String dir = DatasetPathUtils.normalizeDatasetPath(selectedPath);
+      if (dir == null) {
+         studio_.logs().showMessage("Not a recognized Micro-Manager dataset: " + selectedPath);
          return;
       }
 

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -71,6 +71,7 @@ import org.micromanager.ndtiffstorage.EssentialImageMetadata;
 import org.micromanager.ndtiffstorage.MultiresNDTiffAPI;
 import org.micromanager.ndtiffstorage.NDTiffStorage;
 import org.micromanager.propertymap.MutablePropertyMapView;
+import org.micromanager.tileddataprovider.DatasetPathUtils;
 import org.micromanager.tileddataprovider.NDTiffProviderAdapter;
 import org.micromanager.tileddataprovider.OMEBigTiffMultiresStorage;
 import org.micromanager.tileddataprovider.OMEBigTiffTiledStorage;
@@ -432,11 +433,23 @@ public class ExplorerManager {
    }
 
    /**
-    * Opens an existing NDTiff explorer dataset for viewing.
+    * Opens an existing explorer dataset (NDTiff, OME-BigTIFF or OME-Zarr) for viewing.
+    *
+    * @param selectedPath dataset directory, or any file inside it: the file chooser lets the user
+    *                     pick either, so the path is normalized to the dataset root first
     */
-   public void openExplore(String dir) {
+   public void openExplore(String selectedPath) {
       if (exploring_) {
          studio_.logs().showMessage("Explorer session already running.");
+         return;
+      }
+
+      // The chooser (FileDialogs.openDir) allows picking a file inside the dataset, but the
+      // storage backends all expect the dataset root. Resolve before touching any state, so an
+      // unrecognized selection leaves the manager idle rather than half-started.
+      final String dir = DatasetPathUtils.normalizeDatasetPath(selectedPath);
+      if (dir == null) {
+         studio_.logs().showMessage("Not a recognized Micro-Manager dataset: " + selectedPath);
          return;
       }
 
@@ -464,6 +477,8 @@ public class ExplorerManager {
                   ? new OMEBigTiffTiledStorage(dir)
                   : new OMEBigTiffMultiresStorage(dir);
          } else {
+            // normalizeDatasetPath already established this is one of the three known formats,
+            // so reaching here means NDTiff.
             storage_ = new NDTiffStorage(dir, SAVING_QUEUE_SIZE, null);
          }
          storageDir_ = new File(dir).getParent();

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
@@ -316,6 +316,34 @@ public class StitchFrame extends JDialog {
       return null;
    }
 
+   /**
+    * Returns a leaf dataset name that does not collide with anything already in {@code outputDir},
+    * appending {@code _N} if needed.
+    *
+    * <p>A bare-name check alone is not enough, because the backends do not all create a directory
+    * literally named {@code name}: OME-Zarr creates {@code name.ome.zarr}, OME-BigTIFF creates
+    * {@code name.ome.tiff}, and NDTiff creates {@code name_N}. Probing only the bare name would
+    * therefore never see an existing dataset, silently leaving the collision to be resolved a
+    * second time inside the storage layer. Every form is checked here so the name shown in the
+    * viewer title and stored in the profile matches what actually lands on disk. Mirrors
+    * {@code ExplorerManager.uniqueAcqName}.
+    *
+    * @param outputDir directory the dataset will be created in
+    * @param candidate desired leaf name
+    * @return {@code candidate}, or {@code candidate_N} for the first free N
+    */
+   private static String uniqueDatasetName(String outputDir, String candidate) {
+      File base = new File(outputDir);
+      String name = candidate;
+      int suffix = 1;
+      while (new File(base, name).exists()
+            || new File(base, name + ".ome.zarr").exists()
+            || new File(base, name + ".ome.tiff").exists()) {
+         name = candidate + "_" + suffix++;
+      }
+      return name;
+   }
+
    private void updateAlignControls() {
       boolean align = alignCheck_.isSelected();
       SummaryMetadata summary = dataProvider_.getSummaryMetadata();
@@ -374,14 +402,9 @@ public class StitchFrame extends JDialog {
          return;
       }
       if (saveToStack || saveToTiled) {
-         String targetPath = new File(outputDir, namePrefix).getAbsolutePath();
-         String uniquePath = studio_.data().getUniqueSaveDirectory(targetPath);
-         if (uniquePath == null) {
-            studio_.logs().showError("Could not find a unique output directory name.", this);
-            return;
-         }
-         // Strip the parent dir back out — we only want the (possibly suffixed) leaf name.
-         namePrefix = new File(uniquePath).getName();
+         // Checks the bare name and each backend's actual dataset-folder form; see
+         // uniqueDatasetName. Yields the leaf name only, which is what the rest of onExport wants.
+         namePrefix = uniqueDatasetName(outputDir, namePrefix);
       }
 
       // Refuse to stitch a live (still-acquiring) dataset — write-mode readers cannot be
@@ -427,7 +450,11 @@ public class StitchFrame extends JDialog {
       // Capture display state before dispose() closes the window.
       final DisplaySettings sourceDisplaySettings = displayWindow_.getDisplaySettings();
       // Use the (already-uniquified) namePrefix as the dataset name so repeated
-      // exports get distinct viewer titles (e.g. "stitched", "stitched_1", …).
+      // exports get distinct viewer titles (e.g. "stitched", "stitched_1").
+      // Note NDTiff additionally appends its own "_N" internally (createUniqueName=true in
+      // buildTiledStorage), so for that backend the on-disk folder can carry one more suffix
+      // than this name; the viewer follows storage.getDiskLocation(), so it still opens the
+      // directory that was actually written.
       final String datasetName = namePrefix.isEmpty()
             ? dataProvider_.getName() + "_stitched" : namePrefix;
 

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
@@ -320,13 +320,18 @@ public class StitchFrame extends JDialog {
     * Returns a leaf dataset name that does not collide with anything already in {@code outputDir},
     * appending {@code _N} if needed.
     *
-    * <p>A bare-name check alone is not enough, because the backends do not all create a directory
-    * literally named {@code name}: OME-Zarr creates {@code name.ome.zarr}, OME-BigTIFF creates
-    * {@code name.ome.tiff}, and NDTiff creates {@code name_N}. Probing only the bare name would
-    * therefore never see an existing dataset, silently leaving the collision to be resolved a
-    * second time inside the storage layer. Every form is checked here so the name shown in the
-    * viewer title and stored in the profile matches what actually lands on disk. Mirrors
+    * <p>A bare-name check alone is not enough, because the OME backends do not create a directory
+    * literally named {@code name}: OME-Zarr creates {@code name.ome.zarr} and OME-BigTIFF creates
+    * {@code name.ome.tiff}. Probing only the bare name would therefore never see an existing OME
+    * dataset, silently leaving the collision to be resolved a second time inside the storage
+    * layer. All three forms are checked here so the name shown in the viewer title and stored in
+    * the profile matches what actually lands on disk. Mirrors
     * {@code ExplorerManager.uniqueAcqName}.
+    *
+    * <p>The bare-name check still matters: it covers the image-stack format, and NDTiff when
+    * written without unique-naming. Stitch's own NDTiff export passes
+    * {@code createUniqueName=true}, so that backend appends a further {@code _N} of its own on
+    * top of whatever this returns (see the note at the {@code datasetName} assignment).
     *
     * @param outputDir directory the dataset will be created in
     * @param candidate desired leaf name
@@ -451,8 +456,8 @@ public class StitchFrame extends JDialog {
       final DisplaySettings sourceDisplaySettings = displayWindow_.getDisplaySettings();
       // Use the (already-uniquified) namePrefix as the dataset name so repeated
       // exports get distinct viewer titles (e.g. "stitched", "stitched_1").
-      // Note NDTiff additionally appends its own "_N" internally (createUniqueName=true in
-      // buildTiledStorage), so for that backend the on-disk folder can carry one more suffix
+      // Note NDTiff always appends its own "_N" internally (buildTiledStorage passes
+      // createUniqueName=true), so for that backend the on-disk folder carries one more suffix
       // than this name; the viewer follows storage.getDiskLocation(), so it still opens the
       // directory that was actually written.
       final String datasetName = namePrefix.isEmpty()


### PR DESCRIPTION
Also fixes a but in StitchFrame that tested only for the bare name while searching for a unique saving directory, whereas some of the implementatiosn add suffixes to that name.