### PR TITLE
tiledDataViewerBugs

### DIFF
--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerCanvasMouseListenerInterface.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerCanvasMouseListenerInterface.java
@@ -2,6 +2,7 @@ package org.micromanager.tileddataviewer;
 
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
+import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 
 /**
@@ -11,6 +12,41 @@ import java.awt.event.MouseWheelListener;
  * @author henrypinkard
  */
 public interface TiledDataViewerCanvasMouseListenerInterface extends MouseListener,
-         MouseWheelListener, MouseMotionListener{
+         MouseWheelListener, MouseMotionListener {
 
+   /**
+    * Zoom change applied per scrollwheel step.
+    */
+   double ZOOM_FACTOR_MOUSE = 1.4;
+
+   /**
+    * Minimum time between successive scrollwheel zoom steps. A fast scroll delivers many
+    * events; without this a single flick applies a large compounded zoom.
+    */
+   int MOUSE_WHEEL_ZOOM_INTERVAL_MS = 100;
+
+   /**
+    * Zoom factor for one scrollwheel event, or 0 if the event should be ignored.
+    *
+    * <p>Deliberately uses only the sign of the rotation. getWheelRotation() can report several
+    * clicks in a single event (and trackpads deliver rapid bursts), so honouring the count
+    * would let one gesture request an enormous zoom change that the user did not intend. On a
+    * very large tiled dataset an unintended deep zoom-out is expensive enough to freeze the
+    * UI, so the step size is capped here at the source.</p>
+    *
+    * <p>Implementations should combine this with a {@link #MOUSE_WHEEL_ZOOM_INTERVAL_MS}
+    * throttle so scrollwheel zoom behaves identically across all canvas mouse listeners.</p>
+    *
+    * @param mwe the wheel event
+    * @return factor to pass to zoom(), or 0 for no zoom
+    */
+   static double zoomFactorForWheelEvent(MouseWheelEvent mwe) {
+      int rotation = mwe.getWheelRotation();
+      if (rotation < 0) {
+         return 1 / ZOOM_FACTOR_MOUSE; //zoom in
+      } else if (rotation > 0) {
+         return ZOOM_FACTOR_MOUSE; //zoom out
+      }
+      return 0;
+   }
 }

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerDataSource.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/TiledDataViewerDataSource.java
@@ -21,9 +21,32 @@ public interface TiledDataViewerDataSource {
    /**
     * The minimal and maximal pixel coordinates of the image to be viewed.
     *
+    * <p>Returning {@code null} means "unbounded": the viewer will not clamp panning or
+    * zooming to the data. Sources that want free navigation return null here, but should
+    * still implement {@link #getFullResolutionSize()} so the viewer knows how large the data
+    * actually is.</p>
+    *
     * @return 4 element array x_min, y_min, x_max, y_max
     */
    int[] getBounds();
+
+   /**
+    * Size of the whole dataset in full-resolution pixels, independent of any view bounds.
+    *
+    * <p>Unlike {@link #getBounds()} this is purely informational -- reporting it does not
+    * make the viewer clamp navigation to the data. The viewer uses it to keep zoom-out
+    * within a sensible multiple of the data size; without it, it has no idea whether the
+    * dataset is a thousand pixels across or a million, and has to guess.</p>
+    *
+    * <p>The default returns null ("unknown"), which is correct for sources that cannot
+    * determine their extent. Implementations backed by a tiled storage should return the
+    * real value, typically derived from the storage's image bounds.</p>
+    *
+    * @return 2 element array {width, height} in full-resolution pixels, or null if unknown
+    */
+   default int[] getFullResolutionSize() {
+      return null;
+   }
 
    /**
     * Retrieve image with the given parameters so it can be displayed.

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/CanvasMouseListener.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/CanvasMouseListener.java
@@ -13,10 +13,6 @@ import org.micromanager.tileddataviewer.internal.TiledDataViewer;
  */
 public class CanvasMouseListener implements TiledDataViewerCanvasMouseListenerInterface {
 
-   private static final int MOUSE_WHEEL_ZOOM_INTERVAL_MS = 100;
-
-   private static final double ZOOM_FACTOR_MOUSE = 1.4;
-
    //all these are volatile because they are accessed by overlayer
    private volatile Point mouseDragStartPointLeft_;
    private volatile Point mouseDragStartPointRight_;
@@ -34,11 +30,11 @@ public class CanvasMouseListener implements TiledDataViewerCanvasMouseListenerIn
    public void mouseWheelMoved(MouseWheelEvent mwe) {
       long currentTime = System.currentTimeMillis();
       if (currentTime - lastMouseWheelZoomTime_ > MOUSE_WHEEL_ZOOM_INTERVAL_MS) {
-         lastMouseWheelZoomTime_ = currentTime;
-         if (mwe.getWheelRotation() < 0) {
-            display_.zoom(1 / ZOOM_FACTOR_MOUSE, currentMouseLocation_); // zoom in?
-         } else if (mwe.getWheelRotation() > 0) {
-            display_.zoom(ZOOM_FACTOR_MOUSE, currentMouseLocation_); //zoom out
+         double factor = TiledDataViewerCanvasMouseListenerInterface
+                  .zoomFactorForWheelEvent(mwe);
+         if (factor != 0) {
+            lastMouseWheelZoomTime_ = currentTime;
+            display_.zoom(factor, currentMouseLocation_);
          }
       }
    }

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/DisplayModel.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/DisplayModel.java
@@ -19,10 +19,67 @@ import org.micromanager.tileddataviewer.internal.gui.contrast.DisplaySettings;
  */
 public class DisplayModel {
 
+   /**
+    * How far the view may zoom out past the known extent of the data. At the limit the data
+    * spans roughly 1/MAX_ZOOM_OUT_FACTOR of the display in each dimension, i.e. about 10%.
+    *
+    * <p>This bounds more than just the visuals. Once zoomed out past the coarsest pyramid
+    * level the resolution index saturates at getMaxResolutionIndex(), so the downsample factor
+    * stops growing while the requested source size keeps growing. ImageMaker asks the storage
+    * for (fullResSourceDataSize / downsampleFactor) pixels, so without a limit each further
+    * zoom-out step requests a proportionally larger composite -- on a multi-gigapixel tiled
+    * dataset that quickly becomes thousands of tile reads on the render thread and freezes
+    * the UI.</p>
+    */
+   private static final double MAX_ZOOM_OUT_FACTOR = 10.0;
+
+   /**
+    * How far past the data the view may be panned, as a multiple of the data size, on top of
+    * one full view's worth of travel. Generous on purpose: the point of the limit is only to
+    * stop the data being lost entirely, never to make part of it hard to reach.
+    */
+   private static final double PAN_MARGIN_FACTOR = 2.0;
+
+   /**
+    * How far past the coarsest pyramid level the view may zoom out, when the data extent is
+    * unknown and the pyramid depth is the only clue to the size of the dataset. Small,
+    * because the coarsest level already spans the whole dataset -- this only allows a bit of
+    * margin around it.
+    */
+   private static final double PYRAMID_ZOOM_OUT_SLACK = 2.0;
+
    private DisplaySettings displaySettings_;
    protected DataViewCoords viewCoords_;
    private TiledDataViewerDataSource data_;
    private TiledDataViewer display_;
+
+   /**
+    * Largest full-res data extent the viewer has been told about, used to bound zoom-out.
+    * Needed because the data sources for the largest datasets (Stitch, Explorer explore mode,
+    * Deskew) deliberately report null bounds to get free zoom-out, leaving the bounds-based
+    * clamp in zoom() inactive for exactly the datasets that need it most.
+    *
+    * <p>Grows with the data (a live explore acquisition extends its bounds as tiles arrive)
+    * but never shrinks. Only ever grown from an authoritative extent -- getBounds() or an
+    * explicitly set source size -- never from the current zoomed source size, which would
+    * ratchet the limit outward on every zoom-out step and defeat the clamp entirely.</p>
+    */
+   private double maxKnownDataWidth_ = 0;
+   private double maxKnownDataHeight_ = 0;
+
+   /**
+    * Known full-res coordinate range of the data, when the source has reported real bounds.
+    * Tracked separately from the width/height above because data coordinates are absolute
+    * and need not start at the origin: Explorer derives tile positions from the stage, so
+    * the sample can sit at large or negative pixel coordinates. Limiting the view offset
+    * using only a size would then place the allowed range nowhere near the data.
+    *
+    * <p>NaN means no real bounds have been seen yet.</p>
+    */
+   private double knownDataMinX_ = Double.NaN;
+   private double knownDataMinY_ = Double.NaN;
+   private double knownDataMaxX_ = Double.NaN;
+   private double knownDataMaxY_ = Double.NaN;
 
    // Axes may use integer or string positions. Keep track of which
    // uses which ones do this here, and which string values map to which
@@ -44,6 +101,95 @@ public class DisplayModel {
               bounds == null ? null : (double) (bounds[2] - bounds[0]),
               bounds == null ? null : (double) (bounds[3] - bounds[1]),
               data.getBounds(), rgb);
+      growMaxKnownDataSizeFromBounds(bounds);
+   }
+
+   /**
+    * Records a known full-res data extent, growing the zoom-out limit if this is the largest
+    * seen so far. Ignores non-positive sizes so an uninitialized extent never sets the limit.
+    */
+   private void growMaxKnownDataSize(double width, double height) {
+      if (width > 0 && height > 0) {
+         maxKnownDataWidth_ = Math.max(maxKnownDataWidth_, width);
+         maxKnownDataHeight_ = Math.max(maxKnownDataHeight_, height);
+      }
+   }
+
+   /**
+    * Largest full-res source size the view may zoom out to along one dimension, or 0 if no
+    * limit can be determined.
+    *
+    * <p>Prefers the known data extent from getBounds(). Many datasets never report bounds --
+    * a stitched NDTiff has no per-tile position tags, so Explorer returns null for the whole
+    * session -- and for those the pyramid depth is used instead: the storage builds levels
+    * until the whole dataset fits in roughly one tile, so the coarsest level's span,
+    * (2^maxResIndex * canvas), is an upper bound on the data size and scales with it. The
+    * canvas alone must NOT be used here; it says nothing about how big the data is, and a
+    * fixed multiple of the window stops large datasets from ever being fully zoomed out.</p>
+    *
+    * <p>The limit is derived from the LARGER data dimension and applied to both axes. The
+    * source size is inflated along one axis to match the canvas aspect ratio (see
+    * onCanvasResize), so a per-axis limit would stop a wide sample from ever being framed in
+    * a tall window -- the inflated dimension would hit its own axis' limit first.</p>
+    *
+    * @param knownDataSize largest data extent seen along either dimension, or 0 if unknown
+    * @param displaySize largest canvas dimension
+    * @param maxResIndex coarsest available pyramid level index
+    * @return the maximum full-res source size, or 0 if nothing is known yet
+    */
+   private static double zoomOutLimit(double knownDataSize, double displaySize,
+                                      int maxResIndex) {
+      if (knownDataSize > 0) {
+         return knownDataSize * MAX_ZOOM_OUT_FACTOR;
+      }
+      //No bounds available: infer the scale of the data from the pyramid instead. At the
+      //coarsest level the whole dataset is small, so 2^maxResIndex canvases across is a
+      //reasonable stand-in for "the whole dataset", and zooming a little past that is enough.
+      if (maxResIndex > 0 && displaySize > 0) {
+         return displaySize * Math.pow(2, maxResIndex) * PYRAMID_ZOOM_OUT_SLACK;
+      }
+      //Nothing known at all (single-resolution source): fall back to the canvas.
+      return displaySize > 0 ? displaySize * MAX_ZOOM_OUT_FACTOR : 0;
+   }
+
+   /**
+    * Records the dataset's full-resolution size, when the source can report it. This is the
+    * authoritative answer for the zoom-out limit and is available even from sources that
+    * return null bounds to keep navigation unclamped.
+    */
+   private void growMaxKnownDataSizeFromFullResolutionSize() {
+      int[] size = data_.getFullResolutionSize();
+      if (size != null && size.length >= 2) {
+         growMaxKnownDataSize(size[0], size[1]);
+      }
+   }
+
+   /**
+    * Records the extent described by a bounds array, if it is present and initialized.
+    * Bounds are {x_min, y_min, x_max, y_max}; unbounded sources use Integer.MIN_VALUE/MAX_VALUE
+    * sentinels, which must not be taken as a real extent.
+    */
+   private void growMaxKnownDataSizeFromBounds(int[] bounds) {
+      if (bounds == null || bounds[0] == Integer.MIN_VALUE) {
+         return;
+      }
+      growMaxKnownDataSize(bounds[2] - bounds[0], bounds[3] - bounds[1]);
+      //Remember where the data actually is, not just how big it is; these coordinates are
+      //absolute and the data need not start at the origin.
+      knownDataMinX_ = min(knownDataMinX_, bounds[0]);
+      knownDataMinY_ = min(knownDataMinY_, bounds[1]);
+      knownDataMaxX_ = max(knownDataMaxX_, bounds[2]);
+      knownDataMaxY_ = max(knownDataMaxY_, bounds[3]);
+   }
+
+   /** Math.min that treats NaN (no value yet) as absent rather than poisoning the result. */
+   private static double min(double current, double candidate) {
+      return Double.isNaN(current) ? candidate : Math.min(current, candidate);
+   }
+
+   /** Math.max that treats NaN (no value yet) as absent rather than poisoning the result. */
+   private static double max(double current, double candidate) {
+      return Double.isNaN(current) ? candidate : Math.max(current, candidate);
    }
 
    /**
@@ -104,6 +250,7 @@ public class DisplayModel {
    }
 
    public void pan(int dx, int dy) {
+      growMaxKnownDataSizeFromBounds(data_.getBounds());
       Point2D.Double offset = viewCoords_.getViewOffset();
       double newX = offset.x + (dx / viewCoords_.getMagnificationFromResLevel())
               * viewCoords_.getDownsampleFactor();
@@ -117,8 +264,43 @@ public class DisplayModel {
                  Math.max(viewCoords_.yMin_, Math.min(newY, viewCoords_.yMax_
                          - viewCoords_.getFullResSourceDataSize().y)));
       } else {
-         viewCoords_.setViewOffset(newX, newY);
+         //Unbounded source: keep the data within reach anyway. Zoomed far out the
+         //magnification is tiny, so one pixel of drag moves the view a huge distance in
+         //full-res coordinates -- without a limit a single drag lands far outside the data
+         //(a black canvas with no way back) and asks the storage to composite a vast empty
+         //region, which hangs the UI.
+         Point2D.Double viewSize = viewCoords_.getFullResSourceDataSize();
+         viewCoords_.setViewOffset(
+                 clampOffsetForUnboundedData(newX, knownDataMinX_, knownDataMaxX_, viewSize.x),
+                 clampOffsetForUnboundedData(newY, knownDataMinY_, knownDataMaxY_, viewSize.y));
       }
+   }
+
+   /**
+    * Keeps a view offset within a sane distance of the data when the source reports no
+    * bounds, without ever making part of the data unreachable.
+    *
+    * <p>Works in absolute full-res coordinates: the allowed range is the known data range
+    * (which need not start at the origin) grown by a margin on each side. The margin scales
+    * with the current view size as well as the data size, so at any zoom level the view can
+    * always be moved clear across the data and somewhat beyond -- panning must never be able
+    * to cut off the far edge of the sample.</p>
+    *
+    * @param offset requested view offset along one dimension, in full-res pixels
+    * @param dataMin low edge of the known data range, or NaN if unknown
+    * @param dataMax high edge of the known data range, or NaN if unknown
+    * @param viewSize current source size of the view along that dimension
+    * @return the offset, limited to the allowed range
+    */
+   private static double clampOffsetForUnboundedData(double offset, double dataMin,
+                                                     double dataMax, double viewSize) {
+      if (Double.isNaN(dataMin) || Double.isNaN(dataMax) || dataMax <= dataMin) {
+         return offset; //nothing known about where the data is; leave panning unrestricted
+      }
+      //Margin covers a full view plus a multiple of the data size, so the view can always be
+      //scrolled past either edge no matter how far out the zoom is.
+      double margin = (dataMax - dataMin) * PAN_MARGIN_FACTOR + Math.max(viewSize, 0);
+      return Math.max(dataMin - margin, Math.min(offset, dataMax + margin));
    }
 
    public void zoom(double factor, Point mouseLocation) {
@@ -147,10 +329,51 @@ public class DisplayModel {
       if (newSourceDataWidth < 5 || newSourceDataHeight < 5) {
          return; //constrain maximum zoom
       }
+      //Pick up the data extent if it has become available since the last zoom. For a saved
+      //dataset newImageArrived() never fires, so updateDisplayBounds() never runs and the
+      //seeding hooks alone would leave the limit unarmed.
+      growMaxKnownDataSizeFromFullResolutionSize();
+      growMaxKnownDataSizeFromBounds(data_.getBounds());
+      //constrain maximum zoom out. Unlike the bounds-based clamp below this applies even when
+      //the data source reports null bounds, which is the case for the large tiled datasets.
+      //One isotropic limit from the larger dimension, so aspect-ratio inflation of the
+      //smaller axis can never stop the whole sample from being framed.
+      Point2D.Double displayImageSize = viewCoords_.getDisplayImageSize();
+      double limit = zoomOutLimit(Math.max(maxKnownDataWidth_, maxKnownDataHeight_),
+              Math.max(displayImageSize.x, displayImageSize.y),
+              data_.getMaxResolutionIndex());
+      if (limit > 0) {
+         double excess = Math.max(newSourceDataWidth, newSourceDataHeight) / limit;
+         if (excess > 1) {
+            //scale both dimensions by the same factor to preserve the aspect ratio
+            newSourceDataWidth = newSourceDataWidth / excess;
+            newSourceDataHeight = newSourceDataHeight / excess;
+         }
+      }
       if (data_.getBounds() != null) {
-         //don't let either of these go bigger than the actual data
-         double overzoomXFactor = newSourceDataWidth / (viewCoords_.xMax_ - viewCoords_.xMin_);
-         double overzoomYFactor = newSourceDataHeight / (viewCoords_.yMax_ - viewCoords_.yMin_);
+         //Don't zoom out past the point where the whole dataset is visible. Compare against
+         //the source size that just frames the data at the current canvas aspect ratio, NOT
+         //against the raw data extent: the source is inflated along one axis to match the
+         //canvas (see onCanvasResize), so testing the inflated dimension against that axis'
+         //raw extent makes a mismatched aspect look like overzoom when it is not. Doing so
+         //scales BOTH dimensions down and leaves only a fraction of the data visible -- a
+         //4:1 sample in a square window would show just 25% of its width.
+         double dataWidth = viewCoords_.xMax_ - viewCoords_.xMin_;
+         double dataHeight = viewCoords_.yMax_ - viewCoords_.yMin_;
+         double framedWidth = dataWidth;
+         double framedHeight = dataHeight;
+         Point2D.Double canvas = viewCoords_.getDisplayImageSize();
+         if (canvas.x > 0 && canvas.y > 0 && dataWidth > 0 && dataHeight > 0) {
+            double canvasAspect = canvas.x / canvas.y;
+            double dataAspect = dataWidth / dataHeight;
+            if (canvasAspect > dataAspect) {
+               framedWidth = dataHeight * canvasAspect; //letterboxed left/right
+            } else {
+               framedHeight = dataWidth / canvasAspect; //letterboxed top/bottom
+            }
+         }
+         double overzoomXFactor = newSourceDataWidth / framedWidth;
+         double overzoomYFactor = newSourceDataHeight / framedHeight;
          if (overzoomXFactor > 1 || overzoomYFactor > 1) {
             newSourceDataWidth = newSourceDataWidth / Math.max(overzoomXFactor, overzoomYFactor);
             newSourceDataHeight = newSourceDataHeight / Math.max(overzoomXFactor, overzoomYFactor);
@@ -170,7 +393,14 @@ public class DisplayModel {
                  Math.max(viewCoords_.yMin_, Math.min(yOffset,
                          viewCoords_.yMax_ - viewCoords_.getFullResSourceDataSize().y)));
       } else {
-         viewCoords_.setViewOffset(xOffset, yOffset);
+         //Same reachability limit as pan(): a zoom centred near the edge of a far-out view
+         //can also throw the offset well beyond the data.
+         Point2D.Double newViewSize = viewCoords_.getFullResSourceDataSize();
+         viewCoords_.setViewOffset(
+                 clampOffsetForUnboundedData(xOffset, knownDataMinX_, knownDataMaxX_,
+                         newViewSize.x),
+                 clampOffsetForUnboundedData(yOffset, knownDataMinY_, knownDataMaxY_,
+                         newViewSize.y));
       }
    }
 
@@ -224,6 +454,9 @@ public class DisplayModel {
    }
 
    public void setFullResSourceDataSize(double width, double height) {
+      //This is how a source with null bounds (e.g. Stitch) tells the viewer its canvas size,
+      //so it is the only extent information available for the zoom-out limit in that case.
+      growMaxKnownDataSize(width, height);
       viewCoords_.setFullResSourceDataSize(width, height);
    }
 
@@ -236,6 +469,7 @@ public class DisplayModel {
                                                        double requestedHeight) {
       Point2D.Double canvasSize = viewCoords_.getDisplayImageSize();
       if (canvasSize.x == 0 || canvasSize.y == 0) {
+         growMaxKnownDataSize(requestedWidth, requestedHeight);
          viewCoords_.setFullResSourceDataSize(requestedWidth, requestedHeight);
          return;
       }
@@ -260,6 +494,9 @@ public class DisplayModel {
             newH /= scale;
          }
       }
+      //Record the requested extent rather than newW/newH: the latter is inflated to fill the
+      //canvas aspect ratio and would overstate how big the data actually is.
+      growMaxKnownDataSize(requestedWidth, requestedHeight);
       viewCoords_.setFullResSourceDataSize(newW, newH);
    }
 
@@ -372,6 +609,9 @@ public class DisplayModel {
    }
 
    public void setImageBounds(int[] newBounds) {
+      //A live explore acquisition grows its bounds as tiles arrive; without this the zoom-out
+      //limit would stay pinned to the extent of the first tile.
+      growMaxKnownDataSizeFromBounds(newBounds);
       viewCoords_.setImageBounds(newBounds);
    }
 

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/DisplayModel.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/DisplayModel.java
@@ -250,14 +250,17 @@ public class DisplayModel {
    }
 
    public void pan(int dx, int dy) {
-      growMaxKnownDataSizeFromBounds(data_.getBounds());
+      //Fetch once and reuse: getBounds() can be O(tiles) and allocating (ExplorerDataSource
+      //scans every tile position), and this runs on the EDT for every mouse-drag event.
+      int[] bounds = data_.getBounds();
+      growMaxKnownDataSizeFromBounds(bounds);
       Point2D.Double offset = viewCoords_.getViewOffset();
       double newX = offset.x + (dx / viewCoords_.getMagnificationFromResLevel())
               * viewCoords_.getDownsampleFactor();
       double newY = offset.y + (dy / viewCoords_.getMagnificationFromResLevel())
               * viewCoords_.getDownsampleFactor();
 
-      if (data_.getBounds() != null) {
+      if (bounds != null) {
          viewCoords_.setViewOffset(
                  Math.max(viewCoords_.xMin_, Math.min(newX, viewCoords_.xMax_
                          - viewCoords_.getFullResSourceDataSize().x)),
@@ -331,9 +334,12 @@ public class DisplayModel {
       }
       //Pick up the data extent if it has become available since the last zoom. For a saved
       //dataset newImageArrived() never fires, so updateDisplayBounds() never runs and the
-      //seeding hooks alone would leave the limit unarmed.
+      //seeding hooks alone would leave the limit unarmed. Fetch the bounds once and reuse
+      //them below: getBounds() can be O(tiles) and allocating (ExplorerDataSource scans every
+      //tile position), and this runs on the EDT for every wheel event.
       growMaxKnownDataSizeFromFullResolutionSize();
-      growMaxKnownDataSizeFromBounds(data_.getBounds());
+      int[] bounds = data_.getBounds();
+      growMaxKnownDataSizeFromBounds(bounds);
       //constrain maximum zoom out. Unlike the bounds-based clamp below this applies even when
       //the data source reports null bounds, which is the case for the large tiled datasets.
       //One isotropic limit from the larger dimension, so aspect-ratio inflation of the
@@ -350,7 +356,7 @@ public class DisplayModel {
             newSourceDataHeight = newSourceDataHeight / excess;
          }
       }
-      if (data_.getBounds() != null) {
+      if (bounds != null) {
          //Don't zoom out past the point where the whole dataset is visible. Compare against
          //the source size that just frames the data at the current canvas aspect ratio, NOT
          //against the raw data extent: the source is inflated along one axis to match the
@@ -386,7 +392,7 @@ public class DisplayModel {
       double yOffset = (zoomCenter.y - (zoomCenter.y - viewOffset.y)
               * newSourceDataHeight / sourceDataSize.y);
       //make sure view doesn't go outside image bounds
-      if (data_.getBounds() != null) {
+      if (bounds != null) {
          viewCoords_.setViewOffset(
                  Math.max(viewCoords_.xMin_, Math.min(xOffset,
                          viewCoords_.xMax_ - viewCoords_.getFullResSourceDataSize().x)),

--- a/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/ImageMaker.java
+++ b/libraries/TiledDataViewer/src/main/java/org/micromanager/tileddataviewer/internal/gui/ImageMaker.java
@@ -247,11 +247,15 @@ public class ImageMaker {
                //recompute 8 bit image
                channelProcessors_.get(c).recompute();
                   {
-                     TiledDataViewerImageProcessor proc = channelProcessors_.get(c);
-                     boolean noPixels = (proc instanceof TiledDataViewerImageProcessorRGB)
-                           ? ((TiledDataViewerImageProcessorRGB) proc).rProcessor_.reds == null
-                           : proc.reds == null;
-                     if (noPixels) {
+                     // Check the eightBitImage buffers as well as the LUT tables: both are
+                     // dereferenced below, but they become null independently. changePixels()
+                     // clears eightBitImage while leaving reds populated from an earlier
+                     // render, and recompute() returns early (without calling create8BitImage)
+                     // when no pixels have arrived yet -- so a "reds != null" test alone lets a
+                     // null eightBitImage through and NPEs in the pixel loop. Seen when zooming
+                     // during a live explore acquisition. The RGB subclass overrides
+                     // isRenderable() to check all three component processors.
+                     if (!channelProcessors_.get(c).isRenderable(imageWidth_ * imageHeight_)) {
                         continue; // No pixels yet
                      }
                   }
@@ -459,6 +463,18 @@ public class ImageMaker {
          }
       }
 
+      /**
+       * All three component processors are dereferenced when rendering, so all three must be
+       * ready. Note this deliberately ignores the inherited fields, which the RGB path never
+       * populates.
+       */
+      @Override
+      boolean isRenderable(int displayPixelCount) {
+         return rProcessor_.isRenderable(displayPixelCount)
+                  && gProcessor_.isRenderable(displayPixelCount)
+                  && bProcessor_.isRenderable(displayPixelCount);
+      }
+
       /** Returns [R, G, B] raw histograms, or null if no pixels yet. */
       public int[][] getComponentHistograms() {
          if (rProcessor_.rawHistogram == null) {
@@ -611,6 +627,22 @@ public class ImageMaker {
          eightBitImage = null;
       }
 
+      /**
+       * Whether this channel can be drawn into a display image of the given pixel count.
+       *
+       * <p>Requires both the 8 bit buffer and the LUT lookup tables, which can be null
+       * independently of each other, and requires the buffer to be at least as large as the
+       * display image -- a zoom or canvas resize changes the display size, and a buffer
+       * allocated for a previous, smaller size would be read out of bounds.</p>
+       *
+       * @param displayPixelCount number of pixels the caller intends to read
+       * @return true if it is safe to read this channel's buffers
+       */
+      boolean isRenderable(int displayPixelCount) {
+         return eightBitImage != null && eightBitImage.length >= displayPixelCount
+                  && reds != null && greens != null && blues != null;
+      }
+
       public void recompute() {
          // No pixels have been supplied for this channel yet (changePixels not called),
          // so rawHistogram is null. This happens when a channel processor has been created
@@ -722,7 +754,10 @@ public class ImageMaker {
       //Also compute histogram in the process
       private void create8BitImage() {
          int size = width * height;
-         if (eightBitImage == null) {
+         //Reallocate when the size changes, not just when the buffer is absent: a zoom or
+         //canvas resize changes width/height, and keeping a buffer allocated for a smaller
+         //previous size would be read out of bounds by the render loop.
+         if (eightBitImage == null || eightBitImage.length != size) {
             eightBitImage = new byte[size];
          }
          if (pixels == null) {

--- a/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreDataSource.java
+++ b/plugins/Deskew/src/main/java/org/micromanager/deskew/DeskewExploreDataSource.java
@@ -39,7 +39,7 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
          TiledDataViewerOverlayerPlugin,
          TiledDataViewerExploreControls {
 
-   private static final double ZOOM_FACTOR = 1.4;
+   private volatile long lastMouseWheelZoomTime_ = 0;
 
    private final DeskewExploreManager manager_;
    private final CopyOnWriteArrayList<AcquisitionStateListener> acqStateListeners_ =
@@ -530,11 +530,14 @@ public class DeskewExploreDataSource implements TiledDataViewerDataSource,
 
    @Override
    public void mouseWheelMoved(MouseWheelEvent e) {
-      Point mouseLoc = e.getPoint();
-      if (e.getWheelRotation() < 0) {
-         manager_.zoom(1.0 / ZOOM_FACTOR, mouseLoc);
-      } else if (e.getWheelRotation() > 0) {
-         manager_.zoom(ZOOM_FACTOR, mouseLoc);
+      long currentTime = System.currentTimeMillis();
+      if (currentTime - lastMouseWheelZoomTime_ > MOUSE_WHEEL_ZOOM_INTERVAL_MS) {
+         double factor = TiledDataViewerCanvasMouseListenerInterface
+                  .zoomFactorForWheelEvent(e);
+         if (factor != 0) {
+            lastMouseWheelZoomTime_ = currentTime;
+            manager_.zoom(factor, e.getPoint());
+         }
       }
    }
 

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -639,6 +639,30 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
    }
 
    @Override
+   public int[] getFullResolutionSize() {
+      // getBounds() returns null here so the viewer leaves panning and zooming unclamped,
+      // but the viewer still needs to know how big the data is to bound zoom-out. NDTiff
+      // tracks the real extent; getImageBounds() is on the concrete storage class rather
+      // than MultiresNDTiffAPI, hence the instanceof.
+      if (!(storage_ instanceof NDTiffStorage)) {
+         return null;
+      }
+      int[] b = ((NDTiffStorage) storage_).getImageBounds();
+      // NDTiffStorage.getImageBounds() returns {xMin, yMin, xMax, yMax} (verified against its
+      // source). Note the TiledDataProviderAPI javadoc documents {xMin, xMax, yMin, yMax},
+      // which does not match the implementation.
+      if (b == null || b.length < 4) {
+         return null;
+      }
+      int width = b[2] - b[0];
+      int height = b[3] - b[1];
+      if (width <= 0 || height <= 0) {
+         return null;
+      }
+      return new int[]{width, height};
+   }
+
+   @Override
    public int getMaxResolutionIndex() {
       if (storage_ == null) {
          return 0;

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -52,7 +52,7 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
          TiledDataViewerCanvasMouseListenerInterface, TiledDataViewerOverlayerPlugin,
          TiledDataViewerExploreControls {
 
-   private static final double ZOOM_FACTOR = 1.4;
+   private volatile long lastMouseWheelZoomTime_ = 0;
 
    private final ExplorerManager manager_;
    private final CopyOnWriteArrayList<AcquisitionStateListener> acqStateListeners_ =
@@ -947,11 +947,14 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    @Override
    public void mouseWheelMoved(MouseWheelEvent e) {
-      Point mouseLoc = e.getPoint();
-      if (e.getWheelRotation() < 0) {
-         manager_.zoom(1.0 / ZOOM_FACTOR, mouseLoc);
-      } else if (e.getWheelRotation() > 0) {
-         manager_.zoom(ZOOM_FACTOR, mouseLoc);
+      long currentTime = System.currentTimeMillis();
+      if (currentTime - lastMouseWheelZoomTime_ > MOUSE_WHEEL_ZOOM_INTERVAL_MS) {
+         double factor = TiledDataViewerCanvasMouseListenerInterface
+                  .zoomFactorForWheelEvent(e);
+         if (factor != 0) {
+            lastMouseWheelZoomTime_ = currentTime;
+            manager_.zoom(factor, e.getPoint());
+         }
       }
    }
 

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerDataSource.java
@@ -640,10 +640,13 @@ public class ExplorerDataSource implements TiledDataViewerDataSource, TiledDataV
 
    @Override
    public int[] getFullResolutionSize() {
-      // getBounds() returns null here so the viewer leaves panning and zooming unclamped,
-      // but the viewer still needs to know how big the data is to bound zoom-out. NDTiff
-      // tracks the real extent; getImageBounds() is on the concrete storage class rather
-      // than MultiresNDTiffAPI, hence the instanceof.
+      // getBounds() returns null for datasets whose tiles carry no XPositionPix/YPositionPix
+      // tags -- a stitched dataset, for instance -- which leaves the viewer's panning and
+      // zooming unclamped. That is the intended behaviour, but the viewer still needs to know
+      // how big the data is in order to bound zoom-out, and this reports it without
+      // re-enabling those clamps. NDTiff tracks the real extent regardless of position tags;
+      // getImageBounds() is on the concrete storage class rather than MultiresNDTiffAPI,
+      // hence the instanceof.
       if (!(storage_ instanceof NDTiffStorage)) {
          return null;
       }


### PR DESCRIPTION
- **TiledDataViewer: fix NPE rendering a channel whose 8-bit buffer is not ready**
- **TiledDataViewer: one zoom step per scrollwheel event, consistently**
- **TiledDataViewer: bound zoom-out and panning for unbounded data sources**
