### PR TITLE
  Studio: add configurable crop presets to the ROI crop button.    

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/CropPreset.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/CropPreset.java
@@ -1,0 +1,248 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// COPYRIGHT:    University of California, San Francisco, 2026
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+
+package org.micromanager.internal;
+
+import java.awt.Rectangle;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.micromanager.internal.utils.ReportingUtils;
+
+/**
+ * A named, user-defined camera ROI expressed in absolute full-chip coordinates.
+ *
+ * <p>Presets are read from a plain text file named {@value #PRESETS_FILE_NAME} in the
+ * Micro-Manager application directory, alongside the CoreLog.  Each line holds one
+ * preset in the form:
+ *
+ * <pre>
+ * name, x, y, width, height
+ * </pre>
+ *
+ * <p>Blank lines, and lines whose first non-whitespace character is '#', are ignored.
+ * The file is optional; when it is absent no presets are offered and the crop button
+ * keeps its default behavior.
+ */
+public final class CropPreset {
+   public static final String PRESETS_FILE_NAME = "CropPresets.txt";
+
+   private static final int NUM_FIELDS = 5;
+
+   private final String name_;
+   private final int x_;
+   private final int y_;
+   private final int width_;
+   private final int height_;
+
+   /**
+    * Constructs a preset.
+    *
+    * @param name   name shown in the crop menu
+    * @param x      left edge, in full-chip coordinates
+    * @param y      top edge, in full-chip coordinates
+    * @param width  width in pixels, must be positive
+    * @param height height in pixels, must be positive
+    */
+   public CropPreset(String name, int x, int y, int width, int height) {
+      name_ = name;
+      x_ = x;
+      y_ = y;
+      width_ = width;
+      height_ = height;
+   }
+
+   public String getName() {
+      return name_;
+   }
+
+   public Rectangle toRectangle() {
+      return new Rectangle(x_, y_, width_, height_);
+   }
+
+   /**
+    * Returns the file presets are read from: {@value #PRESETS_FILE_NAME} in the
+    * Micro-Manager application directory.
+    *
+    * @return the presets file, or null if the application directory is unknown
+    */
+   public static File getPresetsFile() {
+      String appDirectory = System.getProperty("user.dir");
+      if (appDirectory == null || appDirectory.isEmpty()) {
+         return null;
+      }
+      return new File(appDirectory, PRESETS_FILE_NAME);
+   }
+
+   /**
+    * Returns the contents written by {@link #createTemplateFile()}: a commented example
+    * that documents the file format and defines no presets.
+    */
+   private static String getTemplateContents() {
+      return "# Micro-Manager crop presets." + System.lineSeparator()
+            + "#" + System.lineSeparator()
+            + "# One preset per line, in absolute full-chip coordinates:" + System.lineSeparator()
+            + "#" + System.lineSeparator()
+            + "#     name, x, y, width, height" + System.lineSeparator()
+            + "#" + System.lineSeparator()
+            + "# x and y give the top left corner and may not be negative; width and"
+            + System.lineSeparator()
+            + "# height must be positive.  All four are whole numbers of pixels,"
+            + System.lineSeparator()
+            + "# measured on the full sensor rather than on the current ROI, so a"
+            + System.lineSeparator()
+            + "# preset always selects the same area no matter what ROI is in force."
+            + System.lineSeparator()
+            + "#" + System.lineSeparator()
+            + "# Blank lines and lines starting with '#' are ignored.  A line that"
+            + System.lineSeparator()
+            + "# cannot be read is skipped and noted in the CoreLog; the rest of the"
+            + System.lineSeparator()
+            + "# file is still used.  Preset names cannot contain a comma."
+            + System.lineSeparator()
+            + "#" + System.lineSeparator()
+            + "# Remove the '#' from the examples below to try them, adjusting the"
+            + System.lineSeparator()
+            + "# numbers to suit your camera." + System.lineSeparator()
+            + "#" + System.lineSeparator()
+            + "# Center half, 128, 128, 256, 256" + System.lineSeparator()
+            + "# Line scan, 0, 240, 512, 32" + System.lineSeparator();
+   }
+
+   /**
+    * Creates the presets file, filled with a commented template describing the format.
+    *
+    * <p>Does nothing if the file already exists, so that this can never destroy presets
+    * the user has written.
+    *
+    * @return the file, whether newly created or already present
+    * @throws IOException if the file could not be created
+    */
+   public static File createTemplateFile() throws IOException {
+      File file = getPresetsFile();
+      if (file == null) {
+         throw new IOException(
+               "Unable to determine the Micro-Manager application directory.");
+      }
+      if (file.exists()) {
+         return file;
+      }
+
+      try (Writer writer = new OutputStreamWriter(
+            new FileOutputStream(file), Charset.defaultCharset())) {
+         writer.write(getTemplateContents());
+      }
+      return file;
+   }
+
+   /**
+    * Reads the crop presets file.
+    *
+    * <p>Never returns null and never throws: a missing file yields an empty list, and a
+    * malformed line is logged and skipped so that one bad line does not discard the rest
+    * of the file.
+    *
+    * @return the presets found, in file order; empty if there are none
+    */
+   public static List<CropPreset> loadPresets() {
+      File file = getPresetsFile();
+      if (file == null || !file.isFile()) {
+         return Collections.emptyList();
+      }
+
+      List<CropPreset> presets = new ArrayList<>();
+      try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+         String line;
+         int lineNumber = 0;
+         while ((line = reader.readLine()) != null) {
+            lineNumber++;
+            CropPreset preset = parseLine(line, file, lineNumber);
+            if (preset != null) {
+               presets.add(preset);
+            }
+         }
+      } catch (IOException e) {
+         ReportingUtils.logError(e, "Unable to read crop presets from " + file.getPath());
+         return Collections.emptyList();
+      }
+      return presets;
+   }
+
+   /**
+    * Parses a single line, returning null (after logging) when it is a comment, is blank,
+    * or cannot be understood.
+    */
+   private static CropPreset parseLine(String line, File file, int lineNumber) {
+      String trimmed = line.trim();
+      if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+         return null;
+      }
+
+      String[] fields = trimmed.split(",");
+      if (fields.length != NUM_FIELDS) {
+         logSkipped(file, lineNumber, "expected " + NUM_FIELDS
+               + " comma-separated fields (name, x, y, width, height), found " + fields.length);
+         return null;
+      }
+
+      String name = fields[0].trim();
+      if (name.isEmpty()) {
+         logSkipped(file, lineNumber, "the preset name is empty");
+         return null;
+      }
+
+      int[] values = new int[NUM_FIELDS - 1];
+      for (int i = 0; i < values.length; i++) {
+         try {
+            values[i] = Integer.parseInt(fields[i + 1].trim());
+         } catch (NumberFormatException e) {
+            logSkipped(file, lineNumber, "'" + fields[i + 1].trim() + "' is not a whole number");
+            return null;
+         }
+      }
+
+      int x = values[0];
+      int y = values[1];
+      int width = values[2];
+      int height = values[3];
+      if (width <= 0 || height <= 0) {
+         logSkipped(file, lineNumber, "width and height must both be positive");
+         return null;
+      }
+      if (x < 0 || y < 0) {
+         logSkipped(file, lineNumber, "x and y must not be negative");
+         return null;
+      }
+
+      return new CropPreset(name, x, y, width, height);
+   }
+
+   private static void logSkipped(File file, int lineNumber, String reason) {
+      ReportingUtils.logError("Skipping line " + lineNumber + " of "
+            + file.getPath() + ": " + reason);
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
@@ -42,6 +42,14 @@ import org.micromanager.internal.utils.ReportingUtils;
  * declaring the user's desire for an ROI to be send to the camera.
  */
 public class MMROIManager {
+   // Standard device-adapter properties reporting the full sensor size.
+   private static final String ON_CAMERA_X_SIZE = "OnCameraCCDXSize";
+   private static final String ON_CAMERA_Y_SIZE = "OnCameraCCDYSize";
+
+   // Grouping all ROI complaints under one title and group keeps the Messages window
+   // from filling up when the same out-of-range preset is clicked repeatedly.
+   private static final String ROI_ALERT_TITLE = "Region of Interest";
+
    private final MMStudio studio_;
 
    public MMROIManager(MMStudio studio) {
@@ -236,7 +244,14 @@ public class MMROIManager {
       int yOffset = r.y + height / 2;
 
       curImage.setRoi(xOffset, yOffset, width, height);
-      Roi roi = curImage.getRoi();
+      applyRoiToCameras(curImage.getRoi());
+   }
+
+   /**
+    * Sends the given ImageJ ROI to the camera(s), correcting it for the current camera
+    * ROI and for any Image Flipper transformation.
+    */
+   private void applyRoiToCameras(Roi roi) {
       try {
          if (studio_.core().getNumberOfCameraChannels() < 2) {
             studio_.app().setROI(updateROI(studio_.core().getCameraDevice(), roi));
@@ -251,6 +266,117 @@ public class MMROIManager {
       } catch (Exception e) {
          // Core failed to set new ROI.
          studio_.logs().logError(e, "Unable to set new ROI");
+      }
+   }
+
+   /**
+    * Sets the camera ROI to a rectangle given in absolute, full-chip coordinates.
+    *
+    * <p>Unlike {@link #setROI()} and {@link #setCenterQuad()}, which interpret a
+    * selection relative to whatever ROI is currently in force, the rectangle passed here
+    * is taken to be relative to the full sensor.  Applying the same rectangle twice
+    * therefore leaves the camera in the same state, which is what makes stored crop
+    * presets reproducible.  The rectangle is clamped to the sensor bounds.
+    *
+    * @param r the desired ROI, in full-chip coordinates
+    */
+   public void setAbsoluteROI(Rectangle r) {
+      if (r == null) {
+         return;
+      }
+
+      Rectangle target = new Rectangle(r);
+      // A null chip size means we could not work out how big the sensor is; send the
+      // rectangle as given and let the device adapter reject it if it is unreasonable.
+      Rectangle chip = getFullChipBounds();
+      if (chip != null) {
+         String chipSize = chip.width + " x " + chip.height;
+         target = target.intersection(chip);
+         if (target.isEmpty()) {
+            // Nothing happened, so say so where the user cannot miss it.
+            studio_.alerts().postAlert(ROI_ALERT_TITLE, MMROIManager.class,
+                  "ROI not applied. The requested ROI (" + describe(r)
+                        + ") lies entirely outside the " + chipSize + " sensor.");
+            return;
+         }
+         if (!target.equals(r)) {
+            // Partly off the chip.  Applying the overlap is more useful than refusing,
+            // but say so: otherwise the camera quietly ends up with an ROI that is not
+            // the one that was asked for.
+            studio_.alerts().postAlert(ROI_ALERT_TITLE, MMROIManager.class,
+                  "ROI too large. The requested ROI (" + describe(r)
+                        + ") extends beyond the " + chipSize + " sensor; using "
+                        + describe(target) + " instead.");
+         }
+      }
+
+      try {
+         if (studio_.core().getNumberOfCameraChannels() < 2) {
+            studio_.app().setROI(target);
+         } else {
+            studio_.live().setSuspended(true);
+            try {
+               for (int c = 0; c < studio_.core().getNumberOfCameraChannels(); c++) {
+                  studio_.core().setROI(studio_.core().getCameraChannelName(c),
+                        target.x, target.y, target.width, target.height);
+               }
+            } finally {
+               studio_.cache().refreshValues();
+               studio_.live().setSuspended(false);
+            }
+         }
+         if (!studio_.live().isLiveModeOn() && studio_.settings().getSnapAfterRoiButton()) {
+            studio_.live().snap(true);
+         }
+      } catch (Exception e) {
+         // Core failed to set new ROI.
+         studio_.logs().showError(e, "Unable to set new ROI");
+      }
+   }
+
+   /**
+    * Formats a rectangle the same way the crop presets file spells one out, so that
+    * messages about a bad preset can be compared with the file at a glance.
+    */
+   private static String describe(Rectangle r) {
+      return "x: " + r.x + ", y: " + r.y + ", width: " + r.width + ", height: " + r.height;
+   }
+
+   /**
+    * Returns the full sensor area of the current camera, i.e. the ROI that would be in
+    * force after clearing it.  The origin is always (0, 0).
+    *
+    * @return the full chip bounds, or null if they could not be determined
+    */
+   public Rectangle getFullChipBounds() {
+      try {
+         String camera = studio_.core().getCameraDevice();
+         if (camera == null || camera.isEmpty()) {
+            return null;
+         }
+         if (studio_.core().hasProperty(camera, ON_CAMERA_X_SIZE)
+               && studio_.core().hasProperty(camera, ON_CAMERA_Y_SIZE)) {
+            try {
+               int width = Integer.parseInt(
+                     studio_.core().getProperty(camera, ON_CAMERA_X_SIZE).trim());
+               int height = Integer.parseInt(
+                     studio_.core().getProperty(camera, ON_CAMERA_Y_SIZE).trim());
+               if (width > 0 && height > 0) {
+                  return new Rectangle(0, 0, width, height);
+               }
+            } catch (NumberFormatException e) {
+               // Device reported a chip size we cannot read; fall through to the ROI.
+               studio_.logs().logError(e, "Unreadable chip size reported by " + camera);
+            }
+         }
+         // No chip-size property, so fall back on the current ROI.  That is the full
+         // frame only when no ROI is set, so widen it by the offset we can see; this is
+         // the best guess available without disturbing the camera.
+         Rectangle roi = studio_.core().getROI();
+         return new Rectangle(0, 0, roi.x + roi.width, roi.y + roi.height);
+      } catch (Exception e) {
+         studio_.logs().logError(e, "Unable to determine the full chip size");
+         return null;
       }
    }
 

--- a/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMROIManager.java
@@ -259,8 +259,30 @@ public class MMROIManager {
                studio_.live().snap(true);
             }
          } else {
-            for (int c = 0; c < studio_.core().getNumberOfCameraChannels(); c++) {
-               studio_.app().setROI(updateROI(studio_.core().getCameraChannelName(c), roi));
+            // Address each camera by name.  Application.setROI() sets the ROI on the
+            // current camera only, so using it in this loop would set every rectangle
+            // on the same camera in turn and leave only the last one in force.
+            studio_.live().setSuspended(true);
+            try {
+               for (int c = 0; c < studio_.core().getNumberOfCameraChannels(); c++) {
+                  String cameraChannel = studio_.core().getCameraChannelName(c);
+                  Rectangle r = updateROI(cameraChannel, roi);
+                  if (r == null) {
+                     // updateROI() could not work out this camera's current ROI and has
+                     // logged why; leave it alone rather than abandoning the others.
+                     continue;
+                  }
+                  studio_.core().setROI(cameraChannel, r.x, r.y, r.width, r.height);
+               }
+            } catch (Exception e) {
+               studio_.logs().showError(e);
+            } finally {
+               studio_.cache().refreshValues();
+               studio_.live().setSuspended(false);
+               if (!studio_.live().isLiveModeOn()
+                     && studio_.settings().getSnapAfterRoiButton()) {
+                  studio_.live().snap(true);
+               }
             }
          }
       } catch (Exception e) {
@@ -346,6 +368,11 @@ public class MMROIManager {
     * Returns the full sensor area of the current camera, i.e. the ROI that would be in
     * force after clearing it.  The origin is always (0, 0).
     *
+    * <p>Returns null rather than a guess when the camera does not report its chip size
+    * and an ROI is already set: the current ROI is only a lower bound in that case, and
+    * callers are better off not clamping at all than clamping to a size that is too
+    * small.
+    *
     * @return the full chip bounds, or null if they could not be determined
     */
    public Rectangle getFullChipBounds() {
@@ -369,11 +396,16 @@ public class MMROIManager {
                studio_.logs().logError(e, "Unreadable chip size reported by " + camera);
             }
          }
-         // No chip-size property, so fall back on the current ROI.  That is the full
-         // frame only when no ROI is set, so widen it by the offset we can see; this is
-         // the best guess available without disturbing the camera.
+         // No usable chip-size property.  The current ROI tells us the chip size only
+         // when it is the full frame; once an ROI is set it is a lower bound that can
+         // be far smaller than the sensor.  Guessing from it would clamp valid
+         // rectangles down to the current ROI, and each crop would shrink the guess
+         // again, so report "unknown" instead and let the caller skip clamping.
          Rectangle roi = studio_.core().getROI();
-         return new Rectangle(0, 0, roi.x + roi.width, roi.y + roi.height);
+         if (roi != null && roi.x == 0 && roi.y == 0) {
+            return new Rectangle(0, 0, roi.width, roi.height);
+         }
+         return null;
       } catch (Exception e) {
          studio_.logs().logError(e, "Unable to determine the full chip size");
          return null;

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -28,14 +28,18 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Insets;
 import java.awt.KeyboardFocusManager;
+import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.dnd.DropTarget;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -50,7 +54,10 @@ import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.SwingUtilities;
@@ -73,6 +80,7 @@ import org.micromanager.events.StartupCompleteEvent;
 import org.micromanager.events.internal.MouseMovesStageStateChangeEvent;
 import org.micromanager.events.internal.ShutterDevicesEvent;
 import org.micromanager.internal.dialogs.OptionsDlg;
+import org.micromanager.internal.dialogs.SpecifyCropDialog;
 import org.micromanager.internal.dialogs.StageControlFrame;
 import org.micromanager.internal.utils.DragDropUtil;
 import org.micromanager.internal.utils.GUIUtils;
@@ -507,9 +515,23 @@ public final class MainFrame extends JFrame {
             });
       roiPanel.add(setRoiButton_, SMALLBUTTON_SIZE);
       centerQuadButton_ = createButton(null, "center_quad.png",
-            "Set Region Of Interest to center quad of camera", () -> {
-               mmStudio_.roiManager().setCenterQuad();
-            });
+            "Halve the width and height of the current Region of Interest "
+                  + "(right-click to crop to a region of the camera chip)", () -> {
+                     mmStudio_.roiManager().setCenterQuad();
+                  });
+      centerQuadButton_.addMouseListener(new MouseAdapter() {
+         // The popup trigger arrives on press under Windows but on release
+         // elsewhere, so check for it in both.
+         @Override
+         public void mousePressed(MouseEvent e) {
+            maybeShowCropMenu(e);
+         }
+
+         @Override
+         public void mouseReleased(MouseEvent e) {
+            maybeShowCropMenu(e);
+         }
+      });
       roiPanel.add(centerQuadButton_, SMALLBUTTON_SIZE);
 
       clearRoiButton_ = createButton(null, "arrow_out.png",
@@ -593,6 +615,124 @@ public final class MainFrame extends JFrame {
 
       subPanel.add(autoPanel, "gapleft 16");
       return subPanel;
+   }
+
+   /**
+    * Shows the crop menu when the given event is the platform's popup trigger.
+    *
+    * <p>The menu is rebuilt on every showing so that edits to the crop presets file take
+    * effect without restarting Micro-Manager.
+    *
+    * @param event the mouse event received by the crop button
+    */
+   private void maybeShowCropMenu(MouseEvent event) {
+      if (!event.isPopupTrigger()) {
+         return;
+      }
+
+      // Every item in this menu sets an absolute region on the camera chip.  The
+      // center-quad crop is deliberately absent: it shrinks whatever ROI is currently
+      // in force rather than addressing the chip, and mixing the two meanings in one
+      // menu is confusing.  It remains on a plain click of the button.
+      JPopupMenu menu = new JPopupMenu();
+
+      List<CropPreset> presets = CropPreset.loadPresets();
+      if (!presets.isEmpty()) {
+         for (final CropPreset preset : presets) {
+            final Rectangle rect = preset.toRectangle();
+            JMenuItem item = new JMenuItem(preset.getName());
+            item.setToolTipText("x: " + rect.x + ", y: " + rect.y
+                  + ", width: " + rect.width + ", height: " + rect.height);
+            item.addActionListener(e -> mmStudio_.roiManager().setAbsoluteROI(rect));
+            menu.add(item);
+         }
+         menu.addSeparator();
+      }
+
+      JMenuItem specifyItem = new JMenuItem("Specify...");
+      specifyItem.setToolTipText(
+            "Type an exact Region of Interest, in camera chip coordinates");
+      specifyItem.addActionListener(e ->
+            new SpecifyCropDialog(mmStudio_, MainFrame.this).setVisible(true));
+      menu.add(specifyItem);
+
+      JMenuItem aboutPresetsItem = new JMenuItem("About Crop Presets...");
+      aboutPresetsItem.setToolTipText(
+            "Explain the crop presets file and where it lives");
+      aboutPresetsItem.addActionListener(e -> showCropPresetsHelp());
+      menu.add(aboutPresetsItem);
+
+      menu.show(event.getComponent(), event.getX(), event.getY());
+   }
+
+   /**
+    * Explains the crop presets file format, and offers to create a commented starter
+    * file when the user does not have one yet.
+    */
+   private void showCropPresetsHelp() {
+      File presetsFile = CropPreset.getPresetsFile();
+      if (presetsFile == null) {
+         mmStudio_.logs().showError(
+               "Unable to determine the Micro-Manager application directory, "
+                     + "so crop presets cannot be used.");
+         return;
+      }
+      final boolean exists = presetsFile.isFile();
+
+      String message = "<html><body width='460'>"
+            + "<p>Crop presets are named regions of interest that you can apply from "
+            + "this menu. They are read from a plain text file in the Micro-Manager "
+            + "application directory:</p>"
+            + "<p><tt>" + presetsFile.getPath() + "</tt><br>"
+            + "<i>(" + (exists ? "this file exists" : "you do not have this file yet")
+            + ")</i></p>"
+            + "<p>Each line describes one preset:</p>"
+            + "<p><tt>&nbsp;&nbsp;name, x, y, width, height</tt></p>"
+            + "<p><tt>x</tt> and <tt>y</tt> give the top left corner and may not be "
+            + "negative; <tt>width</tt> and <tt>height</tt> must be positive. All four "
+            + "are whole numbers of pixels measured on the <b>full sensor</b>, not on "
+            + "the current ROI, so a preset always selects the same area no matter what "
+            + "ROI is in force. This differs from a plain click of the crop button, "
+            + "which halves whatever ROI is currently set.</p>"
+            + "<p>For example:</p>"
+            + "<p><tt>&nbsp;&nbsp;Center half, 128, 128, 256, 256</tt><br>"
+            + "<tt>&nbsp;&nbsp;Line scan, 0, 240, 512, 32</tt></p>"
+            + "<p>Blank lines and lines starting with <tt>#</tt> are ignored. A line "
+            + "that cannot be read is skipped and noted in the CoreLog; the rest of the "
+            + "file is still used. Preset names cannot contain a comma.</p>"
+            + "<p>A preset that runs off the edge of the chip is trimmed to fit; one "
+            + "that misses the chip entirely is not applied. Either way a message "
+            + "appears in the Messages window.</p>"
+            + "<p>The file is re-read every time this menu opens, so you do not need to "
+            + "restart Micro-Manager after editing it.</p>"
+            + "</body></html>";
+
+      if (exists) {
+         JOptionPane.showMessageDialog(this, new JLabel(message),
+               "About Crop Presets", JOptionPane.INFORMATION_MESSAGE);
+         return;
+      }
+
+      String[] options = new String[] {"Create Example File", "Close"};
+      int answer = JOptionPane.showOptionDialog(this, new JLabel(message),
+            "About Crop Presets", JOptionPane.DEFAULT_OPTION,
+            JOptionPane.INFORMATION_MESSAGE, null, options, options[0]);
+      if (answer != 0) {
+         return;
+      }
+      try {
+         File created = CropPreset.createTemplateFile();
+         JOptionPane.showMessageDialog(this,
+               "Created " + created.getPath() + "\n\n"
+                     + "It contains commented-out examples. Edit it in a text editor, "
+                     + "then re-open this menu.",
+               "Crop Presets", JOptionPane.INFORMATION_MESSAGE);
+      } catch (IOException ex) {
+         // The application directory is often not writable, e.g. under Program Files.
+         mmStudio_.logs().showError(ex, "Unable to create " + presetsFile.getPath()
+               + ".\nYou may need to create this file by hand, or run Micro-Manager "
+               + "from a directory you can write to.");
+      }
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -23,6 +23,7 @@ package org.micromanager.internal;
 
 import com.bulenkov.iconloader.IconLoader;
 import com.google.common.eventbus.Subscribe;
+import com.google.common.html.HtmlEscapers;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -678,12 +679,15 @@ public final class MainFrame extends JFrame {
          return;
       }
       final boolean exists = presetsFile.isFile();
+      // The path is the only part of this message that is not a literal, and it can
+      // easily contain an ampersand, which would otherwise break the rendering.
+      String escapedPath = HtmlEscapers.htmlEscaper().escape(presetsFile.getPath());
 
       String message = "<html><body width='460'>"
             + "<p>Crop presets are named regions of interest that you can apply from "
             + "this menu. They are read from a plain text file in the Micro-Manager "
             + "application directory:</p>"
-            + "<p><tt>" + presetsFile.getPath() + "</tt><br>"
+            + "<p><tt>" + escapedPath + "</tt><br>"
             + "<i>(" + (exists ? "this file exists" : "you do not have this file yet")
             + ")</i></p>"
             + "<p>Each line describes one preset:</p>"

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/SpecifyCropDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/SpecifyCropDialog.java
@@ -1,0 +1,272 @@
+///////////////////////////////////////////////////////////////////////////////
+//PROJECT:       Micro-Manager
+//SUBSYSTEM:     mmstudio
+//-----------------------------------------------------------------------------
+//
+// COPYRIGHT:    University of California, San Francisco, 2026
+//
+// LICENSE:      This file is distributed under the BSD license.
+//               License text is included with the source distribution.
+//
+//               This file is distributed in the hope that it will be useful,
+//               but WITHOUT ANY WARRANTY; without even the implied warranty
+//               of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//               IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//               CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+
+package org.micromanager.internal.dialogs;
+
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.Window;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import net.miginfocom.swing.MigLayout;
+import org.micromanager.internal.MMROIManager;
+import org.micromanager.internal.MMStudio;
+import org.micromanager.internal.utils.WindowPositioning;
+
+/**
+ * A dialog that lets the user type an exact camera ROI, in the spirit of ImageJ's
+ * "Edit &gt; Selection &gt; Specify..." dialog.
+ *
+ * <p>The rectangle entered here is interpreted in absolute, full-chip coordinates and is
+ * applied through {@link MMROIManager#setAbsoluteROI(Rectangle)}.
+ */
+public final class SpecifyCropDialog extends JDialog {
+   private static final long serialVersionUID = 1L;
+
+   private static final String LAST_X = "lastCropX";
+   private static final String LAST_Y = "lastCropY";
+   private static final String LAST_WIDTH = "lastCropWidth";
+   private static final String LAST_HEIGHT = "lastCropHeight";
+   private static final String CENTERED = "cropCentered";
+
+   private final MMStudio studio_;
+   private final JTextField xField_;
+   private final JTextField yField_;
+   private final JTextField widthField_;
+   private final JTextField heightField_;
+   private final JCheckBox centeredBox_;
+   // Set while we update the x/y fields ourselves, so that our own edits do not
+   // re-trigger the listeners that made them.
+   private boolean adjusting_ = false;
+
+   /**
+    * Creates and shows the dialog.  Blocks until the user closes it.
+    *
+    * @param studio the omnipresent Studio object
+    * @param parent window to center on; may be null
+    */
+   public SpecifyCropDialog(MMStudio studio, Window parent) {
+      super(parent, "Specify Crop");
+      studio_ = studio;
+
+      super.setIconImage(Toolkit.getDefaultToolkit().getImage(
+            MMStudio.class.getResource("/org/micromanager/icons/microscope.gif")));
+      setModal(true);
+      setResizable(false);
+      setLayout(new MigLayout("flowx, insets dialog"));
+
+      Rectangle initial = getInitialRectangle();
+
+      xField_ = new JTextField(Integer.toString(initial.x), 6);
+      yField_ = new JTextField(Integer.toString(initial.y), 6);
+      widthField_ = new JTextField(Integer.toString(initial.width), 6);
+      heightField_ = new JTextField(Integer.toString(initial.height), 6);
+
+      // Same order as a line in the crop presets file: x, y, width, height.
+      add(new JLabel("X:"));
+      add(xField_, "wrap");
+      add(new JLabel("Y:"));
+      add(yField_, "wrap");
+      add(new JLabel("Width:"));
+      add(widthField_, "wrap");
+      add(new JLabel("Height:"));
+      add(heightField_, "wrap");
+
+      centeredBox_ = new JCheckBox("Centered");
+      centeredBox_.setToolTipText(
+            "Center the given width and height on the camera chip, "
+                  + "filling in X and Y for you");
+      centeredBox_.addActionListener(e -> {
+         updateCenteredFields();
+         xField_.setEditable(!centeredBox_.isSelected());
+         yField_.setEditable(!centeredBox_.isSelected());
+      });
+      add(centeredBox_, "span 2, wrap");
+
+      DocumentListener sizeListener = new DocumentListener() {
+         @Override
+         public void insertUpdate(DocumentEvent e) {
+            updateCenteredFields();
+         }
+
+         @Override
+         public void removeUpdate(DocumentEvent e) {
+            updateCenteredFields();
+         }
+
+         @Override
+         public void changedUpdate(DocumentEvent e) {
+            updateCenteredFields();
+         }
+      };
+      widthField_.getDocument().addDocumentListener(sizeListener);
+      heightField_.getDocument().addDocumentListener(sizeListener);
+
+      JButton okButton = new JButton("OK");
+      okButton.addActionListener(e -> onOk());
+      getRootPane().setDefaultButton(okButton);
+      add(okButton, "tag ok, span 2, split");
+
+      JButton cancelButton = new JButton("Cancel");
+      cancelButton.addActionListener(e -> dispose());
+      add(cancelButton, "tag cancel, wrap");
+
+      // Restore the checkbox last, so that its listener sees fully built fields.
+      centeredBox_.setSelected(studio_.profile().getSettings(SpecifyCropDialog.class)
+            .getBoolean(CENTERED, false));
+      xField_.setEditable(!centeredBox_.isSelected());
+      yField_.setEditable(!centeredBox_.isSelected());
+      updateCenteredFields();
+
+      pack();
+      WindowPositioning.setUpLocationMemory(this, this.getClass(), null);
+      if (parent != null) {
+         setLocationRelativeTo(parent);
+      }
+   }
+
+   /**
+    * Returns the rectangle to prefill the fields with: the ROI the camera is using now,
+    * falling back on whatever was entered the last time this dialog was used, and finally
+    * on the full chip.
+    */
+   private Rectangle getInitialRectangle() {
+      try {
+         Rectangle current = studio_.core().getROI();
+         if (current != null && current.width > 0 && current.height > 0) {
+            return current;
+         }
+      } catch (Exception e) {
+         studio_.logs().logError(e, "Unable to read the current ROI");
+      }
+
+      Rectangle chip = studio_.roiManager().getFullChipBounds();
+      int defaultWidth = chip == null ? 512 : chip.width;
+      int defaultHeight = chip == null ? 512 : chip.height;
+      return new Rectangle(
+            studio_.profile().getSettings(SpecifyCropDialog.class).getInteger(LAST_X, 0),
+            studio_.profile().getSettings(SpecifyCropDialog.class).getInteger(LAST_Y, 0),
+            studio_.profile().getSettings(SpecifyCropDialog.class)
+                  .getInteger(LAST_WIDTH, defaultWidth),
+            studio_.profile().getSettings(SpecifyCropDialog.class)
+                  .getInteger(LAST_HEIGHT, defaultHeight));
+   }
+
+   /**
+    * When "Centered" is checked, recomputes x and y so that the requested width and
+    * height sit in the middle of the chip.  Does nothing otherwise.
+    */
+   private void updateCenteredFields() {
+      if (adjusting_ || !centeredBox_.isSelected()) {
+         return;
+      }
+      Rectangle chip = studio_.roiManager().getFullChipBounds();
+      if (chip == null) {
+         return;
+      }
+      Integer width = parseFieldQuietly(widthField_);
+      Integer height = parseFieldQuietly(heightField_);
+      if (width == null || height == null) {
+         // Mid-edit; leave x and y alone until the value makes sense again.
+         return;
+      }
+
+      adjusting_ = true;
+      try {
+         xField_.setText(Integer.toString(Math.max(0, (chip.width - width) / 2)));
+         yField_.setText(Integer.toString(Math.max(0, (chip.height - height) / 2)));
+      } finally {
+         adjusting_ = false;
+      }
+   }
+
+   private static Integer parseFieldQuietly(JTextField field) {
+      try {
+         return Integer.valueOf(field.getText().trim());
+      } catch (NumberFormatException e) {
+         return null;
+      }
+   }
+
+   /**
+    * Validates the entered values and, if they are usable, applies them.  On bad input
+    * the dialog stays open: silently substituting a value would send the camera an ROI
+    * the user did not ask for.
+    */
+   private void onOk() {
+      // Check the fields top to bottom, so that the first complaint is about the
+      // topmost field the user can see.
+      Integer x = parseField(xField_, "X");
+      if (x == null) {
+         return;
+      }
+      Integer y = parseField(yField_, "Y");
+      if (y == null) {
+         return;
+      }
+      Integer width = parseField(widthField_, "Width");
+      if (width == null) {
+         return;
+      }
+      Integer height = parseField(heightField_, "Height");
+      if (height == null) {
+         return;
+      }
+
+      if (width <= 0 || height <= 0) {
+         showInputError("Width and height must both be greater than zero.");
+         return;
+      }
+      if (x < 0 || y < 0) {
+         showInputError("X and Y must not be negative.");
+         return;
+      }
+
+      studio_.profile().getSettings(SpecifyCropDialog.class).putInteger(LAST_X, x);
+      studio_.profile().getSettings(SpecifyCropDialog.class).putInteger(LAST_Y, y);
+      studio_.profile().getSettings(SpecifyCropDialog.class).putInteger(LAST_WIDTH, width);
+      studio_.profile().getSettings(SpecifyCropDialog.class).putInteger(LAST_HEIGHT, height);
+      studio_.profile().getSettings(SpecifyCropDialog.class)
+            .putBoolean(CENTERED, centeredBox_.isSelected());
+
+      dispose();
+      studio_.roiManager().setAbsoluteROI(new Rectangle(x, y, width, height));
+   }
+
+   private Integer parseField(JTextField field, String label) {
+      Integer value = parseFieldQuietly(field);
+      if (value == null) {
+         showInputError(label + " must be a whole number.");
+         field.requestFocusInWindow();
+         field.selectAll();
+      }
+      return value;
+   }
+
+   private void showInputError(String message) {
+      JOptionPane.showMessageDialog(this, message, "Invalid crop",
+            JOptionPane.ERROR_MESSAGE);
+   }
+}

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/SpecifyCropDialog.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/SpecifyCropDialog.java
@@ -95,14 +95,22 @@ public final class SpecifyCropDialog extends JDialog {
       add(heightField_, "wrap");
 
       centeredBox_ = new JCheckBox("Centered");
-      centeredBox_.setToolTipText(
-            "Center the given width and height on the camera chip, "
-                  + "filling in X and Y for you");
       centeredBox_.addActionListener(e -> {
          updateCenteredFields();
          xField_.setEditable(!centeredBox_.isSelected());
          yField_.setEditable(!centeredBox_.isSelected());
       });
+      // Centering needs to know how big the chip is.  When the camera does not say,
+      // withhold the option rather than let it be ticked to no effect.
+      if (studio_.roiManager().getFullChipBounds() == null) {
+         centeredBox_.setEnabled(false);
+         centeredBox_.setToolTipText(
+               "Unavailable: this camera does not report its chip size");
+      } else {
+         centeredBox_.setToolTipText(
+               "Center the given width and height on the camera chip, "
+                     + "filling in X and Y for you");
+      }
       add(centeredBox_, "span 2, wrap");
 
       DocumentListener sizeListener = new DocumentListener() {
@@ -133,9 +141,12 @@ public final class SpecifyCropDialog extends JDialog {
       cancelButton.addActionListener(e -> dispose());
       add(cancelButton, "tag cancel, wrap");
 
-      // Restore the checkbox last, so that its listener sees fully built fields.
-      centeredBox_.setSelected(studio_.profile().getSettings(SpecifyCropDialog.class)
-            .getBoolean(CENTERED, false));
+      // Restore the checkbox last, so that its listener sees fully built fields.  Never
+      // restore it into the selected state while it is disabled: that would lock X and
+      // Y with nothing able to fill them in.
+      centeredBox_.setSelected(centeredBox_.isEnabled()
+            && studio_.profile().getSettings(SpecifyCropDialog.class)
+                  .getBoolean(CENTERED, false));
       xField_.setEditable(!centeredBox_.isSelected());
       yField_.setEditable(!centeredBox_.isSelected());
       updateCenteredFields();

--- a/mmstudio/src/test/java/org/micromanager/internal/CropPresetTest.java
+++ b/mmstudio/src/test/java/org/micromanager/internal/CropPresetTest.java
@@ -1,0 +1,161 @@
+package org.micromanager.internal;
+
+import java.awt.Rectangle;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.List;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests the parsing contract of the crop presets file.
+ *
+ * <p>These drive the public {@link CropPreset#loadPresets()} rather than the parser
+ * directly, so that the file lookup is covered too.  {@code loadPresets} finds its file
+ * relative to {@code user.dir}, which each test points at a temporary directory.
+ */
+public class CropPresetTest {
+   @Rule
+   public final TemporaryFolder folder = new TemporaryFolder();
+
+   private String originalUserDir_;
+
+   @Before
+   public void setUp() {
+      originalUserDir_ = System.getProperty("user.dir");
+      System.setProperty("user.dir", folder.getRoot().getAbsolutePath());
+   }
+
+   @After
+   public void tearDown() {
+      if (originalUserDir_ != null) {
+         System.setProperty("user.dir", originalUserDir_);
+      }
+   }
+
+   /** Writes the presets file that loadPresets() will find. */
+   private void writePresetsFile(String contents) throws IOException {
+      File file = new File(folder.getRoot(), CropPreset.PRESETS_FILE_NAME);
+      try (Writer writer = new OutputStreamWriter(
+            new FileOutputStream(file), Charset.defaultCharset())) {
+         writer.write(contents);
+      }
+   }
+
+   private static void assertRectangle(CropPreset preset, String name,
+         int x, int y, int width, int height) {
+      Assert.assertEquals(name, preset.getName());
+      Assert.assertEquals(new Rectangle(x, y, width, height), preset.toRectangle());
+   }
+
+   @Test
+   public void missingFileYieldsNoPresets() {
+      Assert.assertTrue(CropPreset.loadPresets().isEmpty());
+   }
+
+   @Test
+   public void readsWellFormedPresetsInFileOrder() throws IOException {
+      writePresetsFile("Center half, 128, 128, 256, 256\n"
+            + "Line scan, 0, 240, 512, 32\n");
+
+      List<CropPreset> presets = CropPreset.loadPresets();
+
+      Assert.assertEquals(2, presets.size());
+      assertRectangle(presets.get(0), "Center half", 128, 128, 256, 256);
+      assertRectangle(presets.get(1), "Line scan", 0, 240, 512, 32);
+   }
+
+   @Test
+   public void trimsWhitespaceAroundEveryField() throws IOException {
+      writePresetsFile("   Spaced out  ,  10 ,  20 , 30 , 40   \n");
+
+      List<CropPreset> presets = CropPreset.loadPresets();
+
+      Assert.assertEquals(1, presets.size());
+      assertRectangle(presets.get(0), "Spaced out", 10, 20, 30, 40);
+   }
+
+   @Test
+   public void ignoresBlankAndCommentLines() throws IOException {
+      writePresetsFile("# a leading comment\n"
+            + "\n"
+            + "   \n"
+            + "   # an indented comment\n"
+            + "Only one, 1, 2, 3, 4\n"
+            + "\n");
+
+      List<CropPreset> presets = CropPreset.loadPresets();
+
+      Assert.assertEquals(1, presets.size());
+      assertRectangle(presets.get(0), "Only one", 1, 2, 3, 4);
+   }
+
+   @Test
+   public void skipsMalformedLinesButKeepsTheRest() throws IOException {
+      writePresetsFile("Good one, 0, 0, 64, 64\n"
+            + "too few fields\n"
+            + "Trailing, 1, 2, 3, 4, 5\n"
+            + "Not a number, 0, 0, abc, 100\n"
+            + "Zero width, 0, 0, 0, 100\n"
+            + "Negative height, 0, 0, 100, -1\n"
+            + "Negative origin, -5, 0, 10, 10\n"
+            + " , 0, 0, 10, 10\n"
+            + "Good two, 8, 8, 16, 16\n");
+
+      List<CropPreset> presets = CropPreset.loadPresets();
+
+      Assert.assertEquals(2, presets.size());
+      assertRectangle(presets.get(0), "Good one", 0, 0, 64, 64);
+      assertRectangle(presets.get(1), "Good two", 8, 8, 16, 16);
+   }
+
+   @Test
+   public void acceptsAZeroOrigin() throws IOException {
+      writePresetsFile("Corner, 0, 0, 1, 1\n");
+
+      List<CropPreset> presets = CropPreset.loadPresets();
+
+      Assert.assertEquals(1, presets.size());
+      assertRectangle(presets.get(0), "Corner", 0, 0, 1, 1);
+   }
+
+   @Test
+   public void handlesAFileWithoutATrailingNewline() throws IOException {
+      writePresetsFile("No newline, 1, 2, 3, 4");
+
+      List<CropPreset> presets = CropPreset.loadPresets();
+
+      Assert.assertEquals(1, presets.size());
+      assertRectangle(presets.get(0), "No newline", 1, 2, 3, 4);
+   }
+
+   @Test
+   public void createsATemplateThatDefinesNoPresets() throws IOException {
+      File created = CropPreset.createTemplateFile();
+
+      Assert.assertTrue(created.isFile());
+      Assert.assertEquals(CropPreset.PRESETS_FILE_NAME, created.getName());
+      // Every example in the template is commented out, so a freshly created file must
+      // parse cleanly and contribute nothing to the menu.
+      Assert.assertTrue(CropPreset.loadPresets().isEmpty());
+   }
+
+   @Test
+   public void templateCreationLeavesAnExistingFileAlone() throws IOException {
+      writePresetsFile("Precious, 1, 2, 3, 4\n");
+
+      CropPreset.createTemplateFile();
+
+      List<CropPreset> presets = CropPreset.loadPresets();
+      Assert.assertEquals(1, presets.size());
+      assertRectangle(presets.get(0), "Precious", 1, 2, 3, 4);
+   }
+}


### PR DESCRIPTION
Addresses #2424.  The crop button only ever cropped to the center quadrant                          of the current ROI.  Right-clicking it now offers named crop presets read                           from CropPresets.txt in the application directory, a Specify... dialog for                          typing an exact rectangle, and an About Crop Presets... item that documents                         the file format and can create a commented example.                                                                                                                                                     

Presets and the Specify dialog work in absolute full-chip coordinates, so                           applying one is idempotent, unlike the center-quad crop which shrinks                               whatever ROI is currently in force.  They therefore bypass updateROI(),                             which adds the current ROI offset and applies ImageFlipper corrections.                             The center-quad crop is deliberately absent from the menu to keep the two                           coordinate spaces from being mixed there; a plain click still performs it.                                                                                                                              

A preset that runs off the chip is trimmed to fit, one that misses entirely                         is not applied, and either way an alert appears in the Messages window.                             A missing presets file leaves the button behaving exactly as before.