### PR TITLE
Studio: Make sure that all numbers always roundtrip through NumberUtils,

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/acquisition/internal/acqengjcompat/multimda/MultiMDAFrame.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -481,7 +480,7 @@ public class MultiMDAFrame extends JFrame {
       intervalLabel.setEnabled(framesPanel.isEnabled());
       defaultTimesPanel.add(intervalLabel, "alignx label");
 
-      interval_ = new JFormattedTextField(NumberFormat.getInstance());
+      interval_ = new JFormattedTextField(NumberUtils.getDisplayFormat(3));
       interval_.setColumns(5);
       interval_.setFont(DEFAULT_FONT);
       interval_.setValue(1.0);

--- a/mmstudio/src/main/java/org/micromanager/display/overlay/internal/overlays/PatternOverlay.java
+++ b/mmstudio/src/main/java/org/micromanager/display/overlay/internal/overlays/PatternOverlay.java
@@ -451,6 +451,7 @@ public class PatternOverlay extends AbstractOverlay {
       });
 
       NumberFormat patternSizeTextFormat = NumberFormat.getInstance();
+      patternSizeTextFormat.setGroupingUsed(false);
       patternSizeTextBox_ = new JFormattedTextField(patternSizeTextFormat);
       patternSizeTextBox_.setColumns(2);
       patternSizeLabel_ = new JLabel("%");

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/AcqControlDlg.java
@@ -237,7 +237,7 @@ public final class AcqControlDlg extends JFrame implements PropertyChangeListene
 
       super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 
-      numberFormat_ = NumberFormat.getNumberInstance();
+      numberFormat_ = NumberUtils.getDisplayFormat(3);
 
       super.addWindowListener(new WindowAdapter() {
 

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/CustomTimeIntervalsPanel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/CustomTimeIntervalsPanel.java
@@ -9,7 +9,6 @@ import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionListener;
 import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +32,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 import org.micromanager.Studio;
 import org.micromanager.acquisition.internal.AcquisitionEngine;
 import org.micromanager.internal.utils.DaytimeNighttime;
+import org.micromanager.internal.utils.NumberUtils;
 import org.micromanager.internal.utils.TooltipTextMaker;
 
 /**
@@ -415,7 +415,7 @@ public final class CustomTimeIntervalsPanel extends JPanel {
          nCheck_.addActionListener(boxesListener);
          tCheck_.addActionListener(boxesListener);
 
-         aValue_ = new JFormattedTextField(NumberFormat.getNumberInstance());
+         aValue_ = new JFormattedTextField(NumberUtils.getDisplayFormat(3));
          aValue_.setFont(new Font("Arial", Font.PLAIN, 14));
          aValue_.setValue(1.0);
          aValue_.setPreferredSize(new Dimension(80, 22));
@@ -424,12 +424,12 @@ public final class CustomTimeIntervalsPanel extends JPanel {
          aCombo_.setFont(new Font("Arial", Font.PLAIN, 14));
          row1.add(aValue_);
          row1.add(aCombo_);
-         rValue_ = new JFormattedTextField(NumberFormat.getNumberInstance());
+         rValue_ = new JFormattedTextField(NumberUtils.getDisplayFormat(3));
          rValue_.setFont(new Font("Arial", Font.PLAIN, 14));
          rValue_.setValue(2.0);
          rValue_.setPreferredSize(new Dimension(80, 22));
          row2.add(rValue_);
-         tValue_ = new JFormattedTextField(NumberFormat.getNumberInstance());
+         tValue_ = new JFormattedTextField(NumberUtils.getDisplayFormat(3));
          tValue_.setFont(new Font("Arial", Font.PLAIN, 14));
          tValue_.setValue(1000.0);
          tValue_.setPreferredSize(new Dimension(80, 22));
@@ -635,7 +635,7 @@ public final class CustomTimeIntervalsPanel extends JPanel {
                      + "as possible");
          row2.add(intervalLabel);
 
-         interval_ = new JFormattedTextField(NumberFormat.getNumberInstance());
+         interval_ = new JFormattedTextField(NumberUtils.getDisplayFormat(3));
          interval_.setFont(new Font("Arial", Font.PLAIN, 14));
          interval_.setValue(1.0);
          interval_.setPreferredSize(new Dimension(80, 22));

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/StageControlFrame.java
@@ -204,8 +204,7 @@ public final class StageControlFrame extends JFrame {
       settings_ = studio_.profile().getSettings(StageControlFrame.class);
       uiMovesStageManager_ = ((MMStudio) studio_).getUiMovesStageManager(); // TODO: add to API?
 
-      NumberFormat numberInstance = NumberFormat.getNumberInstance();
-      numberInstance.setMaximumFractionDigits(1);
+      NumberFormat numberInstance = NumberUtils.getDisplayFormat(1);
       xStepTexts_ = new JFormattedTextField[] {
             new JFormattedTextField(numberInstance),
             new JFormattedTextField(numberInstance),
@@ -1045,8 +1044,7 @@ public final class StageControlFrame extends JFrame {
          }
       }
 
-      NumberFormat numberInstance = NumberFormat.getNumberInstance();
-      numberInstance.setMaximumFractionDigits(1);
+      NumberFormat numberInstance = NumberUtils.getDisplayFormat(1);
       JFormattedTextField tf = new JFormattedTextField(numberInstance);
       tf.setHorizontalAlignment(SwingConstants.RIGHT);
       FieldListener listener = new FieldListener(tf, settings, cb, prefix);

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/NumberUtils.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/NumberUtils.java
@@ -102,6 +102,24 @@ public final class NumberUtils {
       return result;
    }
 
+   /**
+    * Returns a NumberFormat suitable for a JFormattedTextField whose contents are read
+    * back with {@link #displayStringToDouble}. Grouping is switched off: the parser
+    * treats both "." and "," as decimal separators and has no notion of grouping, so a
+    * grouped "2,000" would come back as 2.0 (see issue #2444). A fresh instance is
+    * returned each call because a JFormattedTextField keeps a reference to it.
+    *
+    * @param maxFractionDigits Maximum number of digits after the decimal separator
+    * @return A new, non-grouping NumberFormat in the default locale
+    */
+   public static NumberFormat getDisplayFormat(int maxFractionDigits) {
+      NumberFormat format = NumberFormat.getNumberInstance();
+      format.setRoundingMode(RoundingMode.HALF_UP);
+      format.setMaximumFractionDigits(maxFractionDigits);
+      format.setGroupingUsed(false);
+      return format;
+   }
+
    public static int displayStringToInt(Object numberString) throws ParseException {
       return parseIntegerStrict(numberString, INTEGER_PARSE_FORMAT).intValue();
    }

--- a/mmstudio/src/test/java/org/micromanager/internal/utils/NumberUtilsTest.java
+++ b/mmstudio/src/test/java/org/micromanager/internal/utils/NumberUtilsTest.java
@@ -119,4 +119,49 @@ public class NumberUtilsTest {
          assertEquals(value, NumberUtils.displayStringToInt(displayed));
       }
    }
+
+   /**
+    * Regression test for the "2000 shows as 2,000 and reads back as 2.0" bug: a format
+    * handed to a JFormattedTextField must never emit a grouping separator, because
+    * displayStringToDouble() reads "," and "." as decimal separators. Not locale-gated:
+    * the round trip has to hold under every decimal-separator convention.
+    */
+   @Test
+   public void displayFormatRoundTripsThroughDisplayString() throws java.text.ParseException {
+      final double delta = 0.00001;
+      final double[] values = {2000.0, 1234.5, 250000.0, 0.1, -42.5, 1.3, 0.0};
+      final java.util.Locale original = java.util.Locale.getDefault();
+      try {
+         for (java.util.Locale locale : new java.util.Locale[] {
+               java.util.Locale.US, java.util.Locale.GERMANY, java.util.Locale.FRANCE}) {
+            java.util.Locale.setDefault(locale);
+            java.text.NumberFormat format = NumberUtils.getDisplayFormat(1);
+            for (double value : values) {
+               String displayed = format.format(value);
+               assertEquals(locale + ": \"" + displayed + "\"",
+                     value, NumberUtils.displayStringToDouble(displayed), delta);
+            }
+         }
+      } finally {
+         java.util.Locale.setDefault(original);
+      }
+   }
+
+   /**
+    * The specific value from the bug report: 2000 must not acquire a grouping separator,
+    * which displayStringToDouble() would otherwise read as a decimal point (-> 2.0).
+    */
+   @Test
+   public void displayFormatDoesNotGroupThousands() {
+      final java.util.Locale original = java.util.Locale.getDefault();
+      try {
+         for (java.util.Locale locale : new java.util.Locale[] {
+               java.util.Locale.US, java.util.Locale.GERMANY, java.util.Locale.FRANCE}) {
+            java.util.Locale.setDefault(locale);
+            assertEquals("2000", NumberUtils.getDisplayFormat(1).format(2000.0));
+         }
+      } finally {
+         java.util.Locale.setDefault(original);
+      }
+   }
 }

--- a/plugins/ChannelCorrector/src/main/java/org/micromanager/channelcorrector/ChannelCorrectorPanel.java
+++ b/plugins/ChannelCorrector/src/main/java/org/micromanager/channelcorrector/ChannelCorrectorPanel.java
@@ -129,6 +129,7 @@ public class ChannelCorrectorPanel extends JPanel {
       affineTransform_.getMatrix(flatAffine);
       NumberFormat affFormat = NumberFormat.getInstance();
       affFormat.setMinimumFractionDigits(5);
+      affFormat.setGroupingUsed(false);
       for (int row = 0; row < 2; row++) {
          for (int col = 0; col < 3; col++) {
             final int r = row;

--- a/plugins/FluidControl/src/main/java/org/micromanager/plugins/fluidcontrol/PressureControlSubPanel.java
+++ b/plugins/FluidControl/src/main/java/org/micromanager/plugins/fluidcontrol/PressureControlSubPanel.java
@@ -141,6 +141,7 @@ public class PressureControlSubPanel extends JPanel {
       NumberFormat numberFormat = NumberFormat.getNumberInstance();
       numberFormat.setMaximumFractionDigits(2);
       numberFormat.setMinimumFractionDigits(0);
+      numberFormat.setGroupingUsed(false);
       NumberFormatter formatter = new NumberFormatter(numberFormat);
       formatter.setValueClass(Float.class);
       formatter.setMinimum(minValue);

--- a/plugins/FluidControl/src/main/java/org/micromanager/plugins/fluidcontrol/VolumeControlSubPanel.java
+++ b/plugins/FluidControl/src/main/java/org/micromanager/plugins/fluidcontrol/VolumeControlSubPanel.java
@@ -88,6 +88,7 @@ public class VolumeControlSubPanel extends JPanel {
       NumberFormat numberFormat = NumberFormat.getNumberInstance();
       numberFormat.setMaximumFractionDigits(2);
       numberFormat.setMinimumFractionDigits(0);
+      numberFormat.setGroupingUsed(false);
       NumberFormatter formatter = new NumberFormatter(numberFormat);
       formatter.setValueClass(Float.class);
       formatter.setMinimum(0);

--- a/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombinerConfigurator.java
+++ b/plugins/FrameCombiner/src/main/java/org/micromanager/plugins/framecombiner/FrameCombinerConfigurator.java
@@ -68,6 +68,7 @@ public class FrameCombinerConfigurator extends JFrame implements ProcessorConfig
 
       final JPanel jPanel1 = new JPanel();
       final NumberFormat format = NumberFormat.getInstance();
+      format.setGroupingUsed(false);
       final NumberFormatter formatter = new NumberFormatter(format);
       formatter.setValueClass(Integer.class);
       formatter.setMinimum(1);

--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
@@ -25,7 +25,6 @@ import java.awt.Color;
 import java.awt.Toolkit;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.DefaultComboBoxModel;
@@ -48,6 +47,7 @@ import org.jfree.data.xy.XYSeriesCollection;
 import org.micromanager.display.inspector.internal.panels.sharpnessinspector.SharpnessInspectorController;
 import org.micromanager.display.inspector.internal.panels.sharpnessinspector.SharpnessInspectorPlugin;
 import org.micromanager.imageprocessing.ImgSharpnessAnalysis;
+import org.micromanager.internal.utils.NumberUtils;
 
 /**
  *
@@ -270,9 +270,9 @@ public class SharpnessInspectorPanel extends JPanel {
         
    private class ScanDialog extends JDialog {
       private final JFormattedTextField interval =
-              new JFormattedTextField(NumberFormat.getNumberInstance());
+              new JFormattedTextField(NumberUtils.getDisplayFormat(3));
       private final JFormattedTextField range =
-              new JFormattedTextField(NumberFormat.getNumberInstance());
+              new JFormattedTextField(NumberUtils.getDisplayFormat(3));
       private final JButton startButton = new JButton("Start");
 
       public ScanDialog() {


### PR DESCRIPTION
so as to avoid presesnting a comma as a thousands grouping separator but interpreting it as a decimal separator.