### PR TITLE
SharpnessInspector: fix NPE that prevents the Inspector from opening

### DIFF
--- a/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
+++ b/plugins/SharpnessInspector/src/main/java/org/micromanager/sharpnessinspector/ui/SharpnessInspectorPanel.java
@@ -23,8 +23,6 @@ package org.micromanager.display.inspector.internal.panels.sharpnessinspector.ui
 
 import java.awt.Color;
 import java.awt.Toolkit;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.DefaultComboBoxModel;
@@ -113,8 +111,6 @@ public class SharpnessInspectorPanel extends JPanel {
            .getSeries(SERIES_NAME);
    private final XYSeries tDataSeries = ((XYSeriesCollection) tChart.getXYPlot().getDataset())
            .getSeries(SERIES_NAME);
-
-   private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
     
    public SharpnessInspectorPanel() {
       super(new MigLayout("fill, nogrid"));
@@ -163,7 +159,7 @@ public class SharpnessInspectorPanel extends JPanel {
       });
 
       evaluationMode.addActionListener((evt) -> {
-         this.pcs.firePropertyChange("evalMethod", null,
+         this.firePropertyChange("evalMethod", null,
                  (ImgSharpnessAnalysis.Method) evaluationMode.getSelectedItem());
       });
         
@@ -186,16 +182,6 @@ public class SharpnessInspectorPanel extends JPanel {
       super.add(infoButton);
    }
 
-   @Override
-   public void addPropertyChangeListener(PropertyChangeListener listener) {
-      this.pcs.addPropertyChangeListener(listener);
-   }
-    
-   @Override
-   public void addPropertyChangeListener(String property, PropertyChangeListener listener) {
-      this.pcs.addPropertyChangeListener(property, listener);
-   }
-    
    public void setValue(double z, double time, double sharpness) {
       //Add an XY value to the plot. if the x value already exists the old value will be replaced.
       this.zDataSeries.addOrUpdate(z, sharpness);
@@ -265,7 +251,7 @@ public class SharpnessInspectorPanel extends JPanel {
       if (plotModeBox.getSelectedItem() != mode) {
          plotModeBox.setSelectedItem(mode);
       }
-      this.pcs.firePropertyChange("plotMode", null, mode);
+      this.firePropertyChange("plotMode", null, mode);
    }
         
    private class ScanDialog extends JDialog {


### PR DESCRIPTION
The short version is that Image Inspector was broken on Linux. The commit and the following message are Claude Code's diagnosis of the issue. I have manually verified that this fixes the issue on Linux but I don't have access to a Windows box so I don't know if this breaks there.

## Problem

On Linux, `Window → Inspector` with a display window open and focused does nothing at all: no
window appears, no error dialog, nothing new in the window list. The only evidence is in the
CoreLog:

```
java.lang.NullPointerException
  at org.micromanager.display.inspector.internal.panels.sharpnessinspector.ui.SharpnessInspectorPanel.addPropertyChangeListener(SharpnessInspectorPanel.java:191)
  at com.formdev.flatlaf.ui.FlatPanelUI.installUI(FlatPanelUI.java:75)
```

The entire Inspector is lost because of this one panel. `InspectorController` builds its sections
with

```java
for (InspectorPanelPlugin plugin : plugins) {
   InspectorPanelController panelController = plugin.createPanelController(studio_);
   ...
}
```

with no guard, so an exception while constructing any single panel aborts construction of the whole
Inspector frame.

## Root cause

`SharpnessInspectorPanel` overrode `addPropertyChangeListener` to divert registrations into a
private `PropertyChangeSupport`:

```java
private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);   // inline initializer

@Override
public void addPropertyChangeListener(PropertyChangeListener listener) {
   this.pcs.addPropertyChangeListener(listener);      // line 191
}
```

Inline field initializers run *after* the superclass constructor returns. `JPanel`'s constructor
calls `updateUI() → setUI() → PanelUI.installUI()`, and `FlatPanelUI.installUI` registers a
property-change listener on the panel at line 75. That reaches the override while `pcs` is still
null.

## Which look-and-feels are affected

This is not really about FlatLaf — it is any `PanelUI` that registers a listener in `installUI`:

| PanelUI | what `installUI` does | result |
| --- | --- | --- |
| `BasicPanelUI` (Metal) | `installDefaults` only | OK |
| `SynthPanelUI` (GTK+, Nimbus) | `installListeners()`, which is `p.addPropertyChangeListener(this)` | **NPE** |
| `FlatPanelUI` (FlatLaf) | `c.addPropertyChangeListener(this)` at line 75 | **NPE** |

So the panel has been vulnerable since it was added in f0040ec62 (2021-03-05). Before 57d54bf2d the
Linux path was `UIManager.getSystemLookAndFeelClassName()`, which resolves to `GTKLookAndFeel` under
GNOME — where this panel was **already** broken — but to Metal on other desktops, where the defect
was hidden. Since 57d54bf2d Linux always gets `FlatLightLaf`, so it now fails on every Linux
desktop. Windows and macOS keep their system L&F, and I have not seen this reported there.

## Fix

Delete the two `addPropertyChangeListener` overrides and the private `PropertyChangeSupport`, and
fire through the `PropertyChangeSupport` that `JComponent` already provides.

Overriding `addPropertyChangeListener` on a Swing component is the actual problem, and not only
because of the NPE: it also hijacked the component's own listener registry, so the UI delegate's
listener was diverted into a support object that only ever fires `evalMethod`/`plotMode` and would
never have received the Swing property changes it subscribed to. `removePropertyChangeListener` was
not overridden to match, so `uninstallUI` removed from the other list.

`SharpnessInspectorController` is the only consumer, and it registers through the two-argument
`addPropertyChangeListener("evalMethod", ...)`, which `JComponent` supports directly — so its
contract is unchanged and no listener is silently dropped. (`plotMode` is fired but has no
listeners.)

I preferred this over null-guarding the override, which would have left both of the defects above
in place.

## Testing

Built from 8b607ac60 with `ant -f plugins/SharpnessInspector/build.xml jar` (JDK 11).

Driving the real compiled classes through the failing path — `SharpnessInspectorPlugin
.createPanelController(studio)`, the same call `InspectorController` makes — before and after, under
each available look-and-feel:

```
                                    before                        after
Metal  == BasicPanelUI        ctor OK | Volath, Tenengrad   ctor OK | Volath, Tenengrad
GTK+   == SynthPanelUI        NullPointerException          ctor OK | Volath, Tenengrad
Nimbus == SynthPanelUI        NullPointerException          ctor OK | Volath, Tenengrad
FlatLaf Light == FlatPanelUI  NullPointerException          ctor OK | Volath, Tenengrad
```

"Volath, Tenengrad" are two successive `evalMethod` property changes arriving at a controller-style
listener, driven through the panel's Method combo and registered in the same order the controller
registers it. After the fix `createPanelController` returns a working `SharpnessInspectorController`
— section title "Image Sharpness", panel with its 8 children laid out.

**Not verified:** I have no Windows or macOS machine here, and neither L&F can be loaded on a Linux
JDK. The Metal row above exercises `BasicPanelUI`, the same delegate the Windows L&F uses, and is
observationally identical before and after; beyond that, the panel now has no override at all, so
its listener behaviour is stock `JPanel`. I also did not run the pre-commit checkstyle hook locally
(it wants to download a JRE and the tool); the diff is deletions plus two shortened lines.