### PR TITLE
Fix endless ChannelGroup loop when editing a preset during live mode.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
@@ -225,8 +225,8 @@ public class MMCache {
       // Build the string on the calling thread: it is assembled from fields that the
       // stage polling thread writes, so deferring the whole method could format values
       // read at some arbitrary later time and show a mix of old and new state. Only the
-      // Swing call below is moved to the EDT, since this can be called off the EDT (the
-      // stage position events are posted from the polling timer thread).
+      // Swing call below needs the EDT, and it is deferred only when we are not already
+      // on it (the stage position events are posted from the polling timer thread).
       String text = String.format(
             "Image info (from camera): %s X %s X %s bytes, Intensity range: %s bits, %s nm/px",
             width_, height_, bytesPerPixel_, imageBitDepth_,
@@ -240,8 +240,12 @@ public class MMCache {
                TextUtils.removeNegativeZero(TextUtils.FMT2.format(x_)),
                TextUtils.removeNegativeZero(TextUtils.FMT2.format(y_)));
       }
-      final String infoText = text;
-      SwingUtilities.invokeLater(() -> frame_.updateInfoDisplay(infoText));
+      if (SwingUtilities.isEventDispatchThread()) {
+         frame_.updateInfoDisplay(text);
+      } else {
+         final String infoText = text;
+         SwingUtilities.invokeLater(() -> frame_.updateInfoDisplay(infoText));
+      }
    }
 
    public double getStageX() {

--- a/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMCache.java
@@ -23,6 +23,7 @@ package org.micromanager.internal;
 
 import com.google.common.eventbus.Subscribe;
 import java.awt.geom.AffineTransform;
+import javax.swing.SwingUtilities;
 import mmcorej.CMMCore;
 import org.micromanager.Studio;
 import org.micromanager.events.PixelSizeAffineChangedEvent;
@@ -221,6 +222,11 @@ public class MMCache {
     * Updates the information line in the UI.
     */
    public void updateInfoDisplay() {
+      // Build the string on the calling thread: it is assembled from fields that the
+      // stage polling thread writes, so deferring the whole method could format values
+      // read at some arbitrary later time and show a mix of old and new state. Only the
+      // Swing call below is moved to the EDT, since this can be called off the EDT (the
+      // stage position events are posted from the polling timer thread).
       String text = String.format(
             "Image info (from camera): %s X %s X %s bytes, Intensity range: %s bits, %s nm/px",
             width_, height_, bytesPerPixel_, imageBitDepth_,
@@ -234,7 +240,8 @@ public class MMCache {
                TextUtils.removeNegativeZero(TextUtils.FMT2.format(x_)),
                TextUtils.removeNegativeZero(TextUtils.FMT2.format(y_)));
       }
-      frame_.updateInfoDisplay(text);
+      final String infoText = text;
+      SwingUtilities.invokeLater(() -> frame_.updateInfoDisplay(infoText));
    }
 
    public double getStageX() {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -1348,8 +1348,16 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
     */
    @Subscribe
    public void onChannelGroupChanged(ChannelGroupChangedEvent event) {
-      getAcquisitionEngine().setSequenceSettings(getAcquisitionEngine().getSequenceSettings()
-            .copyBuilder().channelGroup(event.getNewChannelGroup()).build());
+      // Track the Core, which owns the channel group. Only rewrite the settings when the
+      // group really changed: setSequenceSettings() synchronously posts an
+      // AcquisitionSettingsChangedEvent that redraws this dialog, and there is no point
+      // doing that for a no-op change.
+      SequenceSettings sequenceSettings = getAcquisitionEngine().getSequenceSettings();
+      if (!sequenceSettings.channelGroup().equals(event.getNewChannelGroup())) {
+         getAcquisitionEngine().setSequenceSettings(sequenceSettings
+               .copyBuilder().channelGroup(event.getNewChannelGroup()).build());
+      }
+      // The list of groups may need refreshing even when the selection did not change.
       updateChannelAndGroupCombo();
    }
 
@@ -1362,6 +1370,31 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
       return false;
    }
 
+   /**
+    * Returns true when the given name is a config group currently defined in the Core.
+    *
+    * <p>This deliberately consults the complete list of defined config groups rather than
+    * AcquisitionEngine.getAvailableGroups(), which filters out groups that are deemed
+    * unsuitable as a channel group. That filter performs live Core queries and can
+    * transiently reject a perfectly well defined group (for instance while a preset is
+    * being edited). Using it to decide whether the current channel group is still valid
+    * caused the channel group to be reassigned spuriously (issue #2439).
+    *
+    * @param group name of the config group to look for
+    * @return true if the Core has a config group with this name
+    */
+   private boolean isConfigGroupDefined(String group) {
+      if (group == null || group.isEmpty()) {
+         return false;
+      }
+      StrVector groups = mmStudio_.core().getAvailableConfigGroups();
+      for (String candidate : groups) {
+         if (group.equals(candidate)) {
+            return true;
+         }
+      }
+      return false;
+   }
 
    /**
     * Closes a(and disposes) the MDA window.
@@ -1396,12 +1429,24 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
          channelGroupCombo_.removeActionListener(al);
       }
       if (groups.length != 0) {
-         channelGroupCombo_.setModel(new DefaultComboBoxModel<>(groups));
-         if (!inArray(getAcquisitionEngine().getChannelGroup(), groups)) {
+         String currentGroup = getAcquisitionEngine().getChannelGroup();
+         // Judge validity against the groups the Core actually defines, not against the
+         // filtered list above: that filter can transiently drop a valid group, and
+         // reassigning the channel group because of it caused an endless loop with
+         // updateGUIFromSequenceSettings() (issue #2439).
+         if (!isConfigGroupDefined(currentGroup)) {
+            // The fallback choice does use the filtered list, since we want to land on a
+            // group that is actually usable as a channel group.
             getAcquisitionEngine().setChannelGroup(getAcquisitionEngine().getFirstConfigGroup());
+            currentGroup = getAcquisitionEngine().getChannelGroup();
          }
-
-         channelGroupCombo_.setSelectedItem(getAcquisitionEngine().getChannelGroup());
+         // A group can be valid yet missing from the filtered list. Rebuilding the model
+         // then would leave it unable to represent the current selection, so leave the
+         // model alone for this pass.
+         if (inArray(currentGroup, groups)) {
+            channelGroupCombo_.setModel(new DefaultComboBoxModel<>(groups));
+            channelGroupCombo_.setSelectedItem(currentGroup);
+         }
       }
       for (ActionListener al : als) {
          channelGroupCombo_.addActionListener(al);
@@ -1505,7 +1550,14 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
             channelGroupCombo_.removeActionListener(cgsal);
          }
          channelGroupCombo_.setSelectedItem(sequenceSettings.channelGroup());
-         getAcquisitionEngine().setChannelGroup(sequenceSettings.channelGroup());
+         // Deliberately no setChannelGroup() here: this method only reflects state in the
+         // UI, it must not write hardware state. It runs synchronously from
+         // setSequenceSettings() -> AcquisitionSettingsChangedEvent, at which point the
+         // Core has not been updated yet, so writing the settings value back here undid
+         // the change that the Core had just reported and the two ping-ponged forever
+         // (issue #2439). The Core is the source of truth for the channel group; the
+         // settings follow it via onChannelGroupChanged(), and the group remembered in
+         // the profile is pushed into the Core once, from onConfigurationLoaded().
          for (ActionListener cgsal : cgsals) {
             channelGroupCombo_.addActionListener(cgsal);
          }
@@ -1620,6 +1672,35 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
     */
    @Subscribe
    public void onConfigurationLoaded(SystemConfigurationLoadedEvent sle) {
+      // Push the channel group restored from the profile into the Core. This has to wait
+      // until a configuration is loaded, since there are no config groups before that:
+      // this dialog is constructed before the system configuration is read. It used to
+      // happen as a side effect of updateGUIFromSequenceSettings(), which caused an
+      // endless loop with the Core's change callback (issue #2439).
+      //
+      // Only fill in a group when the Core does not have one. The Core leaves the channel
+      // group empty unless it is set explicitly (it never picks a group by itself), so a
+      // non-empty value here means the configuration asked for it -- typically through
+      // "Core,ChannelGroup,..." in the System-Startup preset, which is applied while the
+      // configuration is loaded, just before this event. That is a deliberate choice by
+      // whoever wrote the configuration and must win over the group we remembered.
+      String coreChannelGroup = mmStudio_.core().getChannelGroup();
+      if (coreChannelGroup.isEmpty()) {
+         String settingsChannelGroup = getAcquisitionEngine().getSequenceSettings().channelGroup();
+         if (isConfigGroupDefined(settingsChannelGroup)) {
+            getAcquisitionEngine().setChannelGroup(settingsChannelGroup);
+         }
+      } else {
+         // The configuration chose the group. Adopt it into our settings: the Core set it
+         // before this dialog was listening for events, so onChannelGroupChanged() did not
+         // see it and the remembered group would otherwise be shown here instead.
+         SequenceSettings sequenceSettings = getAcquisitionEngine().getSequenceSettings();
+         if (!coreChannelGroup.equals(sequenceSettings.channelGroup())) {
+            getAcquisitionEngine().setSequenceSettings(sequenceSettings
+                  .copyBuilder().channelGroup(coreChannelGroup).build());
+         }
+      }
+
       final StrVector zDrives = mmStudio_.core().getLoadedDevicesOfType(DeviceType.StageDevice);
       if (!zDrives.isEmpty()) {
          slicesPanel_.setEnabled(true);

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -137,6 +137,15 @@ public final class StageControlFrame extends JFrame {
    private JCheckBox enableRefreshCB_;
    private JCheckBox snapAfterMoveCB_;
    private Timer timer_ = null;
+   // Last positions posted to the event bus, so that polling does not dispatch an event
+   // every second while the stage sits still. The device name is part of the key: when
+   // the selected stage changes we must post again rather than compare against the
+   // previous device's coordinates. Written and read only from the polling timer thread.
+   private String lastXyDevice_ = null;
+   private double lastX_;
+   private double lastY_;
+   private final String[] lastZDevice_ = new String[MAX_NUM_Z_PANELS];
+   private final double[] lastZ_ = new double[MAX_NUM_Z_PANELS];
    // Ordered small, medium, large.
    private final JFormattedTextField[] xStepTexts_;
    private final JFormattedTextField[] yStepTexts_;
@@ -777,6 +786,9 @@ public final class StageControlFrame extends JFrame {
    private void startTimer() {
       // end any existing updater before starting (anew)
       stopTimer();
+      // Report a position on the first tick even if it matches what we posted before
+      // polling was last turned off.
+      clearLastPostedPositions();
       timer_ = new Timer(true);
       timer_.scheduleAtFixedRate(new TimerTask() {
          @Override
@@ -797,6 +809,17 @@ public final class StageControlFrame extends JFrame {
    private void stopTimer() {
       if (timer_ != null) {
          timer_.cancel();
+      }
+   }
+
+   /**
+    * Forgets the positions last posted to the event bus, so that the next poll posts
+    * again even when the position it reads is unchanged.
+    */
+   private void clearLastPostedPositions() {
+      lastXyDevice_ = null;
+      for (int idx = 0; idx < MAX_NUM_Z_PANELS; ++idx) {
+         lastZDevice_[idx] = null;
       }
    }
 
@@ -920,10 +943,20 @@ public final class StageControlFrame extends JFrame {
       // position. Clear the label when skipping so a previously shown position
       // is not left stale (e.g. after the device is unset or a config reload).
       if (!isDeviceInitialized(xyStageDevice)) {
-         xyPositionLabel_.setText("");
+         // Runs on the polling timer thread, so touch Swing on the EDT.
+         SwingUtilities.invokeLater(() -> xyPositionLabel_.setText(""));
+         lastXyDevice_ = null;
          return;
       }
       Point2D.Double pos = core_.getXYStagePosition(xyStageDevice);
+      // Skip the post when nothing moved: this event is dispatched synchronously to a
+      // number of subscribers across the application, once per second per device.
+      if (xyStageDevice.equals(lastXyDevice_) && pos.x == lastX_ && pos.y == lastY_) {
+         return;
+      }
+      lastXyDevice_ = xyStageDevice;
+      lastX_ = pos.x;
+      lastY_ = pos.y;
       studio_.events().post(new DefaultXYStagePositionChangedEvent(
                xyStageDevice, pos.x, pos.y));
    }
@@ -941,10 +974,18 @@ public final class StageControlFrame extends JFrame {
       // position. Clear the label when skipping so a previously shown position
       // is not left stale (e.g. after the device is unset or a config reload).
       if (!isDeviceInitialized(zStageDevice)) {
-         zPositionLabel_[idx].setText("");
+         // Runs on the polling timer thread, so touch Swing on the EDT.
+         SwingUtilities.invokeLater(() -> zPositionLabel_[idx].setText(""));
+         lastZDevice_[idx] = null;
          return;
       }
       double zPos = core_.getPosition(zStageDevice);
+      // Skip the post when nothing moved; see getXYPosLabelFromCore().
+      if (zStageDevice.equals(lastZDevice_[idx]) && zPos == lastZ_[idx]) {
+         return;
+      }
+      lastZDevice_[idx] = zStageDevice;
+      lastZ_[idx] = zPos;
       studio_.events().post(new DefaultStagePositionChangedEvent(zStageDevice, zPos));
    }
 
@@ -1021,6 +1062,10 @@ public final class StageControlFrame extends JFrame {
       // Stop polling immediately to avoid interfering with configuration reload
       stopTimer();
 
+      // Devices and positions may be entirely different now; forget what we last posted
+      // so the next poll reports the new state even if a value happens to be unchanged.
+      clearLastPostedPositions();
+
       // Defer initialization to allow hardware to stabilize and avoid EDT conflicts
       SwingUtilities.invokeLater(() -> {
          // Always reinitialize to reflect the current configuration state
@@ -1049,11 +1094,18 @@ public final class StageControlFrame extends JFrame {
     */
    @Subscribe
    public void onStagePositionChanged(StagePositionChangedEvent event) {
-      for (int idx = 0; idx < MAX_NUM_Z_PANELS; ++idx) {
-         if (event.getDeviceName().equals(zDriveSelect_[idx].getSelectedItem())) {
-            setZPosLabel(event.getPos(), idx);
+      // These events are posted from the polling timer thread onto a synchronous event
+      // bus, so handlers run off the EDT. Do the Swing work on the EDT, using the
+      // information from the event rather than querying the hardware again.
+      final String deviceName = event.getDeviceName();
+      final double pos = event.getPos();
+      SwingUtilities.invokeLater(() -> {
+         for (int idx = 0; idx < MAX_NUM_Z_PANELS; ++idx) {
+            if (deviceName.equals(zDriveSelect_[idx].getSelectedItem())) {
+               setZPosLabel(pos, idx);
+            }
          }
-      }
+      });
    }
 
    /**
@@ -1063,9 +1115,15 @@ public final class StageControlFrame extends JFrame {
     */
    @Subscribe
    public void onXYStagePositionChanged(XYStagePositionChangedEvent event) {
-      if (event.getDeviceName().contentEquals(core_.getXYStageDevice())) {
-         setXYPosLabel(event.getXPos(), event.getYPos());
-      }
+      // See onStagePositionChanged(): these events can arrive off the EDT.
+      final String deviceName = event.getDeviceName();
+      final double xpos = event.getXPos();
+      final double ypos = event.getYPos();
+      SwingUtilities.invokeLater(() -> {
+         if (deviceName.contentEquals(core_.getXYStageDevice())) {
+            setXYPosLabel(xpos, ypos);
+         }
+      });
    }
 
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -34,6 +34,7 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.ImageIcon;
@@ -140,11 +141,19 @@ public final class StageControlFrame extends JFrame {
    // Last positions posted to the event bus, so that polling does not dispatch an event
    // every second while the stage sits still. The device name is part of the key: when
    // the selected stage changes we must post again rather than compare against the
-   // previous device's coordinates. Written and read only from the polling timer thread.
-   private String lastXyDevice_ = null;
+   // previous device's coordinates.
+   //
+   // The positions are only ever read and written by the polling timer thread, but the
+   // device names are also cleared from other threads (clearLastPostedPositions(), called
+   // from startTimer() on the EDT and from onSystemConfigurationLoaded()), so those are
+   // volatile to make the invalidation visible to the timer. A clear that raced with a
+   // poll would at worst cost one redundant event, never a missed one: the device names
+   // are always compared first and a null there forces a post.
+   private volatile String lastXyDevice_ = null;
    private double lastX_;
    private double lastY_;
-   private final String[] lastZDevice_ = new String[MAX_NUM_Z_PANELS];
+   private final AtomicReferenceArray<String> lastZDevice_ =
+         new AtomicReferenceArray<>(MAX_NUM_Z_PANELS);
    private final double[] lastZ_ = new double[MAX_NUM_Z_PANELS];
    // Ordered small, medium, large.
    private final JFormattedTextField[] xStepTexts_;
@@ -819,7 +828,7 @@ public final class StageControlFrame extends JFrame {
    private void clearLastPostedPositions() {
       lastXyDevice_ = null;
       for (int idx = 0; idx < MAX_NUM_Z_PANELS; ++idx) {
-         lastZDevice_[idx] = null;
+         lastZDevice_.set(idx, null);
       }
    }
 
@@ -976,15 +985,15 @@ public final class StageControlFrame extends JFrame {
       if (!isDeviceInitialized(zStageDevice)) {
          // Runs on the polling timer thread, so touch Swing on the EDT.
          SwingUtilities.invokeLater(() -> zPositionLabel_[idx].setText(""));
-         lastZDevice_[idx] = null;
+         lastZDevice_.set(idx, null);
          return;
       }
       double zPos = core_.getPosition(zStageDevice);
       // Skip the post when nothing moved; see getXYPosLabelFromCore().
-      if (zStageDevice.equals(lastZDevice_[idx]) && zPos == lastZ_[idx]) {
+      if (zStageDevice.equals(lastZDevice_.get(idx)) && zPos == lastZ_[idx]) {
          return;
       }
-      lastZDevice_[idx] = zStageDevice;
+      lastZDevice_.set(idx, zStageDevice);
       lastZ_[idx] = zPos;
       studio_.events().post(new DefaultStagePositionChangedEvent(zStageDevice, zPos));
    }


### PR DESCRIPTION
Fixes #2439 and #2174.  Opening the Preset Editor while live mode was running left the                        Core's ChannelGroup flipping between two groups forever, restarting the live                        sequence acquisition on every flip and stalling the UI.                                                                                                                                                 updateGUIFromSequenceSettings() unconditionally wrote the channel group back                        into the Core.  That method runs synchronously from setSequenceSettings() ->                        AcquisitionSettingsChangedEvent, at which point the Core has not been updated                       yet, so it undid the change the Core had just reported, whose callback then                         undid that in turn.  It is a GUI update method and should only reflect state,                       so the write is gone; the Core is now the single source of truth and the                            sequence settings follow it through onChannelGroupChanged().                                                                                                                                            The channel group remembered in the user profile is instead pushed into the                         Core once, from onConfigurationLoaded() -- the dialog is constructed before                         the system configuration is read, so there are no config groups yet at                              construction time.  This only happens when the Core's channel group is empty:                       the Core never picks a group by itself, so a non-empty value can only come                          from the configuration ("Core,ChannelGroup,..." in the System-Startup preset,                       applied just before this event) and that deliberate choice must win over the                        remembered one.  When the configuration does win, its group is adopted into                         the sequence settings, since the Core set it before this dialog was listening                       for events.                    


 StageControl: do Swing work for polled stage positions on the EDT.                                                                                                                                      The polling timer posted stage position events from its own thread onto a                           synchronous event bus, so subscribers mutated Swing components off the EDT --                       both StageControlFrame's own labels and, via MMCache, the main window info                          line.  Marshal those updates onto the EDT, following the pattern already used                       in PositionListDlg.                                                                                                                                                                                     Also skip posting a position event when the position has not changed.  These                        events are dispatched synchronously to a number of subscribers across the                           application, once per second per device, and with a stationary stage none of                        them had anything to redisplay.                                