### PR TITLE
Explorer plugin: adds choice between MDA and current settings

### DIFF
--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerDataProviderAPI.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerDataProviderAPI.java
@@ -41,6 +41,18 @@ public interface TiledDataViewerDataProviderAPI extends DataProvider {
    Image getDownsampledImageByAxes(HashMap<String, Object> axes) throws IOException;
 
    /**
+    * Return the MM channel index this provider assigned to a channel name.
+    *
+    * <p>Channels are registered as images arrive, so a channel that appeared after the
+    * dataset was created still has an index here even though it is absent from the summary
+    * metadata. Callers use this to address the channel in DisplaySettings.</p>
+    *
+    * @param channelName the channel name as it appears in the axes map
+    * @return the MM channel index, or -1 if the name is not known
+    */
+   int getChannelIndex(String channelName);
+
+   /**
     * Return the storage backend for read-only access (e.g. for export).
     */
    TiledDataProviderAPI getStorage();

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataProvider.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/TiledDataViewerDataProvider.java
@@ -204,6 +204,11 @@ public final class TiledDataViewerDataProvider implements TiledDataViewerDataPro
    }
 
    @Override
+   public int getChannelIndex(String channelName) {
+      return axesBridge_.getChannelIndex(channelName);
+   }
+
+   @Override
    public SummaryMetadata getSummaryMetadata() {
       if (summaryMetadata_ != null) {
          return summaryMetadata_;

--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/AcqEngJAdapter.java
@@ -1286,9 +1286,16 @@ public class AcqEngJAdapter implements AcquisitionEngine, MMAcquistionControlCal
 
    /**
     * Will notify registered AcqSettingsListeners that the settings have changed.
+    *
+    * <p>Test acquisitions (e.g. the tiles acquired by the Explorer plugin) derive their
+    * settings from the MDA window and switch off whatever they do not need, such as frames,
+    * the position list, or channels. Those derived settings are not the MDA window's own, so
+    * they are posted as non-primary: redrawing the MDA window from them would silently
+    * uncheck the user's Time/Positions/Channels boxes.
     */
    private void settingsChanged(SequenceSettings sequenceSettings) {
-      studio_.events().post(new DefaultAcquisitionSettingsChangedEvent(sequenceSettings));
+      studio_.events().post(new DefaultAcquisitionSettingsChangedEvent(
+            sequenceSettings, !sequenceSettings.isTestAcquisition()));
    }
 
 

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -40,6 +40,9 @@ public class ExplorerFrame extends JFrame {
    private static final int DEFAULT_WIN_X = 100;
    private static final int DEFAULT_WIN_Y = 100;
    private static final String DIALOG_TITLE = "Explorer";
+   // Shared width (px) for the Open Existing / Start / Interrupt / Help buttons, so the two
+   // bottom rows line up. Sized to fit the widest label, "Open Existing".
+   private static final int BUTTON_WIDTH = 114;
 
    static final String EXPLORE_TMP_PATH = "ExploreTmpPath";
    static final String EXPLORE_OVERLAP_PERCENT = "ExploreOverlapPercent";
@@ -355,7 +358,10 @@ public class ExplorerFrame extends JFrame {
       // A read-only, word-wrapping JTextArea styled as a label: long status/Note text wraps to
       // multiple lines (reporting its true height to the layout, so nothing is clipped) instead
       // of widening the window.
-      positionStatusLabel_ = new JTextArea(" ");
+      positionStatusLabel_ = new JTextArea("");
+      // Hidden while empty so it takes up no vertical space; setPositionStatus() shows it
+      // again when there is something to report.
+      positionStatusLabel_.setVisible(false);
       positionStatusLabel_.setEditable(false);
       positionStatusLabel_.setFocusable(false);
       positionStatusLabel_.setLineWrap(true);
@@ -367,22 +373,32 @@ public class ExplorerFrame extends JFrame {
       positionPanel.add(positionStatusLabel_, "span, growx, wmin 0, wmax 400, wrap");
       add(positionPanel, "growx, wrap");
 
+      // "Open Existing" gets its own centered row; Start/Interrupt/Help share the one below.
+      // Both rows span the frame's two columns and are centered, so the buttons keep their
+      // preferred width instead of being stretched by the growing first column.
       JButton openButton = new JButton("Open Existing");
       openButton.setToolTipText("Open a previously saved Explorer dataset.");
       openButton.addActionListener(e -> openExplore());
-      add(openButton, "split 4");
+      // All four buttons share one fixed width so the two rows line up. BUTTON_WIDTH is the
+      // preferred width of the widest label ("Open Existing"); an explicit width is needed
+      // because the layout's first column is "[grow, fill]" and would otherwise stretch them.
+      add(openButton, "span, align center, w " + BUTTON_WIDTH + "!, wrap");
+
+      // The three buttons live in their own panel so they stay grouped with even gaps: a
+      // "split 3" row in the outer layout spreads them across the frame's full width instead.
+      final JPanel buttonRow = new JPanel(new MigLayout("insets 0"));
 
       JButton startButton = new JButton("Start");
       startButton.setToolTipText(
             "Start explore mode. Right-click to select tiles, left-click to acquire.");
       startButton.addActionListener(e -> explorerManager_.startExplore());
-      add(startButton);
+      buttonRow.add(startButton, "w " + BUTTON_WIDTH + "!");
 
       stopButton_ = new JButton("Interrupt");
       stopButton_.setToolTipText("Interrupt tile acquisition after the current tile finishes.");
       stopButton_.setEnabled(false);
       stopButton_.addActionListener(e -> explorerManager_.interruptAcquisition());
-      add(stopButton_);
+      buttonRow.add(stopButton_, "w " + BUTTON_WIDTH + "!");
 
       JButton helpButton = new JButton("Help");
       helpButton.addActionListener(e -> JOptionPane.showMessageDialog(
@@ -392,7 +408,10 @@ public class ExplorerFrame extends JFrame {
                   + "Images pass through the active Data Processing Pipeline.\n"
                   + "Configure the pipeline in MM's Data Processing Pipeline window.",
             "Explorer Help", JOptionPane.PLAIN_MESSAGE));
-      add(helpButton, "wrap");
+      buttonRow.add(helpButton, "w " + BUTTON_WIDTH + "!");
+      // "w pref!" keeps the panel at its own width: the outer layout is "fillx", which would
+      // otherwise stretch it across the frame and leave its buttons bunched on the left.
+      add(buttonRow, "span, align center, w pref!, wrap");
 
       pack();
    }
@@ -573,9 +592,11 @@ public class ExplorerFrame extends JFrame {
     * multiple lines rather than widening the window. Called from ExplorerManager; switches to EDT.
     */
    public void setPositionStatus(String text) {
-      final String shown = (text == null || text.isEmpty()) ? " " : text;
+      final String shown = (text == null) ? "" : text.trim();
       SwingUtilities.invokeLater(() -> {
          positionStatusLabel_.setText(shown);
+         // Hide the (empty) status rather than leaving a blank line above the buttons.
+         positionStatusLabel_.setVisible(!shown.isEmpty());
          // Re-pack so the window grows taller for a wrapped (multi-line) status, never wider.
          pack();
       });

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -1,10 +1,12 @@
 package org.micromanager.explorer;
 
 import java.awt.Toolkit;
+import java.awt.event.ActionListener;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -13,6 +15,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import javax.swing.JSpinner;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
@@ -41,6 +44,9 @@ public class ExplorerFrame extends JFrame {
    static final String EXPLORE_TMP_PATH = "ExploreTmpPath";
    static final String EXPLORE_OVERLAP_PERCENT = "ExploreOverlapPercent";
    static final String VESSEL_TYPE = "VesselType";
+   // When true, the MDA Z-stack and channel settings are ignored and every tile is
+   // acquired with the microscope's current focus position and channel preset.
+   static final String USE_CURRENT_SETTINGS = "UseCurrentSettings";
    // Deprecated: superseded by STORAGE_BACKEND. Used only as the fallback default when
    // STORAGE_BACKEND has never been set; no value is ever written back under this key.
    static final String USE_OME_ZARR = "UseOmeZarrStorage";
@@ -59,6 +65,11 @@ public class ExplorerFrame extends JFrame {
 
    private JButton stopButton_;
    private JComboBox<VesselType> vesselCombo_;
+
+   // Source of the Z-stack and channel settings. Read once at session start; the radios
+   // are disabled while a session runs (see updateAnchorPanels()).
+   private JRadioButton mdaSettingsRadio_;
+   private JRadioButton currentSettingsRadio_;
 
    // Create-Positions controls (live session only).
    private JButton createPositionsButton_;
@@ -107,6 +118,26 @@ public class ExplorerFrame extends JFrame {
       }
       setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
       setLayout(new MigLayout("fillx", "[grow, fill][]"));
+
+      // Source of the Z-stack and channel settings for each tile. Locked at session start.
+      add(new JLabel("Settings:"), "split 3");
+      boolean useCurrent = settings_.getBoolean(USE_CURRENT_SETTINGS, false);
+      mdaSettingsRadio_ = new JRadioButton("From MDA", !useCurrent);
+      currentSettingsRadio_ = new JRadioButton("Current", useCurrent);
+      ButtonGroup settingsGroup = new ButtonGroup();
+      settingsGroup.add(mdaSettingsRadio_);
+      settingsGroup.add(currentSettingsRadio_);
+      mdaSettingsRadio_.setToolTipText(
+            "Use the Z-stack and channel settings from the MDA window.");
+      currentSettingsRadio_.setToolTipText(
+            "<html>Ignore the MDA Z-stack and channel settings; acquire each tile at the<br>"
+            + "current focus position with the current channel preset.</html>");
+      ActionListener settingsSourceListener = e ->
+            settings_.putBoolean(USE_CURRENT_SETTINGS, currentSettingsRadio_.isSelected());
+      mdaSettingsRadio_.addActionListener(settingsSourceListener);
+      currentSettingsRadio_.addActionListener(settingsSourceListener);
+      add(mdaSettingsRadio_);
+      add(currentSettingsRadio_, "wrap");
 
       add(new JLabel("Tmp Path:"), "split 4");
       JTextField tmpPathField = new JTextField(25);
@@ -427,6 +458,16 @@ public class ExplorerFrame extends JFrame {
       return withinVesselCheck_ != null && withinVesselCheck_.isSelected();
    }
 
+   /**
+    * Returns whether the microscope's current Z and channel settings should be used
+    * instead of the MDA window's settings.
+    *
+    * @return true when the "Current" settings radio is selected
+    */
+   public boolean isUseCurrentSettingsSelected() {
+      return currentSettingsRadio_ != null && currentSettingsRadio_.isSelected();
+   }
+
    /** Returns the vessel currently selected in the combo box. */
    public VesselType getSelectedVessel() {
       VesselType v = (VesselType) vesselCombo_.getSelectedItem();
@@ -443,6 +484,13 @@ public class ExplorerFrame extends JFrame {
 
       simpleAnchorPanel_.setVisible(isSimple);
       wellAnchorPanel_.setVisible(isMultiWell);
+
+      // The settings source is locked for the duration of a session: switching it mid-session
+      // would change the dataset's axes shape and make already-acquired tiles disappear.
+      if (mdaSettingsRadio_ != null) {
+         mdaSettingsRadio_.setEnabled(!sessionActive_);
+         currentSettingsRadio_.setEnabled(!sessionActive_);
+      }
 
       simpleAnchorButtons_.forEach(b -> b.setEnabled(sessionActive_ && isSimple));
 

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerFrame.java
@@ -90,7 +90,6 @@ public class ExplorerFrame extends JFrame {
    // Multi-well anchor panel: HCS calibration status + optional well selector.
    private JPanel wellAnchorPanel_;
    private JLabel hcsStatusLabel_;
-   private JButton refreshHcsButton_;
    private JComboBox<String> wellRowCombo_;
    private JSpinner wellColSpinner_;
    private JButton setWellAnchorButton_;
@@ -105,6 +104,11 @@ public class ExplorerFrame extends JFrame {
       explorerManager_ = new ExplorerManager(studio, this);
 
       initComponents();
+
+      // The vessel combo is restored from the profile before its listener is attached, so
+      // push the restored value through the manager here. Otherwise a remembered multi-well
+      // plate would show a stale "Not found" HCS status until the selection was changed.
+      explorerManager_.setVesselType(getSelectedVessel());
 
       super.setLocation(DEFAULT_WIN_X, DEFAULT_WIN_Y);
       WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
@@ -275,13 +279,7 @@ public class ExplorerFrame extends JFrame {
       wellAnchorPanel_ = new JPanel(new MigLayout("insets 0, fillx"));
       wellAnchorPanel_.add(new JLabel("HCS cal:"));
       hcsStatusLabel_ = new JLabel("Not found");
-      wellAnchorPanel_.add(hcsStatusLabel_);
-      refreshHcsButton_ = new JButton("Refresh");
-      refreshHcsButton_.setToolTipText(
-            "Re-read HCS plugin calibration from the profile and apply it");
-      refreshHcsButton_.setEnabled(false);
-      refreshHcsButton_.addActionListener(e -> explorerManager_.refreshHcsCalibration());
-      wellAnchorPanel_.add(refreshHcsButton_, "wrap");
+      wellAnchorPanel_.add(hcsStatusLabel_, "wrap");
 
       wellAnchorPanel_.add(new JLabel("Anchor well:"));
       wellRowCombo_ = new JComboBox<>();
@@ -493,8 +491,6 @@ public class ExplorerFrame extends JFrame {
       }
 
       simpleAnchorButtons_.forEach(b -> b.setEnabled(sessionActive_ && isSimple));
-
-      refreshHcsButton_.setEnabled(sessionActive_ && isMultiWell);
 
       boolean hcsFound = hcsStatusLabel_.getText().startsWith("Found");
       boolean wellAnchorEnabled = sessionActive_ && isMultiWell && !hcsFound;

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -3779,10 +3779,13 @@ public class ExplorerManager {
          dataSource_.clearVesselOutline();
          redrawOverlay();
       }
-      if (exploring_ && vesselType_.isMultiWell()) {
+      if (vesselType_.isMultiWell()) {
+         // Report the calibration status even before a session starts: it is read from the
+         // HCS plugin's profile, which does not depend on an active session. Only applying
+         // it does, since that needs the pixel/stage transforms set up by startExplore().
          Point2D.Double hcsOffset = tryReadHcsCalibration();
          frame_.setHcsCalibrationStatus(hcsOffset != null);
-         if (hcsOffset != null) {
+         if (hcsOffset != null && exploring_) {
             applyHcsCalibration(hcsOffset);
          }
       } else {
@@ -3897,21 +3900,6 @@ public class ExplorerManager {
          viewer_.setViewOffset(offsetX, offsetY);
          viewer_.setFullResSourceDataSizeAspectCorrected(displayW, displayH);
       });
-   }
-
-   /**
-    * Re-reads the HCS calibration from the profile and applies it if found.
-    * Called from ExplorerFrame when the operator clicks "Refresh".
-    */
-   public void refreshHcsCalibration() {
-      if (!exploring_ || !vesselType_.isMultiWell()) {
-         return;
-      }
-      Point2D.Double hcsOffset = tryReadHcsCalibration();
-      frame_.setHcsCalibrationStatus(hcsOffset != null);
-      if (hcsOffset != null) {
-         applyHcsCalibration(hcsOffset);
-      }
    }
 
    private void applyHcsCalibration(Point2D.Double offset) {

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -188,6 +188,10 @@ public class ExplorerManager {
    // Set to true after the first time we notify the user that MDA slice settings were
    // overridden; prevents showing the same dialog on every subsequent tile.
    private volatile boolean mdaSliceOverrideWarningShown_ = false;
+   // When true, the MDA z-stack and channel settings are ignored for this session and every
+   // tile is acquired with the microscope's current focus position and channel preset. Chosen
+   // in ExplorerFrame and locked at session start, along with the z-axis decision above.
+   private boolean sessionUseCurrentSettings_ = false;
 
    // Vessel outline: type selected in ExplorerFrame, anchor set at runtime.
    // Vessel axes are assumed parallel to stage X/Y (standard setup).
@@ -285,8 +289,13 @@ public class ExplorerManager {
          // Lock the z-axis decision for the whole session (see field comment). Editing
          // the MDA slice settings after this point will not change the dataset's axes
          // shape, so previously acquired tiles never disappear.
+         // When the user pinned this session to the microscope's current settings, the MDA
+         // slice and channel settings are ignored entirely (see sessionUseCurrentSettings_).
+         sessionUseCurrentSettings_ = frame_.getSettings()
+                 .getBoolean(ExplorerFrame.USE_CURRENT_SETTINGS, false);
          SequenceSettings startSettings = studio_.acquisitions().getAcquisitionSettings();
-         sessionUseSlices_ = startSettings.useSlices() && startSettings.slices().size() > 0;
+         sessionUseSlices_ = !sessionUseCurrentSettings_
+                 && startSettings.useSlices() && startSettings.slices().size() > 0;
          sessionIsZStack_ = sessionUseSlices_ && startSettings.slices().size() > 1;
          sessionSlices_ = sessionUseSlices_
                  ? new java.util.ArrayList<>(startSettings.slices())
@@ -1395,8 +1404,10 @@ public class ExplorerManager {
       try {
          SequenceSettings settings = studio_.acquisitions().getAcquisitionSettings();
 
-         // Detect if the user changed MDA slice settings mid-session and warn once.
-         if (!mdaSliceOverrideWarningShown_) {
+         // Detect if the user changed MDA slice settings mid-session and warn once. Skipped
+         // when this session ignores the MDA settings anyway (sessionUseCurrentSettings_):
+         // the comparison against the session snapshot would be meaningless there.
+         if (!mdaSliceOverrideWarningShown_ && !sessionUseCurrentSettings_) {
             boolean currentUseSlices = settings.useSlices() && !settings.slices().isEmpty();
             boolean slicesDiffer = (currentUseSlices != sessionUseSlices_)
                     || (sessionUseSlices_ && !settings.slices().equals(sessionSlices_));
@@ -1435,11 +1446,12 @@ public class ExplorerManager {
                  .shouldDisplayImages(false)
                  .isTestAcquisition(true);
 
-         // Preserve channel settings from MDA
-         if (settings.useChannels()) {
-            sb.useChannels(true);
-         }
-         if (!settings.useChannels() && !useSlices) {
+         // Preserve channel settings from MDA, unless this session is pinned to the
+         // microscope's current settings. Set explicitly: the settings copied from the MDA
+         // carry useChannels == true, so the engine would switch presets without this.
+         boolean useChannels = !sessionUseCurrentSettings_ && settings.useChannels();
+         sb.useChannels(useChannels);
+         if (!useChannels && !useSlices) {
             // AcquisitionEventIterator requires at least one acquisition function;
             // when no channels/slices/positions are used, enable a single frame.
             sb.useFrames(true).numFrames(1).intervalMs(0);
@@ -3389,12 +3401,56 @@ public class ExplorerManager {
 
    // ===================== Private helpers =====================
 
+   /**
+    * Returns the channel group the microscope is currently set to, or "" if none is set.
+    * Used in current-settings mode, where the MDA channel group does not apply.
+    */
+   private String currentChannelGroup() {
+      try {
+         String group = studio_.core().getChannelGroup();
+         return group != null ? group : "";
+      } catch (Exception e) {
+         return "";
+      }
+   }
+
+   /**
+    * Returns the name of the preset the current channel group is set to, falling back to
+    * "Default" when no channel group is configured or no preset matches the current state.
+    *
+    * <p>This mirrors what Snap and Live do (see SnapLiveManager.makeChannelName()), so an
+    * Explorer tile acquired in current-settings mode is labelled with the same channel name
+    * -- and therefore picks up the same remembered display settings -- as a snapped image.
+    * Explorer stores one image per channel, so only the single-camera-channel branch of
+    * that method applies here.
+    *
+    * @return the current preset name, or "Default"
+    */
+   private String currentChannelName() {
+      String group = currentChannelGroup();
+      String preset = "";
+      if (!group.isEmpty()) {
+         try {
+            // From the cache: this runs per tile, and the state cache is what Snap reads too.
+            preset = studio_.core().getCurrentConfigFromCache(group);
+         } catch (Exception e) {
+            // An unset or invalid group throws rather than returning "": fall back below.
+            preset = "";
+         }
+      }
+      return (preset == null || preset.isEmpty()) ? "Default" : preset;
+   }
+
    private SummaryMetadata buildSummaryMetadata(int width, int height) {
       try {
          SequenceSettings settings = studio_.acquisitions().getAcquisitionSettings();
 
          List<String> chNames = new ArrayList<>();
-         if (settings.useChannels() && settings.channels().size() > 0) {
+         // In current-settings mode the MDA channels are not acquired, so their names must
+         // not be recorded here: getSafeChannelName() would then mislabel every tile. The
+         // current preset is used instead (see the chNames.isEmpty() fallback below).
+         if (!sessionUseCurrentSettings_ && settings.useChannels()
+               && settings.channels().size() > 0) {
             for (int i = 0; i < settings.channels().size(); i++) {
                if (settings.channels().get(i).useChannel()) {
                   chNames.add(settings.channels().get(i).config());
@@ -3402,13 +3458,18 @@ public class ExplorerManager {
             }
          }
          if (chNames.isEmpty()) {
-            chNames.add("Default");
+            // Name the channel after the preset the scope is currently set to, as Snap does.
+            chNames.add(currentChannelName());
          }
+         // In current-settings mode the channels come from the hardware, not the MDA, so the
+         // group must match: it is half of the RememberedDisplaySettings key "<group>:<name>".
+         String channelGroup = sessionUseCurrentSettings_
+                 ? currentChannelGroup() : settings.channelGroup();
 
          SummaryMetadata.Builder smb = studio_.data().summaryMetadataBuilder()
                .sequenceSettings(settings)
                .channelNames(chNames)
-               .channelGroup(settings.channelGroup())
+               .channelGroup(channelGroup)
                .userName(System.getProperty("user.name"))
                .profileName(studio_.profile().getProfileName())
                .startDate(LocalDateTime.now().toString())
@@ -3416,7 +3477,7 @@ public class ExplorerManager {
                .imageHeight(height)
                .initialScopeData(studio_.acquisitions().scopeData()
                      .configurationToPropertyMap(studio_.core().getSystemStateCache()));
-         if (settings.useSlices()) {
+         if (settings.useSlices() && !sessionUseCurrentSettings_) {
             smb.zStepUm(settings.sliceZStepUm());
          }
          DefaultSummaryMetadata sm = (DefaultSummaryMetadata) smb.build();
@@ -3457,7 +3518,10 @@ public class ExplorerManager {
          SequenceSettings settings = studio_.acquisitions().getAcquisitionSettings();
          DisplaySettings.Builder dsBuilder = studio_.displays().displaySettingsBuilder();
          int displayChannelIndex = 0;
-         if (settings.useChannels() && settings.channels().size() > 0) {
+         // As in buildSummaryMetadata(): in current-settings mode the dataset has a single
+         // channel named after the current preset, so fall through to the branch below.
+         if (!sessionUseCurrentSettings_ && settings.useChannels()
+               && settings.channels().size() > 0) {
             for (int i = 0; i < settings.channels().size(); i++) {
                if (settings.channels().get(i).useChannel()) {
                   String channelGroup = settings.channelGroup();
@@ -3486,9 +3550,13 @@ public class ExplorerManager {
                dsBuilder.colorModeComposite();
             }
          } else {
-            // Single-channel (including RGB) — load remembered settings for "Default"
-            String channelGroup = settings.channelGroup();
-            String channelName = "Default";
+            // Single channel (including RGB). In current-settings mode name it after the
+            // preset the scope is set to, as Snap does, so it shares the remembered display
+            // settings keyed on "<group>:<name>"; otherwise keep the "Default" fallback.
+            String channelGroup = sessionUseCurrentSettings_
+                    ? currentChannelGroup() : settings.channelGroup();
+            String channelName = sessionUseCurrentSettings_
+                    ? currentChannelName() : "Default";
             org.micromanager.display.ChannelDisplaySettings remembered =
                   RememberedDisplaySettings.loadChannel(
                         studio_, channelGroup, channelName, null);

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -3522,13 +3522,15 @@ public class ExplorerManager {
             }
          }
          if (chNames.isEmpty()) {
-            // Name the channel after the preset the scope is currently set to, as Snap does.
-            // Only the current preset is declared: TiledDataViewerDataProvider seeds its
-            // AxesBridge from every name listed here, and the Intensity Inspector sizes its
-            // histogram panels to that count, so declaring the group's other presets would
-            // open a histogram panel per preset before any of them had been acquired.
+            // In current-settings mode, name the channel after the preset the scope is set to,
+            // as Snap does. Outside that mode keep the plain "Default" fallback: the rest of
+            // the code (initDisplaySettings() and the per-tile naming in
+            // acquireSingleTileBlocking()) uses "Default" there, and the names must agree.
+            // Only this one name is declared: TiledDataViewerDataProvider seeds its AxesBridge
+            // from every name listed here and the Intensity Inspector sizes its histogram
+            // panels to that count, so listing more would open a panel per unacquired preset.
             // Presets acquired later are registered from the images themselves.
-            chNames.add(currentChannelName());
+            chNames.add(sessionUseCurrentSettings_ ? currentChannelName() : "Default");
          }
          // In current-settings mode the channels come from the hardware, not the MDA, so the
          // group must match: it is half of the RememberedDisplaySettings key "<group>:<name>".

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -1626,11 +1626,18 @@ public class ExplorerManager {
             final int tileRow = row;
             final int tileCol = col;
             displayExecutor_.submit(() -> {
+               // Snapshot every field this task touches: stopExplore() nulls them from
+               // another thread, and its shutdownNow() only interrupts this task, it does
+               // not wait for it to finish. Re-reading a field mid-task can therefore see
+               // it change from non-null to null between the guard and the call.
+               final TiledDataViewerDataViewerAPI viewerRef = mm2Viewer_;
+               final TiledDataViewerDataProviderAPI providerRef = mm2DataProvider_;
+               final ExplorerDataSource dataSourceRef = dataSource_;
                for (int i = 0; i < tileImages.size() && i < displayAxesList.size(); i++) {
-                  if (mm2DataProvider_ != null) {
+                  if (providerRef != null) {
                      // Use axes-only overload so the image is re-read from storage,
                      // ensuring per-image metadata tags are included.
-                     mm2DataProvider_.newImageArrived(fullAxesList.get(i));
+                     providerRef.newImageArrived(fullAxesList.get(i));
                   }
                   try {
                      viewer_.newImageArrived(displayAxesList.get(i));
@@ -1638,16 +1645,18 @@ public class ExplorerManager {
                      // NDViewer histogram not yet initialized
                   }
                }
-               if (mm2Viewer_ != null) {
-                  mm2Viewer_.newTileArrived(tileImages, displayAxesList);
+               if (viewerRef != null) {
+                  viewerRef.newTileArrived(tileImages, displayAxesList);
                   // newTileArrived has now assigned an MM channel index to any channel this
                   // tile introduced; give it its name so the Inspector does not label it
                   // "channel <n>" (only the session's first channel is in the metadata).
-                  for (HashMap<String, Object> axes : displayAxesList) {
-                     Object ch = axes.get("channel");
-                     if (ch instanceof String) {
-                        nameChannelInDisplaySettings((String) ch,
-                                mm2DataProvider_.getChannelIndex((String) ch));
+                  if (providerRef != null) {
+                     for (HashMap<String, Object> axes : displayAxesList) {
+                        Object ch = axes.get("channel");
+                        if (ch instanceof String) {
+                           nameChannelInDisplaySettings((String) ch,
+                                   providerRef.getChannelIndex((String) ch));
+                        }
                      }
                   }
                }
@@ -1656,7 +1665,9 @@ public class ExplorerManager {
                } catch (NullPointerException e) {
                   // NDViewer histogram not yet initialized
                }
-               dataSource_.removePendingTile(tileRow, tileCol);
+               if (dataSourceRef != null) {
+                  dataSourceRef.removePendingTile(tileRow, tileCol);
+               }
                redrawOverlay();
             });
          } else {
@@ -3475,11 +3486,14 @@ public class ExplorerManager {
     * @param index       the MM channel index the viewer assigned to it
     */
    private void nameChannelInDisplaySettings(String channelName, int index) {
-      if (mm2Viewer_ == null || channelName == null || channelName.isEmpty() || index < 0) {
+      // Snapshot the viewer: this runs on the display executor, and stopExplore() can null
+      // the field between the guard below and the calls that follow.
+      final TiledDataViewerDataViewerAPI viewer = mm2Viewer_;
+      if (viewer == null || channelName == null || channelName.isEmpty() || index < 0) {
          return;
       }
       try {
-         DisplaySettings current = mm2Viewer_.getDisplaySettings();
+         DisplaySettings current = viewer.getDisplaySettings();
          if (current == null) {
             return;
          }
@@ -3498,7 +3512,7 @@ public class ExplorerManager {
          if (remembered != null && !remembered.getColor().equals(Color.WHITE)) {
             chBuilder.color(remembered.getColor());
          }
-         mm2Viewer_.setDisplaySettings(
+         viewer.setDisplaySettings(
                  current.copyBuilderWithChannelSettings(index, chBuilder.build()).build());
       } catch (Exception e) {
          studio_.logs().logError(e, "Explorer: could not name channel " + channelName);

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -1568,6 +1568,15 @@ public class ExplorerManager {
          // the MDA slice settings are edited mid-session (see sessionIsZStack_).
          boolean isZStack = sessionIsZStack_;
 
+         // In current-settings mode the acquisition returns a single plane at channel index 0
+         // whatever the scope is set to, so the summary metadata cannot say which preset it
+         // came from. Read the live preset once per tile instead: switching presets between
+         // tiles then yields a correctly named channel. A preset first acquired mid-session
+         // is registered from the image itself (AxesBridge.registerChannel), which is also
+         // what grows the Inspector's histogram panels, so no panel appears until its
+         // channel actually has data.
+         String currentModeChannel = sessionUseCurrentSettings_ ? currentChannelName() : null;
+
          for (Coords c : allCoords) {
             Image img = testStore.getImage(c);
             if (img == null) {
@@ -1591,7 +1600,8 @@ public class ExplorerManager {
                }
             }
             int channelIndex = c.getChannel();
-            String channelName = summaryMeta.getSafeChannelName(channelIndex);
+            String channelName = currentModeChannel != null
+                    ? currentModeChannel : summaryMeta.getSafeChannelName(channelIndex);
             // Pass the z-slice index only for z-stacks (-1 means "no z axis").
             int zIndex = isZStack ? c.getZSlice() : -1;
             HashMap<String, Object> axes = storeImage(img, row, col, channelName, zIndex);
@@ -1630,6 +1640,16 @@ public class ExplorerManager {
                }
                if (mm2Viewer_ != null) {
                   mm2Viewer_.newTileArrived(tileImages, displayAxesList);
+                  // newTileArrived has now assigned an MM channel index to any channel this
+                  // tile introduced; give it its name so the Inspector does not label it
+                  // "channel <n>" (only the session's first channel is in the metadata).
+                  for (HashMap<String, Object> axes : displayAxesList) {
+                     Object ch = axes.get("channel");
+                     if (ch instanceof String) {
+                        nameChannelInDisplaySettings((String) ch,
+                                mm2DataProvider_.getChannelIndex((String) ch));
+                     }
+                  }
                }
                try {
                   viewer_.update();
@@ -3441,6 +3461,50 @@ public class ExplorerManager {
       return (preset == null || preset.isEmpty()) ? "Default" : preset;
    }
 
+   /**
+    * Gives a channel that appeared after session start a display-settings name, so the
+    * Inspector labels it with the preset name instead of a generic "channel &lt;n&gt;".
+    *
+    * <p>Only the channel present at session start is listed in the summary metadata, so
+    * ChannelIntensityController's fallback to getSafeChannelName() cannot name a channel
+    * discovered later. It prefers ChannelDisplaySettings.getName() when that is non-empty,
+    * which is what this sets. The remembered color for the preset is applied too, matching
+    * what initDisplaySettings() does for the first channel.
+    *
+    * @param channelName the preset name the tile was acquired under
+    * @param index       the MM channel index the viewer assigned to it
+    */
+   private void nameChannelInDisplaySettings(String channelName, int index) {
+      if (mm2Viewer_ == null || channelName == null || channelName.isEmpty() || index < 0) {
+         return;
+      }
+      try {
+         DisplaySettings current = mm2Viewer_.getDisplaySettings();
+         if (current == null) {
+            return;
+         }
+         org.micromanager.display.ChannelDisplaySettings existing =
+                 current.getChannelSettings(index);
+         if (existing != null && channelName.equals(existing.getName())) {
+            return;
+         }
+         String group = currentChannelGroup();
+         org.micromanager.display.ChannelDisplaySettings.Builder chBuilder =
+                 existing != null ? existing.copyBuilder()
+                         : studio_.displays().channelDisplaySettingsBuilder();
+         chBuilder.groupName(group).name(channelName);
+         org.micromanager.display.ChannelDisplaySettings remembered =
+                 RememberedDisplaySettings.loadChannel(studio_, group, channelName, null);
+         if (remembered != null && !remembered.getColor().equals(Color.WHITE)) {
+            chBuilder.color(remembered.getColor());
+         }
+         mm2Viewer_.setDisplaySettings(
+                 current.copyBuilderWithChannelSettings(index, chBuilder.build()).build());
+      } catch (Exception e) {
+         studio_.logs().logError(e, "Explorer: could not name channel " + channelName);
+      }
+   }
+
    private SummaryMetadata buildSummaryMetadata(int width, int height) {
       try {
          SequenceSettings settings = studio_.acquisitions().getAcquisitionSettings();
@@ -3459,6 +3523,11 @@ public class ExplorerManager {
          }
          if (chNames.isEmpty()) {
             // Name the channel after the preset the scope is currently set to, as Snap does.
+            // Only the current preset is declared: TiledDataViewerDataProvider seeds its
+            // AxesBridge from every name listed here, and the Intensity Inspector sizes its
+            // histogram panels to that count, so declaring the group's other presets would
+            // open a histogram panel per preset before any of them had been acquired.
+            // Presets acquired later are registered from the images themselves.
             chNames.add(currentChannelName());
          }
          // In current-settings mode the channels come from the hardware, not the MDA, so the
@@ -3518,8 +3587,8 @@ public class ExplorerManager {
          SequenceSettings settings = studio_.acquisitions().getAcquisitionSettings();
          DisplaySettings.Builder dsBuilder = studio_.displays().displaySettingsBuilder();
          int displayChannelIndex = 0;
-         // As in buildSummaryMetadata(): in current-settings mode the dataset has a single
-         // channel named after the current preset, so fall through to the branch below.
+         // As in buildSummaryMetadata(): in current-settings mode the channels come from the
+         // channel group, not the MDA, so fall through to the branch below.
          if (!sessionUseCurrentSettings_ && settings.useChannels()
                && settings.channels().size() > 0) {
             for (int i = 0; i < settings.channels().size(); i++) {

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -1058,6 +1058,10 @@ public class SiteGenerator extends JFrame implements ParentPlateGUI {
       regenerate();
       moveStage_.setEnabled(true);
       setA1Button_.setEnabled(usesA1Center((String) plateIDCombo_.getSelectedItem()));
+      // Persist right away rather than waiting for this window to close. Other plugins read
+      // the calibration from the profile (the Explorer reads "site_offset"), and without this
+      // a freshly calibrated plate stays invisible to them until the HCS window is closed.
+      saveSettings();
    }
    
    private void regenerate() {


### PR DESCRIPTION
Also enables manually switching channels, resulting in a multi-channel explorer (but only where you choose to image those channels). 
Better detection of HCS calibration. 
Improve the Explorer Frame UI a bit.