### PR TITLE
Studio: prevent profile poisoning by a bad file path.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -214,8 +214,11 @@ public final class DefaultDataManager implements DataManager {
       // If the user selected a TIFF file, select the directory the file is in
       File dirFile = new File(directory);
       if (!dirFile.isDirectory()) {
-         String parentDir = dirFile.getParent();
+         // Resolve against the absolute path, so that a relative file name
+         // such as "data.tif" still yields the directory containing it.
+         String parentDir = dirFile.getAbsoluteFile().getParent();
          if (parentDir == null) {
+            // Only a filesystem root has no parent at all.
             throw new IOException("Cannot determine directory for " + directory);
          }
          directory = parentDir;

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -214,7 +214,11 @@ public final class DefaultDataManager implements DataManager {
       // If the user selected a TIFF file, select the directory the file is in
       File dirFile = new File(directory);
       if (!dirFile.isDirectory()) {
-         directory = dirFile.getParent();
+         String parentDir = dirFile.getParent();
+         if (parentDir == null) {
+            throw new IOException("Cannot determine directory for " + directory);
+         }
+         directory = parentDir;
       }
 
       DefaultDatastore result = new DefaultDatastore(studio_);

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -480,8 +480,11 @@ public class DefaultDatastore implements Datastore {
       } else {
          chooser.setFileFilter(SINGLEPLANEFILTER);
       }
-      chooser.setSelectedFile(
-            new File(FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET)));
+      File suggested = FileDialogs.safeStartFile(
+            FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET));
+      if (suggested != null) {
+         chooser.setSelectedFile(suggested);
+      }
       int option = chooser.showSaveDialog(parent);
       if (option != JFileChooser.APPROVE_OPTION) {
          // User cancelled.

--- a/mmstudio/src/main/java/org/micromanager/internal/menus/FileMenu.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/menus/FileMenu.java
@@ -29,6 +29,8 @@ import org.micromanager.propertymap.MutablePropertyMapView;
 public final class FileMenu {
    private static final String FILE_HISTORY = "list of recently-viewed files";
    private static final int MAX_HISTORY_SIZE = 15;
+   // Ugly overloading of IOException to indicate that the user cancelled.
+   private static final String USER_CANCELED = "User Canceled";
    private final Studio studio_;
    private final MutablePropertyMapView settings_;
    private boolean enableCloseAll_ = false;
@@ -98,6 +100,16 @@ public final class FileMenu {
       );
    }
 
+   /**
+    * Returns true if the exception signals that the user cancelled.
+    *
+    * <p>Note that getMessage() can be null, so the comparison has to be made
+    * in this order.
+    */
+   private static boolean isUserCancel(Exception e) {
+      return USER_CANCELED.equals(e.getMessage());
+   }
+
    private void promptToOpenFile(final boolean isVirtual) {
       new Thread(() -> {
          try {
@@ -117,10 +129,13 @@ public final class FileMenu {
             studio_.displays().loadDisplays(store);
             updateFileHistory(store.getSavePath());
          } catch (IOException ex) {
-            // ugly overloading of IOException to indicate user cancelling.
-            if (!ex.getMessage().equals("User Canceled")) {
+            if (!isUserCancel(ex)) {
                ReportingUtils.showError(ex, "There was an error when opening data");
             }
+         } catch (RuntimeException ex) {
+            // Never let an unchecked exception die silently on this bare
+            // thread; that turns a bug into a menu item that does nothing.
+            ReportingUtils.showError(ex, "There was an error when opening data");
          }
       }).start();
    }
@@ -139,10 +154,11 @@ public final class FileMenu {
                DisplayWindow display = studio_.displays().createDisplay(sdp);
                studio_.displays().addViewer(display);
             } catch (IOException ioe) {
-               // ugly overloading of IOException to indicate user cancelling.
-               if (!ioe.getMessage().equals("User Canceled")) {
+               if (!isUserCancel(ioe)) {
                   studio_.logs().showError(ioe, "There was an error while opening data");
                }
+            } catch (RuntimeException ioe) {
+               studio_.logs().showError(ioe, "There was an error while opening data");
             }
          }).start();
       }
@@ -174,10 +190,11 @@ public final class FileMenu {
                }
                updateFileHistory(path);
             } catch (IOException ioe) {
-               // ugly overloading of IOException to indicate user cancelling.
-               if (!ioe.getMessage().equals("User Canceled")) {
+               if (!isUserCancel(ioe)) {
                   ReportingUtils.showError(ioe, "There was an error while opening data");
                }
+            } catch (RuntimeException ioe) {
+               ReportingUtils.showError(ioe, "There was an error while opening data");
             }
          }).start());
          result.add(item);

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/FileDialogs.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/FileDialogs.java
@@ -221,7 +221,7 @@ public final class FileDialogs {
       String startFile = getSuggestedFile(type);
       File startDir = safeStartFile(startFile);
       if (startFile != null && startDir != null
-            && !startFile.trim().equals(startDir.getPath())) {
+            && !startFile.equals(startDir.getPath())) {
          // Repair a bad remembered path now, so that the user recovers without
          // having to delete their profile directory (issue #2232).
          storePath(type, startDir);
@@ -266,7 +266,7 @@ public final class FileDialogs {
     *
     * <p>If the path is malformed or no longer reachable, walks up to the nearest
     * existing ancestor, and otherwise falls back to the user's home directory.
-    * A path that still exists is returned unchanged, so remembered locations
+    * A path that still exists is returned verbatim, so remembered locations
     * behave exactly as before.
     *
     * @param path remembered path, may be null or malformed
@@ -275,7 +275,11 @@ public final class FileDialogs {
    public static File safeStartFile(String path) {
       File candidate = null;
       if (isUsablePath(path)) {
-         candidate = new File(path.trim());
+         // Deliberately not trimmed: on Unix-like systems leading and trailing
+         // spaces are legal parts of a file name, so trimming would silently
+         // point at a different file.  Paths that Windows cannot use have
+         // already been rejected by isUsablePath().
+         candidate = new File(path);
       }
       // Walk up to the nearest ancestor that both parses and exists.  The
       // parse check has to be repeated on every hop, since getParentFile() of

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/FileDialogs.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/FileDialogs.java
@@ -20,6 +20,7 @@ import java.awt.FileDialog;
 import java.awt.Frame;
 import java.awt.Window;
 import java.io.File;
+import java.nio.file.Paths;
 import javax.swing.JFileChooser;
 import org.micromanager.ApplicationSkin;
 import org.micromanager.ApplicationSkin.SkinMode;
@@ -163,28 +164,49 @@ public final class FileDialogs {
          // the "night" UI. So we temporarily force the "Daytime" look and
          // feel, without redrawing the entire program UI, just for as long as
          // it takes us to create this chooser.
-         skin.suspendToMode(SkinMode.DAY);
-         JFileChooser fc = new JFileChooser();
-         if (selectDirectories) {
-            fc.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
-         }
-         if (startFile != null) {
-            if (startFile.isDirectory()) {
-               fc.setCurrentDirectory(startFile);
-            } else {
-               fc.setSelectedFile(startFile);
+         JFileChooser fc;
+         try {
+            skin.suspendToMode(SkinMode.DAY);
+            fc = new JFileChooser();
+            if (selectDirectories) {
+               fc.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
             }
+            if (startFile != null) {
+               try {
+                  if (startFile.isDirectory()) {
+                     fc.setCurrentDirectory(startFile);
+                  } else {
+                     fc.setSelectedFile(startFile);
+                  }
+               } catch (RuntimeException e) {
+                  // Some paths blow up inside the chooser's own machinery.
+                  // Its state is no longer trustworthy at this point, so start
+                  // over with no location rather than failing the whole action.
+                  ReportingUtils.logError(e, "Could not use " + startFile
+                        + " as file chooser start location");
+                  fc = new JFileChooser();
+                  if (selectDirectories) {
+                     fc.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+                  }
+               }
+            }
+         } finally {
+            skin.resume();
          }
-         skin.resume();
          fc.setDialogTitle(title);
          if (fileSuffixes != null) {
             fc.setFileFilter(filter);
          }
          int returnVal;
-         if (load) {
-            returnVal = fc.showOpenDialog(parent);
-         } else {
-            returnVal = fc.showSaveDialog(parent);
+         try {
+            if (load) {
+               returnVal = fc.showOpenDialog(parent);
+            } else {
+               returnVal = fc.showSaveDialog(parent);
+            }
+         } catch (RuntimeException e) {
+            ReportingUtils.showError(e, "Error displaying the file chooser");
+            return null;
          }
          if (returnVal == JFileChooser.APPROVE_OPTION) {
             selectedFile = fc.getSelectedFile();
@@ -197,9 +219,12 @@ public final class FileDialogs {
                                      FileType type, boolean selectDirectories, boolean load,
                                      ApplicationSkin skin) {
       String startFile = getSuggestedFile(type);
-      File startDir = null;
-      if (startFile != null) {
-         startDir = new File(startFile.trim());
+      File startDir = safeStartFile(startFile);
+      if (startFile != null && startDir != null
+            && !startFile.trim().equals(startDir.getPath())) {
+         // Repair a bad remembered path now, so that the user recovers without
+         // having to delete their profile directory (issue #2232).
+         storePath(type, startDir);
       }
       File result = promptForFile(parent, title, startDir, selectDirectories,
             load, type.description, type.suffixes, type.suggestFileOnSave, skin);
@@ -209,9 +234,104 @@ public final class FileDialogs {
       return result;
    }
 
+   /**
+    * Returns true if the given string can be used as a path on this platform.
+    *
+    * <p>Some strings are accepted by the File constructor but rejected by
+    * java.nio.file.  On Windows a trailing space is the common case.  Such a
+    * path throws InvalidPathException from deep inside JFileChooser, where it
+    * escapes as an unchecked exception (issue #2232).
+    *
+    * @param path path to check, may be null
+    * @return true if the path is usable
+    */
+   static boolean isUsablePath(String path) {
+      if (path == null || path.trim().isEmpty()) {
+         return false;
+      }
+      try {
+         Paths.get(path);
+         // File -> Path is the round trip that JFileChooser and ShellFolder
+         // perform internally.  Exercise it here so that we fail now, where
+         // we can recover, rather than inside the chooser, where we cannot.
+         new File(path).getAbsoluteFile().toPath();
+         return true;
+      } catch (RuntimeException e) {
+         return false;
+      }
+   }
+
+   /**
+    * Converts a remembered path into a File usable as a chooser start location.
+    *
+    * <p>If the path is malformed or no longer reachable, walks up to the nearest
+    * existing ancestor, and otherwise falls back to the user's home directory.
+    * A path that still exists is returned unchanged, so remembered locations
+    * behave exactly as before.
+    *
+    * @param path remembered path, may be null or malformed
+    * @return a usable start location, or null to let the chooser choose
+    */
+   public static File safeStartFile(String path) {
+      File candidate = null;
+      if (isUsablePath(path)) {
+         candidate = new File(path.trim());
+      }
+      // Walk up to the nearest ancestor that both parses and exists.  The
+      // parse check has to be repeated on every hop, since getParentFile() of
+      // a malformed path can itself be malformed.
+      File walker = candidate;
+      while (walker != null) {
+         if (walker.exists()) {
+            return walker;
+         }
+         File parent = walker.getParentFile();
+         if (parent == null || !isUsablePath(parent.getPath())) {
+            break;
+         }
+         walker = parent;
+      }
+      if (candidate != null) {
+         // Parses, but nothing along the chain exists.  Most often this is an
+         // offline network share, which can stall the chooser for a long time,
+         // so prefer somewhere known to be reachable.
+         ReportingUtils.logMessage("FileDialogs: remembered path is not "
+               + "reachable, falling back to home directory: " + path);
+      }
+      String home = System.getProperty("user.home");
+      if (isUsablePath(home)) {
+         return new File(home);
+      }
+      return null;
+   }
+
+   /**
+    * Remembers the given path as the starting location for this file type.
+    *
+    * <p>Paths that cannot be used on this platform are rejected rather than
+    * stored, since a stored bad path would break every later use of the
+    * chooser for this file type (issue #2232).
+    *
+    * @param type file type whose location should be remembered
+    * @param path location to remember
+    */
    public static void storePath(FileType type, File path) {
+      if (path == null) {
+         return;
+      }
+      String absPath;
+      try {
+         absPath = path.getAbsolutePath();
+      } catch (RuntimeException e) {
+         ReportingUtils.logError(e, "Unable to store path for " + type.name);
+         return;
+      }
+      if (!isUsablePath(absPath)) {
+         ReportingUtils.logError("Refusing to remember unusable path: " + absPath);
+         return;
+      }
       UserProfile profile = MMStudio.getInstance().profile();
-      type.defaultFileName = path.getAbsolutePath();
+      type.defaultFileName = absPath;
       profile.getSettings(FileDialogs.class).putString(type.name,
             type.defaultFileName);
    }

--- a/mmstudio/src/test/java/org/micromanager/internal/utils/FileDialogsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/internal/utils/FileDialogsTest.java
@@ -1,0 +1,79 @@
+package org.micromanager.internal.utils;
+
+import java.io.File;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the path sanitizing that protects the file choosers from unusable
+ * remembered paths (issue #2232).
+ */
+public class FileDialogsTest {
+
+   // Deliberately not JavaUtils.isWindows(), so that this test does not drag
+   // in the look and feel classes that JavaUtils refers to.
+   private static boolean isWindows() {
+      return System.getProperty("os.name").toLowerCase().contains("win");
+   }
+
+   @Test
+   public void testNullAndEmptyAreNotUsable() {
+      Assert.assertFalse(FileDialogs.isUsablePath(null));
+      Assert.assertFalse(FileDialogs.isUsablePath(""));
+      Assert.assertFalse(FileDialogs.isUsablePath("   "));
+   }
+
+   @Test
+   public void testOrdinaryPathIsUsable() {
+      Assert.assertTrue(FileDialogs.isUsablePath(System.getProperty("user.home")));
+   }
+
+   /**
+    * On Windows a trailing space makes the path unusable, even though the File
+    * constructor accepts it.  This is the case reported in issue #2232.  On
+    * other platforms a trailing space is a legal file name.
+    */
+   @Test
+   public void testTrailingSpaceRejectedOnWindows() {
+      if (!isWindows()) {
+         return;
+      }
+      Assert.assertFalse(FileDialogs.isUsablePath(System.getProperty("user.home") + " "));
+   }
+
+   @Test
+   public void testExistingPathIsReturnedUnchanged() {
+      String home = System.getProperty("user.home");
+      File result = FileDialogs.safeStartFile(home);
+      Assert.assertNotNull(result);
+      Assert.assertEquals(new File(home), result);
+   }
+
+   @Test
+   public void testMissingPathWalksUpToExistingAncestor() {
+      File home = new File(System.getProperty("user.home"));
+      File missing = new File(home, "no-such-dir-2232/nor-this-one/nor-this");
+      File result = FileDialogs.safeStartFile(missing.getPath());
+      Assert.assertNotNull(result);
+      Assert.assertTrue("expected an existing directory, got " + result, result.exists());
+      Assert.assertEquals(home, result);
+   }
+
+   @Test
+   public void testNullFallsBackToSomethingUsable() {
+      File result = FileDialogs.safeStartFile(null);
+      Assert.assertNotNull(result);
+      Assert.assertTrue(result.exists());
+   }
+
+   /**
+    * An unusable path must never leave the caller holding something that will
+    * blow up later inside the file chooser.
+    */
+   @Test
+   public void testUnusablePathYieldsUsableResult() {
+      File result = FileDialogs.safeStartFile(System.getProperty("user.home") + " ");
+      Assert.assertNotNull(result);
+      Assert.assertTrue(FileDialogs.isUsablePath(result.getPath()));
+   }
+}

--- a/mmstudio/src/test/java/org/micromanager/internal/utils/FileDialogsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/internal/utils/FileDialogsTest.java
@@ -49,6 +49,26 @@ public class FileDialogsTest {
       Assert.assertEquals(new File(home), result);
    }
 
+   /**
+    * An existing path has to come back verbatim.  Trimming it would point at a
+    * different file on systems where a trailing space is part of the name.
+    */
+   @Test
+   public void testExistingPathIsNotTrimmed() {
+      if (isWindows()) {
+         // Windows cannot represent such a directory in the first place.
+         return;
+      }
+      File dir = new File(System.getProperty("java.io.tmpdir"), "mm2232 test ");
+      Assert.assertTrue("could not create " + dir, dir.mkdirs() || dir.isDirectory());
+      try {
+         File result = FileDialogs.safeStartFile(dir.getPath());
+         Assert.assertEquals(dir.getPath(), result.getPath());
+      } finally {
+         dir.delete();
+      }
+   }
+
    @Test
    public void testMissingPathWalksUpToExistingAncestor() {
       File home = new File(System.getProperty("user.home"));

--- a/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
+++ b/plugins/Duplicator/src/main/java/org/micromanager/duplicator/DuplicatorPluginFrame.java
@@ -377,7 +377,11 @@ public class DuplicatorPluginFrame extends JDialog {
       } else {
          chooser.setFileFilter(SINGLEPLANEFILTER);
       }
-      chooser.setSelectedFile(new File(FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET)));
+      File suggested = FileDialogs.safeStartFile(
+            FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET));
+      if (suggested != null) {
+         chooser.setSelectedFile(suggested);
+      }
       int option = chooser.showDialog(this, "Select");
       if (option != JFileChooser.APPROVE_OPTION) {
          // User cancelled.

--- a/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
+++ b/plugins/Explorer/src/main/java/org/micromanager/explorer/ExplorerManager.java
@@ -1008,9 +1008,9 @@ public class ExplorerManager {
             JFileChooser chooser = new JFileChooser();
             chooser.setDialogTitle("Move Explorer Data To");
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-            String suggestedPath = FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET);
-            if (suggestedPath != null) {
-               File suggested = new File(suggestedPath);
+            File suggested = FileDialogs.safeStartFile(
+                  FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET));
+            if (suggested != null) {
                File dir = suggested.isDirectory() ? suggested : suggested.getParentFile();
                if (dir != null) {
                   chooser.setCurrentDirectory(dir);

--- a/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
+++ b/plugins/Stitch/src/main/java/org/micromanager/stitch/StitchFrame.java
@@ -405,9 +405,13 @@ public class StitchFrame extends JDialog {
          File cur = new File(current);
          chooser.setCurrentDirectory(cur.isDirectory() ? cur : cur.getParentFile());
       } else {
-         File suggested = new File(FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET));
-         if (suggested.getParentFile() != null) {
-            chooser.setCurrentDirectory(suggested.getParentFile());
+         File suggested = FileDialogs.safeStartFile(
+               FileDialogs.getSuggestedFile(FileDialogs.MM_DATA_SET));
+         if (suggested != null) {
+            File dir = suggested.isDirectory() ? suggested : suggested.getParentFile();
+            if (dir != null) {
+               chooser.setCurrentDirectory(dir);
+            }
          }
       }
       if (chooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {


### PR DESCRIPTION
 Closes #2232.  

The file open path in the profile could get poisoned by inserting a bad character.  This was a non-recoverable error as the exception was not propagated.  This PR avoids the insertion of a bad path into the profile and also deals gracefully with a bad path in the profile.